### PR TITLE
Contracts

### DIFF
--- a/src/base.ml
+++ b/src/base.ml
@@ -334,6 +334,12 @@ let init trans =
     (SMTSolver.declare_fun solver)
     Numeral.(~- one) Numeral.zero ;
 
+  SMTSolver.trace_comment solver "Declaring global consts." ;
+
+  (* Declaring constant global state variables. *)
+  TransSys.declare_vars_global_const
+    (SMTSolver.declare_fun solver) ;
+
   (* Asserting init. *)
   TransSys.init_of_bound trans Numeral.zero
   |> SMTSolver.assert_term solver

--- a/src/base.ml
+++ b/src/base.ml
@@ -68,8 +68,10 @@ let split trans solver k falsifiable to_split actlits =
     (* Get-model function. *)
     let get_model = SMTSolver.get_model solver in
     (* Getting the model. *)
-    let model = TransSys.vars_of_bounds trans k k
-                |> get_model in
+    let model =
+      TransSys.vars_of_bounds trans k k
+      |> get_model
+    in
     (* Extracting the counterexample. *)
     let cex =
       TransSys.path_from_model trans get_model k in
@@ -334,9 +336,10 @@ let init trans =
     (SMTSolver.declare_fun solver)
     Numeral.(~- one) Numeral.zero ;
 
-  (* Declaring constant global state variables. *)
-  TransSys.declare_vars_global_const
-    (SMTSolver.declare_fun solver) ;
+  (* Constraining max depth. *)
+  TransSys.get_max_depth trans
+  |> TransSys.depth_inputs_constraint trans
+  |> SMTSolver.assert_term solver ;
 
   (* Asserting init. *)
   TransSys.init_of_bound trans Numeral.zero

--- a/src/base.ml
+++ b/src/base.ml
@@ -334,8 +334,6 @@ let init trans =
     (SMTSolver.declare_fun solver)
     Numeral.(~- one) Numeral.zero ;
 
-  SMTSolver.trace_comment solver "Declaring global consts." ;
-
   (* Declaring constant global state variables. *)
   TransSys.declare_vars_global_const
     (SMTSolver.declare_fun solver) ;

--- a/src/invGenCandTermGen.ml
+++ b/src/invGenCandTermGen.ml
@@ -254,17 +254,17 @@ module CandidateTermGen = struct
                   | Type.Real ->
                      (* It is, adding >= and <=. *)
                     set
-                    (* |> TSet.add (flat_to_term term) *)
+                    |> TSet.add (flat_to_term flat)
                     |> TSet.add (Term.mk_geq kids)
                     |> TSet.add (Term.mk_leq kids)
                   | _ -> set )
 
             | `LEQ -> set
               |> TSet.add (Term.mk_geq kids)
-              |> TSet.add (Term.mk_leq kids)
+              |> TSet.add (flat_to_term flat)
 
             | `GEQ -> set
-              |> TSet.add (Term.mk_geq kids)
+              |> TSet.add (flat_to_term flat)
               |> TSet.add (Term.mk_leq kids)
 
             | `GT  -> set

--- a/src/invGenGraph.ml
+++ b/src/invGenGraph.ml
@@ -208,11 +208,12 @@ module Make (InModule : In) : Out = struct
   let is_one_state_running () = Flags.enable () |> List.mem `INVGENOS
 
   (* Guards a term with init if in two state mode. *)
