### PR TITLE
Slice to top properties, tag invariants with scope

### DIFF
--- a/src/PDR.ml
+++ b/src/PDR.ml
@@ -1404,7 +1404,7 @@ let fwd_propagate
 *)
               (* Send invariant *)
               List.iter 
-                (fun c -> Event.invariant (Clause.to_term c))
+                (fun c -> Event.invariant [] (Clause.to_term c))
                 inductive;
 
               Stat.record_time Stat.pdr_inductive_check_time;
@@ -2149,7 +2149,7 @@ let handle_events
   in
 
   (* Assert all received invariants *)
-  List.iter (fun (_, i) -> add_invariant i) invariants_recvd;
+  List.iter add_invariant (Event.top_invariants_of_invariants invariants_recvd);
 
   (* Restart if one of the properties to prove has been disproved *)
   List.iter

--- a/src/base.ml
+++ b/src/base.ml
@@ -17,7 +17,7 @@
 *)
 
 open Lib
-open TypeLib
+open TermLib
 open Actlit
 
 module Solver = SolverMethods.Make(SMTSolver.Make(SMTLIBSolver))
@@ -184,7 +184,7 @@ let rec next (trans, solver, k, invariants, unknowns) =
            else
              list )
          (* New invariant properties are added to new invariants. *)
-         ( List.map snd new_invs )
+         ( Event.top_invariants_of_invariants new_invs )
            
   in
 

--- a/src/event.mli
+++ b/src/event.mli
@@ -82,7 +82,7 @@ val terminate_log : unit -> unit
 
 (** Events exposed to callers *)
 type event = 
-  | Invariant of Term.t 
+  | Invariant of string list * Term.t 
   | PropStatus of string * TransSys.prop_status
 
 (** Pretty-print an event *)
@@ -103,7 +103,7 @@ val stat : (string * Stat.stat_item list) list -> unit
 val progress : int -> unit
 
 (** Broadcast a discovered invariant *)
-val invariant : Term.t -> unit 
+val invariant : string list -> Term.t -> unit 
 
 (** Broadcast a property status *)
 val prop_status : TransSys.prop_status -> TransSys.t -> string -> unit
@@ -132,7 +132,12 @@ val check_termination: unit -> unit
     proved properties are added as invariants.
 
     Counterexamples are ignored. *)
-val update_trans_sys : TransSys.t -> (Lib.kind_module * event) list -> (Lib.kind_module * Term.t) list * (Lib.kind_module * (string * TransSys.prop_status)) list
+val update_trans_sys : TransSys.t -> (Lib.kind_module * event) list -> (Lib.kind_module * (string list * Term.t)) list * (Lib.kind_module * (string * TransSys.prop_status)) list
+
+(** Filter list of invariants with their scope for invariants of empty
+    (top) scope *)
+val top_invariants_of_invariants : (Lib.kind_module * (string list * Term.t)) list -> Term.t list
+
 
 (** {1 Messaging} *)
 

--- a/src/invGenGraph.ml
+++ b/src/invGenGraph.ml
@@ -633,7 +633,7 @@ module Make (InModule : In) : Out = struct
                 |> List.rev_append list)
               []
           (* Broadcasting new invariant. *)
-          |> List.iter Event.invariant
+          |> List.iter (Event.invariant [])
         ) else (
           match new_invariants with
             | [] -> ()
@@ -642,7 +642,7 @@ module Make (InModule : In) : Out = struct
               |> Term.mk_and
               |> sanitize_term
               |> get_top_inv_add_invariants lsd sys
-              |> List.iter Event.invariant
+              |> List.iter (Event.invariant [])
         );
 
         (* Returning updated invariant set. *)
@@ -675,7 +675,7 @@ module Make (InModule : In) : Out = struct
             else
               list )
           (* New invariant properties are added to new invariants. *)
-          ( List.map snd new_invs )
+          ( Event.top_invariants_of_invariants new_invs )
     in
 
     (* Adding new invariants to LSD. *)

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1194,32 +1194,6 @@ let file_row_col_of_pos = function
   | { pos_fname; pos_lnum; pos_cnum } -> (pos_fname, pos_lnum, pos_cnum)
 
 
