### PR TITLE
Numeral constants can be negative in Lustre input

### DIFF
--- a/src/lustreSimplify.ml
+++ b/src/lustreSimplify.ml
@@ -1976,12 +1976,14 @@ and int_const_of_ast_expr context pos expr =
         let ei' = (ei :> Term.t) in let es' = (es :> Term.t) in 
         Term.equal ei' es' -> 
 
-      (match Term.destruct (E.base_term_of_expr E.base_offset ei) with 
-        | Term.T.Const c when Symbol.is_numeral c ->
-          Symbol.numeral_of_symbol c
+      (* Get term for initial value of expression, is equal to step *)
+      let ti = E.base_term_of_expr E.base_offset ei in
 
-        (* Expression is not a constant integer *)
-        | _ ->       
+      (if Term.is_numeral ti then
+
+         Term.numeral_of_term ti
+
+       else
 
           fail_at_position pos "Expression must be an integer")
 

--- a/src/term.ml
+++ b/src/term.ml
@@ -199,37 +199,37 @@ let name_of_named t =  match node_of_term t with
 
 
 (* Return true if the term is an integer constant *)
-let rec is_numeral t = match node_of_term t with 
+let rec is_numeral t = match destruct t with 
 
   (* Term is a numeral constant *)
-  | T.Leaf s when Symbol.is_numeral s -> true
+  | T.Const s when Symbol.is_numeral s -> true
 
   (* Term is a decimal constant coinciding with an integer *)
-  | T.Leaf s when 
+  | T.Const s when 
       Symbol.is_decimal s && Decimal.is_int (Symbol.decimal_of_symbol s) -> 
 
     true
 
   (* Term is a negated numeral constant *)
-  | T.Node (s, [a]) when s == Symbol.s_minus && is_numeral a -> true
+  | T.App (s, [a]) when s == Symbol.s_minus && is_numeral a -> true
 
   | _ -> false
 
 
 (* Return integer constant of a term *)
-let rec numeral_of_term t = match node_of_term t with 
+let rec numeral_of_term t = match destruct t with 
 
   (* Term is a numeral constant *)
-  | T.Leaf s when Symbol.is_numeral s -> Symbol.numeral_of_symbol s
+  | T.Const s when Symbol.is_numeral s -> Symbol.numeral_of_symbol s
 
   (* Term is a decimal constant coinciding with an integer *)
-  | T.Leaf s when 
+  | T.Const s when 
       Symbol.is_decimal s && Decimal.is_int (Symbol.decimal_of_symbol s) -> 
 
     Numeral.of_big_int (Decimal.to_big_int (Symbol.decimal_of_symbol s))
 
   (* Term is a negated numeral constant *)
-  | T.Node (s, [a]) when s == Symbol.s_minus && is_numeral a -> 
+  | T.App (s, [a]) when s == Symbol.s_minus && is_numeral a -> 
 
     Numeral.(~- (numeral_of_term a))
 


### PR DESCRIPTION
Numerals are always positive, negative numerals have a unary minus
applied to their absolute values. Allow negative numerals as constants
in Lustre input.