-  let sanitize_term =
+  let sanitize_term sys =
     if two_state then
       ( fun term ->
         Term.mk_or
-          [ TransSys.init_flag_var Numeral.zero |> Term.mk_var ;
+          [ TransSys.init_flag_of_trans_sys sys Numeral.zero
+            |> Term.mk_var ;
             term ] )
     else identity
 
@@ -574,11 +575,13 @@ module Make (InModule : In) : Out = struct
        (* All intermediary invariants and top level ones. *)
        let ((_, top_invariants), intermediary_invariants) =
          if top_sys == sys then
-           (top_sys, List.map sanitize_term invariants), []
+           (top_sys,
+            List.map (sanitize_term sys) invariants),
+           []
          else
            Term.mk_and invariants
            (* Guarding with init if needed. *)
-           |> sanitize_term
+           |> sanitize_term sys
            (* Instantiating at all levels. *)
            |> TransSys.instantiate_term_all_levels sys
        in

--- a/src/lockStepDriver.ml
+++ b/src/lockStepDriver.ml
@@ -122,17 +122,26 @@ let common_setup (solver,sys,actlit) =
     sys
     (SMTSolver.define_fun solver)
     (SMTSolver.declare_fun solver)
-    Numeral.zero Numeral.(~- one) ;
+    Numeral.zero Numeral.(~- one);
 
   SMTSolver.trace_comment solver "Done defining, declaring now." ;
 
   (* Declaring unrolled vars at [-1] and [0]. *)
-  TransSys.declare_vars_of_bounds_no_global
+  TransSys.declare_vars_of_bounds
     sys
     (SMTSolver.declare_fun solver)
     Numeral.(~- one) Numeral.zero ;
 
-  solver, sys, Actlit.term_of_actlit actlit
+  let actlit_term = Actlit.term_of_actlit actlit in
+
+  (* Constraining max depth. *)
+  Term.mk_implies
+    [ actlit_term ;
+      TransSys.get_max_depth sys
+      |> TransSys.depth_inputs_constraint sys ]
+  |> SMTSolver.assert_term solver ;
+
+  solver, sys, actlit_term
 
 let base_setup (solver,sys,actlit) =
 
@@ -158,7 +167,7 @@ let step_setup (solver, sys, actlit) =
   |> SMTSolver.assert_term solver ;
 
   (* Declaring unrolled vars at [1]. *)
-  TransSys.declare_vars_of_bounds_no_global
+  TransSys.declare_vars_of_bounds
     sys
     (SMTSolver.declare_fun solver)
     Numeral.one Numeral.one ;
@@ -184,7 +193,7 @@ let unroll_solver solver sys actlit k =
   |> SMTSolver.trace_comment solver ;
 
   (* Declaring unrolled vars at [k+1]. *)
-  TransSys.declare_vars_of_bounds_no_global
+  TransSys.declare_vars_of_bounds
     sys (SMTSolver.declare_fun solver) k k ;
 
   (* Conditionally asserting transition predicate at [k]. *)
@@ -291,14 +300,6 @@ let unroll_sys
           (* Getting the next [k]. *)
           let kp1 = Numeral.succ k in
 
-          if Numeral.(kp1 > last_k) then (
-            TransSys.init_flag_uf kp1
-            |> SMTSolver.declare_fun base_solver ;
-            TransSys.init_flag_uf Numeral.(succ kp1)
-            |> SMTSolver.declare_fun step_solver ;
-            lsd.last_k <- kp1
-          ) ;
-
           (* Unrolling base solver at [k+1]. *)
           unroll_solver base_solver system actlit kp1 ;
           (* Unrolling step solver at [k+2]. *)
@@ -325,25 +326,14 @@ let create two_state top_only sys =
     new_inst_sys (), new_inst_sys (), new_inst_sys ()
   in
 
-  let init_solver solver =
-    TransSys.declare_vars_of_bounds_global
-      (SMTSolver.declare_fun solver)
-      Numeral.(~- one) Numeral.zero ;
-    TransSys.declare_vars_global_const
-      (SMTSolver.declare_fun solver)
-  in
+  (* let init_solver solver = *)
+  (*   TransSys.declare_vars_global_const *)
+  (*     (SMTSolver.declare_fun solver) *)
+  (* in *)
 
-  init_solver base_solver ;
-  init_solver step_solver ;
-  init_solver pruning_solver ;
-  TransSys.init_flag_uf Numeral.one
-  |> SMTSolver.declare_fun step_solver ;
-  TransSys.init_flag_uf Numeral.one
-  |> SMTSolver.declare_fun pruning_solver ;
-
-  (* declare_init_flag base_solver minus_one Numeral.zero ; *)
-  (* declare_init_flag step_solver minus_one Numeral.one ; *)
-  (* declare_init_flag pruning_solver minus_one Numeral.one ; *)
+  (* init_solver base_solver ; *)
+  (* init_solver step_solver ; *)
+  (* init_solver pruning_solver ; *)
 
   (* Building the associative list from (sub)systems to the k up to
      which they are asserted, their init and trans actlit. *)

--- a/src/lustreAst.ml
+++ b/src/lustreAst.ml
@@ -217,12 +217,12 @@ let mk_ensure pos e = pos, e
 
 (* A contract clause *)
 type contract =
-    Lib.position * string * require list * ensure list
+    TermLib.contract_source * string * require list * ensure list
 
 (* Creates a contract from a name, a list of requires and a list of
    ensures. *)
-let mk_contract pos lustre_ident requires ensures =
-  pos, LustreIdent.string_of_ident true lustre_ident, requires, ensures
+let mk_contract source lustre_ident requires ensures =
+  source, LustreIdent.string_of_ident true lustre_ident, requires, ensures
 
 (* A node declaration *)
 type node_decl =

--- a/src/lustreAst.mli
+++ b/src/lustreAst.mli
@@ -183,12 +183,16 @@ val mk_ensure : Lib.position -> expr -> ensure
 
 (** A contract clause *)
 type contract =
-    Lib.position * string * require list * ensure list
+    TermLib.contract_source * string * require list * ensure list
 
 (** Creates a contract from a name, a list of requires and a list of
     ensures. *)
 val mk_contract :
-  Lib.position -> LustreIdent.t -> require list -> ensure list -> contract
+  TermLib.contract_source ->
+  LustreIdent.t ->
+  require list ->
+  ensure list ->
+  contract
 
 (** Declaration of a node as a tuple of 
 

--- a/src/lustreAst.mli
+++ b/src/lustreAst.mli
@@ -167,13 +167,28 @@ type node_equation =
   | AnnotMain 
   | AnnotProperty of Lib.position * expr
 
-(** A clause of an assume guarantee contract *)
-type contract_clause = 
-  | Requires of Lib.position * expr 
-  | Ensures of Lib.position * expr
+(** A require for a contract. *)
+type require =
+    Lib.position * expr
 
-(** The contract of a node as a list of clauses *)
-type contract = contract_clause list
+(** Constructs a require for a contract. *)
+val mk_require : Lib.position -> expr -> require
+
+(** An ensure for a contract. *)
+type ensure =
+    Lib.position * expr
+
+(** Constructs an enuser for a contract. *)
+val mk_ensure : Lib.position -> expr -> ensure
+
+(** A contract clause *)
+type contract =
+    Lib.position * string * require list * ensure list
+
+(** Creates a contract from a name, a list of requires and a list of
+    ensures. *)
+val mk_contract :
+  Lib.position -> LustreIdent.t -> require list -> ensure list -> contract
 
 (** Declaration of a node as a tuple of 
 
@@ -183,12 +198,16 @@ type contract = contract_clause list
     - the list of its outputs,
     - the list of its local constant and variable declarations,
     - its equations, assertions and annotiations, and
-    - its contract. 
+    - its contracts.
 *)
 type node_decl =
-  ident * node_param list * const_clocked_typed_decl list * 
-  clocked_typed_decl list * node_local_decl list * node_equation list * 
-  contract
+    ident
+    * node_param list
+    * const_clocked_typed_decl list
+    * clocked_typed_decl list
+    * node_local_decl list
+    * node_equation list
+    * contract list
 
 (** Declaration of a function as a tuple of 
 
@@ -241,8 +260,9 @@ val pp_print_node_local_decl :
   Format.formatter -> node_local_decl list -> unit
 val pp_print_struct_item : Format.formatter -> struct_item -> unit
 val pp_print_node_equation : Format.formatter -> node_equation -> unit
-val pp_print_contract_clause : Format.formatter -> contract_clause -> unit
-val pp_print_contract : Format.formatter -> contract_clause list -> unit
+val pp_print_require  : Format.formatter -> require -> unit
+val pp_print_ensure   : Format.formatter -> ensure -> unit
+val pp_print_contract : Format.formatter -> contract -> unit
 val pp_print_declaration : Format.formatter -> declaration -> unit
 val pp_print_program : Format.formatter -> t -> unit
 

--- a/src/lustreIdent.ml
+++ b/src/lustreIdent.ml
@@ -332,6 +332,16 @@ let depth_input_ident_string =  "__depth_input"
 let init_uf_string = "__node_init"
 let trans_uf_string = "__node_trans"
 
+let reserved_strings =
+  [ abs_ident_string ;
+    oracle_ident_string ;
+    observer_ident_string ;
+    first_tick_ident_string ;
+    depth_input_ident_string ;
+    init_uf_string ;
+    trans_uf_string ]
+  @ StateVar.reserved_strings
+
 (* let top_scope_string = "__top" *)
 
 
@@ -341,15 +351,9 @@ let ident_is_reserved ident =
   (* Get string part of identifier *)
   let ident_string, _ : t :> string * _ = ident in
 
-  (* Return false if identical to any reserved identifier *)
-  string_starts_with ident_string abs_ident_string
-  || string_starts_with ident_string oracle_ident_string
-  || string_starts_with ident_string observer_ident_string
-  || string_starts_with ident_string first_tick_ident_string
-  || string_starts_with ident_string depth_input_ident_string
-  || string_starts_with ident_string init_uf_string
-  || string_starts_with ident_string trans_uf_string
-(*  || string_starts_with ident_string top_scope_string *)
+  reserved_strings
+  |> List.exists
+       (string_starts_with ident_string)
   
 
 (* Identifier for new variables from abstrations *)

--- a/src/lustreIdent.ml
+++ b/src/lustreIdent.ml
@@ -328,7 +328,6 @@ let abs_ident_string =  "__abs"
 let oracle_ident_string =  "__nondet" 
 let observer_ident_string =  "__observer" 
 let first_tick_ident_string =  "__first_tick"
-let depth_input_ident_string =  "__depth_input"
 let init_uf_string = "__node_init"
 let trans_uf_string = "__node_trans"
 
@@ -337,7 +336,6 @@ let reserved_strings =
     oracle_ident_string ;
     observer_ident_string ;
     first_tick_ident_string ;
-    depth_input_ident_string ;
     init_uf_string ;
     trans_uf_string ]
   @ StateVar.reserved_strings
@@ -367,9 +365,6 @@ let observer_ident = mk_string_ident observer_ident_string
 
 (* Identifier for new clock initialization flag *)
 let first_tick_ident = mk_string_ident first_tick_ident_string
-
-(* Identifier for depth input of a node *)
-let depth_input_ident = mk_string_ident depth_input_ident_string
 
 (*
 (* Scope for top-level variables *)

--- a/src/lustreIdent.ml
+++ b/src/lustreIdent.ml
@@ -327,7 +327,8 @@ let scope_of_ident (ident, index) = ident :: (scope_of_index index)
 let abs_ident_string =  "__abs" 
 let oracle_ident_string =  "__nondet" 
 let observer_ident_string =  "__observer" 
-let first_tick_ident_string =  "__first_tick" 
+let first_tick_ident_string =  "__first_tick"
+let depth_input_ident_string =  "__depth_input"
 let init_uf_string = "__node_init"
 let trans_uf_string = "__node_trans"
 
@@ -345,6 +346,7 @@ let ident_is_reserved ident =
   || string_starts_with ident_string oracle_ident_string
   || string_starts_with ident_string observer_ident_string
   || string_starts_with ident_string first_tick_ident_string
+  || string_starts_with ident_string depth_input_ident_string
   || string_starts_with ident_string init_uf_string
   || string_starts_with ident_string trans_uf_string
 (*  || string_starts_with ident_string top_scope_string *)
@@ -361,6 +363,9 @@ let observer_ident = mk_string_ident observer_ident_string
 
 (* Identifier for new clock initialization flag *)
 let first_tick_ident = mk_string_ident first_tick_ident_string
+
+(* Identifier for depth input of a node *)
+let depth_input_ident = mk_string_ident depth_input_ident_string
 
 (*
 (* Scope for top-level variables *)

--- a/src/lustreIdent.mli
+++ b/src/lustreIdent.mli
@@ -184,10 +184,7 @@ val oracle_ident : t
 val observer_ident : t
 
 (** Identifier for clock initialization flag *)
-val first_tick_ident : t 
-
-(** Identifier for the depth input of a node *)
-val depth_input_ident : t 
+val first_tick_ident : t
 
 (** Identifier of uninterpreted symbol for initial state constraint *)
 val init_uf_string : string 

--- a/src/lustreIdent.mli
+++ b/src/lustreIdent.mli
@@ -186,6 +186,9 @@ val observer_ident : t
 (** Identifier for clock initialization flag *)
 val first_tick_ident : t 
 
+(** Identifier for the depth input of a node *)
+val depth_input_ident : t 
+
 (** Identifier of uninterpreted symbol for initial state constraint *)
 val init_uf_string : string 
 

--- a/src/lustreLexer.mll
+++ b/src/lustreLexer.mll
@@ -456,22 +456,24 @@ and comment = parse
         | "PROPERTY" -> PROPERTY
 
         (* Warn and ignore rest of line *)
-        | _ -> (Format.printf "Warninng: unknown annotation %s skipped@." p; 
+        | _ -> (Format.printf "Warning: unknown annotation %s skipped@." p; 
                 skip_to_eol lexbuf ) }
 
   (* Contract *)
   | "@" (id as p) 
-      { match p with 
+        { match p with
 
-        (* Return token, continue with rest of line *)
-        | "requires" -> REQUIRES
+          | "contract" -> Format.printf "Lexing contract@." ; CONTRACT
 
-        (* Return token, continue with rest of line *)
-        | "ensures" -> ENSURES
+          (* Return token, continue with rest of line *)
+          | "require" -> Format.printf "Lexing require@." ; REQUIRES
 
-        (* Warn and ignore rest of line *)
-        | _ -> (Format.printf "Warninng: unknown contract %s skipped@." p; 
-                skip_to_eol lexbuf ) }
+          (* Return token, continue with rest of line *)
+          | "ensure" -> Format.printf "Lexing ensure@." ; ENSURES
+
+          (* Warn and ignore rest of line *)
+          | _ -> (Format.printf "Warning: unknown contract %s skipped@." p; 
+                  skip_to_eol lexbuf ) }
 
   (* Count new line and resume *)
   | newline { Lexing.new_line lexbuf; token lexbuf } 

--- a/src/lustreLexer.mll
+++ b/src/lustreLexer.mll
@@ -463,13 +463,13 @@ and comment = parse
   | "@" (id as p) 
         { match p with
 
-          | "contract" -> Format.printf "Lexing contract@." ; CONTRACT
+          | "contract" -> CONTRACT
 
           (* Return token, continue with rest of line *)
-          | "require" -> Format.printf "Lexing require@." ; REQUIRES
+          | "require" -> REQUIRES
 
           (* Return token, continue with rest of line *)
-          | "ensure" -> Format.printf "Lexing ensure@." ; ENSURES
+          | "ensure" -> ENSURES
 
           (* Warn and ignore rest of line *)
           | _ -> (Format.printf "Warning: unknown contract %s skipped@." p; 

--- a/src/lustreNode.ml
+++ b/src/lustreNode.ml
@@ -149,7 +149,11 @@ type t =
     props : (StateVar.t * TermLib.prop_source) list;
 
     (* The contracts of the node. *)
-    contracts : (string * LustreExpr.t list * LustreExpr.t list) list;
+    contracts :
+      (string
+       * TermLib.contract_source
+       * LustreExpr.t list
+       * LustreExpr.t list) list;
 
     (* Node is annotated as main node *)
     is_main : bool;
@@ -304,7 +308,7 @@ let pp_print_ensure safe ppf expr =
     (E.pp_print_lustre_expr safe) expr
 
 (* Pretty-print a contract. *)
-let pp_print_contract safe ppf (name, requires, ensures) =
+let pp_print_contract safe ppf (name, _, requires, ensures) =
   Format.fprintf
     ppf
     "@[<hv 2>--@@contract : %s ;@ @[<v>%a@ %a@]@]"
@@ -935,7 +939,7 @@ let exprs_of_node { equations; calls; asserts; props; contracts } =
   (* Add all the expressions appearing in the contract. *)
   contracts
   |> List.fold_left
-       ( fun list (_, reqs, ens) ->
+       ( fun list (_, _, reqs, ens) ->
          reqs @ ens @ list )
        exprs_asserts
 
@@ -1470,7 +1474,7 @@ let reduce_to_props_coi nodes main_name =
          (* Property annotations, contracts and generated constraints
             are in the cone of influence *)
          | TermLib.PropAnnot _ 
-         | TermLib.Contract _ 
+         | TermLib.SubRequirement _
          | TermLib.Generated _ -> state_var :: accum
 
          (* Properties instantiated from subnodes are not *)

--- a/src/lustreNode.mli
+++ b/src/lustreNode.mli
@@ -123,11 +123,8 @@ type t =
     (** Proof obligations for node *)
     props : (StateVar.t * TermLib.prop_source) list;
 
-    (** Contract for node, assumptions *)
-    requires : LustreExpr.t list;
-
-    (** Contract for node, guarantees *)
-    ensures : LustreExpr.t list;
+    (** Contracts for node. *)
+    contracts: (string * LustreExpr.t list * LustreExpr.t list) list;
 
     (** Node is annotated as main node *)
     is_main : bool;

--- a/src/lustreNode.mli
+++ b/src/lustreNode.mli
@@ -124,7 +124,10 @@ type t =
     props : (StateVar.t * TermLib.prop_source) list;
 
     (** Contracts for node. *)
-    contracts: (string * LustreExpr.t list * LustreExpr.t list) list;
+    contracts: (string
+                * TermLib.contract_source
+                * LustreExpr.t list
+                * LustreExpr.t list) list;
 
     (** Node is annotated as main node *)
     is_main : bool;

--- a/src/lustreParser.mly
+++ b/src/lustreParser.mly
@@ -102,6 +102,7 @@ let mk_pos = Lib.position_of_lexing
 %token MAIN
 %token REQUIRES
 %token ENSURES
+%token CONTRACT
 
 (* Token for assertions *)
 %token ASSERT
@@ -330,7 +331,7 @@ node_decl:
     RETURNS; 
     o = tlist(LPAREN, SEMICOLON, RPAREN, clocked_typed_idents); 
     SEMICOLON;
-    r = contract;
+    r = list(contract);
     l = list(node_local_decl);
     LET;
     e = list(node_equation);
@@ -364,13 +365,20 @@ node_sep: DOT | SEMICOLON { }
 
 (* A list of contract clauses *)
 contract:
-  | l = list(contract_clause) { l }
+  | CONTRACT;
+    COLON;
+    n = ident;
+    SEMICOLON;
+    reqs = list(require);
+    ens = list(ensure); { A.mk_contract (mk_pos $startpos) n reqs ens }
 
+(* A require for a contract. *)
+require:
+  | REQUIRES; e = expr; SEMICOLON { A.mk_require (mk_pos $startpos) e }
 
-(* A requires or ensures annotation *)
-contract_clause:
-  | REQUIRES; e = expr; SEMICOLON { A.Requires (mk_pos $startpos, e) }
-  | ENSURES; e = expr; SEMICOLON { A.Ensures (mk_pos $startpos, e) }
+(* A ensure for a contract. *)
+ensure:
+  | ENSURES; e = expr; SEMICOLON { A.mk_ensure (mk_pos $startpos) e }
 
 
 (* A static parameter is a type *)

--- a/src/lustreParser.mly
+++ b/src/lustreParser.mly
@@ -370,7 +370,9 @@ contract:
     n = ident;
     SEMICOLON;
     reqs = list(require);
-    ens = list(ensure); { A.mk_contract (mk_pos $startpos) n reqs ens }
+    ens = list(ensure); { A.mk_contract
+                            (TermLib.ContractAnnot (mk_pos $startpos))
+                            n reqs ens }
 
 (* A require for a contract. *)
 require:

--- a/src/lustreSimplify.ml
+++ b/src/lustreSimplify.ml
@@ -3271,7 +3271,7 @@ and assertion_to_node context node abstractions pos expr =
   (context, node', abstractions)
 
 (* Add a contract to a node. *)
-and contract_to_node context node abstractions pos contract =
+and contract_to_node context node abstractions contract =
 
   let node' =
     { node with N.contracts = contract :: node.N.contracts }
@@ -3799,7 +3799,7 @@ let rec parse_node_contracts
 
 
   (* Assumption *)
-  | (pos, name, requires, ensures) :: tail ->
+  | (source, name, requires, ensures) :: tail ->
 
      let requires', abstractions' =
        requires
@@ -3845,7 +3845,7 @@ let rec parse_node_contracts
 
      (* Add contract to node *)
      let context', node', abstractions' = 
-       contract_to_node context node abstractions' pos (name, requires', ensures')
+       contract_to_node context node abstractions' (name, source, requires', ensures')
      in
 
      (* Continue with next contract clauses *)

--- a/src/lustreTransSys.ml
+++ b/src/lustreTransSys.ml
@@ -1439,10 +1439,6 @@ let rec trans_sys_of_nodes' nodes node_defs = function
 
     E.set_state_var_source depth_input_svar E.Abstract;
 
-    Format.printf
-      "Depth_input created: %a\n"
-      StateVar.pp_print_state_var depth_input_svar ;
-
     let init_flag_svar = TransSys.init_flag_svar in
 
     (* Input variables *)

--- a/src/lustreTransSys.ml
+++ b/src/lustreTransSys.ml
@@ -948,6 +948,8 @@ let rec definitions_of_node_calls
             (* Arguments for node call in initial state constraint
                with state variables at init. *)
             let init_call_init_args =
+              (* Depth input. *)
+              [ actual_depth_input ] @
               (* Actual parameter for the init flag of the node is the
                  first_tick flag. *)
               [ first_tick_init ] @

--- a/src/lustreTransSys.ml
+++ b/src/lustreTransSys.ml
@@ -1685,16 +1685,12 @@ let rec trans_sys_of_nodes' nodes node_defs = function
                   depth. If above the max depth, then the abstract
                   contract init is activated. *)
                (fun props concrete_init ->
-                let bla: Term.t list =
-                  List.map
-                    (fun (_,_,term) ->
-                     Term.mk_eq [ term ; Term.t_true ])
-                    props
-                in
-                let abstract_init: Term.t =
+                let abstract_init =
                   Term.mk_and
                     (abstract_contract_init
-                     :: (bla))
+                     :: (props
+                         |> List.map
+                              (fun (_,_,term) -> term)))
                 in
                 Term.mk_and
                   [ Term.mk_implies
@@ -1712,8 +1708,7 @@ let rec trans_sys_of_nodes' nodes node_defs = function
                     (abstract_contract_trans
                      :: (props
                          |> List.map
-                              (fun (_,_,term) ->
-                               Term.mk_eq [ term ; Term.t_true ])))
+                              (fun (_,_,term) -> term)))
                 in
                 Term.mk_and
                   [ Term.mk_implies

--- a/src/lustreTransSys.ml
+++ b/src/lustreTransSys.ml
@@ -76,7 +76,8 @@ type node_def =
     (* Properties in node *)
     props : (string * TermLib.prop_source * Term.t) list;
 
-    (* Contracts on the node. *)
+    (* Contracts on the node. A contract is a name, a list of
+       requires, and a list of ensures. *)
     contracts : (string * Term.t list * Term.t list) list ;
 
   }

--- a/src/lustreTransSys.ml
+++ b/src/lustreTransSys.ml
@@ -76,11 +76,8 @@ type node_def =
     (* Properties in node *)
     props : (string * TermLib.prop_source * Term.t) list;
 
-    (* Assumptions in contract of node *)
-    requires : Term.t list;
-
-    (* Guarantees in contract of node *)
-    ensures : Term.t list;
+    (* Contracts on the node. *)
+    contracts : (string * Term.t list * Term.t list) list ;
 
   }
 
@@ -376,8 +373,7 @@ let rec definitions_of_node_calls
           outputs;
           locals;
           props;
-          requires;
-          ensures } = 
+          contracts } = 
 
         (* Find called node by name *)
         try 
@@ -1236,17 +1232,20 @@ let definitions_of_asserts = definitions_of_exprs
 
 
 (* Return assumptions and guarantees from contract *)
-let definitions_of_contract requires ensures = 
+let definitions_of_contract =
 
-  let init_requires, step_requires = 
-    definitions_of_exprs [] [] requires 
-  in
+  List.map
+    ( fun (name, requires, ensures) ->
 
-  let init_ensures, step_ensures = 
-    definitions_of_exprs [] [] ensures 
-  in
+      let init_requires, step_requires = 
+        definitions_of_exprs [] [] requires 
+      in
 
-  (init_requires, init_ensures), (step_requires, step_ensures)
+      let init_ensures, step_ensures = 
+        definitions_of_exprs [] [] ensures 
+      in
+
+      name, (init_requires, init_ensures), (step_requires, step_ensures) )
 
 
 (* Return node definitions of nodes *)
@@ -1946,8 +1945,7 @@ let rec trans_sys_of_nodes' nodes node_defs = function
         outputs = outputs @ observers;
         locals = locals;
         props = props;
-        requires = [];
-        ensures = [] }
+        contracts = [] }
     in
 
     (* Continue with next nodes *)

--- a/src/lustreTransSys.ml
+++ b/src/lustreTransSys.ml
@@ -1852,21 +1852,29 @@ let rec trans_sys_of_nodes' nodes node_defs = function
                 Term.pp_print_term t
                 (function ppf -> function 
                   | TermLib.PropAnnot p -> 
-                    Format.fprintf ppf "annot at %a" pp_print_position p
+                     Format.fprintf
+                       ppf "annot at %a" pp_print_position p
 
-                  | TermLib.Contract p ->
-                    Format.fprintf ppf "contract at %a" pp_print_position p
+                  | TermLib.Contract (name, p) ->
+                     Format.fprintf
+                       ppf "contract %s at %a" name pp_print_position p
+
+                  | TermLib.SubRequirement (scope, p) ->
+                     Format.fprintf
+                       ppf "requirement from subsystem %s at %a"
+                       (String.concat "/" scope)
+                       pp_print_position p
 
                   | TermLib.Generated l -> 
-                    Format.fprintf ppf "generated for %a" 
-                      (pp_print_list StateVar.pp_print_state_var ",@ ") l
+                     Format.fprintf
+                       ppf "generated for %a" 
+                       (pp_print_list StateVar.pp_print_state_var ",@ ") l
 
                   | TermLib.Instantiated (s, n) -> 
-                    Format.fprintf ppf
-                      "instantiated from %s in %a" 
+                     Format.fprintf
+                       ppf "instantiated from %s in %a" 
                       n
-                      (pp_print_list Format.pp_print_string ".")
-                      s)
+                      (pp_print_list Format.pp_print_string ".") s)
                 s)
            ",@ ")
         props
