### PR TITLE
Better support for CVC4

### DIFF
--- a/src/PDR.ml
+++ b/src/PDR.ml
@@ -2356,6 +2356,16 @@ let rec pdr
 *)
 let main trans_sys =
 
+  if 
+    not (Flags.pdr_qe () = `Cooper) && 
+    not (Flags.smtsolver () = `Z3_SMTLIB) 
+  then
+ 
+    (Event.log L_fatal "Precise quantifier elimination needs Z3 as SMT solver";
+
+     failwith "Unsupported SMT solver for options");
+        
+
   (* PDR solving starts now *)
   Stat.start_timer Stat.pdr_total_time;
 
@@ -2686,7 +2696,13 @@ let main trans_sys =
                 "Problem contains real valued variables, \
                  switching off approximate QE";
 
-              Flags.set_pdr_qe `Z3;
+              if Flags.smtsolver () = `Z3_SMTLIB then 
+                Flags.set_pdr_qe `Z3
+              else
+                (Event.log 
+                   L_fatal
+                   "Precise quantifier elimination needs Z3 as SMT solver";
+                 failwith "Unsupported SMT solver for options");              
 
               props
 

--- a/src/QE.ml
+++ b/src/QE.ml
@@ -46,7 +46,7 @@ let get_solver_instance trans_sys =
       let solver =     
         Solver.new_solver 
           ~produce_assignments:true
-          `UFLIA
+          (TransSys.get_logic trans_sys)
       in
       
       (* Declare uninterpreted function symbols *)

--- a/src/solverMethods.ml
+++ b/src/solverMethods.ml
@@ -255,7 +255,23 @@ struct
     let model =
       List.map
         (function (v, e) -> 
-          (SMTExpr.var_of_smtexpr v, SMTExpr.term_of_smtexpr e))
+          (let v', e' = 
+            SMTExpr.var_of_smtexpr v, SMTExpr.term_of_smtexpr e 
+           in
+           let tv', te' = 
+             Var.type_of_var v', Term.type_of_term e'
+           in
+           if
+             Type.equal_types tv' te'
+           then 
+             (v', e') 
+           else if 
+             Type.equal_types tv' Type.t_real && 
+             Type.equal_types te' Type.t_int 
+           then
+             (v', Term.mk_to_real e')
+           else
+             (v', e')))
         smt_model
     in
 
@@ -299,7 +315,23 @@ struct
     let values =
       List.map
         (function (v, e) -> 
-          (SMTExpr.term_of_smtexpr v, SMTExpr.term_of_smtexpr e))
+          (let v', e' = 
+            SMTExpr.term_of_smtexpr v, SMTExpr.term_of_smtexpr e 
+           in
+           let tv', te' = 
+             Term.type_of_term v', Term.type_of_term e'
+           in
+           if
+             Type.equal_types tv' te'
+           then 
+             (v', e') 
+           else if 
+             Type.equal_types tv' Type.t_real && 
+             Type.equal_types te' Type.t_int 
+           then
+             (v', Term.mk_to_real e')
+           else
+             (v', e')))
         smt_values
     in
 


### PR DESCRIPTION
- Cast integer literals to reals if returned in a model for a real-valued term or variable
- Fail if using precise quantifier elimination or switching to it
