### PR TITLE
Detect logic fragment for input system (Fixes kind2-mc/kind2-dev#68)

### DIFF
--- a/src/CVC4Driver.ml
+++ b/src/CVC4Driver.ml
@@ -151,7 +151,8 @@ let string_of_logic l =
   let open TermLib in
   let open TermLib.FeatureSet in
   (* CVC4 fails to give model when given a non linear arithmetic logic *)
-  if mem NA l then "ALL_SUPPORTED"
-  else GenericSMTLIBDriver.string_of_logic l
+  match l with
+  | `Inferred l when mem NA l -> "ALL_SUPPORTED"
+  | _ -> GenericSMTLIBDriver.string_of_logic l
 
 let pp_print_logic fmt l = Format.pp_print_string fmt (string_of_logic l)

--- a/src/CVC4Driver.ml
+++ b/src/CVC4Driver.ml
@@ -145,3 +145,13 @@ let cvc4_expr_or_lambda_of_string_sexpr' ({ s_define_fun } as conv) bound_vars =
 
 let lambda_of_string_sexpr = 
   gen_expr_or_lambda_of_string_sexpr smtlib_string_sexpr_conv
+
+
+let string_of_logic l =
+  let open TermLib in
+  let open TermLib.FeatureSet in
+  (* CVC4 fails to give model when given a non linear arithmetic logic *)
+  if mem NA l then "ALL_SUPPORTED"
+  else GenericSMTLIBDriver.string_of_logic l
+
+let pp_print_logic fmt l = Format.pp_print_string fmt (string_of_logic l)

--- a/src/QE.ml
+++ b/src/QE.ml
@@ -30,7 +30,17 @@ let solver_qe = ref None
 let solver_check = ref None
 
 (* Add quantifiers to logic *)
-let add_quantifiers l = TermLib.FeatureSet.add TermLib.Q l
+let add_quantifiers = function
+  | `None -> `None
+  | `Inferred l -> `Inferred (TermLib.FeatureSet.add TermLib.Q l)
+  | `SMTLogic s as l ->
+    try
+      let s =
+        if String.sub s 0 3 = "QF_" then
+          String.sub s 3 (String.length s - 3)
+        else s in
+      `SMTLogic s
+    with Invalid_argument _ -> l
 
 (* Get the current solver instance or create a new instance *)
 let get_solver_instance trans_sys = 

--- a/src/QE.ml
+++ b/src/QE.ml
@@ -29,6 +29,9 @@ let solver_qe = ref None
 (* The current solver instance in use *)
 let solver_check = ref None
 
+(* Add quantifiers to logic *)
+let add_quantifiers l = TermLib.FeatureSet.add TermLib.Q l
+
 (* Get the current solver instance or create a new instance *)
 let get_solver_instance trans_sys = 
 
@@ -41,7 +44,7 @@ let get_solver_instance trans_sys =
       (* Create solver instance : only Z3 for the moment *)
       let solver = SMTSolver.create_instance
           ~produce_assignments:true
-          (TransSys.get_logic trans_sys)
+          (add_quantifiers (TransSys.get_logic trans_sys))
           `Z3_SMTLIB
       in
 
@@ -102,11 +105,12 @@ let get_checking_solver_instance trans_sys =
     (* Need to create a new instance *)
     | None -> 
 
-      (* Create solver instance *)
+      (* Create solver instance with support for quantifiers *)
       let solver =     
         SMTSolver.create_instance 
           ~produce_assignments:true
-          `UFLIA
+          (* add quantifiers to system logic *)
+          (add_quantifiers (TransSys.get_logic trans_sys))
           (Flags.smtsolver ())
       in
 (*

--- a/src/SMTExpr.ml
+++ b/src/SMTExpr.ml
@@ -50,9 +50,9 @@ module type Conv =
 
     val smtexpr_of_var : Var.t -> Term.t list -> t
 
-    val string_of_logic : Term.logic -> string 
+    val string_of_logic : TermLib.logic -> string 
 
-    val pp_print_logic : Format.formatter -> Term.logic -> unit
+    val pp_print_logic : Format.formatter -> TermLib.logic -> unit
 
     val pp_print_sort : Format.formatter -> sort -> unit
 

--- a/src/SMTExpr.mli
+++ b/src/SMTExpr.mli
@@ -56,10 +56,10 @@ sig
   (** {2 Pretty-printing and String Conversions} *)
 
   (** Return an SMTLIB string expression for the logic *)
-  val string_of_logic : Term.logic -> string 
+  val string_of_logic : TermLib.logic -> string 
 
   (** Pretty-print a logic in SMTLIB format *)
-  val pp_print_logic : Format.formatter -> Term.logic -> unit
+  val pp_print_logic : Format.formatter -> TermLib.logic -> unit
 
   (** Pretty-print a sort in SMTLIB format *)
   val pp_print_sort : Format.formatter -> sort -> unit

--- a/src/SMTLIBSolver.ml
+++ b/src/SMTLIBSolver.ml
@@ -803,9 +803,9 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
     in
 
     let header_logic =
-      if Flags.smtlogic () then
-        [Format.sprintf "(set-logic %s)" (string_of_logic logic)]
-      else [] in
+      let s = string_of_logic logic in
+      if s = "" then []
+      else [Format.sprintf "(set-logic %s)" s] in
     
     let headers =
       "(set-option :print-success true)" ::

--- a/src/SMTLIBSolver.ml
+++ b/src/SMTLIBSolver.ml
@@ -19,13 +19,7 @@
 open Lib
 open SolverResponse
 
-(* Dummy Event module when compiling a custom toplevel*)
-module Event = 
-struct
-  let get_module () = `Parser
-  let log _ = Format.printf
-end
-  
+
 (* ********************************************************************* *)
 (* Types                                                                 *)
 (* ********************************************************************* *)

--- a/src/SMTLIBSolver.ml
+++ b/src/SMTLIBSolver.ml
@@ -808,20 +808,21 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
         solver_trace_coms = ftrace_coms; }
     in
 