@@ -1959,6 +1967,7 @@ let rec trans_sys_of_nodes' nodes node_defs = function
         pred_def_trans
         called_trans_sys
         props
+        contracts
         (TransSys.Lustre (List.rev (node :: called_nodes)))
     in
 

--- a/src/lustreTransSys.mli
+++ b/src/lustreTransSys.mli
@@ -87,6 +87,26 @@
     node calls. Equational definitions of not stateful variable are
     substituted by binding the variable to a [let] definition.
 
+    The [depth_input] and [max_depth_input] control the abstraction of
+    the nodes for which a contract is available. Both are constants
+    and are inputs of the node. When instantiating a node with a
+    contract, the value of the depth input is the caller's depth input
+    plus one, meaning that since this node has a contract we are going
+    down one abstraction level. The max depth input always has the
+    same value and is passed as an input for the sake of uniformity.
+
+    The init / trans predicates are conditional on the depth input.
+    If the value of the depth input is greater than the max depth
+    input, then the contract definition of the node is used instead of
+    the actual init / trans predicate. In this case, lifting the
+    properties of the subnode might not make sense since the actual
+    init / trans predicate is not used. The abstract predicates
+    therefore constrain all the properties to evaluate to true.
+
+    Predicates are thus defined as
+    {[     (depth_input < max_depth_input) => contract and (props = true) ]}
+    {[ not (depth_input < max_depth_input) => concrete_predicate ]}
+
 
     {1 Condact Encoding}
 

