### PR TITLE
Improved candidate term generation scalability

### DIFF
--- a/src/invGenCandTermGen.ml
+++ b/src/invGenCandTermGen.ml
@@ -27,12 +27,6 @@ module CandidateTermGen = struct
   (* Bool type. *)
   let bool_type = Type.t_bool
 
-  (* Returns true when given unit. *)
-  let true_of_unit () = true
-
-  (* Returns false when given unit. *)
-  let false_of_unit () = false
-
   (* Constructs a term. *)
   let flat_to_term = Term.construct
 

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -23,6 +23,12 @@
 (* Identity function. *)
 let identity anything = anything
 
+(* Returns true when given unit. *)
+let true_of_unit () = true
+
+(* Returns false when given unit. *)
+let false_of_unit () = false
+
 (* ********************************************************************** *)
 (* Arithmetic functions                                                   *)
 (* ********************************************************************** *)

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -22,7 +22,14 @@
 *)
 
 (** {1 Helper functions} *)
+(** Identity function. *)
 val identity : 'a -> 'a
+
+(** Returns true when given unit. *)
+val true_of_unit : unit -> bool
+
+(** Returns false when given unit. *)
+val false_of_unit : unit -> bool
 
 (** {1 Option types} *)
 


### PR DESCRIPTION
Candidate term generation was eagerly checking that terms had variables.
This was killing performance on systems with deep expressions, such as fmcad/large/ccp*.

A lazy non-recursive version of the check was actually already in place, so it really served no purpose whatsoever...