-    let header_logic = function
-      | `detect -> []
-      | _ -> [Format.sprintf "(set-logic %s)" (string_of_logic logic)]
-    in
+    let header_logic =
+      if Flags.smtlogic () then
+        [Format.sprintf "(set-logic %s)" (string_of_logic logic)]
+      else [] in
     
     let headers =
       "(set-option :print-success true)" ::
       (headers ()) @
       [ 
         (* Format.sprintf "(set-option :produce-models %B)" produce_models :: *)
-        Format.sprintf "(set-option :produce-assignments %B)" produce_assignments;
+        Format.sprintf
+          "(set-option :produce-assignments %B)" produce_assignments;
         Format.sprintf "(set-option :produce-unsat-cores %B)" produce_cores
       ] @
-      (header_logic logic)
+      header_logic
     in
 
     (* Print specific headers specifications *)

--- a/src/SMTSolver.mli
+++ b/src/SMTSolver.mli
@@ -32,7 +32,7 @@ val create_instance :
   ?produce_assignments:bool ->
   ?produce_proofs:bool ->
   ?produce_cores:bool ->
-  Term.logic ->
+  TermLib.logic ->
   Flags.smtsolver ->
   t
 

--- a/src/Z3Driver.ml
+++ b/src/Z3Driver.ml
@@ -37,3 +37,16 @@ let check_sat_assuming_supported () = true
 let check_sat_assuming_cmd () = "check-sat"
 
 let headers () = [ "(set-option :interactive-mode true)" ]
+
+
+let string_of_logic l =
+  let open TermLib in
+  let open TermLib.FeatureSet in
+  if is_empty l then "QF_UF"
+  else
+    if mem IA l && mem RA l then
+      if mem Q l then "AUFLIRA" 
+      else "QF_AUFLIRA"
+    else GenericSMTLIBDriver.string_of_logic l
+
+let pp_print_logic fmt l = Format.pp_print_string fmt (string_of_logic l)

--- a/src/Z3Driver.ml
+++ b/src/Z3Driver.ml
@@ -42,11 +42,11 @@ let headers () = [ "(set-option :interactive-mode true)" ]
 let string_of_logic l =
   let open TermLib in
   let open TermLib.FeatureSet in
-  if is_empty l then "QF_UF"
-  else
-    if mem IA l && mem RA l then
-      if mem Q l then "AUFLIRA" 
-      else "QF_AUFLIRA"
-    else GenericSMTLIBDriver.string_of_logic l
-
+  match l with
+  | `Inferred l when is_empty l -> "QF_UF"
+  | `Inferred l when mem IA l && mem RA l ->
+    if mem Q l then "AUFLIRA"
+    else "QF_AUFLIRA"
+  | _ -> GenericSMTLIBDriver.string_of_logic l
+    
 let pp_print_logic fmt l = Format.pp_print_string fmt (string_of_logic l)

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -177,28 +177,13 @@ let smtsolver_default = `detect
 
 (* ********** *) 
 