--- a/src/stateVar.ml
+++ b/src/stateVar.ml
@@ -338,18 +338,47 @@ let mk_state_var
 (* Init flag string. *)
 let init_flag_string = "__init_flag"
 
-(* Transition system reserved strings. *)
-let reserved_strings = [ init_flag_string ]
+(* Abstraction depth input string. *)
+let depth_input_string = "__depth_input"
 
-(* Returns a scope init flag. *)
+(* Abstraction depth input string. *)
+let max_depth_input_string = "__max_depth_input"
+
+(* Transition system reserved strings. *)
+let reserved_strings =
+  [ init_flag_string ;
+    depth_input_string ;
+    max_depth_input_string ]
+
+(* Returns a scoped init flag. *)
 let mk_init_flag scope =
   mk_state_var
-    ~is_input:false
+    ~is_input:true
     ~is_const:false
     ~for_inv_gen:false
     init_flag_string
     scope
     Type.t_bool
+
+(* Returns a scoped depth input. *)
+let mk_depth_input scope =
+  mk_state_var
+    ~is_input:true
+    ~is_const:true
+    ~for_inv_gen:false
+    depth_input_string
+    scope
+    Type.t_int
+
+(* Returns a scoped max depth input. *)
+let mk_max_depth_input scope =
+  mk_state_var
+    ~is_input:true
+    ~is_const:true
+    ~for_inv_gen:false
+    max_depth_input_string
+    scope
+    Type.t_int
 
 
 (* Import a state variable from a different instance into this

--- a/src/stateVar.ml
+++ b/src/stateVar.ml
@@ -335,6 +335,22 @@ let mk_state_var
        (* Return state variable *)
        state_var
 
+(* Init flag string. *)
+let init_flag_string = "__init_flag"
+
+(* Transition system reserved strings. *)
+let reserved_strings = [ init_flag_string ]
+
+(* Returns a scope init flag. *)
+let mk_init_flag scope =
+  mk_state_var
+    ~is_input:false
+    ~is_const:false
+    ~for_inv_gen:false
+    init_flag_string
+    scope
+    Type.t_bool
+
 
 (* Import a state variable from a different instance into this
    hashcons table *)

--- a/src/stateVar.mli
+++ b/src/stateVar.mli
@@ -71,10 +71,18 @@ module StateVarMap : Map.S with type key = t
     harmless and will simply return the previously declared state
     variable. However, re-declaring a state variable with a different
     signature will raise an [Invalid_argument] exception. *)