-(* ********************************************************************** *)
-(* Properties of transition systems                                       *)
-(* ********************************************************************** *)
-
-(* Source of a property *)
-type prop_source =
-
-  (* Property is from an annotation *)
-  | PropAnnot of position
-
-  (* Property is part of a contract *)
-  | Contract of position
-
-  (* Property was generated, for example, from a subrange
-     constraint *)
-  | Generated of position
-
-  (* Property is an instance of a property in a called node
-     
-     Reference the instantiated property by the [scope] of the
-     subsystem and the name of the property *)
-  | Instantiated of string list * string 
-
-
-
-
 
 (* 
    Local Variables:

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -325,27 +325,6 @@ val file_row_col_of_pos : position -> string * int * int
 (** Convert a position of the lexer to a position *)
 val position_of_lexing : Lexing.position -> position
  
-(** {1 Properties of transition systems} *)
-
-
-(** Source of a property *)
-type prop_source =
-
-  (** Property is from an annotation *)
-  | PropAnnot of position
-
-  (** Property is part of a contract *)
-  | Contract of position
-
-  (** Property was generated, for example, from a subrange
-      constraint *)
-  | Generated of position
-
-  (** Property is an instance of a property in a called node
-
-      Reference the instantiated property by the [scope] of the
-      subsystem and the name of the property *)
-  | Instantiated of string list * string 
 
 (* 
    Local Variables:

--- a/src/lockStepDriver.ml
+++ b/src/lockStepDriver.ml
@@ -17,7 +17,7 @@
 *)
 
 open Lib
-open TypeLib
+open TermLib
 open Actlit
 
 

--- a/src/lockStepDriver.mli
+++ b/src/lockStepDriver.mli
@@ -17,7 +17,7 @@
 *)
 
 open Lib
-open TypeLib
+open TermLib
 open Actlit
 
 (** Type of a lock step kind context. *)

--- a/src/lustreNode.mli
+++ b/src/lustreNode.mli
@@ -121,7 +121,7 @@ type t =
     asserts : LustreExpr.t list;
 
     (** Proof obligations for node *)
-    props : (StateVar.t * Lib.prop_source) list;
+    props : (StateVar.t * TermLib.prop_source) list;
 
     (** Contract for node, assumptions *)
     requires : LustreExpr.t list;

--- a/src/lustreSimplify.ml
+++ b/src/lustreSimplify.ml
@@ -3306,7 +3306,7 @@ and equation_to_node
             node
             abstractions 
             dummy_pos 
-            (Generated pos)
+            (TermLib.Generated [state_var])
             range_expr
 
         | t, s -> 
@@ -3554,7 +3554,13 @@ let rec parse_node_equations
       
       (* Add assertion to node *)
       let context', node', abstractions' = 
-        property_to_node context node abstractions' pos (PropAnnot pos) expr'
+        property_to_node 
+          context 
+          node
+          abstractions'
+          pos
+          (TermLib.PropAnnot pos) 
+          expr'
       in
       
       (* Continue with next node statements *)

--- a/src/lustreTransSys.ml
+++ b/src/lustreTransSys.ml
@@ -74,7 +74,7 @@ type node_def =
     locals : StateVar.t list;
 
     (* Properties in node *)
-    props : (string * prop_source * Term.t) list;
+    props : (string * TermLib.prop_source * Term.t) list;
 
     (* Assumptions in contract of node *)
     requires : Term.t list;
@@ -604,7 +604,7 @@ let rec definitions_of_node_calls
         List.map 
           (function (n, s, t) -> 
             (lift_prop_name node_name pos n, 
-             Instantiated (I.scope_of_ident node_name, n),
+             TermLib.Instantiated (I.scope_of_ident node_name, n),
              LustreExpr.lift_term pos node_name t))
           props 
 
@@ -1772,16 +1772,17 @@ let rec trans_sys_of_nodes' nodes node_defs = function
                 n
                 Term.pp_print_term t
                 (function ppf -> function 
-                  | PropAnnot p -> 
+                  | TermLib.PropAnnot p -> 
                     Format.fprintf ppf "annot at %a" pp_print_position p
 
-                  | Contract p ->
+                  | TermLib.Contract p ->
                     Format.fprintf ppf "contract at %a" pp_print_position p
 
-                  | Generated p -> 
-                    Format.fprintf ppf "generated at %a" pp_print_position p
+                  | TermLib.Generated l -> 
+                    Format.fprintf ppf "generated for %a" 
+                      (pp_print_list StateVar.pp_print_state_var ",@ ") l
 
-                  | Instantiated (s, n) -> 
+                  | TermLib.Instantiated (s, n) -> 
                     Format.fprintf ppf
                       "instantiated from %s in %a" 
                       n

--- a/src/pets.ml
+++ b/src/pets.ml
@@ -17,7 +17,7 @@
 *)
 
 open Lib
-open TypeLib
+open TermLib
 open Actlit
 
 module Solver = SolverMethods.Make(SMTSolver.Make(SMTLIBSolver))