-type smtlogic = [ `QF_LIA | `QF_LRA | `QF_LIRA |`QF_UFLIA | `QF_UFLRA | `detect ]
-    
-let smtlogic_of_string = function
-  | "UFLIA" -> `QF_UFLIA
-  | "UFLRA" -> `QF_UFLRA
-  | "LIA" -> `QF_LIA
-  | "LRA" -> `QF_LRA
-  | "LIRA" -> `QF_LIRA
-  | "detect" -> `detect
-  | _ -> raise (Arg.Bad "Bad value for --smtlogic")
+type smtlogic = bool
 
-let string_of_smtlogic = function 
-  | `QF_UFLIA -> "UFLIA"
-  | `QF_UFLRA -> "UFLRA"
-  | `QF_LIA -> "LIA"
-  | `QF_LRA -> "LRA"
-  | `QF_LIRA -> "LIRA"
-  | `detect -> "detect"
+let smtlogic_of_bool b = b
 
-let smtlogic_values = "UFLIA, UFLRA, LIA, LRA, LIRA, detect"
+let bool_of_smtlogic b = b
 
-let smtlogic_default = `detect
+let smtlogic_default = true
 
 (* ********** *) 
 
@@ -721,13 +706,12 @@ let smtsolver_spec =
 
 (* ********** *) 
 
-let smtlogic_action o = flags.smtlogic <- (smtlogic_of_string o)
+let smtlogic_action o = flags.smtlogic <- false
   
 let smtlogic_spec = 
-  ("--smtlogic", 
-   Arg.String smtlogic_action, 
-   Format.sprintf "choose SMT logic (available: %s, default: %s)"
-                  smtlogic_values (string_of_smtlogic smtlogic_default))
+  ("--no_detect_smtlogic", 
+   Arg.Unit smtlogic_action, 
+   "disable detection of logic for SMT solvers")
 
 (* ********** *) 
 

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -177,13 +177,19 @@ let smtsolver_default = `detect
 
 (* ********** *) 
 
-type smtlogic = bool
+type smtlogic = [ `None | `detect | `Logic of string ]
 
-let smtlogic_of_bool b = b
+let smtlogic_of_string = function
+  | "none" | "None" -> `None
+  | "detect" | "Detect" -> `detect
+  | s -> `Logic s
 
-let bool_of_smtlogic b = b
+let string_of_smtlogic = function
+  | `None -> "none"
+  | `detect -> "detect"
+  | `Logic s -> s
 
-let smtlogic_default = true
+let smtlogic_default = `None
 
 (* ********** *) 
 
@@ -695,12 +701,14 @@ let smtsolver_spec =
 
 (* ********** *) 
 
-let smtlogic_action o = flags.smtlogic <- false
+let smtlogic_action o = flags.smtlogic <- (smtlogic_of_string o)
   
 let smtlogic_spec = 
-  ("--no_detect_smtlogic", 
-   Arg.Unit smtlogic_action, 
-   "disable detection of logic for SMT solvers")
+  ("--smtlogic", 
+   Arg.String smtlogic_action, 
+   "select logic for SMT solvers (\"none\" for no logic (default), and \
+    \"detect\" to detect with the input system, other SMTLIB logics will be \
+    passed to the solver)")
 
 (* ********** *) 
 

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -225,15 +225,6 @@ let string_of_yices_bin s = s
 
 let yices_bin_default = "yices"
 
-(* ********** *) 
-
-type yices_arith_only = bool
-
-let yices_arith_only_of_bool b = b
-
-let bool_of_yices_arith_only s = s 
-
-let yices_arith_only_default = false
 
 (* ********** *) 
 
@@ -582,7 +573,6 @@ type flags =
       mutable cvc4_bin : cvc4_bin;
       mutable mathsat5_bin : mathsat5_bin;
       mutable yices_bin : yices_bin;
-      mutable yices_arith_only : yices_arith_only;
       mutable yices2smt2_bin : yices2smt2_bin;
       mutable smt_trace : smt_trace;
       mutable smt_trace_dir : smt_trace_dir;
@@ -634,7 +624,6 @@ let flags =
     cvc4_bin = cvc4_bin_default;
     mathsat5_bin = mathsat5_bin_default;
     yices_bin = yices_bin_default;
-    yices_arith_only = yices_arith_only_default;
     yices2smt2_bin = yices2smt2_bin_default;
     smt_trace = smt_trace_default;
     smt_trace_dir = smt_trace_dir_default;
@@ -752,17 +741,6 @@ let yices_bin_spec =
    Arg.String yices_bin_action, 
    Format.sprintf "executable of Yices solver (default: %s)"
                   (string_of_yices_bin yices_bin_default))
