### PR TITLE
Added easily greppable tags for timeout, error, and interruption.

### DIFF
--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -125,7 +125,7 @@ let status_of_exn process = function
     (
 
       Event.log L_error 
-        "Wallclock timeout";
+        "<Timeout> Wallclock timeout";
 
       status_timeout
 
@@ -137,7 +137,7 @@ let status_of_exn process = function
     (
       
       Event.log L_error
-        "CPU timeout"; 
+        "<Timeout> CPU timeout"; 
 
       status_timeout
 
@@ -149,7 +149,7 @@ let status_of_exn process = function
     (
       
       Event.log L_fatal
-        "Caught signal%t. Terminating." 
+        "<Interruption> Caught signal%t. Terminating." 
         (function ppf -> 
           match s with 
             | 0 -> () 
@@ -169,7 +169,7 @@ let status_of_exn process = function
       let backtrace = Printexc.get_backtrace () in
 
       Event.log L_fatal
-        "Runtime error: %s" 
+        "<Error> Runtime error: %s" 
         (Printexc.to_string e);
 
       if Printexc.backtrace_status () then


### PR DESCRIPTION
Tags appear on the output as
<Timeout>
<Error>
<Interruption>
respectively.