@@ -458,7 +458,7 @@ let rec next trans solver k unfalsifiables unknowns =
     (* Extracting invariant module/term pairs. *)
     |> fst
     (* Extracting invariant terms. *)
-    |> List.map snd
+    |> Event.top_invariants_of_invariants
   in
 
   (* Cleaning unknowns and unfalsifiables. *)

--- a/src/step.ml
+++ b/src/step.ml
@@ -17,7 +17,7 @@
 *)
 
 open Lib
-open TypeLib
+open TermLib
 open Actlit
 
 module Solver = SolverMethods.Make(SMTSolver.Make(SMTLIBSolver))
@@ -440,7 +440,7 @@ let rec next trans solver k unfalsifiables unknowns =
     (* Extracting invariant module/term pairs. *)
     |> fst
     (* Extracting invariant terms. *)
-    |> List.map snd
+    |> Event.top_invariants_of_invariants
   in
 
   (* Cleaning unknowns and unfalsifiables. *)

--- a/src/termLib.ml
+++ b/src/termLib.ml
@@ -16,6 +16,8 @@
 
 *)
 
+open Lib
+
 type invariants = Term.t list
 type model = (Var.t * Term.t) list
 type path = (StateVar.t * Term.t list) list
@@ -23,3 +25,30 @@ type property = (string * Term.t)
 type properties = property list
 type cex = (property list * path)
 type cexs = cex list
+
+
+
+(* ********************************************************************** *)
+(* Properties of transition systems                                       *)
+(* ********************************************************************** *)
+
+(* Source of a property *)
+type prop_source =
+
+  (* Property is from an annotation *)
+  | PropAnnot of position
+
+  (* Property is part of a contract *)
+  | Contract of position
+
+  (* Property was generated, for example, from a subrange
+     constraint *)
+  | Generated of StateVar.t list
+
+  (* Property is an instance of a property in a called node
+
+     Reference the instantiated property by the [scope] of the
+     subsystem and the name of the property *)
+  | Instantiated of string list * string 
+
+

--- a/src/termLib.mli
+++ b/src/termLib.mli
@@ -16,7 +16,11 @@
 
 *)
 
-open Lib
+(** Utilty functions for transition systems 
+
+    Functions that use term data structures and can be used by
+    any module above {!TransSys} go here.
+*)
 
 type invariants = Term.t list
 type model = (Var.t * Term.t) list
@@ -26,3 +30,25 @@ type properties = property list
 type cex = (property list * path)
 type cexs = cex list
 
+
+(** {1 Properties of transition systems} *)
+
+
+(** Source of a property *)
+type prop_source =
+
+  (** Property is from an annotation *)
+  | PropAnnot of Lib.position
+
+  (** Property is part of a contract *)
+  | Contract of Lib.position
+
+  (** Property was generated, for example, from a subrange
+      constraint *)
+  | Generated of StateVar.t list
+
+  (** Property is an instance of a property in a called node
+
+      Reference the instantiated property by the [scope] of the
+      subsystem and the name of the property *)
+  | Instantiated of string list * string 

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -63,7 +63,7 @@ type property =
     prop_name : string;
 
     (* Source of the property *)
-    prop_source : prop_source;
+    prop_source : TermLib.prop_source;
 
     (* Term with variables at offsets [prop_base] and [prop_base - 1] *)
     prop_term : Term.t;
@@ -514,10 +514,10 @@ let pp_print_uf_defs
 
 
 let pp_print_prop_source ppf = function 
-  | PropAnnot _ -> Format.fprintf ppf ":user"
-  | Contract _ -> Format.fprintf ppf ":contract"
-  | Generated p -> Format.fprintf ppf ":generated"
-  | Instantiated _ -> Format.fprintf ppf ":subsystem"
+  | TermLib.PropAnnot _ -> Format.fprintf ppf ":user"
+  | TermLib.Contract _ -> Format.fprintf ppf ":contract"
+  | TermLib.Generated p -> Format.fprintf ppf ":generated"
+  | TermLib.Instantiated _ -> Format.fprintf ppf ":subsystem"
 
 let pp_print_property ppf { prop_name; prop_source; prop_term; prop_status } = 
 

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -79,7 +79,7 @@ val mk_trans_sys :
   UfSymbol.t * (Var.t list * Term.t) ->
   UfSymbol.t * (Var.t list * Term.t) ->
   t list ->
-  (string * Lib.prop_source * Term.t) list ->
+  (string * TermLib.prop_source * Term.t) list ->
   source ->
   t
 


### PR DESCRIPTION
Do not consider properties from subrange constraints in the top node for
the cone of influence.

Enable tagging discovered invariants with a node scope to communicate
subnode invariants.
