### PR TITLE
Parallelism fix

### DIFF
--- a/src/analysis.mli
+++ b/src/analysis.mli
@@ -20,7 +20,7 @@ open Lib
 
 (** Result returned by an analysis. *)
 type analysis_result =
-  | Ok | Timeout | Error
+  | Ok | Timeout | Error of int
 
 (** Exit status for errors. *)
 val status_error : int

--- a/src/event.ml
+++ b/src/event.ml
@@ -425,9 +425,13 @@ let proved_pt mdl level trans_sys k prop =
       (* (TransSys.named_term_of_prop_name trans_sys prop) *)
       (match TransSys.get_prop_source trans_sys prop with
        | None -> assert false
-       | Some source ->
+       | Some (TermLib.PropAnnot _ as source)
+       | Some (TermLib.Generated _ as source)
+       | Some (TermLib.Instantiated _ as source) ->
           Format.asprintf
-            "%s (%a)" prop TermLib.pp_print_prop_source source)
+            "%s (%a)" prop TermLib.pp_print_prop_source source
+       | _ -> prop)
+      
       (function ppf -> match k with
          | None -> ()
          | Some k -> Format.fprintf ppf "for k=%d " k)
@@ -994,11 +998,13 @@ let log_execution_path mdl level trans_sys path =
 
 
 (* Output summary of status of properties *)
-let log_prop_status level prop_status =
-  match !log_format with 
-    | F_pt -> prop_status_pt level prop_status
-    | F_xml -> prop_status_xml level prop_status
-    | F_relay -> ()
+let log_prop_status level = function
+  | [] -> ()
+  | prop_status ->
+     match !log_format with 
+     | F_pt -> prop_status_pt level prop_status
+     | F_xml -> prop_status_xml level prop_status
+     | F_relay -> ()
 
 
 (* Output statistics of a section of a source *)

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -353,10 +353,11 @@ let launch_analysis sys log msg_setup =
   | Analysis.Timeout ->
      (* No error, we can keep going. *)
      ()
-  | Analysis.Error ->
+  | Analysis.Error(status) ->
      (* Error, we must stop there. *)
      print_final_things sys log ;
-     exit Analysis.status_error
+     (* Exiting with corresponding status. *)
+     exit status
 
 let rec launch_compositional sys log msg_setup =
 