-val mk_state_var : ?is_input:bool -> ?is_const:bool -> ?for_inv_gen:bool -> string -> string list -> Type.t -> t
+val mk_state_var :
+  ?is_input:bool -> ?is_const:bool -> ?for_inv_gen:bool ->
+  string -> string list -> Type.t -> t
 
-(** Creates a scoped init_flag. *)
+(** Creates a scoped init flag. *)
 val mk_init_flag : string list -> t
+
+(** Creates a scoped depth input. *)
+val mk_depth_input : string list -> t
+
+(** Creates a scoped depth input. *)
+val mk_max_depth_input : string list -> t
 
 (** State var reserved strings. *)
 val reserved_strings : string list

--- a/src/stateVar.mli
+++ b/src/stateVar.mli
@@ -73,6 +73,12 @@ module StateVarMap : Map.S with type key = t
     signature will raise an [Invalid_argument] exception. *)
 val mk_state_var : ?is_input:bool -> ?is_const:bool -> ?for_inv_gen:bool -> string -> string list -> Type.t -> t
 
+(** Creates a scoped init_flag. *)
+val mk_init_flag : string list -> t
+
+(** State var reserved strings. *)
+val reserved_strings : string list
+
 (** Import a state variable from a different instance into this
    hashcons table *)
 val import : t -> t

--- a/src/step.ml
+++ b/src/step.ml
@@ -651,16 +651,21 @@ let launch trans =
     (* Declaring path compression function. *)
     Compress.init (SMTSolver.declare_fun solver) trans ;
 
