### PR TITLE
Ignore redundant parentheses in S-expressions

### DIFF
--- a/src/SMTExpr.ml
+++ b/src/SMTExpr.ml
@@ -486,13 +486,8 @@ let rec expr_of_string_sexpr' bound_vars = function
       quantified_vars
       (expr_of_string_sexpr' (bound_vars @ bound_vars') t)
 
-  (* A singleton list *)
-  | HStringSExpr.List [_] as e -> 
-
-    (* Cannot convert to an expression *)
-    failwith 
-      ("Invalid singleton list in S-expression " ^ 
-         (string_of_t HStringSExpr.pp_print_sexpr e))
+  (* A singleton list: treat as atom *)
+  | HStringSExpr.List [e] -> expr_of_string_sexpr' bound_vars e
 
   (* A list with a non-atom at the head *)
   | HStringSExpr.List (HStringSExpr.List _ :: _) -> 

--- a/src/kind2-terms.mltop
+++ b/src/kind2-terms.mltop
@@ -1,3 +1,4 @@
+Debug
 Kind2Config
 Version
 Decimal
@@ -13,4 +14,9 @@ TermAttr
 Type
 UfSymbol
 Var
-
+HString
+SExprLexer
+SExprParser
+SExprBase
+HStringSExpr
+SMTExpr


### PR DESCRIPTION
Treat singleton lists in an S-expression are as identical to the enclosed S-expression