-
-(* ********** *) 
-
-let yices_arith_only_action o =
-  flags.yices_arith_only <- true
-  
-let yices_arith_only_spec = 
-  ("--yices_arith_only", 
-   Arg.Unit yices_arith_only_action, 
-   "Tell Yices to deactivate all theories excepted SAT and linear arithmetic. \
-    Will fail if this is not possible.")
 
 (* ********** *) 
 
@@ -1213,8 +1191,6 @@ let mathsat5_bin () = flags.mathsat5_bin
 
 let yices_bin () = flags.yices_bin
 
-let yices_arith_only () = flags.yices_arith_only
-
 let yices2smt2_bin () = flags.yices_bin
 
 let smt_trace () = flags.smt_trace
@@ -1339,9 +1315,6 @@ and speclist =
 
     (* Set executable for Yices solver *)
     yices_bin_spec;
-
-    (* Set arith only option of yices *)
-    yices_arith_only_spec;
 
     (* Set executable for Yices2 SMT2 solver *)
     yices2smt2_bin_spec;

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -72,10 +72,6 @@ val mathsat5_bin : unit -> mathsat5_bin
 type yices_bin = string
 val yices_bin : unit -> yices_bin
 
-(** Executable of Yices solver *)
-type yices_arith_only = bool
-val yices_arith_only : unit -> yices_arith_only
-
 (** Executable of Yices2 SMT2 solver *)
 type yices2smt2_bin = string
 val yices2smt2_bin : unit -> yices2smt2_bin

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -52,8 +52,8 @@ val set_smtsolver : smtsolver -> string -> unit
 (* (\** Return SMT solver to use with Quantifier Elimination *\) *)
 (* val qe_smtsolver : unit -> smtsolver  *)
 
-(** SMT Logic to use *)
-type smtlogic = [ `QF_LIA | `QF_LRA | `QF_LIRA |`QF_UFLIA | `QF_UFLRA | `detect ]
+(** detect logic to send SMT solver *)
+type smtlogic = bool
 val smtlogic : unit -> smtlogic 
 
 (** Executable of Z3 solver *)

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -53,7 +53,7 @@ val set_smtsolver : smtsolver -> string -> unit
 (* val qe_smtsolver : unit -> smtsolver  *)
 
 (** detect logic to send SMT solver *)