+  SMTSolver.trace_comment
+    solver
+    "Init define fun." ;
+
   (* Defining uf's and declaring variables. *)
   TransSys.init_define_fun_declare_vars_of_bounds
     trans
     (SMTSolver.define_fun solver)
     (SMTSolver.declare_fun solver)
     Numeral.(~- one) Numeral.zero ;
-  
-  (* Declaring constant global state variables. *)
-  TransSys.declare_vars_global_const
-    (SMTSolver.declare_fun solver) ;
+
+  (* Constraining max depth. *)
+  TransSys.get_max_depth trans
+  |> TransSys.depth_inputs_constraint trans
+  |> SMTSolver.assert_term solver ;
 
   (* Invariants of the system at 0. *)
   TransSys.invars_of_bound trans Numeral.zero

--- a/src/step.ml
+++ b/src/step.ml
@@ -657,6 +657,10 @@ let launch trans =
     (SMTSolver.define_fun solver)
     (SMTSolver.declare_fun solver)
     Numeral.(~- one) Numeral.zero ;
+  
+  (* Declaring constant global state variables. *)
+  TransSys.declare_vars_global_const
+    (SMTSolver.declare_fun solver) ;
 
   (* Invariants of the system at 0. *)
   TransSys.invars_of_bound trans Numeral.zero

--- a/src/term.ml
+++ b/src/term.ml
@@ -1406,6 +1406,58 @@ end
 
 
 
+(* Gets the term corresponding to [var] in [map] and bumps it if [var]
+   is not a constant. Raises [Not_found] if [var] is not defined in
+   [map]. *)
+let term_of_var map var =
+  
+  (* Getting the state variable. *)
+  let sv = Var.state_var_of_state_var_instance var in
+  (* Getting corresponding state variable. *)
+  let sv' = List.assq sv map in
+  
+  if StateVar.is_const sv
+  then
+    (* Original state var is a constant, new one should be to. *)
+    Var.mk_const_state_var sv'
+    |> mk_var
+  else if StateVar.is_const sv' then
+    (* New state var is a constant. *)
+    Var.mk_const_state_var sv'
+    |> mk_var
+  else
+    (* None of the state variables is constant. *)
+    Var.mk_state_var_instance
+      sv'
+      (Var.offset_of_state_var_instance var)
+    |> mk_var
+
+
+(* Substitute state variables according a mapping. *)
+let substitute_vars map =
+  ( fun _ term ->
+
+    (* Is the term a free variable? *)
+    if is_free_var term then
+      try
+        (* Extracting state variable. *)
+        free_var_of_term term
+        (* Getting corresponding variable as a term, bumping if
+           necessary. *)
+        |> term_of_var map
+      with
+        (* Variable is not in map, nothing to do. *)
+        Not_found -> term
+
+    else
+      (* Term is not a var, nothing to do. *)
+      term )
+
+(* Substitutes the free variables appearing in a term according to a
+   state var mapping. *)
+let substitute_variables mapping =
+  substitute_vars mapping |> map
+
 
 
 (* 

--- a/src/term.mli
+++ b/src/term.mli
@@ -431,6 +431,10 @@ val eval_t : (T.flat -> 'a list -> 'a) -> t -> 'a
     indexes can be adjusted in the subterm if necessary. *)
 val map : (int -> T.t -> T.t) -> t -> t
 
+(** Substitutes the free variables appearing in a term according to a
+    state var mapping. *)
+val substitute_variables : (StateVar.t * StateVar.t) list -> t -> t
+
 (** Convert [(= 0 (mod t n))] to [(divisble n t)]
 
     The term [n] must be an integer numeral. *)

--- a/src/termLib.ml
+++ b/src/termLib.ml
@@ -38,9 +38,6 @@ type prop_source =
   (* Property is from an annotation *)
   | PropAnnot of position
 
-  (* Property is part of a contract: contract name and position. *)
-  | Contract of (string * position)
-
   (* Property is a requirement for a subsystem: scope of the subsystem
      and position. *)
   | SubRequirement of (string list * position)
@@ -53,6 +50,12 @@ type prop_source =
 
      Reference the instantiated property by the [scope] of the
      subsystem and the name of the property *)
-  | Instantiated of string list * string 
+  | Instantiated of string list * string
+
+(* Source of a contract. *)
+type contract_source =
+
+  (* Contract is from an annotation. *)
+  | ContractAnnot of position
 
 

--- a/src/termLib.ml
+++ b/src/termLib.ml
@@ -38,8 +38,12 @@ type prop_source =
   (* Property is from an annotation *)
   | PropAnnot of position
 
-  (* Property is part of a contract *)
-  | Contract of position
+  (* Property is part of a contract: contract name and position. *)
+  | Contract of (string * position)
+
+  (* Property is a requirement for a subsystem: scope of the subsystem
+     and position. *)
+  | SubRequirement of (string list * position)
 
   (* Property was generated, for example, from a subrange
      constraint *)

--- a/src/termLib.mli
+++ b/src/termLib.mli
@@ -40,9 +40,6 @@ type prop_source =
   (** Property is from an annotation *)
   | PropAnnot of Lib.position
 
-  (** Property is part of a contract: contract name and position. *)
-  | Contract of (string * Lib.position)
-
   (** Property is a requirement for a subsystem: scope of the
       subsystem and position. *)
   | SubRequirement of (string list * Lib.position)
@@ -56,3 +53,9 @@ type prop_source =
       Reference the instantiated property by the [scope] of the
       subsystem and the name of the property *)
   | Instantiated of string list * string 
+
+(** Source of a contract. *)
+type contract_source =
+
+  (** Contract is from an annotation. *)
+  | ContractAnnot of Lib.position

--- a/src/termLib.mli
+++ b/src/termLib.mli
@@ -40,8 +40,12 @@ type prop_source =
   (** Property is from an annotation *)
   | PropAnnot of Lib.position
 
-  (** Property is part of a contract *)
-  | Contract of Lib.position
+  (** Property is part of a contract: contract name and position. *)
+  | Contract of (string * Lib.position)
+
+  (** Property is a requirement for a subsystem: scope of the
+      subsystem and position. *)
+  | SubRequirement of (string list * Lib.position)
 
   (** Property was generated, for example, from a subrange
       constraint *)

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -22,13 +22,22 @@ type source =
   | Lustre of LustreNode.t list 
   | Native
 
-(* Global is_init state var *)
+(* Global init flag state var. *)
 let init_flag_svar =
-  StateVar.mk_state_var ~for_inv_gen:false "x_is_init_x" ["transSys"] Type.t_bool
+  let res =
+    StateVar.mk_state_var
+      ~for_inv_gen:false
+      "x_is_init_x"
+      ["transSys"]
+      Type.t_bool
+  in
+  LustreExpr.set_state_var_source res LustreExpr.Abstract ;
+  res
 
-(* Instantiate init flag at k *)
+(* Instantiate init flag at k. *)
 let init_flag_var = Var.mk_state_var_instance init_flag_svar
 
+(* UF version of the init flag. *)
 let init_flag_uf k =
   init_flag_var k |> Var.unrolled_uf_of_state_var_instance
 
@@ -43,7 +52,23 @@ let is_uf_init_flag uf =
   with
   | Not_found -> false
 