--- a/src/termLib.ml
+++ b/src/termLib.ml
@@ -266,5 +266,236 @@ let string_of_logic = function
   | `None -> ""
   | `Inferred l -> string_of_features l
   | `SMTLogic s -> s
+
+
+
+
+module Signals: sig
+
+  (** Pretty printer for signal info. *)
+  val pp_print_signals: Format.formatter -> unit -> unit
+
+  (** Sets the handler for sigalrm to ignore. *)
+  val ignore_sigalrm: unit -> unit
+  (** Sets the handler for sigint to ignore. *)
+  val ignore_sigint: unit -> unit
+  (** Sets the handler for sigquit to ignore. *)
+  val ignore_sigquit: unit -> unit
+  (** Sets the handler for sigterm to ignore. *)
+  val ignore_sigterm: unit -> unit
+
+  (** Sets the handler for sigalrm to [exception_on_signal] or raise
+      [TimeoutWall] depending on the flags. *)
+  val set_sigalrm: unit -> unit
+  (** Sets an exception handler for sigint. *)
+  val set_sigint: unit -> unit
+  (** Sets an exception handler for sigquit. *)
+  val set_sigquit: unit -> unit
+  (** Sets an exception handler for sigterm. *)
+  val set_sigterm: unit -> unit
+
+  (** Sets a timeout. *)
+  val set_timeout: float -> unit
+  (** Sets a timeout from the timeout flag. *)
+  val set_timeout_from_flag: unit -> unit
+  (** Deactivates timeout. *)
+  val unset_timeout: unit -> unit
+
+  (** Raise exception on ctrl+c if true. *)
+  val catch_break: bool -> unit
+
+end = struct
+
+  type handler = | Ignore | Exn | Timeout
+
+  let pp_print_handler fmt = function
+    | Ignore ->
+       Format.fprintf
+         fmt
+         "ignore"
+    | Exn ->
+       Format.fprintf
+         fmt
+         "raise exception"
+    | Timeout ->
+       Format.fprintf
+         fmt
+         "raise timeout"
+
+  type t = {
+      (* Signals. *)
+      mutable sigalrm: handler ;
+      mutable sigint:  handler ;
+      mutable sigquit: handler ;
+      mutable sigterm: handler ;
+
+      (* Timeout value. *)
+      mutable timeout: float option ;
+
+      (* Raise [Break] on ctrl+c. *)
+      mutable break: bool ;
+  }
+
+  let signals = {
+      sigalrm = Ignore ;
+      sigint  = Ignore ;
+      sigterm = Ignore ;
+      sigquit = Ignore ;
+      timeout = None   ;
+      break   = false  ;
+  }
+
+  let pp_print_signals fmt () =
+    Format.fprintf
+      fmt
+      "Signals: @[<v>\
+       sigalrm | %a@ \
+       sigint  | %a@ \
+       sigquit | %a@ \
+       sigterm | %a@ \
+       timeout | %a@ \
+       break   | %b@]"
+      pp_print_handler signals.sigalrm
+      pp_print_handler signals.sigint
+      pp_print_handler signals.sigquit
+      pp_print_handler signals.sigterm
+      (pp_print_option Format.pp_print_float)
+      signals.timeout
+      signals.break
+
+  let catch_break b =
+    if signals.break = b then ()
+    else (
+      signals.break <- b ;
+      Sys.catch_break b
+    )
+
+  (* Sets the handler to ignore for some signal. *)
+  let ignore_sig s =
+    Sys.set_signal s Sys.Signal_ignore
+
+  (* Sets the handler for sigalrm to ignore. *)
+  let ignore_sigalrm () =
+    if signals.sigalrm = Ignore then ()
+    else (
+      signals.sigalrm <- Ignore ;
+      ignore_sig Sys.sigalrm
+    )
+
+  (* Sets the handler for sigint to ignore. *)
+  let ignore_sigint () =
+    if signals.sigint = Ignore then ()
+    else (
+      signals.sigint <- Ignore ;
+      ignore_sig Sys.sigint
+    )
+
+  (* Sets the handler for sigquit to ignore. *)
+  let ignore_sigquit () =
+    if signals.sigquit = Ignore then ()
+    else (
+      signals.sigquit <- Ignore ;
+      ignore_sig Sys.sigquit
+    )
+
+  (* Sets the handler for sigterm to ignore. *)
+  let ignore_sigterm () =
+    if signals.sigterm = Ignore then ()
+    else (
+      signals.sigterm <- Ignore ;
+      ignore_sig Sys.sigterm
+    )
+
+  (* Ignore all signals. *)
+  let ignore_all_sigs () =
+    ignore_sigalrm () ;
+    ignore_sigint () ;
+    ignore_sigquit () ;
+    ignore_sigterm () ;
+    catch_break false
+
+  (* Sets a handler for a signal. *)
+  let set_sig s f =
+    Sys.set_signal s ( Sys.Signal_handle f )
+
+
+  (* Sets a handler for sigalrm. *)
+  let set_sigalrm () =
+    (* If there is a timeout, then raise [TimeoutWall]. Otherwise use
+       usual exeption thing. *)
+    let behavior, handler =
+      if Flags.timeout_wall () >  0. then
+	(fun _ -> raise TimeoutWall), Timeout
+      else
+	exception_on_signal, Exn
+    in
+
+    (* Only changing if necessary. *)
+    if signals.sigalrm = handler then ()
+    else (
+      signals.sigalrm <- handler ;
+      set_sig Sys.sigalrm behavior
+    )
+
+  (* Sets a handler for sigint. *)
+  let set_sigint () =
+    if signals.sigint = Exn then ()
+    else (
+      signals.sigint <- Exn ;
+      set_sig Sys.sigint exception_on_signal
+    )
+
+  (* Sets a handler for sigquit. *)
+  let set_sigquit () =
+    if signals.sigquit = Exn then ()
+    else (
+      signals.sigquit <- Exn ;
+      set_sig Sys.sigquit exception_on_signal
+    )
+
+  (* Sets a handler for sigterm. *)
+  let set_sigterm () =
+    if signals.sigterm = Exn then ()
+    else (
+      signals.sigterm <- Exn ;
+      set_sig Sys.sigterm exception_on_signal
+    )
+
+
+  (* Sets a timeout. *)
+  let set_timeout_value ?(interval = 0.) value =
+    Unix.setitimer
+      Unix.ITIMER_REAL
+      { Unix.it_interval = interval ;
+        Unix.it_value = value }
+    |> ignore
+
+  (* Sets a timeout. *)
+  let set_timeout value =
+    signals.timeout <- Some(value) ;
+    set_timeout_value value
+
+  (* Sets a timeout based on the flag value. *)
+  let set_timeout_from_flag () =
+    if Flags.timeout_wall () > 0.
+    then Flags.timeout_wall () |> set_timeout else ()
+
+  (* Deactivates timeout. *)
+  let unset_timeout () =
+    if signals.timeout = None then ()
+    else (
+      signals.timeout <- None ;
+      set_timeout_value 0.
+    )
+
+  end
+
+(* 
+   Local Variables:
+   compile-command: "make -C .. -k"
+   tuareg-interactive-program: "./kind2.top -I ./_build -I ./_build/SExpr"
+   indent-tabs-mode: nil
+   End: 
+*)
   
 

--- a/src/termLib.mli
+++ b/src/termLib.mli
@@ -106,3 +106,47 @@ val pp_print_logic : Format.formatter -> logic -> unit
 (** String correspinding to a logic *)
 val string_of_logic : logic -> string
 
+(** Gathers signal related stuff. *)
+module Signals: sig
+
+  (** Pretty printer for signal info. *)
+  val pp_print_signals: Format.formatter -> unit -> unit
+
+  (** Sets the handler for sigalrm to ignore. *)
+  val ignore_sigalrm: unit -> unit
+  (** Sets the handler for sigint to ignore. *)
+  val ignore_sigint: unit -> unit
+  (** Sets the handler for sigquit to ignore. *)
+  val ignore_sigquit: unit -> unit
+  (** Sets the handler for sigterm to ignore. *)
+  val ignore_sigterm: unit -> unit
+
+  (** Sets a handler for sigalrm. *)
+  val set_sigalrm: unit -> unit
+  (** Sets a handler for sigint. *)
+  val set_sigint: unit -> unit
+  (** Sets a handler for sigquit. *)
+  val set_sigquit: unit -> unit
+  (** Sets a handler for sigterm. *)
+  val set_sigterm: unit -> unit
+
+  (** Sets a timeout. *)
+  val set_timeout: float -> unit
+  (** Sets a timeout based on the timeout flag. *)
+  val set_timeout_from_flag: unit -> unit
+  (** Deactivates timeout. *)
+  val unset_timeout: unit -> unit
+
+  (** Raise exception on ctrl+c if true. *)
+  val catch_break: bool -> unit
+
+end
+ 
+(* 
+   Local Variables:
+   compile-command: "make -C .. -k"
+   tuareg-interactive-program: "./kind2.top -I ./_build -I ./_build/SExpr"
+   indent-tabs-mode: nil
+   End: 
+*)
+


### PR DESCRIPTION
Fixes the odd parallelism issues we had so far. The problem seems to be that when sending sigterm to terminate kids, setting a timeout and waiting for the answer or the end of the timeout, sigalarm was ignored. Since the timeout throws sigalarm, it was missed by the supervisor / invariant manager causing it to hang.

This is fixed, but unfortunately does not completely work. For some reason sending sigterm to the kids does not seem to be doing anything.

So right now, the supervisor sends sigterm to the kids, sets a timeout of 0.3 seconds, and waits observing the kids. The kids do not respond to the sigterm and the supervisor timeouts, at which point it sends them sigkills and wait without a timeout. If after that some kids are still alive (maybe the user ctrl+c-ed), a warning is output to the user advising to kill the processes by hand. This has yet to happen during my tests.

# TermLib.Signals

Signal related code has been factored in the TermLib.Signals module. Any modification in signal handling / timeouts / catch_break should go through the functions defined in this module.

The point is that it keeps track of the state of the signal handlers and the timeout settings.
```ocaml
val pp_print_signals: Format.formatter -> unit -> unit
```
pretty prints this state, making it easier to debug signal related problems.