-type smtlogic = bool
+type smtlogic = [ `None | `detect | `Logic of string ]
 val smtlogic : unit -> smtlogic 
 
 (** Executable of Z3 solver *)

--- a/src/genericSMTLIBDriver.ml
+++ b/src/genericSMTLIBDriver.ml
@@ -428,39 +428,10 @@ let gen_expr_or_lambda_of_string_sexpr conv =
 (* ********************************************************************** *)
 
 (* Convert a logic to a string *)
-let string_of_logic = function
-  | `AUFLIA -> "AUFLIA"
-  | `AUFLIRA -> "AUFLIRA"
-  | `AUFNIRA -> "AUFNIRA"
-  | `LRA -> "LRA"
-  | `LIA -> "LIA"
-  | `QF_ABV -> "QF_ABV"
-  | `QF_AUFBV -> "QF_AUFBV"
-  | `QF_AUFLIA -> "QF_AUFLIA"
-  | `QF_AX -> "QF_AX"
-  | `QF_BV -> "QF_BV"
-  | `QF_IDL -> "QF_IDL"
-  | `QF_LIA -> "QF_LIA"
-  | `QF_LRA -> "QF_LRA"
-  | `QF_NIA -> "QF_NIA"
-  | `QF_NRA -> "QF_NRA"
-  | `QF_RDL -> "QF_RDL"
-  | `QF_UF -> "QF_UF"
-  | `QF_UFBV -> "QF_UFBV"
-  | `QF_UFIDL -> "QF_UFIDL"
-  | `QF_UFLIA -> "QF_UFLIA"
-  | `QF_UFLRA -> "QF_UFLRA"
-  | `QF_UFNRA -> "QF_UFNRA"
-  | `UFLIA -> "UFLIA"
-  | `UFLRA -> "UFLRA"
-  | `UFNIA -> "UFNIA"
-  | _ -> raise (Invalid_argument "Unsupported logic")
-
+let string_of_logic = TermLib.string_of_logic
 
 (* Pretty-print a logic identifier *)
-let pp_print_logic ppf l = 
-  Format.pp_print_string ppf (string_of_logic l) 
-
+let pp_print_logic = TermLib.pp_print_logic
 
 (* Convert type *)
 let interpr_type t = match Type.node_of_type t with

--- a/src/solverDriver.ml
+++ b/src/solverDriver.ml
@@ -54,10 +54,10 @@ module type S = sig
   val string_of_sort : Type.t -> string
 
   (** Return an SMTLIB string expression for the logic *)
-  val string_of_logic : Term.logic -> string 
+  val string_of_logic : TermLib.logic -> string 
 
   (** Pretty-print a logic in SMTLIB format *)
-  val pp_print_logic : Format.formatter -> Term.logic -> unit
+  val pp_print_logic : Format.formatter -> TermLib.logic -> unit
 
   (** Pretty-print a symbol *)
   val pp_print_symbol :  ?arity:int -> Format.formatter -> Symbol.t -> unit

--- a/src/solverDriver.mli
+++ b/src/solverDriver.mli
@@ -54,10 +54,10 @@ module type S = sig
   val string_of_sort : Type.t -> string
 
   (** Return an SMTLIB string expression for the logic *)
-  val string_of_logic : Term.logic -> string 
+  val string_of_logic : TermLib.logic -> string 
 
   (** Pretty-print a logic in SMTLIB format *)
-  val pp_print_logic : Format.formatter -> Term.logic -> unit
+  val pp_print_logic : Format.formatter -> TermLib.logic -> unit
 
   (** Pretty-print a symbol *)
   val pp_print_symbol :  ?arity:int -> Format.formatter -> Symbol.t -> unit

--- a/src/solverSig.mli
+++ b/src/solverSig.mli
@@ -27,7 +27,7 @@ module type Params = sig
 
   val produce_proofs : bool
 
-  val logic : Term.logic
+  val logic : TermLib.logic
 
   val id : int
 

--- a/src/symbol.ml
+++ b/src/symbol.ml
@@ -520,8 +520,14 @@ let s_lt = mk_symbol `LEQ
 (* Constant modulus operator symbol *)
 let s_mod = mk_symbol `MOD
 
+(* Constant plus operator *)
+let s_plus = mk_symbol `PLUS
+
 (* Constant minus operator *)
 let s_minus = mk_symbol `MINUS
+
+(* Constant times operator *)
+let s_times = mk_symbol `TIMES
 
 (* Constant division operator *)
 let s_div = mk_symbol `DIV

--- a/src/symbol.mli
+++ b/src/symbol.mli
@@ -230,8 +230,14 @@ val s_lt : t
 (** Constant modulus operator symbol *)
 val s_mod : t
 
+(** Constant plus operator symbol *)
+val s_plus : t
+
 (** Constant minus operator symbol *)
 val s_minus : t
+
+(** Constant times operator symbol *)
+val s_times : t
 
 (** Constant division operator symbol *)
 val s_div : t

--- a/src/term.ml
+++ b/src/term.ml
@@ -18,36 +18,6 @@
 
 open Lib
 
-type logic = 
-  [ `detect
-  | `AUFLIA
-  | `AUFLIRA
-  | `AUFNIRA
-  | `LRA 
-  | `LIA
-  | `QF_ABV
-  | `QF_AUFBV
-  | `QF_AUFLIA
-  | `QF_AX
-  | `QF_BV
-  | `QF_IDL
-  | `QF_LIA
-  | `QF_LRA
-  | `QF_LIRA
-  | `QF_NIA
-  | `QF_NRA
-  | `QF_RDL
-  | `QF_UF
-  | `QF_UFBV
-  | `QF_UFIDL
-  | `QF_UFLIA
-  | `QF_UFLRA
-  | `QF_UFNRA
-  | `UFLIA
-  | `UFLRA
-  | `UFNIA
-  ]
-
 (* We have three hashconsed types: uninterpreted function symbols,
    symbols and terms. Hashconsing has been extended to store a record
    of properties with each value, here we store mainly type

--- a/src/term.ml
+++ b/src/term.ml
@@ -138,7 +138,7 @@ type lambda = T.lambda
 
 let stats = T.stats
 
-(* Return the type of a term *)
+(* Return the node of the hashconsed term *)
 let node_of_term = T.node_of_t
 
 

--- a/src/term.mli
+++ b/src/term.mli
@@ -36,40 +36,6 @@
 *)
 
 
-(** {1 Logics} *)
-
-(** The defined logics in SMTLIB *)
-type logic = 
-  [ `detect
-  | `AUFLIA
-  | `AUFLIRA
-  | `AUFNIRA
-  | `LRA 
-  | `LIA
-  | `QF_ABV
-  | `QF_AUFBV
-  | `QF_AUFLIA
-  | `QF_AX
-  | `QF_BV
-  | `QF_IDL
-  | `QF_LIA
-  | `QF_LRA
-  | `QF_LIRA
-  | `QF_NIA
-  | `QF_NRA
-  | `QF_RDL
-  | `QF_UF
-  | `QF_UFBV
-  | `QF_UFIDL
-  | `QF_UFLIA
-  | `QF_UFLRA
-  | `QF_UFNRA
-  | `UFLIA
-  | `UFLRA
-  | `UFNIA
-  ]
-
-
 (** {1 Types and hash-consing} *)
 
 module T : Ltree.S

--- a/src/termLib.ml
+++ b/src/termLib.ml
@@ -101,7 +101,7 @@ module FeatureSet = Set.Make (struct
 
 
 (* Logic fragments for terms *)
-type logic = FeatureSet.t
+type features = FeatureSet.t
 
 (* Try to remove top level quantifief by instantiating with fresh symbols *)
 let remove_top_level_quantifier removed t =
@@ -206,10 +206,11 @@ let logic_of_term t =
   |> (if !removed_q then FeatureSet.add Q else Lib.identity)
 
 
+
 module L = FeatureSet
 
 
-let pp_print_logic fmt l =
+let pp_print_features fmt l =
   if not (L.mem Q l) then fprintf fmt "QF_";
   if L.is_empty l then fprintf fmt "SAT";
   if L.mem UF l then fprintf fmt "UF";
@@ -220,4 +221,20 @@ let pp_print_logic fmt l =
   if L.mem IA l || L.mem RA l then fprintf fmt "A"
 
 
-let string_of_logic l = asprintf "%a" pp_print_logic l
+let string_of_features l = asprintf "%a" pp_print_features l
+
+
+type logic = [ `None | `Inferred of features | `SMTLogic of string ]
+
+let pp_print_logic fmt = function
+  | `None -> ()
+  | `Inferred l -> pp_print_features fmt l
+  | `SMTLogic s -> pp_print_string fmt s
+
+
+let string_of_logic = function
+  | `None -> ""
+  | `Inferred l -> string_of_features l
+  | `SMTLogic s -> s
+  
+

--- a/src/termLib.ml
+++ b/src/termLib.ml
@@ -189,6 +189,10 @@ let logic_of_flat t acc =
                             || s == s_intdiv || s == s_mod) ->
     add NA (sup_logics acc)
 
+  | App (s, l) when Symbol.(s == s_lt || s == s_gt ||
+                            s == s_leq || s == s_geq) ->
+    add LA (sup_logics acc)
+
   | App _ -> sup_logics acc
 
   

--- a/src/termLib.mli
+++ b/src/termLib.mli
@@ -55,6 +55,11 @@ type prop_source =
   | Instantiated of string list * string 
 
 
+(** {1 Utilities functions on terms } *)
+
+
+(** {2 Default values } *)
+
 (** Return the default value of the type: 
 
     By default, a Boolean value is false, integer and real values are
@@ -62,3 +67,26 @@ type prop_source =
     range. Array scalar types do not have defaults. The function fails
     with [Invalid_argument] in this case. *)
 val default_of_type : Type.t -> Term.t
+
+
+(** {2 Logic fragments } *)
+
+(** A feature of a logic fragment for terms *)
+type feature =
+  | Q  (** Quantifiers *)
+  | UF (** Equality over uninterpreted functions *)
+  | IA (** Integer arithmetic *)
+  | RA (** Real arithmetic *)
+  | LA (** Linear arithmetic *)
+  | NA (** Non-linear arithmetic *)
+
+(** Set of features *)
+module FeatureSet : Set.S with type elt = feature
+
+(** Logic fragments for terms *)
+type logic = FeatureSet.t
+
+
+(** Returns the logic fragment used by a term *)
+val logic_of_term : Term.t -> logic
+

--- a/src/termLib.mli
+++ b/src/termLib.mli
@@ -84,13 +84,16 @@ type feature =
 module FeatureSet : Set.S with type elt = feature
 
 (** Logic fragments for terms *)
-type logic = FeatureSet.t
+type features = FeatureSet.t
 
 (** Returns the sup of the logics given as arguments *)
-val sup_logics : logic list -> logic
+val sup_logics : features list -> features
 
 (** Returns the logic fragment used by a term *)
-val logic_of_term : Term.t -> logic
+val logic_of_term : Term.t -> features
+
+(** Logic fragments for terms *)
+type logic = [ `None | `Inferred of features | `SMTLogic of string ]
 
 (** Print a logic *)
 val pp_print_logic : Format.formatter -> logic -> unit

--- a/src/termLib.mli
+++ b/src/termLib.mli
@@ -86,7 +86,8 @@ module FeatureSet : Set.S with type elt = feature
 (** Logic fragments for terms *)
 type logic = FeatureSet.t
 
+(** Returns the sup of the logics given as arguments *)
+val sup_logics : logic list -> logic
 
 (** Returns the logic fragment used by a term *)
 val logic_of_term : Term.t -> logic
-

--- a/src/termLib.mli
+++ b/src/termLib.mli
@@ -91,3 +91,10 @@ val sup_logics : logic list -> logic
 
 (** Returns the logic fragment used by a term *)
 val logic_of_term : Term.t -> logic
+
+(** Print a logic *)
+val pp_print_logic : Format.formatter -> logic -> unit
+
+(** String correspinding to a logic *)
+val string_of_logic : logic -> string
+

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -524,11 +524,8 @@ let pp_print_callers ppf (t, c) =
     (pp_print_list pp_print_caller "@ ") c
 
 
-(* Determine the required logic for the SMT solver 
-
-   TODO: Fix this to QF_UFLIA for now, dynamically determine later *)
-let get_logic _ = ((Flags.smtlogic ()) :> Term.logic)
-
+(* Determine the required logic for the SMT solver *)
+let get_logic t = t.logic
 
 (* Return the state variables of the transition system *)
 let state_vars t = t.state_vars

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -1093,6 +1093,7 @@ let pp_print_trans_sys
        properties;
        invars;
        source;
+       logic;
        callers } as trans_sys) = 
 
   Format.fprintf 
