### PR TITLE
build.sh: $* -> "$@"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Configure 
-./configure $* 
+./configure "$@"
 
 # Build ocamlczmq first 
 pushd ocamlczmq && ./build.sh && popd


### PR DESCRIPTION
The $\* syntax fails in case the user calls the script with arguments
containing spaces, eg. build.sh --prefix '/home/My Software/'. The "$@"
syntax just does the right thing.