-let _ = LustreExpr.set_state_var_source init_flag_svar LustreExpr.Abstract
+(* Global max contract depth state var *)
+let max_contract_depth_svar =
+  let res =
+    StateVar.mk_state_var
+      ~is_input:false
+      ~is_const:true
+      ~for_inv_gen:false
+      "x_max_depth_x"
+      ["transSys"]
+      Type.t_int
+  in
+  LustreExpr.set_state_var_source res LustreExpr.Abstract ;
+  res
+
+(* Global max contract depth state var. *)
+let max_contract_depth_var =
+  Var.mk_const_state_var max_contract_depth_svar
 
 
 type pred_def = (UfSymbol.t * (Var.t list * Term.t)) 

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -619,8 +619,7 @@ let mk_trans_sys scope state_vars init trans subsystems props source =
     { scope = scope;
       uf_defs = get_uf_defs [ (init, trans) ] subsystems ;
       state_vars =
-        init_flag_svar :: state_vars
-        |> List.sort StateVar.compare_state_vars ;
+        state_vars |> List.sort StateVar.compare_state_vars ;
       init = init ;
       trans = trans ;
       properties =

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -70,6 +70,12 @@ let max_contract_depth_svar =
 let max_contract_depth_var =
   Var.mk_const_state_var max_contract_depth_svar
 
+(* Global non-constant state variables. *)
+let global_svars = [ init_flag_svar ]
+
+(* Global constant state variables. *)
+let global_constant_svars = [ max_contract_depth_svar ]
+
 
 type pred_def = (UfSymbol.t * (Var.t list * Term.t)) 
 
@@ -776,14 +782,30 @@ let rec vars_of_bounds' state_vars lbound ubound accum =
     (* Recurse to next lower bound *)
     |> vars_of_bounds' state_vars lbound Numeral.(pred ubound)
 
+(* Declares variables of the transition system between two offsets. *)
 let vars_of_bounds trans_sys lbound ubound =
   vars_of_bounds' trans_sys.state_vars lbound ubound []
 
-let declare_vars_of_bounds_no_init sys declare lbound ubound =
+(* Declares non global state variables of the transition system
+   between two offsets. *)
+let declare_vars_of_bounds_no_global sys declare lbound ubound =
   vars_of_bounds'
     (sys.state_vars |> List.filter (fun sv -> sv != init_flag_svar))
     lbound ubound []
   |> Var.declare_vars declare
+
+(* Declares global state variables of the transition system between
+   two offsets. *)
+let declare_vars_of_bounds_global declare lbound ubound =
+  vars_of_bounds' global_svars lbound ubound []
+  |> Var.declare_vars declare
+
+(* Declares global constant state variables of the transition system between
+   two offsets. *)
+let declare_vars_global_const declare =
+  global_constant_svars
+  |> List.map (Var.mk_const_state_var)
+  |> Var.declare_constant_vars declare
 
 
 (* Declares variables of the transition system between two offsets. *)

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -447,6 +447,8 @@ let get_contracts_implications { contracts } =
   |> List.map
        ( fun (name, requires, ensures) ->
          (name,
+          (* Building the implication between the requires and the
+             ensures. *)
           Term.mk_implies
             [ Term.mk_and requires ;
               Term.mk_and ensures ]) )

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -83,6 +83,10 @@ type property =
 
   }
 
+(* A contract of a transition system. *)
+type contract =
+    string * Term.t list * Term.t list
+
 
 
 (* Return the length of the counterexample *)
@@ -147,7 +151,10 @@ type t = {
   subsystems: t list ;
 
   (* Properties of the transition system to prove invariant *)
-  properties : property list; 
+  properties : property list;
+
+  (* The contracts of this system. *)
+  contracts : contract list ;
 
   (* The source which produced this system. *)
   source: source ;
@@ -431,6 +438,19 @@ let instantiation_count { callers } =
        0
 
 
+(* Returns the contracts of a system. *)
+let get_contracts { contracts } = contracts
+
+(* Returns the contracts of a system as a list of implications. *)
+let get_contracts_implications { contracts } =
+  contracts
+  |> List.map
+       ( fun (name, requires, ensures) ->
+         (name,
+          Term.mk_implies
+            [ Term.mk_and requires ;
+              Term.mk_and ensures ]) )
+
 (* Returns the subsystems of a system. *)
 let get_subsystems { subsystems } = subsystems
 
@@ -630,6 +650,7 @@ let mk_trans_sys scope state_vars init trans subsystems props source =
                prop_term = t; 
                prop_status = PropUnknown })
           props ;
+      contracts = [] ;
       subsystems = subsystems ;
       source = source ;
       invars = invars_of_types ;

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -80,6 +80,7 @@ val mk_trans_sys :
   UfSymbol.t * (Var.t list * Term.t) ->
   t list ->
   (string * TermLib.prop_source * Term.t) list ->
+  (string * Term.t list * Term.t list) list ->
   source ->
   t
 
@@ -151,7 +152,7 @@ val init_term : t -> Term.t
 val trans_term : t -> Term.t
 
 (** The contracts of a system. *)
-val get_contracts : t -> (string * Term.t list * Term.t list) list
+val get_contracts : t -> (string * Term.t list * Term.t list * prop_status) list
 
 (** The contracts of a system, as a list of implications. *)
 val get_contracts_implications : t -> (string * Term.t) list

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -193,12 +193,24 @@ val get_name : t -> string
    transition system *)
 val vars_of_bounds : t -> Numeral.t -> Numeral.t -> Var.t list
 
-(** Declares variables of the transition system between two offsets. *)
-val declare_vars_of_bounds : t -> (UfSymbol.t -> unit) -> Numeral.t -> Numeral.t -> unit
-
-(** Declares variables of the transition system between two offsets. *)
-val declare_vars_of_bounds_no_init :
+(** Declares variables of the transition system between two
+    offsets. *)
+val declare_vars_of_bounds :
   t -> (UfSymbol.t -> unit) -> Numeral.t -> Numeral.t -> unit
+
+(** Declares non global state variables of the transition system
+    between two offsets. *)
+val declare_vars_of_bounds_no_global :
+  t -> (UfSymbol.t -> unit) -> Numeral.t -> Numeral.t -> unit
+
+(** Declares global state variables of the transition system between
+    two offsets. *)
+val declare_vars_of_bounds_global :
+  (UfSymbol.t -> unit) -> Numeral.t -> Numeral.t -> unit
+
+(** Declares global constant state variables of the transition
+    system. *)
+val declare_vars_global_const : (UfSymbol.t -> unit) -> unit
 
 (** Instantiate the initial state constraint to the bound *)
 val init_of_bound : t -> Numeral.t -> Term.t

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -119,27 +119,6 @@ val instantiation_count: t -> int
 (** Returns true if the system is the top level system. *)
 val is_top : t -> bool
 
-(** Global init flag state var. *)
-val init_flag_svar: StateVar.t
-
-(** Instantiate init flag at k. *)
-val init_flag_var: Numeral.t -> Var.t
-
-(** UF version of the init flag. *)
-val init_flag_uf: Numeral.t -> UfSymbol.t
-                                  
-(** Tests if a var is an instanciation of the init_flag. *)
-val is_var_init_flag: Var.t -> bool
-                                  
-(** Tests if a uf is an instanciation of the init_flag. *)
-val is_uf_init_flag: UfSymbol.t -> bool
-
-(** Global max contract depth state var *)
-val max_contract_depth_svar : StateVar.t
-
-(** Global max contract depth state var. *)
-val max_contract_depth_var : Var.t
-
 (** Predicate for the initial state constraint *)
 val init_uf_symbol : t -> UfSymbol.t
 
@@ -180,6 +159,9 @@ val state_vars : t -> StateVar.t list
 (** Return the source used to produce the transition system *)
 val get_source : t -> source
 
+(** Returns the max depth of a transition system. *)
+val get_max_depth : t -> Numeral.t
+
 (** Return the scope of the transition system *)
 val get_scope : t -> string list
 
@@ -189,28 +171,29 @@ val subsystem_of_scope : t -> string list -> t
 (** Return the name of the transition system *)
 val get_name : t -> string
 
-(** Return the variables at current and previous instants of the
-   transition system *)
-val vars_of_bounds : t -> Numeral.t -> Numeral.t -> Var.t list
+(** Returns the variables of the transition system between two
+    bounds. *)
+val vars_of_bounds :
+  t -> Numeral.t -> Numeral.t ->
+  Var.t list
 
 (** Declares variables of the transition system between two
     offsets. *)
 val declare_vars_of_bounds :
-  t -> (UfSymbol.t -> unit) -> Numeral.t -> Numeral.t -> unit
+  t -> (UfSymbol.t -> unit) ->
+  Numeral.t -> Numeral.t -> unit
 