@@ -1104,6 +1105,7 @@ let pp_print_trans_sys
           @[<hv 2>(props@ (@[<v>%a@]))@]@,\
           @[<hv 2>(invar@ (@[<v>%a@]))@]@,\
           @[<hv 2>(source@ (@[<v>%a@]))@]@,\
+          @[<hv 2>(logic %a)@]@,\
           @[<hv 2>(callers@ (@[<v>%a@]))@]@."
     (pp_print_list pp_print_state_var "@ ") state_vars
     (pp_print_list pp_print_uf_defs "@ ") (uf_defs)
@@ -1112,6 +1114,7 @@ let pp_print_trans_sys
     (pp_print_list pp_print_property "@ ") properties
     (pp_print_list Term.pp_print_term "@ ") invars
     (pp_print_list (fun ppf { LustreNode.name } -> LustreIdent.pp_print_ident false ppf name) "@ ") (match source with Lustre l -> l | _ -> [])
+    TermLib.pp_print_logic logic
     (pp_print_list pp_print_callers "@,") callers
       
  

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -93,7 +93,7 @@ val pp_print_uf_def : Format.formatter -> pred_def -> unit
 val pp_print_trans_sys : Format.formatter -> t -> unit
 
 (** Get the required logic for the SMT solver *)
-val get_logic : t -> Term.logic
+val get_logic : t -> TermLib.logic
                        
 (** Instantiates a term for all (over)systems instantiating, possibly
     more than once, the input system. *)

--- a/src/yicesDriver.ml
+++ b/src/yicesDriver.ml
@@ -45,21 +45,12 @@ let check_sat_assuming_cmd _ =
 
 let headers () =
 
-  let missing = 
+  [
 
-    [
-      
-      (* Define functions for int / real conversions *)
-      "(define to_int::(-> x::real (subtype (y::int) (and (<= y x) (< x (+ y 1))))))";
-      "(define to_real::(-> x::int (subtype (y::real) (= y x))))";
-    ] 
-
-  in
-  
-  if Flags.yices_arith_only () then
-    "(set-arith-only! true)" :: missing
-  else 
-    missing
+    (* Define functions for int / real conversions *)
+    "(define to_int::(-> x::real (subtype (y::int) (and (<= y x) (< x (+ y 1))))))";
+    "(define to_real::(-> x::int (subtype (y::real) (= y x))))";
+  ] 
 
 
 let trace_extension = "ys"

--- a/src/yicesNative.ml
+++ b/src/yicesNative.ml
@@ -1195,9 +1195,12 @@ let create_instance
     (match produce_assignments with Some o -> o | None -> false)
   in
 
-  let header_logic = function
-    | `LIA | `LRA | `QF_LIA | `QF_LRA | `QF_LIRA -> ["(set-arith-only! true)"]
-    | _ -> []
+  let header_logic logic =
+    let open TermLib in
+    let open TermLib.FeatureSet in
+    if Flags.smtlogic () && subset logic (of_list [IA; RA; LA]) then
+      ["(set-arith-only! true)"]
+    else []
   in
     
   

--- a/src/yicesNative.ml
+++ b/src/yicesNative.ml
@@ -1115,7 +1115,10 @@ let create_instance
   let arith_only =
     let open TermLib in
     let open TermLib.FeatureSet in
-    Flags.smtlogic () && subset logic (of_list [IA; RA; LA])
+    match logic with
+    | `Inferred l -> subset l (of_list [IA; RA; LA])
+    | `SMTLogic ("QF_LIA" | "QF_LRA" | "QF_LIRA") -> true
+    | _ -> false
   in
   
   

--- a/src/yicesNative.ml
+++ b/src/yicesNative.ml
@@ -24,12 +24,6 @@ open Conv
 
 open SolverResponse
 
-(* Dummy Event module when compiling a custom toplevel *)
-module Event = 
-struct
-  let get_module () = `Parser
-  let log _ = Format.printf
-end
 
 (* ********************************************************************* *)
 (* Types                                                                 *)