-(** Declares non global state variables of the transition system
-    between two offsets. *)
-val declare_vars_of_bounds_no_global :
-  t -> (UfSymbol.t -> unit) -> Numeral.t -> Numeral.t -> unit
+(** The init flag of a transition system, as a [Var]. *)
+val init_flag_of_trans_sys : t -> Numeral.t -> Var.t
 
-(** Declares global state variables of the transition system between
-    two offsets. *)
-val declare_vars_of_bounds_global :
-  (UfSymbol.t -> unit) -> Numeral.t -> Numeral.t -> unit
+(** The depth input of a transition system, as a [Var]. *)
+val depth_input_of_trans_sys : t -> Var.t
 
-(** Declares global constant state variables of the transition
-    system. *)
-val declare_vars_global_const : (UfSymbol.t -> unit) -> unit
+(** The max depth input of a transition system, as a [Var]. *)
+val max_depth_input_of_trans_sys : t -> Var.t
+
+(** Constrains the top level depth and max depth inputs. *)
+val depth_inputs_constraint : t -> Numeral.t -> Term.t
 
 (** Instantiate the initial state constraint to the bound *)
 val init_of_bound : t -> Numeral.t -> Term.t
@@ -303,11 +286,11 @@ val iter_state_var_declarations : t -> (UfSymbol.t -> unit) -> unit
 (** Define uf definitions, declare constant state variables and declare
     variables from [lbound] to [upbound]. *)
 val init_define_fun_declare_vars_of_bounds :
-      t ->
-      (UfSymbol.t -> Var.t list -> Term.t -> unit) ->
-      (UfSymbol.t -> unit) ->
-      Numeral.t -> Numeral.t ->
-      unit
+  t ->
+  (UfSymbol.t -> Var.t list -> Term.t -> unit) ->
+  (UfSymbol.t -> unit) ->
+  Numeral.t -> Numeral.t ->
+  unit
 
 
 (** Extract a path in the transition system, return an association

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -150,6 +150,12 @@ val init_term : t -> Term.t
 (** Definition of the transition relation *)
 val trans_term : t -> Term.t
 
+(** The contracts of a system. *)
+val get_contracts : t -> (string * Term.t list * Term.t list) list
+
+(** The contracts of a system, as a list of implications. *)
+val get_contracts_implications : t -> (string * Term.t) list
+
 
 (** The subsystems of a system. *)
 val get_subsystems : t -> t list

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -192,7 +192,8 @@ val depth_input_of_trans_sys : t -> Var.t
 (** The max depth input of a transition system, as a [Var]. *)
 val max_depth_input_of_trans_sys : t -> Var.t
 
-(** Constrains the top level depth and max depth inputs. *)
+(** Constrains the top level depth and max depth inputs. The second
+    argument is the value to constrain the max depth input to. *)
 val depth_inputs_constraint : t -> Numeral.t -> Term.t
 
 (** Instantiate the initial state constraint to the bound *)

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -119,12 +119,13 @@ val instantiation_count: t -> int
 (** Returns true if the system is the top level system. *)
 val is_top : t -> bool
 
-(** Global init flag state var *)
+(** Global init flag state var. *)
 val init_flag_svar: StateVar.t
 
-(** Instantiate init flag at k *)
+(** Instantiate init flag at k. *)
 val init_flag_var: Numeral.t -> Var.t
 
+(** UF version of the init flag. *)
 val init_flag_uf: Numeral.t -> UfSymbol.t
                                   
 (** Tests if a var is an instanciation of the init_flag. *)
@@ -132,6 +133,12 @@ val is_var_init_flag: Var.t -> bool
                                   
 (** Tests if a uf is an instanciation of the init_flag. *)
 val is_uf_init_flag: UfSymbol.t -> bool
+
+(** Global max contract depth state var *)
+val max_contract_depth_svar : StateVar.t
+
+(** Global max contract depth state var. *)
+val max_contract_depth_var : Var.t
 
 (** Predicate for the initial state constraint *)
 val init_uf_symbol : t -> UfSymbol.t

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -80,7 +80,7 @@ val mk_trans_sys :
   UfSymbol.t * (Var.t list * Term.t) ->
   t list ->
   (string * TermLib.prop_source * Term.t) list ->
-  (string * Term.t list * Term.t list) list ->
+  (string * TermLib.contract_source * Term.t list * Term.t list) list ->
   source ->
   t
 
@@ -152,7 +152,13 @@ val init_term : t -> Term.t
 val trans_term : t -> Term.t
 
 (** The contracts of a system. *)
-val get_contracts : t -> (string * Term.t list * Term.t list * prop_status) list
+val get_contracts :
+  t ->
+  (string
+   * TermLib.contract_source
+   * Term.t list
+   * Term.t list
+   * prop_status) list
 
 (** The contracts of a system, as a list of implications. *)
 val get_contracts_implications : t -> (string * Term.t) list

--- a/tests/lustre/contract_multi_node.lus
+++ b/tests/lustre/contract_multi_node.lus
@@ -1,0 +1,44 @@
+-- Increments its output only when [incr] is true, starting at 0.
+node d (incr: bool) returns (out: int) ;
+let
+  out = 0 -> if incr then pre out + 1 else pre out ;
+  --%PROPERTY out >= 0 ;
+tel
+
+-- Memorizes the value of [in] when [mem] is true.
+node c (in: int; mem: bool) returns (out: int) ;
+--@contract : something ;
+--@require in >= 0 ;
+--@ensure  out >= 0 ;
+let
+  out = in -> if mem then in else pre out ;
+  --%PROPERTY out >= 0 ;
+tel
+
+-- Increments [out] when [incr] is true, memorizes [out] when [mem] is
+-- true.
+node b (incr, mem: bool) returns (out, old_out: int) ;
+let
+  out = d(incr) ;
+  old_out = c(out, mem) ;
+tel
+
+-- Increments [out] when [incr] is true, with a sliding window
+-- memorizing the 3 last values of [out] when [mem] is true.
+node a (incr, mem: bool) returns (out, p_out, pp_out, ppp_out: int) ;
+--@contract : bla ;
+--@require not (incr and mem) ;
+--@ensure not (out = p_out) ; 
+--@contract : bli ;
+--@require not (incr and mem) ;
+--@ensure not (out = p_out) ; 
+let
+  out, p_out = b(incr, mem) ;
+  pp_out = c(out -> pre p_out, mem) ;
+  ppp_out = c(out -> pre pp_out, mem) ;
+  --%MAIN;
+  --%PROPERTY out >= 0 ;
+  --%PROPERTY p_out >= 0 ;
+  --%PROPERTY pp_out >= 0 ;
+  --%PROPERTY ppp_out >= 0 ;
+tel


### PR DESCRIPTION
Init flag is now scoped.

Added a depth input and a max depth input for every node to control the abstraction depth in a contract-based compositional analysis. See the comments of `lustreTransSys.ml(i)` for more details.

It is now necessary to constrain the depth and max depth inputs at top level. Transition systems know their max depth; for a monolithic analysis, the max depth input should be the system max depth. A solver initialization extracted from `base.ml` follows. This will be changed in the future as compositional contract-based analysis is implemented.

```ocaml
(* Defining uf's and declaring variables. *)
TransSys.init_define_fun_declare_vars_of_bounds
  trans
  (SMTSolver.define_fun solver)
  (SMTSolver.declare_fun solver)
  Numeral.(~- one) Numeral.zero ;

(* Constraining max depth. *)                                                                                                                                                                
TransSys.get_max_depth trans
|> TransSys.depth_inputs_constraint trans
|> SMTSolver.assert_term solver ;
```                                    