--- a/src/yicesNative.ml
+++ b/src/yicesNative.ml
@@ -514,7 +514,8 @@ let ensure_symbol_qf_lira s =
 (*  | `STORE *)
     ->
     let msg = Format.sprintf "Yices was run with set-arith-only, but the \
-                              symbol %s is out of the supported theories."
+                              symbol %s is not interpreted correctly in this \
+                              mode. Run Kind 2 with --no_detect_logic instead."
         (Symbol.string_of_symbol s)
     in
     Event.log L_error "%s" msg;


### PR DESCRIPTION
Resolves kind2-mc/kind2-dev#68
Fixes kind2-mc/kind2-dev#81

A logic fragment is represented internally as a set of features (e.g. ```{UF, IA, LA}``` for ```QF_UFLIA```).

The logic is detected by going through the terms at the time of construction of the system (e.g. division by a constant is classified as a linear operation). Though the default is to not detect the logic for the moment (we need to eliminate ```div```, ```mod```, ... for Yices driver). The detection can be enabled by the flag ```--smtlogic detect```, or a specified logic can be passed to the underlying SMT solver with _e.g._ ```--smtsolver QF_LIA```.


Handling of this set of features is done in a solver specific way.
  - For example, Z3 does not support ```QF_LIRA``` so it uses a larger logic ```QF_AUFLIRA``` instead.
  - CVC4 fails to output models when specified a non-linear logic (like ```QF_NRA```) so we use the logic ```ALL_SUPPORTED``` instead (maybe we need to check if this is still the case with v ```1.5```)