### PR TITLE
Native input

### DIFF
--- a/examples/two_counters.kind2
+++ b/examples/two_counters.kind2
@@ -1,148 +1,153 @@
 (define-node intcounter
-  
-  ((transSys.x_is_init_x Bool)
-   (intcounter.reset Bool :input :for-inv-gen)
-   (intcounter.max Int :const :input :for-inv-gen)
-   (intcounter.out Bool :for-inv-gen)
-   (intcounter.t Int :for-inv-gen))
+((transSys.x_is_init_x Bool)
+ (intcounter.reset Bool :input :for-inv-gen)
+ (intcounter.max Int :const :input :for-inv-gen)
+ (intcounter.out Bool :for-inv-gen)
+ (intcounter.t Int :for-inv-gen))
 
   (init
-   (and
-    transSys.x_is_init_x
-    (= intcounter.t 0)
-    (= intcounter.out (= intcounter.t 2))))
+    (and
+     transSys.x_is_init_x
+     (= intcounter.t 0)
+     (= intcounter.out (= intcounter.t 2))))
 
   (trans
-   (and
-    (not (prime transSys.x_is_init_x))
-    (=
-     (prime intcounter.t)
-     (ite
-      (or (prime intcounter.reset) (= intcounter.t intcounter.max))
-      0
-      (+ intcounter.t 1)))
-    (= (prime intcounter.out) (= (prime intcounter.t) 2))))
+    (and
+     (not (prime transSys.x_is_init_x))
+     (=
+      (prime intcounter.t)
+      (ite
+       (or (prime intcounter.reset) (= intcounter.t intcounter.max))
+       0
+       (+ intcounter.t 1)))
+     (= (prime intcounter.out) (= (prime intcounter.t) 2))))
 
   (callers
-   ((top
+    (top
      ((transSys.x_is_init_x transSys.x_is_init_x)
       (intcounter.max top.__abs_2)
       (intcounter.reset top.__abs_0)
       (intcounter.t top.__abs_4)
       (intcounter.out top.__abs_3))
-     (fun t t))))
+      (lambda ((X1 Bool)) (X1))))
+
   )
 
 
 (define-node greycounter
-
-  ((transSys.x_is_init_x Bool)
-   (greycounter.reset Bool :input :for-inv-gen)
-   (greycounter.out Bool :for-inv-gen)
-   (greycounter.a Bool :for-inv-gen)
-   (greycounter.b Bool :for-inv-gen))
+((transSys.x_is_init_x Bool)
+ (greycounter.reset Bool :input :for-inv-gen)
+ (greycounter.out Bool :for-inv-gen)
+ (greycounter.a Bool :for-inv-gen)
+ (greycounter.b Bool :for-inv-gen))
 
   (init
-   (and
-    transSys.x_is_init_x
-    (= greycounter.b false)
-    (= greycounter.a false)
-    (= greycounter.out (and greycounter.a greycounter.b))))
+    (and
+     transSys.x_is_init_x
+     (= greycounter.b false)
+     (= greycounter.a false)
+     (= greycounter.out (and greycounter.a greycounter.b))))
 
   (trans
-   (and
-    (not (prime transSys.x_is_init_x))
-    (= (prime greycounter.b) (and (not (prime greycounter.reset)) greycounter.a))
-    (= (prime greycounter.a) (and (not (prime greycounter.reset)) (not greycounter.b)))
-    (= (prime greycounter.out) (and (prime greycounter.a) (prime greycounter.b)))))
+    (and
+     (not (prime transSys.x_is_init_x))
+     (=
+      (prime greycounter.b)
+      (and (not (prime greycounter.reset)) greycounter.a))
+     (=
+      (prime greycounter.a)
+      (and (not (prime greycounter.reset)) (not greycounter.b)))
+     (=
+      (prime greycounter.out)
+      (and (prime greycounter.a) (prime greycounter.b)))))
 
   (callers
-   ((top
+    (top
      ((transSys.x_is_init_x transSys.x_is_init_x)
       (greycounter.reset top.__abs_0)
       (greycounter.a top.__abs_6)
       (greycounter.b top.__abs_5)
       (greycounter.out top.__abs_1))
-     (fun t t))))
+      (lambda ((X1 Bool)) (X1))))
+
   )
 
 
 (define-node top
-
-  ((transSys.x_is_init_x Bool)
-   (top.reset Bool :input :for-inv-gen)
-   (top.OK Bool :for-inv-gen)
-   (top.OK2 Bool :for-inv-gen)
-   (top.__abs_0 Bool :for-inv-gen)
-   (top.__abs_1 Bool :for-inv-gen)
-   (top.__abs_2 (IntRange 3 3) :const :for-inv-gen)
-   (top.__abs_3 Bool :for-inv-gen)
-   (top.__abs_4 Int :for-inv-gen)
-   (top.__abs_5 Bool :for-inv-gen)
-   (top.__abs_6 Bool :for-inv-gen))
+((transSys.x_is_init_x Bool)
+ (top.reset Bool :input :for-inv-gen)
+ (top.OK Bool :for-inv-gen)
+ (top.OK2 Bool :for-inv-gen)
+ (top.__abs_0 Bool :for-inv-gen)
+ (top.__abs_1 Bool :for-inv-gen)
+ (top.__abs_2 (IntRange 3 3) :const :for-inv-gen)
+ (top.__abs_3 Bool :for-inv-gen)
+ (top.__abs_4 Int :for-inv-gen)
+ (top.__abs_5 Bool :for-inv-gen)
+ (top.__abs_6 Bool :for-inv-gen))
 
   (init
-   (and
-    transSys.x_is_init_x
-    (= top.__abs_0 top.reset)
-    (let
-        ((X1 top.__abs_3))
+    (and
+     transSys.x_is_init_x
+     (= top.__abs_0 top.reset)
+     (let
+      ((X1 top.__abs_3))
       (and
        (= top.OK2 (not X1))
        (let
-           ((X2 top.__abs_1))
-         (and
-          (= top.OK (= X2 X1))
-          (= top.__abs_2 3)
-          (__node_init_greycounter
-           transSys.x_is_init_x
-           top.__abs_0
-           top.__abs_1
-           top.__abs_6
-           top.__abs_5)
-          (__node_init_intcounter
-           transSys.x_is_init_x
-           top.__abs_0
-           top.__abs_2
-           top.__abs_3
-           top.__abs_4)))))))
+        ((X2 top.__abs_1))
+        (and
+         (= top.OK (= X2 X1))
+         (= top.__abs_2 3)
+         (__node_init_greycounter
+          transSys.x_is_init_x
+          top.__abs_0
+          top.__abs_1
+          top.__abs_6
+          top.__abs_5)
+         (__node_init_intcounter
+          transSys.x_is_init_x
+          top.__abs_0
+          top.__abs_2
+          top.__abs_3
+          top.__abs_4)))))))
+
   (trans
-   (and
-    (not (prime transSys.x_is_init_x))
-    (= (prime top.__abs_0) (prime top.reset))
-    (let
-        ((X1 (prime top.__abs_3)))
+    (and
+     (not (prime transSys.x_is_init_x))
+     (= (prime top.__abs_0) (prime top.reset))
+     (let
+      ((X1 (prime top.__abs_3)))
       (and
        (= (prime top.OK2) (not X1))
        (let
-           ((X2 (prime top.__abs_1)))
-         (and
-          (= (prime top.OK) (= X2 X1))
-          (= top.__abs_2 3)
-          (__node_trans_greycounter
-           (prime transSys.x_is_init_x)
-           (prime top.__abs_0)
-           (prime top.__abs_1)
-           (prime top.__abs_6)
-           (prime top.__abs_5)
-           transSys.x_is_init_x
-           top.__abs_0
-           top.__abs_1
-           top.__abs_6
-           top.__abs_5)
-          (__node_trans_intcounter
-           (prime transSys.x_is_init_x)
-           (prime top.__abs_0)
-           top.__abs_2
-           (prime top.__abs_3)
-           (prime top.__abs_4)
-           transSys.x_is_init_x
-           top.__abs_0
-           top.__abs_3
-           top.__abs_4)))))))
-  
+        ((X2 (prime top.__abs_1)))
+        (and
+         (= (prime top.OK) (= X2 X1))
+         (= top.__abs_2 3)
+         (__node_trans_greycounter
+          (prime transSys.x_is_init_x)
+          (prime top.__abs_0)
+          (prime top.__abs_1)
+          (prime top.__abs_6)
+          (prime top.__abs_5)
+          transSys.x_is_init_x
+          top.__abs_0
+          top.__abs_1
+          top.__abs_6
+          top.__abs_5)
+         (__node_trans_intcounter
+          (prime transSys.x_is_init_x)
+          (prime top.__abs_0)
+          top.__abs_2
+          (prime top.__abs_3)
+          (prime top.__abs_4)
+          transSys.x_is_init_x
+          top.__abs_0
+          top.__abs_3
+          top.__abs_4)))))))
 
-  (props ((OK2 top.OK2)
-          (OK top.OK)))
+  (props ((OK2 top.OK2 :user :26-4)
+          (OK top.OK :user :25-4)))
 
   )

--- a/examples/two_counters.kind2
+++ b/examples/two_counters.kind2
@@ -1,73 +1,148 @@
-(define-pred greycounter
-
-  ((reset Bool)
-   (out Bool)
-   (a Bool)
-   (b Bool))
+(define-node intcounter
   
-  (init 
-   (and
-    (= b false)
-    (= a false)
-    (= out (and a b))))
-  
-  (trans
-   (and	
-    (= (prime b) (and (not (prime reset)) a))
-    (= (prime a) (and (not (prime reset)) (not b)))
-    (= (prime out) (and (prime a) (prime b))))))
-
-(define-pred intcounter
-  
-  ((reset Bool)
-   (max Int :const)
-   (out Bool)
-   (t Int))
+  ((transSys.x_is_init_x Bool)
+   (intcounter.reset Bool :input :for-inv-gen)
+   (intcounter.max Int :const :input :for-inv-gen)
+   (intcounter.out Bool :for-inv-gen)
+   (intcounter.t Int :for-inv-gen))
 
   (init
    (and
-    (= t 0)
-    (= out (= t 2))))
-  
+    transSys.x_is_init_x
+    (= intcounter.t 0)
+    (= intcounter.out (= intcounter.t 2))))
+
   (trans
    (and
-    (= (prime t) (ite (or (prime reset) (= t max)) 0 (+ t 1)))
-    (= (prime out) (= (prime t) 2)))))
+    (not (prime transSys.x_is_init_x))
+    (=
+     (prime intcounter.t)
+     (ite
+      (or (prime intcounter.reset) (= intcounter.t intcounter.max))
+      0
+      (+ intcounter.t 1)))
+    (= (prime intcounter.out) (= (prime intcounter.t) 2))))
 
-(define-pred top
-  ((reset Bool)
-   (OK Bool)
-   (b Bool)
-   (d Bool)
-   (g.a Bool)
-   (g.b Bool)
-   (i.t Int))
+  (callers
+   ((top
+     ((transSys.x_is_init_x transSys.x_is_init_x)
+      (intcounter.max top.__abs_2)
+      (intcounter.reset top.__abs_0)
+      (intcounter.t top.__abs_4)
+      (intcounter.out top.__abs_3))
+     (fun t t))))
+  )
+
+
+(define-node greycounter
+
+  ((transSys.x_is_init_x Bool)
+   (greycounter.reset Bool :input :for-inv-gen)
+   (greycounter.out Bool :for-inv-gen)
+   (greycounter.a Bool :for-inv-gen)
+   (greycounter.b Bool :for-inv-gen))
 
   (init
    (and
-    (= OK (= b d))
-    (greycounter.init reset b g.a g.b)
-    (intcounter.init reset 3 d i.t)))
+    transSys.x_is_init_x
+    (= greycounter.b false)
+    (= greycounter.a false)
+    (= greycounter.out (and greycounter.a greycounter.b))))
 
   (trans
    (and
-    (= (prime OK) (= (prime b) (prime d)))
-    (greycounter.trans 
-     reset
-     b
-     g.a
-     g.b
-     (prime reset)
-     (prime b)
-     (prime g.a)
-     (prime g.b))
-    (intcounter.trans
-     reset
-     3
-     d
-     i.t
-     (prime reset)
-     (prime d)
-     (prime i.t)))))
+    (not (prime transSys.x_is_init_x))
+    (= (prime greycounter.b) (and (not (prime greycounter.reset)) greycounter.a))
+    (= (prime greycounter.a) (and (not (prime greycounter.reset)) (not greycounter.b)))
+    (= (prime greycounter.out) (and (prime greycounter.a) (prime greycounter.b)))))
 
-(check-prop ((OK OK)))
+  (callers
+   ((top
+     ((transSys.x_is_init_x transSys.x_is_init_x)
+      (greycounter.reset top.__abs_0)
+      (greycounter.a top.__abs_6)
+      (greycounter.b top.__abs_5)
+      (greycounter.out top.__abs_1))
+     (fun t t))))
+  )
+
+
+(define-node top
+
+  ((transSys.x_is_init_x Bool)
+   (top.reset Bool :input :for-inv-gen)
+   (top.OK Bool :for-inv-gen)
+   (top.OK2 Bool :for-inv-gen)
+   (top.__abs_0 Bool :for-inv-gen)
+   (top.__abs_1 Bool :for-inv-gen)
+   (top.__abs_2 (IntRange 3 3) :const :for-inv-gen)
+   (top.__abs_3 Bool :for-inv-gen)
+   (top.__abs_4 Int :for-inv-gen)
+   (top.__abs_5 Bool :for-inv-gen)
+   (top.__abs_6 Bool :for-inv-gen))
+
+  (init
+   (and
+    transSys.x_is_init_x
+    (= top.__abs_0 top.reset)
+    (let
+        ((X1 top.__abs_3))
+      (and
+       (= top.OK2 (not X1))
+       (let
+           ((X2 top.__abs_1))
+         (and
+          (= top.OK (= X2 X1))
+          (= top.__abs_2 3)
+          (__node_init_greycounter
+           transSys.x_is_init_x
+           top.__abs_0
+           top.__abs_1
+           top.__abs_6
+           top.__abs_5)
+          (__node_init_intcounter
+           transSys.x_is_init_x
+           top.__abs_0
+           top.__abs_2
+           top.__abs_3
+           top.__abs_4)))))))
+  (trans
+   (and
+    (not (prime transSys.x_is_init_x))
+    (= (prime top.__abs_0) (prime top.reset))
+    (let
+        ((X1 (prime top.__abs_3)))
+      (and
+       (= (prime top.OK2) (not X1))
+       (let
+           ((X2 (prime top.__abs_1)))
+         (and
+          (= (prime top.OK) (= X2 X1))
+          (= top.__abs_2 3)
+          (__node_trans_greycounter
+           (prime transSys.x_is_init_x)
+           (prime top.__abs_0)
+           (prime top.__abs_1)
+           (prime top.__abs_6)
+           (prime top.__abs_5)
+           transSys.x_is_init_x
+           top.__abs_0
+           top.__abs_1
+           top.__abs_6
+           top.__abs_5)
+          (__node_trans_intcounter
+           (prime transSys.x_is_init_x)
+           (prime top.__abs_0)
+           top.__abs_2
+           (prime top.__abs_3)
+           (prime top.__abs_4)
+           transSys.x_is_init_x
+           top.__abs_0
+           top.__abs_3
+           top.__abs_4)))))))
+  
+
+  (props ((OK2 top.OK2)
+          (OK top.OK)))
+
+  )

--- a/src/SMTExpr.ml
+++ b/src/SMTExpr.ml
@@ -162,9 +162,11 @@ struct
         (* Annotated term *)
         | Term.T.Attr (t, _) -> var_term_of_smtexpr t
 
+        (* Already variables *)
+        | Term.T.Var _ -> e
+  
         (* Other expressions *)
-        | Term.T.App _ 
-        | Term.T.Var _ -> 
+        | Term.T.App _ -> 
 
           invalid_arg 
             "var_of_smtexpr: \

--- a/src/event.ml
+++ b/src/event.ml
@@ -448,14 +448,10 @@ let pp_print_counterexample_pt level trans_sys prop_name ppf = function
         (* Native input *)
         | TransSys.Native ->
 
-          assert false
-
-      (*
           (* Output counterexample *)
           Format.fprintf ppf 
-            "Counterexample:@,%a"
-            NativeInput.pp_print_path_pt cex
-*)
+            "Counterexample:@,%a" NativeInput.pp_print_path_pt cex
+
 
     )
 

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -539,7 +539,7 @@ let string_of_input_format = function
 
 let input_format_values = "lustre, native"
 
-let input_format_default = `Lustre
+let input_format_default = `Default
 
 (* ********** *) 
 
@@ -617,7 +617,7 @@ type flags =
       mutable debug_log : string option;
       mutable log_level : log_level;
       mutable log_format_xml : bool;
-      mutable input_format : input_format;
+      mutable input_format : [`Default | input_format];
       mutable input_file : string option }
     
 (* Defaults for all flags *)
@@ -1171,7 +1171,7 @@ let input_format_spec =
    Arg.String input_format_action, 
    Format.sprintf "Format of input file (available: %s, default: %s)"
                   input_format_values
-                  (string_of_input_format input_format_default))
+                  (string_of_input_format `Lustre))
 
 
 (* ********************************************************************** *)
@@ -1279,11 +1279,29 @@ let log_level () = flags.log_level
 
 let log_format_xml () = flags.log_format_xml
 
-let input_format () = flags.input_format 
-
 let input_file () = match flags.input_file with 
   | Some f -> f 
   | None -> failwith "No input file given"
+
+let input_format () =
+  match flags.input_format with
+
+  (* If the input format has been specified, use it independently of the file
+     extension *)
+  | `Lustre | `Native | `Horn as f -> f
+
+  (* If the input format has not been specified infer it with the file
+     extension *)
+  | `Default ->
+    try
+      let f = input_file () in
+      if Filename.check_suffix f "lus"
+      || Filename.check_suffix f "ec" then `Lustre
+      else if Filename.check_suffix f "smt2" then `Horn
+      else if Filename.check_suffix f "kind2"
+           || Filename.check_suffix f "k2" then `Native
+      else `Lustre
+    with Failure _ -> `Lustre
 
 
 (* ********************************************************************** *)

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -543,6 +543,18 @@ let input_format_default = `Default
 
 (* ********** *) 
 
+type dump_native = bool
+
+let dump_native_default = false
+
+(* ********** *) 
+
+type dump_dir = string
+
+let dump_dir_default = Sys.getcwd ()
+
+(* ********** *) 
+
 type lustre_main = string option
 
 let lustre_main_of_string s = Some s
@@ -582,6 +594,8 @@ type flags =
       mutable yices2smt2_bin : yices2smt2_bin;
       mutable smt_trace : smt_trace;
       mutable smt_trace_dir : smt_trace_dir;
+      mutable dump_native : dump_native;
+      mutable dump_dir : dump_dir;
       mutable enable : enable;
       mutable check_version : check_version;
       mutable bmc_max : bmc_max;
@@ -633,6 +647,8 @@ let flags =
     yices2smt2_bin = yices2smt2_bin_default;
     smt_trace = smt_trace_default;
     smt_trace_dir = smt_trace_dir_default;
+    dump_native = dump_native_default;
+    dump_dir = dump_dir_default;
     enable = enable_default_init;
     check_version = check_version_default;
     bmc_max = bmc_max_default;
@@ -779,6 +795,24 @@ let smt_trace_dir_spec =
    Arg.String smt_trace_dir_action, 
    Format.sprintf "Directory for trace logs of SMT commands (default: %s)"
                   smt_trace_dir_default)
+(* ********** *) 
+
+let dump_native_action o = flags.dump_native <- true
+  
+let dump_native_spec = 
+  ("--dump_native", 
+   Arg.Unit dump_native_action, 
+   Format.sprintf "Dump transition system in native format")
+
+(* ********** *) 
+
+let dump_dir_action o = flags.dump_dir <- o
+  
+let dump_dir_spec = 
+  ("--dump_dir", 
+   Arg.String dump_dir_action, 
+   Format.sprintf "Directory for dumping files (default: %s)"
+                  dump_dir_default)
 
 (* ********** *) 
 
@@ -1205,6 +1239,10 @@ let smt_trace () = flags.smt_trace
 
 let smt_trace_dir () = flags.smt_trace_dir
 
+let dump_native () = flags.dump_native
+
+let dump_dir () = flags.dump_dir
+
 let enable () = flags.enable 
 
 let check_version () = flags.check_version 
@@ -1350,6 +1388,12 @@ and speclist =
 
     (* Directory for  trace logs of SMT commands *)
     smt_trace_dir_spec;
+
+    (* Dump to native format *)
+    dump_native_spec;
+
+    (* Dump directory *)
+    dump_dir_spec;
 
     (* Set enabled modules *)
     enable_spec;

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -84,6 +84,14 @@ val smt_trace : unit -> smt_trace
 type smt_trace_dir = string 
 val smt_trace_dir : unit -> smt_trace_dir
 
+(** Dumping to native format *)
+type dump_native = bool
+val dump_native : unit -> dump_native
+
+(** Directory for dumping files *)
+type dump_dir = string 
+val dump_dir : unit -> dump_dir
+
 (** Enabled Kind modules *)
 type enable = Lib.kind_module list
 val enable : unit -> enable 

--- a/src/genericSMTLIBDriver.ml
+++ b/src/genericSMTLIBDriver.ml
@@ -71,6 +71,9 @@ type expr_of_string_sexpr_conv =
     (* String constant for unary minus operator *) 
     s_minus : HString.t;
 
+    (* String constant for prime symbol if there is one *) 
+    prime_symbol : HString.t option;
+
     (* String constant for define-fun keyword *) 
     s_define_fun : HString.t;
 
@@ -173,12 +176,13 @@ let gen_expr_of_string_sexpr'
        s_forall; 
        s_exists; 
        s_div; 
-       s_minus; 
+       s_minus;
+       prime_symbol;
        const_of_atom; 
        symbol_of_atom;
        expr_of_string_sexpr;
        expr_or_lambda_of_string_sexpr } as conv)
-    bound_vars = 
+    bound_vars =
 
   function 
 
@@ -301,11 +305,19 @@ let gen_expr_of_string_sexpr'
           (HString.string_of_hstring d |> of_string))
 
 
-    (* Atom or singleton list *)
+    (* Atom *)
     | HStringSExpr.Atom s ->
 
       (* Leaf in the symbol tree *)
       (const_of_atom bound_vars s)
+
+    (* Prime symbol if it exists *)
+    | HStringSExpr.List [HStringSExpr.Atom s; e]
+      when (match prime_symbol with
+          | None -> false
+          | Some s' -> s == s') -> 
+
+      expr_of_string_sexpr conv bound_vars e |> Term.bump_state Numeral.one
 
     (*  A list with more than one element *)
     | HStringSExpr.List ((HStringSExpr.Atom h) :: tl) -> 
@@ -414,8 +426,8 @@ let gen_expr_or_lambda_of_string_sexpr' ({ s_define_fun } as conv) bound_vars =
     | _ -> invalid_arg "gen_expr_of_lambda_string_sexpr"
 
 
-(* Call function with an empty list of bound variables *)      
-let gen_expr_of_string_sexpr conv = 
+(* Call function with an empty list of bound variables and no prime symbol *)
+let gen_expr_of_string_sexpr conv =
   gen_expr_of_string_sexpr' conv [] 
 
 (* Call function with an empty list of bound variables *)      
@@ -703,6 +715,25 @@ let const_of_smtlib_atom b t =
 
                   try 
 
+                    (* Name of state variable *)
+                    let state_var_name = HString.string_of_hstring t in
+
+                    (* State variable of name and given scope *)
+                    let state_var = 
+                      StateVar.state_var_of_long_string state_var_name in
+
+                    (* State variable at instant zero *)
+                    let var = 
+                      Var.mk_state_var_instance state_var Numeral.zero in
+
+                    (* Return term *)
+                    Term.mk_var var
+
+                (* String is not a state variable *)
+                with Not_found -> 
+
+                  try 
+
                     (* Return uninterpreted constant *)
                     Term.mk_uf 
                       (UfSymbol.uf_symbol_of_string
@@ -766,6 +797,7 @@ let smtlib_string_sexpr_conv =
     s_div = HString.mk_hstring "/";
     s_minus = HString.mk_hstring "-";
     s_define_fun = HString.mk_hstring "define-fun";
+    prime_symbol = None;
     const_of_atom = const_of_smtlib_atom;
     symbol_of_atom = symbol_of_smtlib_atom;
     type_of_sexpr = type_of_smtlib_sexpr;

--- a/src/genericSMTLIBDriver.ml
+++ b/src/genericSMTLIBDriver.ml
@@ -606,7 +606,7 @@ let string_of_symbol ?arity s = string_of_t (pp_print_symbol ?arity) s
 
 
 let pp_print_term ppf t =
-  Term.T.pp_print_term_w pp_print_symbol ppf t
+  Term.T.pp_print_term_w pp_print_symbol Var.pp_print_var ppf t
         
     
 (* Pretty-print an expression *)

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -873,7 +873,10 @@ let main () =
             
         | `Native -> 
 
-          Some (NativeInput.of_file (Flags.input_file ()))
+          let sys = NativeInput.of_file (Flags.input_file ()) in
+          if Flags.dump_native () then NativeInput.dump_native sys;
+          
+          Some sys
 
         | `Horn -> 
           
@@ -883,7 +886,7 @@ let main () =
     (* Output the transition system *)
     (debug parse
         "%a"
-        TransSys.pp_print_trans_sys
+        NativeInput.pp_print_native
         (get !trans_sys)
      end);
 

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -872,18 +872,8 @@ let main () =
                (Flags.input_file ()))
             
         | `Native -> 
-          
-          (
 
-          (* Some (NativeInput.of_file (Flags.input_file ())) *)
-
-            Event.log
-              L_fatal
-              "Native input deactivated while refactoring transition system.";
-          
-            assert false
-
-          )
+          Some (NativeInput.of_file (Flags.input_file ()))
 
         | `Horn -> 
           

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -873,16 +873,17 @@ let main () =
             
         | `Native -> 
 
-          let sys = NativeInput.of_file (Flags.input_file ()) in
-          if Flags.dump_native () then NativeInput.dump_native sys;
-          
-          Some sys
+          Some (NativeInput.of_file (Flags.input_file ()))
 
         | `Horn -> 
           
           (* Horn.of_file (Flags.input_file ()) *)
           assert false);
 
+
+    (* Dump transition system *)
+    if Flags.dump_native () then NativeInput.dump_native (get !trans_sys);
+    
     (* Output the transition system *)
     (debug parse
         "%a"

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1227,6 +1227,13 @@ let extract_scope_name name =
   loop name []
 
 
+
+(* Create a directory if it does not already exists. *)
+let create_dir dir =
+  try if not (Sys.is_directory dir) then failwith (dir^" is not a directory")
+  with Sys_error _ -> Unix.mkdir dir 0o755
+
+
 (* 
    Local Variables:
    compile-command: "make -C .. -k"

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1204,6 +1204,28 @@ let file_row_col_of_pos = function
   | { pos_fname; pos_lnum; pos_cnum } -> (pos_fname, pos_lnum, pos_cnum)
 
 
+let pos_of_file_row_col (pos_fname, pos_lnum, pos_cnum) =
+  { pos_fname; pos_lnum; pos_cnum }
+
+
+(* Split a string at its first dot. Raises {Not_found} if there are not dots *)
+let split_dot s =
+  let open String in
+  let n = (index s '.') in
+  sub s 0 n, sub s (n+1) (length s - n - 1)
+
+
+(* Extract scope from a concatenated name *)
+let extract_scope_name name =
+
+  let rec loop s scope =
+    try
+      let next_scope, s' = split_dot s in
+      loop s' (next_scope :: scope)
+    with Not_found -> s, List.rev scope
+  in
+  loop name []
+
 
 (* 
    Local Variables:

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -332,8 +332,14 @@ val pp_print_position : Format.formatter -> position -> unit
     position *)
 val file_row_col_of_pos : position -> string * int * int
 
+(** Inverse of {!file_row_col_of_pos} *)
+val pos_of_file_row_col : string * int * int -> position
+
 (** Convert a position of the lexer to a position *)
 val position_of_lexing : Lexing.position -> position
+
+(** Extract scope from a concatenated name *)
+val extract_scope_name : string -> string * string list
  
 (* 
    Local Variables:

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -340,7 +340,10 @@ val position_of_lexing : Lexing.position -> position
 
 (** Extract scope from a concatenated name *)
 val extract_scope_name : string -> string * string list
- 
+
+(* Create a directory if it does not already exists. *)
+val create_dir : string -> unit
+
 (* 
    Local Variables:
    compile-command: "make -C .. -k"

--- a/src/ltree.ml
+++ b/src/ltree.ml
@@ -157,10 +157,14 @@ sig
 
   val pp_print_term : ?db:int -> Format.formatter -> t -> unit
     
-  val pp_print_lambda_w : (?arity:int -> Format.formatter -> symbol -> unit) ->
+  val pp_print_lambda_w :
+    (?arity:int -> Format.formatter -> symbol -> unit) ->
+    (Format.formatter -> var -> unit) ->
     ?db:int -> Format.formatter -> lambda -> unit
 
-  val pp_print_term_w : (?arity:int -> Format.formatter -> symbol -> unit) ->
+  val pp_print_term_w :
+    (?arity:int -> Format.formatter -> symbol -> unit) ->
+    (Format.formatter -> var -> unit) ->
     ?db:int -> Format.formatter -> t -> unit
 
   val print_term : ?db:int -> t -> unit
@@ -606,7 +610,7 @@ struct
 
   (* Pretty-print a lambda abstraction given the de Bruijn index of
      the most recent bound variable *)
-  let rec pp_print_lambda' pp_symbol db ppf = function 
+  let rec pp_print_lambda' pp_symbol pp_var db ppf = function 
 
     | { H.node = L (l, t) } ->
 
@@ -615,11 +619,11 @@ struct
       Format.fprintf ppf
         "@[<hv 1>(lambda@ (%a)@ (%a))@]"
         (pp_print_var_seq db) l
-        (pp_print_term' pp_symbol (db + (List.length l))) t
+        (pp_print_term' pp_symbol pp_var (db + (List.length l))) t
 
 
   (* Pretty-print a list of variable term bindings *)
-  and pp_print_let_bindings pp_symbol i db ppf = function 
+  and pp_print_let_bindings pp_symbol pp_var i db ppf = function 
 
     (* Print nothing for the empty list *)
     | [] -> ()
@@ -635,20 +639,20 @@ struct
         ppf 
         "@[<hv 1>(X%i@ %a)@]" 
         db' 
-        (pp_print_term' pp_symbol (db - i)) t;
+        (pp_print_term' pp_symbol pp_var (db - i)) t;
 
       (* Add space and recurse if more bindings follow *)
       if not (tl = []) then 
         (Format.pp_print_space ppf (); 
-         pp_print_let_bindings pp_symbol (succ i) db' ppf tl)
+         pp_print_let_bindings pp_symbol pp_var (succ i) db' ppf tl)
 
 
   (* Pretty-print a higer-order abstract syntax term given the de
      Bruijn index of the most recent bound variable *)
-  and pp_print_term' pp_symbol db ppf = function 
+  and pp_print_term' pp_symbol pp_var db ppf = function 
 
     (* Delegate printing of free variables to function in input module *)
-    | { H.node = FreeVar v } -> T.pp_print_var ppf v
+    | { H.node = FreeVar v } -> pp_var ppf v
 
     (* Print bound variable with its de Bruijn index *)
     | { H.node = BoundVar dbv } -> Format.fprintf ppf "X%i" (db - dbv + 1)
@@ -662,15 +666,15 @@ struct
       Format.fprintf ppf 
         "@[<hv 1>(%a@ %a)@]" 
         (pp_symbol ?arity:(Some (List.length a))) s 
-        (pp_print_term_list pp_symbol db) a
+        (pp_print_term_list pp_symbol pp_var db) a
 
     (* Print a let binding *)
     | { H.node = Let ({ H.node = L (_, t) }, b) } -> 
 
       Format.fprintf ppf 
         "@[<hv 1>(let@ @[<hv 1>(%a)@]@ %a)@]" 
-        (pp_print_let_bindings pp_symbol 0 db) b
-        (pp_print_term' pp_symbol (db + List.length b)) t
+        (pp_print_let_bindings pp_symbol pp_var 0 db) b
+        (pp_print_term' pp_symbol pp_var (db + List.length b)) t
 
     (* Print an existential quantification *)
     | { H.node = Exists { H.node = L (x, t) } } -> 
@@ -678,7 +682,7 @@ struct
       Format.fprintf ppf 
         "@[<hv 1>(exists@ @[<hv 1>(%a)@ %a@])@]" 
         (pp_print_typed_var_list db) x
-        (pp_print_term' pp_symbol (db + List.length x)) t
+        (pp_print_term' pp_symbol pp_var (db + List.length x)) t
 
     (* Print a universal quantification *)
     | { H.node = Forall { H.node = L (x, t) } } -> 
@@ -686,20 +690,20 @@ struct
       Format.fprintf ppf 
         "@[<hv 1>(forall@ @[<hv 1>(%a)@ %a@])@]" 
         (pp_print_typed_var_list db) x
-        (pp_print_term' pp_symbol (db + List.length x)) t
+        (pp_print_term' pp_symbol pp_var (db + List.length x)) t
 
     (* Print an annotated term *)
     | { H.node = Annot (t, a) } ->
 
       Format.fprintf ppf 
         "@[<hv 1>(!@ @[<hv 1>%a@] @[<hv 1>%a@])@]" 
-        (pp_print_term' pp_symbol db) t
+        (pp_print_term' pp_symbol pp_var db) t
         T.pp_print_attr a
 
 
   (* Pretty-print a list of higher-order abstract syntax terms given
      the de Bruijn index of the most recent bound variable *)
-  and pp_print_term_list pp_symbol db ppf = function
+  and pp_print_term_list pp_symbol pp_var db ppf = function
 
     (* Terminate at end of list *)
     | [] -> ()
@@ -707,43 +711,45 @@ struct
     | t :: tl -> 
 
       (* Print term a head of list *)
-      pp_print_term' pp_symbol db ppf t;
+      pp_print_term' pp_symbol pp_var db ppf t;
 
       (* Continue if not at the end of the list *)
       if not (tl = []) then
         (Format.pp_print_space ppf ();
-         pp_print_term_list pp_symbol db ppf tl)
+         pp_print_term_list pp_symbol pp_var db ppf tl)
 
 
   (* Top-level pretty-printing function, start with given de Bruijn
      index or default to zero *)
-  let pp_print_term_w pp_symbol ?(db = 0) ppf term = 
+  let pp_print_term_w pp_symbol pp_var ?(db = 0) ppf term = 
 
     (* Pretty-print term into buffer *)
-    pp_print_term' pp_symbol db ppf term
+    pp_print_term' pp_symbol pp_var db ppf term
 
  
   (* Top-level pretty-printing function, start with given de Bruijn
      index or default to zero *)
-  let pp_print_lambda_w pp_symbol ?(db = 0) ppf term = 
+  let pp_print_lambda_w pp_symbol pp_var ?(db = 0) ppf term = 
 
     (* Pretty-print term into buffer *)
-    pp_print_lambda' pp_symbol db ppf term
+    pp_print_lambda' pp_symbol pp_var db ppf term
 
  
   
-  let pp_print_term = pp_print_term_w (fun ?arity -> T.pp_print_symbol)
+  let pp_print_term =
+    pp_print_term_w (fun ?arity -> T.pp_print_symbol) T.pp_print_var
 
   let print_term ?db = pp_print_term ?db Format.std_formatter
 
-  let pp_print_lambda = pp_print_lambda_w (fun ?arity -> T.pp_print_symbol)
+  let pp_print_lambda =
+    pp_print_lambda_w (fun ?arity -> T.pp_print_symbol) T.pp_print_var
 
   let print_lambda ?db = pp_print_lambda ?db Format.std_formatter
 
   (* Pretty-print a flattened term *)
-  let rec pp_print_flat pp_symbol ppf = function 
+  let rec pp_print_flat pp_symbol pp_var ppf = function 
 
-    | Var v -> Format.fprintf ppf "Var@ %a" T.pp_print_var v
+    | Var v -> Format.fprintf ppf "Var@ %a" pp_var v
 
     | Const s -> Format.fprintf ppf "Const@ %a" (pp_symbol ?arity:(Some 0)) s
 
@@ -753,7 +759,7 @@ struct
         ppf 
         "App@ (%a,@ %a)" 
         (pp_symbol ?arity:None) s 
-        (pp_print_term_list pp_symbol 0) l
+        (pp_print_term_list pp_symbol pp_var 0) l
 
     | Attr (t, a) -> 
 
@@ -763,7 +769,8 @@ struct
         (pp_print_term ~db:0) t 
         T.pp_print_attr a
 
-  let pp_print_flat = pp_print_flat (fun ?arity -> T.pp_print_symbol)
+  let pp_print_flat =
+    pp_print_flat (fun ?arity -> T.pp_print_symbol) T.pp_print_var
 
   (* ********************************************************************* *)
   (* Auxiliary functions                                                   *)

--- a/src/ltree.mli
+++ b/src/ltree.mli
@@ -271,10 +271,14 @@ sig
   (** Pretty-print a term *)
   val pp_print_term : ?db:int -> Format.formatter -> t -> unit
     
-  val pp_print_lambda_w : (?arity:int -> Format.formatter -> symbol -> unit) ->
+  val pp_print_lambda_w :
+    (?arity:int -> Format.formatter -> symbol -> unit) ->
+    (Format.formatter -> var -> unit) ->
     ?db:int -> Format.formatter -> lambda -> unit
 
-  val pp_print_term_w : (?arity:int -> Format.formatter -> symbol -> unit) ->
+  val pp_print_term_w :
+    (?arity:int -> Format.formatter -> symbol -> unit) ->
+    (Format.formatter -> var -> unit) ->
     ?db:int -> Format.formatter -> t -> unit
 
   (** Pretty-print a term *)

--- a/src/lustreTransSys.ml
+++ b/src/lustreTransSys.ml
@@ -1865,7 +1865,8 @@ let rec trans_sys_of_nodes' nodes node_defs = function
     let trans_sys = 
       TransSys.mk_trans_sys 
         (I.scope_of_ident node_name)
-        (inputs @ oracles @ outputs @ observers @ locals)
+        (TransSys.init_flag_svar ::
+         inputs @ oracles @ outputs @ observers @ locals)
         pred_def_init
         pred_def_trans
         called_trans_sys

--- a/src/nativeInput.ml
+++ b/src/nativeInput.ml
@@ -18,52 +18,56 @@
 
 open Lib
 
-module S = SExprBase.Make(HStringSExpr.HStringAtom)
+module HH = HString.HStringHashtbl
+module HS = HStringSExpr
+module D = GenericSMTLIBDriver
 
-(* Distingushed strings in input *)
-let s_define_pred = HString.mk_hstring "define-pred"
+let s_prime = HString.mk_hstring "prime"
+
+module Conv = SMTExpr.Converter(D)
+let conv = { D.smtlib_string_sexpr_conv with
+             D.prime_symbol = Some s_prime }
+let conv_type_of_sexpr = conv.D.type_of_sexpr
+let conv_term_of_sexpr = D.gen_expr_of_string_sexpr conv
+
+  
+let s_define_node = HString.mk_hstring "define-node"
 let s_init = HString.mk_hstring "init"
 let s_trans = HString.mk_hstring "trans"
+let s_callers = HString.mk_hstring "callers"
+let s_fun = HString.mk_hstring "fun"
 let s_opt_const = HString.mk_hstring ":const"
-let s_prime = HString.mk_hstring "prime"
-let s_check_prop = HString.mk_hstring "check-prop"
-let s_int = HString.mk_hstring "Int"
-let s_real = HString.mk_hstring "Real"
-let s_bool = HString.mk_hstring "Bool"
+let s_opt_input = HString.mk_hstring ":input"
+let s_opt_for_inv_gen = HString.mk_hstring ":for-inv-gen"
+let s_annot = HString.mk_hstring ":annot"
+let s_contract = HString.mk_hstring ":contract"
+let s_gen = HString.mk_hstring ":gen"
+let s_inst = HString.mk_hstring ":inst"
+let s_props = HString.mk_hstring "props"
 let s_intrange = HString.mk_hstring "IntRange"
-let s_let = HString.mk_hstring "let"
 
-let top_scope = ["__top"]
-
-(* Suffix of initial state predicate *)
-let init_pred_suff = ".init"
-
-(* Suffix of transition relation predicate *)
-let trans_pred_suff = ".trans"
 
 (* Return the name of the initial state constraint predicate *)
-let init_pred_name pred = Format.sprintf "%s%s" pred init_pred_suff
+let init_pred_hname pred =
+  Format.sprintf "%s_%s" LustreIdent.init_uf_string
+    (HString.string_of_hstring pred)
 
 (* Return the name of the transition relation predicate *)
-let trans_pred_name pred = Format.sprintf "%s%s" pred trans_pred_suff
+let trans_pred_hname pred =
+  Format.sprintf "%s_%s" LustreIdent.trans_uf_string
+    (HString.string_of_hstring pred)
+
 
 (* Return a type of an S-expression *)
 let type_of_sexpr = function 
 
-  (* Integer type *)
-  | HStringSExpr.Atom c when c == s_int -> Type.t_int
-
-  (* Real type  *)
-  | HStringSExpr.Atom c when c == s_real -> Type.t_real
-
-  (* Boolean type *)
-  | HStringSExpr.Atom c when c == s_bool -> Type.t_bool
-
   (* Integer range type *)
-  | HStringSExpr.List [HStringSExpr.Atom c; HStringSExpr.Atom l; HStringSExpr.Atom u] when c == s_intrange -> 
+  | HS.List [HS.Atom c;
+             HS.Atom l;
+             HS.Atom u] when c == s_intrange -> 
 
     (* Numeral of lower bound *)
-    let nl = 
+    let nl =
       try Numeral.of_string (HString.string_of_hstring l) with 
         | Invalid_argument _ -> 
           failwith "Invalid argument for integer range type"
@@ -79,437 +83,192 @@ let type_of_sexpr = function
     (* Create integer range type *)
     Type.mk_int_range nl nu
 
-  | _ -> failwith "Invalid type"
+  | s ->
+    (* Otherwise get SMTLIB type *)
+    conv_type_of_sexpr s
+
+
 
 (* Create a state variable with the given scope from the S-expression *)
-let state_var_of_sexpr scope = function 
+let state_var_of_sexpr = function 
 
   (* State variable definition is the name, its type and options *)
-  | HStringSExpr.List (HStringSExpr.Atom v :: t :: opts) -> 
+  | HS.List (HS.Atom v :: t :: opts) -> 
 
     (* Name of the variable *)
-    let var_name = HString.string_of_hstring v in
+    let var_name, scope =
+      Lib.extract_scope_name (HString.string_of_hstring v) in
 
     (* Type of the variable *)
     let var_type = type_of_sexpr t in
 
     (* Options of the variable *)
-    let is_const, is_input = 
+    let is_const, is_input, for_inv_gen  = 
       List.fold_left 
 
         (* Parse input and modify options *)
-        (fun (is_const, is_input) -> function 
-           | HStringSExpr.Atom c when c == s_opt_const -> (true, is_input)
+        (fun (is_const, is_input, for_inv_gen) -> function 
+           | HS.Atom c when c == s_opt_const ->
+             (true, is_input, for_inv_gen)
+           | HS.Atom c when c == s_opt_input ->
+             (is_const, true, for_inv_gen)
+           | HS.Atom c when c == s_opt_for_inv_gen ->
+             (is_const, is_input, true)
            | _ -> failwith "Invalid option for state variable")
 
         (* Defaults for the options *)
-        (false, false)
+        (false, false, false)
 
         opts
     in
 
     (* Create state variable and return *)
-    StateVar.mk_state_var ~is_input ~is_const var_name scope var_type
+    StateVar.mk_state_var ~is_input ~is_const ~for_inv_gen
+      var_name scope var_type
 
   | _ -> failwith "Invalid state variable declaration"
 
 
-(* Association list of strings to function symbols *) 
-let string_symbol_list =
-  [("not", Symbol.mk_symbol `NOT);
-   ("=>", Symbol.mk_symbol `IMPLIES);
-   ("and", Symbol.mk_symbol `AND);
-   ("or", Symbol.mk_symbol `OR);
-   ("xor", Symbol.mk_symbol `XOR);
-   ("=", Symbol.mk_symbol `EQ);
-   ("distinct", Symbol.mk_symbol `DISTINCT);
-   ("ite", Symbol.mk_symbol `ITE);
-   ("-", Symbol.mk_symbol `MINUS);
-   ("+", Symbol.mk_symbol `PLUS);
-   ("*", Symbol.mk_symbol `TIMES);
-   ("/", Symbol.mk_symbol `DIV);
-   ("div", Symbol.mk_symbol `INTDIV);
-   ("mod", Symbol.mk_symbol `MOD);
-   ("abs", Symbol.mk_symbol `ABS);
-   ("<=", Symbol.mk_symbol `LEQ);
-   ("<", Symbol.mk_symbol `LT);
-   (">=", Symbol.mk_symbol `GEQ);
-   (">", Symbol.mk_symbol `GT);
-   ("to_real", Symbol.mk_symbol `TO_REAL);
-   ("to_int", Symbol.mk_symbol `TO_INT);
-   ("is_int", Symbol.mk_symbol `IS_INT);
-   ("concat", Symbol.mk_symbol `CONCAT);
-   ("bvnot", Symbol.mk_symbol `BVNOT);
-   ("bvneg", Symbol.mk_symbol `BVNEG);
-   ("bvand", Symbol.mk_symbol `BVAND);
-   ("bvor", Symbol.mk_symbol `BVOR);
-   ("bvadd", Symbol.mk_symbol `BVADD);
-   ("bvmul", Symbol.mk_symbol `BVMUL);
-   ("bvdiv", Symbol.mk_symbol `BVDIV);
-   ("bvurem", Symbol.mk_symbol `BVUREM);
-   ("bvshl", Symbol.mk_symbol `BVSHL);
-   ("bvlshr", Symbol.mk_symbol `BVLSHR);
-   ("bvult", Symbol.mk_symbol `BVULT);
-   ("select", Symbol.mk_symbol `SELECT);
-   ("store", Symbol.mk_symbol `STORE)]
 
-(* Hashtable for hashconsed strings to function symbols *)
-let hstring_symbol_table = HString.HStringHashtbl.create 50 
+(* Convert an s-expression to a term *)
+let term_of_sexpr s = conv_term_of_sexpr s
 
 
-(* Populate hashtable with hashconsed strings and their symbol *)
-let _ = 
-  List.iter
-    (function (s, v) -> 
-      HString.HStringHashtbl.add 
-        hstring_symbol_table 
-        (HString.mk_hstring s)
-        v)
-    string_symbol_list 
+
+(* Arguments of initial state predicate *)
+let init_args_of_state_vars state_vars =
+  List.map
+    (fun sv -> Var.mk_state_var_instance sv Numeral.zero)
+    state_vars
+
+(* Arguments of transition relation predicate *)
+let trans_args_of_state_vars state_vars =
+  let at0 = init_args_of_state_vars state_vars in
+  let at1 = List.map (Var.bump_offset_of_state_var_instance Numeral.one) at0 in
+  let at0 = List.filter (fun v -> not (Var.is_const_state_var v)) at0 in
+  at1 @ at0
 
 
-(* Reserved words that cannot be a symbol *)
-let reserved_word_list = 
-  List.map 
-    HString.mk_hstring 
-    ["par"; "_"; "!"; "as"; "let"; "forall"; "exists" ]
 
+let state_var_map_of_sexpr = function
+  | HS.List [HS.Atom v1; HS.Atom v2] ->
+    (try
+       StateVar.state_var_of_long_string (HString.string_of_hstring v1),
+       StateVar.state_var_of_long_string (HString.string_of_hstring v2)
+     with Not_found -> failwith "Invalid state variable map in caller")
+  | _ -> failwith "Invalid state variable map in caller"
 
-(* Lookup symbol of a hashconsed string *)
-let symbol_of_hstring s = 
+let caller_of_sexpr = function
+  | HS.List 
+      [HS.Atom c;
+       HS.List m;
+       HS.List [HS.Atom f; HS.List v; g]] 
+    when f == s_fun ->
+    (* Get name of caller *)
+    let name = c in
+    (* Get variable map *)
+    let map = List.map state_var_map_of_sexpr m in
+    (* Get guard of boolean function *)
+    (* Get list of variables of fun *)
+    let vars = D.gen_bound_vars_of_string_sexpr conv [] [] v in
+    let guard_lambda = Term.mk_lambda vars (term_of_sexpr g) in
+    let guard_fun = (fun t -> Term.eval_lambda guard_lambda [t]) in
+    (* Assemble caller *)
+    name, map, guard_fun
 
-  try 
-
-    (* Map hashconsed string to symbol *)
-    HString.HStringHashtbl.find hstring_symbol_table s
-
-  (* String is not one of our symbols *)
-  with Not_found -> 
-
-    (* Check if string is a reserved word *)
-    if List.memq s reserved_word_list then 
-      
-      (* Cannot parse S-expression *)
-      raise 
-        (Invalid_argument 
-           (Format.sprintf 
-              "Unsupported reserved word '%s' in expression"
-              (HString.string_of_hstring s)))
-
-    else
-
-      (* String is not a symbol *)
-      raise Not_found 
-
-
-(* Convert an atom to a term *)
-let term_of_hstring scope bound_vars t = 
-  
-  (* Empty strings are invalid *)
-  if HString.length t = 0 then
+  | _ -> failwith "Invalid caller description"
     
-    (* String is empty *)
-    raise (Invalid_argument "const_of_hstring")
-      
-  else
-
-    try
-
-      (* Return numeral of string *)
-      Term.mk_num (Numeral.of_string (HString.string_of_hstring t))
-
-    (* String is not a decimal *)
-    with Invalid_argument _ -> 
-
-      try 
-
-        (* Return decimal of string *)
-        Term.mk_dec (Decimal.of_string (HString.string_of_hstring t))
-          
-      with Invalid_argument _ -> 
 
-        try 
-
-          (* Return bitvector of string *)
-          Term.mk_bv (bitvector_of_hstring t)
-            
-        with Invalid_argument _ -> 
-          
-          try 
-            
-            (* Return propositional constant of string *)
-            Term.mk_bool (bool_of_hstring t)
 
-          (* String is not an interpreted symbol *)
-          with Invalid_argument _ -> 
 
-            try 
-              
-              (* Return bound symbol *)
-              Term.mk_var (List.assq t bound_vars)
+let file_row_col_of_string s =
+  Scanf.sscanf s "%s@:%d-%d" (fun x1 x2 x3-> x1, x2, x3)
 
-            (* String is not a bound variable *)
-            with Not_found -> 
-              
-              try 
+let state_var_of_atom = function
+  | HS.Atom v ->
+    StateVar.state_var_of_long_string (HString.string_of_hstring v)
+  | _ -> failwith "Not a state var"
 
-                (* Name of state variable *)
-                let state_var_name = HString.string_of_hstring t in
+let prop_source_of_sexpr = function
+  | [] -> TermLib.PropAnnot Lib.dummy_pos
 
-                (* State variable of name and given scope *)
-                let state_var = 
-                  StateVar.state_var_of_string
-                    (state_var_name, scope) 
-                in
-                
-                (* State variable at instant zero *)
-                let var = 
-                  Var.mk_state_var_instance state_var Numeral.zero
-                in
+  | [HS.Atom c; HS.Atom pos]
+    when c == s_annot || c == s_contract ->
+    let frc_pos = file_row_col_of_string (HString.string_of_hstring pos) in
+    let ppos = Lib.pos_of_file_row_col frc_pos in
+    if c == s_annot then TermLib.PropAnnot ppos
+    else if c == s_contract then TermLib.Contract ppos
+    else assert false
 
-                (* Return term *)
-                Term.mk_var var
+  | [HS.Atom c; HS.List svs] when c == s_gen ->
+    let vars = List.map state_var_of_atom svs in
+    TermLib.Generated vars
 
-              with Not_found -> 
-                
-                (* Cannot convert to an expression *)
-                failwith 
-                  (Format.asprintf 
-                     "Invalid expression %a" 
-                     HString.pp_print_hstring t)
+  | [HS.Atom c; HS.Atom scopedprop] when c == s_inst ->
+    let p, scope =
+      Lib.extract_scope_name (HString.string_of_hstring scopedprop) in
+    TermLib.Instantiated (scope, p)
 
+  | _ -> failwith "Invalid property source"
 
-let rec term_of_sexpr scope bound_vars = function 
 
-  | HStringSExpr.List [] -> failwith "Invalid nil in expression"
-  | HStringSExpr.List [_] -> failwith "Invalid singleton list in expression"
+let prop_of_sexpr = function
+  | HS.List (HS.Atom n :: p :: source) ->
+    (HString.string_of_hstring n,
+     prop_source_of_sexpr source,
+     term_of_sexpr p)
+  | _ -> failwith "Invalid property"
 
-  (* Let binding *)
-  | HStringSExpr.List [HStringSExpr.Atom a; HStringSExpr.List v; t] when a == s_let -> 
 
-    (* Convert bindings and obtain a list of bound variables *)
-    let bindings = bindings_of_sexpr scope bound_vars [] v in
+let rec optional_fields_of_sexprs (callers, props) = function
+  (* Callers *)
+  | HS.List [HS.Atom ca; HS.List ca_l] :: rs
+    when ca = s_callers ->
+    let callers = List.map caller_of_sexpr ca_l in
+    optional_fields_of_sexprs (callers, props) rs
 
-    (* Convert bindings to an association list from strings to
-       variables *)
-    let bound_vars' = 
-      List.map 
-        (function (v, _) -> (Var.hstring_of_temp_var v, v))
-        bindings 
-    in
+  (* Propeties *)
+  | HS.List [HS.Atom p; HS.List ps] :: rs
+    when p = s_props ->
+    let props = List.map prop_of_sexpr ps in 
+    optional_fields_of_sexprs (callers, props) rs
 
-    (* Parse the subterm, giving an association list of bound
-       variables and return a let bound term *)
-    Term.mk_let 
-      bindings
-      (term_of_sexpr scope (bound_vars @ bound_vars') t)
+  | [] -> (callers, props)
 
-  (* Not a valid let binding *)
-  | HStringSExpr.List (HStringSExpr.Atom a :: _) when a == s_let -> 
-    failwith "Invalid let binding in expression"
+  | _ -> failwith "Invalid field in node"
 
-  (* Atom *)
-  | HStringSExpr.Atom a -> term_of_hstring scope bound_vars a 
 
-  (* A primed variable *)
-  | HStringSExpr.List [HStringSExpr.Atom c; HStringSExpr.Atom a] when c == s_prime -> 
 
-    (* Term of primed atom *)
-    let t = term_of_hstring scope bound_vars a in
-
-    (* Prime term if it is a variable *)
-    if Term.is_free_var t then Term.bump_state Numeral.one t else
-
-      failwith "Prime only applies to variables"
-
-  (* A function application *)
-  | HStringSExpr.List (HStringSExpr.Atom h :: tl) -> 
-
-    (try 
-
-       (* Built-in symbol of string *)
-       Term.mk_app
-         (symbol_of_hstring h)
-         (List.map (term_of_sexpr scope bound_vars) tl)
-
-     with Not_found -> 
-
-       (* String of hashconsed string *)
-       let s = HString.string_of_hstring h in
-
-       (* Length of suffix for initial state predicate name  *)
-       let init_len = String.length init_pred_suff in
-
-       (* String must be longer than suffix *)
-       if String.length s > init_len then 
-
-         if 
-
-           (* String has suffix of initial state predicate? *)
-           String.sub
-             s
-             (String.length s - init_len)
-             init_len 
-           = init_pred_suff
-
-         then
-
-           (* Uninterpreted function symbol *)
-           let uf_symbol = 
-
-             try 
-
-               UfSymbol.uf_symbol_of_string s 
-
-             with Not_found -> 
-
-               failwith
-                 (Format.sprintf "Predicate %s not defined" s)
-
-           in
-
-           if 
-
-             (* Number of arguments must match definition *)
-             (List.length (UfSymbol.arg_type_of_uf_symbol uf_symbol))
-             = List.length tl 
-
-           then
-
-             (* Application of predicate symbol *)
-             Term.mk_uf 
-               uf_symbol
-               (List.map (term_of_sexpr scope bound_vars) tl)
-
-           else
-
-             failwith "Wrong number of arguments"
-
-         else
-
-           (* Length of suffix for transition relation predicate name  *)
-           let trans_len = String.length trans_pred_suff in
-
-           (* String must be longer than suffix *)
-           if String.length s > trans_len then 
-
-             if 
-
-               (* String has suffix of transition relation predicate? *)
-               String.sub
-                 s
-                 (String.length s - trans_len)
-                 trans_len 
-               = trans_pred_suff
-
-             then
-
-               (* Uninterpreted function symbol *)
-               let uf_symbol = 
-
-                 try 
-
-                   UfSymbol.uf_symbol_of_string s 
-
-                 with Not_found -> 
-
-                   failwith "Predicate not defined"
-
-               in
-
-               if 
-
-                 (* Number of arguments must match definition *)
-                 (List.length (UfSymbol.arg_type_of_uf_symbol uf_symbol))
-                 = List.length tl 
-
-               then
-
-                 (* Application of predicate symbol *)
-                 Term.mk_uf 
-                   uf_symbol
-                   (List.map (term_of_sexpr scope bound_vars) tl)
-
-               else
-
-                 failwith "Wrong number of arguments"
-
-             else
-
-               failwith "Undefined function symbol" 
-
-           else
-
-             failwith "Undefined function symbol" 
-
-       else
-
-         failwith "Undefined function symbol") 
-
-
-  | _ -> Term.t_false
-
-
-(* Convert a list of bindings *)
-and bindings_of_sexpr scope b accum = function 
-
-  (* All bindings consumed: return accumulator in original order *)
-  | [] -> List.rev accum
-
-  (* Take first binding *)
-  | HStringSExpr.List [HStringSExpr.Atom v; t] :: tl -> 
-
-    (* Convert to an expression *)
-    let term = term_of_sexpr scope b t in
-
-    (* Get the type of the expression *)
-    let term_type = Term.type_of_term term in
-
-    (* Create a variable of the identifier and the type of the expression *)
-    let var = Var.mk_temp_var v term_type in
-
-    (* Add bound expresssion to accumulator *)
-    bindings_of_sexpr scope b ((var, term) :: accum) tl
-
-  (* Expression must be a pair *)
-  | e :: _ -> 
-
-    failwith "Invalid expression in let binding"
-      
 
 (* Convert a predicate definition *)
-let pred_def_of_sexpr = function
+let node_def_of_sexpr = function
 
-  (* (define-pred NAME (VARS) (init INIT) (trans TRANS)) *)
-  | HStringSExpr.List 
-      [HStringSExpr.Atom c; 
-       HStringSExpr.Atom p; 
-       HStringSExpr.List v; 
-       HStringSExpr.List [HStringSExpr.Atom ci; i]; 
-       HStringSExpr.List [HStringSExpr.Atom ct; t]] 
-    when c == s_define_pred && ci == s_init && ct = s_trans -> 
+  (* (define-node NAME (VARS) (init INIT) (trans TRANS) (callers CALLERS))?
+     (props PROPS)? (invars INVS)? *)
+  | HS.List 
+      (HS.Atom c :: 
+       HS.Atom n ::
+       HS.List v ::
+       HS.List [HS.Atom ci; i] ::
+       HS.List [HS.Atom ct; t] ::
+       others
+      ) 
+    when c == s_define_node &&
+         ci == s_init &&
+         ct = s_trans ->
 
     (* Get name of defined predicate *)
-    let pred_name = HString.string_of_hstring p in
+    let node_name = n in
 
     (* Create state variables *)
-    let state_vars = List.map (state_var_of_sexpr [pred_name]) v in
+    let state_vars = List.map state_var_of_sexpr v in
 
     (* Arguments of initial state predicate *)
-    let init_args = 
-      List.map
-        (fun sv -> Var.mk_state_var_instance sv Numeral.zero)
-        state_vars
-    in
-
+    let init_args = init_args_of_state_vars state_vars in
+    
     (* Arguments of transition relation predicate *)
-    let trans_args = 
-      init_args @
-      List.map 
-        (fun sv -> Var.mk_state_var_instance sv Numeral.one)
-        (List.filter (fun sv -> not (StateVar.is_const sv)) state_vars)
-    in
-
+    let trans_args = trans_args_of_state_vars state_vars in
+    
     (* Types of initial state predicate arguments *)
     let init_args_types = List.map Var.type_of_var init_args in
 
@@ -519,7 +278,7 @@ let pred_def_of_sexpr = function
     (* Predicate symbol for initial state predicate *)
     let init_uf_symbol = 
       UfSymbol.mk_uf_symbol
-        (init_pred_name pred_name) 
+        (init_pred_hname node_name) 
         init_args_types
         Type.t_bool 
     in
@@ -527,185 +286,113 @@ let pred_def_of_sexpr = function
     (* Predicate symbol for transition relation predicate *)
     let trans_uf_symbol = 
       UfSymbol.mk_uf_symbol
-        (trans_pred_name pred_name) 
+        (trans_pred_hname node_name) 
         trans_args_types
         Type.t_bool 
     in
     
     (* Initial state constraint *)
-    let init_term = term_of_sexpr [pred_name] [] i in
+    let init_term = term_of_sexpr i in
 
     (* Transition relation *)
-    let trans_term = term_of_sexpr [pred_name] [] t in
+    let trans_term = term_of_sexpr t in
 
-    (* Definitions of initial state and transition relation *)
-    ((init_uf_symbol, (init_args, init_term)), 
-     (trans_uf_symbol, (trans_args, trans_term)))
+    (* Optional callers and properties *)
+    let callers, props = optional_fields_of_sexprs ([], []) others in
+    
+    (* Intermediate representation of node/system *)
+    (
+      node_name,
+      state_vars,
+      (init_uf_symbol, (init_args, init_term)), 
+      (trans_uf_symbol, (trans_args, trans_term)),
+      callers,
+      props
+    )
 
-  | HStringSExpr.Atom _ 
-  | HStringSExpr.List _ -> failwith "Invalid format of predicate definition"
-
-
-(* Create a copy of the state variable at the top level *)
-let state_var_of_top_scope state_var =
-  
-  (* Create state variable with same parameters except scope *)
-  StateVar.mk_state_var
-    ~is_input:(StateVar.is_input state_var)
-    ~is_const:(StateVar.is_const state_var)
-    (StateVar.name_of_state_var state_var)
-    top_scope
-    (StateVar.type_of_state_var state_var)
+  | HS.Atom _ 
+  | HS.List _ -> failwith "Invalid format of node definition"
 
 
-(* Create a copy of the state variable instance at the top level *)
-let var_of_top_scope var = 
 
-  (* State variable *)
-  let state_var = Var.state_var_of_state_var_instance var in
 
-  (* State variable of top scope *)
-  let state_var' = state_var_of_top_scope state_var in
-
-  (* Create state variable instance of top scope *)
-  Var.mk_state_var_instance 
-    state_var'
-    (Var.offset_of_state_var_instance var)
 
 
 (* Parse from input channel *)
 let of_channel in_ch = 
 
-  (* Create a lexing buffer on solver's stdout *)
   let lexbuf = Lexing.from_channel in_ch in
-
-  (* Parse S-expression and return *)
   let sexps = SExprParser.sexps SExprLexer.main lexbuf in
 
-  (* Create definitions of expressions, last expression is list of
-     properties *)
-  let rec aux defs = function 
+  (* Callers mapping to transition system *)
+  let calling_table = HH.create (List.length sexps) in
+  let callers_table = HH.create (List.length sexps) in
 
-    | [] -> failwith "Empty input"
+  (* Parse sexps and register callers *)
+  let sys_and_calls =
+    List.map (fun sexp ->
 
-    (* List must end with check-prop atom *)
-    | [HStringSExpr.List [HStringSExpr.Atom s; HStringSExpr.List p]] 
-      when s == s_check_prop -> 
+        let node_name, state_vars, init_pred, trans_pred, callers, props =
+          node_def_of_sexpr sexp in
 
-      (* Last element in (reversed list) is topmost definition *)
-      let top_init, top_trans = match defs with
-        | [] -> failwith "Empty definitions"
-        | h :: _ -> h
-      in
-      
-      (* Predicate symbol and arguments of initial state constraint *)
-      let (top_init_uf_symbol, (top_init_vars, _)) = top_init in
+        (* Scope from name *)
+        let node_scope =
+          let n, s =
+            Lib.extract_scope_name (HString.string_of_hstring node_name) in
+          s @ [n] in
 
-      (* Predicate symbol and arguments of transition relation *)
-      let (top_trans_uf_symbol, (top_trans_vars, _)) = top_trans in
+        (* find who calls me *)
+        let my_callers =
+          HH.find calling_table node_name
+          |> snd
+          |> List.map (fun (a,_,_) -> a)
+        in
 
-      (* Copy state variables of top node to new scope
+        (* Create transition system *)
+        let sys = TransSys.mk_trans_sys
+            node_scope state_vars init_pred trans_pred my_callers props
+            TransSys.Native in
 
-         Must do this first, because variables in property are of top
-         scope. *)
-      let state_vars = 
-        List.map 
-          (fun v -> 
-             state_var_of_top_scope 
-           (Var.state_var_of_state_var_instance v))
-          top_init_vars
-      in
-  
-      (* Copy variables in signature of top node to new scope *)
-      let init_vars = 
-        List.map var_of_top_scope top_init_vars 
-      in
-      
-      (* Copy variables in signature of top node to new scope *)
-      let trans_vars = 
-        List.map var_of_top_scope top_trans_vars 
-      in
-      
-      (* Expression for initial state constraint *)
-      let init_term = 
-        Term.mk_uf 
-          top_init_uf_symbol 
-          (List.map Term.mk_var init_vars)
-      in
-      
-      (* Expression for transition relation *)
-      let trans_term = 
-        Term.mk_uf
-          top_trans_uf_symbol
-          (List.map Term.mk_var trans_vars)
-      in
+        (* Add calling information *)
+        List.iter (fun (c, m, g) ->
+            let n, calling_c =
+              try HH.find calling_table c
+              with Not_found -> None, []
+            in
+            HH.replace calling_table c (n, (sys, m, g) :: calling_c);
+          ) callers;
 
-      let init = 
-        (top_init_uf_symbol, 
-         (List.combine 
-            top_init_vars 
-            (List.map Term.mk_var init_vars)))
-      in
-
-      let trans =
-        (top_trans_uf_symbol, 
-         (List.combine 
-            top_trans_vars
-            (List.map Term.mk_var trans_vars)))
-      in
-
-      (* Collect all properties to prove *)
-      let props = 
-        List.fold_left 
-          (function accum -> function
-
-             (* Property must be a pair of name and term *)
-             | HStringSExpr.List [HStringSExpr.Atom p; t] -> 
-
-               (* Convert S-expression to term *)
-               (HString.string_of_hstring p, 
-                term_of_sexpr top_scope  [] t) 
-               :: accum
-
-             | _ -> failwith "Invalid format of property")
-          []
-          p
-      in
-
-      (* Return definititons in original order and properties *)
-      List.rev defs, state_vars, init, trans, props
-
-    | [HStringSExpr.List (HStringSExpr.Atom s :: _)] when s == s_check_prop -> 
-
-      failwith "Invalid format of check-prop statement"
-
-    | [_] -> failwith "Definitions must end with check-prop statement"
-               
-    (* First element of a list of at least two elements is a predicate
-       definition *)
-    | h :: tl -> aux ((pred_def_of_sexpr h) :: defs) tl
-                   
+        (* Return constructed system and callers *)
+        sys, callers
+      ) sexps
   in
 
-  (* Definitions and properties in input *)
-  let defs, state_vars, init, trans, props = aux [] sexps in
-
-  let res = 
-    TransSys.mk_trans_sys 
-      defs
-      state_vars
-      init
-      trans
-      props
-      TransSys.Native
+  (* Add callers *)
+  let all_sys =
+    List.fold_left (fun acc (sys, callers) ->
+        (* Add callers *)
+        List.iter (fun (c, m, g) ->
+            let c_sys = match fst (HH.find calling_table c) with
+              | None -> assert false
+              | Some s -> s in
+            TransSys.add_caller sys c_sys (m, g)
+          ) callers;
+        sys :: acc
+      ) [] sys_and_calls
   in
 
-  debug nativeInput
-    "%a"
-    TransSys.pp_print_trans_sys res
-  in
+  (* Return top level system *)
+  match all_sys with
+  | top_sys :: _ ->
 
-  res
+    debug nativeInput
+      "%a"
+      TransSys.pp_print_trans_sys top_sys
+    in
+
+    top_sys
+      
+  | _ -> failwith "No systems"
 
 
 
@@ -717,6 +404,9 @@ let of_file filename =
     let in_ch = use_file in
 
     of_channel in_ch
+
+
+
 
 (* ************************************************************ *)
 (* Counterexample output in plain text                          *)

--- a/src/nativeInput.ml
+++ b/src/nativeInput.ml
@@ -47,7 +47,6 @@ let s_props = HString.mk_hstring "props"
 let s_intrange = HString.mk_hstring "IntRange"
 
 
-
 (*********************************************)
 (* Parsing of systems in native input format *)
 (*********************************************)
@@ -427,7 +426,13 @@ let of_channel in_ch =
             let bvars = List.map (fun v -> Var.hstring_of_free_var v, v) vars in
             let guard_lambda =
               Term.mk_lambda vars (term_of_sexpr_bound_vars bvars g) in
-            let guard_fun = (fun t -> Term.eval_lambda guard_lambda [t]) in
+            let guard_fun =
+              if Term.is_lambda_identity guard_lambda then
+                (* Simply return the identity (on terms) function if the guard
+                   is lambda x.x *)
+                (fun t -> t)
+              else (fun t -> Term.eval_lambda guard_lambda [t])
+            in
 
             TransSys.add_caller sys c_sys (map, guard_fun)
           ) callers;

--- a/src/nativeInput.ml
+++ b/src/nativeInput.ml
@@ -244,7 +244,7 @@ let prop_of_sexpr = function
 
 let rec optional_fields_of_sexprs (callers, props) = function
   (* Callers *)
-  | HS.List [HS.Atom ca; HS.List ca_l] :: rs
+  | HS.List (HS.Atom ca :: ca_l) :: rs
     when ca = s_callers ->
     let callers = List.map caller_of_sexpr ca_l in
     optional_fields_of_sexprs (callers, props) rs
@@ -266,7 +266,7 @@ let rec optional_fields_of_sexprs (callers, props) = function
 let node_def_of_sexpr = function
 
   (* (define-node NAME (VARS) (init INIT) (trans TRANS) (callers CALLERS))?
-     (props PROPS)? (invars INVS)? *)
+     (props PROPS)? *)
   | HS.List 
       (HS.Atom c :: 
        HS.Atom n ::
@@ -525,9 +525,10 @@ let pp_print_property ppf (prop_name, prop_source, prop_term) =
     pp_print_prop_source prop_source
 
 
-let pp_print_caller ppf (m, ft) =
+let pp_print_caller name_c ppf (m, ft) =
   Format.fprintf ppf 
-    "@[<hv 1>(%a)@,@[<v>%a@]@]"
+    "(%s@ @[<hv 1>(%a)@,@[<v>%a@]@])"
+    name_c
     (pp_print_list 
        (fun ppf (s, t) ->
           Format.fprintf ppf
@@ -542,11 +543,11 @@ let pp_print_caller ppf (m, ft) =
      Term.mk_lambda [v] (ft tv))
 
 
-let pp_print_callers ppf (t, c) = 
+let pp_print_callers ppf (t, c) =
+  let name_c = String.concat "." (TransSys.get_scope t) in
   Format.fprintf ppf
-    "@[<hv 1>(%a@ %a)@]"
-    (pp_print_list Format.pp_print_string ".") (TransSys.get_scope t)
-    (pp_print_list pp_print_caller "@ ") c
+    "@[<hv 1>%a@]"
+    (pp_print_list (pp_print_caller name_c) "@ ") c
 
 
 let pp_print_props ppf sys =
@@ -561,7 +562,7 @@ let pp_print_callers ppf sys =
   let callers = TransSys.get_callers sys in
   if callers <> [] then
   Format.fprintf ppf
-     "@[<hv 2>(callers@ (@[<v>%a@]))@]\n@,"
+     "@[<hv 2>(callers@ @[<v>%a@])@]\n@,"
      (pp_print_list pp_print_callers "@ ") callers
      
 

--- a/src/nativeInput.ml
+++ b/src/nativeInput.ml
@@ -575,10 +575,24 @@ let pp_print_callers ppf sys =
      (pp_print_list pp_print_callers "@ ") callers
      
 
-let rec pp_print_native ppf sys = 
+let eq_sys s1 s2 =
+  TransSys.get_name s1 = TransSys.get_name s2 &&
+  TransSys.get_scope s1 = TransSys.get_scope s2 &&
+  List.for_all2 StateVar.equal_state_vars
+    (TransSys.state_vars s1) (TransSys.state_vars s2) &&
+  Term.equal (TransSys.init_term s1) (TransSys.init_term s2) &&
+  Term.equal (TransSys.trans_term s1) (TransSys.trans_term s2)
 
-  List.iter (Format.fprintf ppf "%a\n@." pp_print_native)
-    (TransSys.get_subsystems sys);
+let all_systems sys =
+  let rec all_systems_rec acc sys =
+    let acc = List.fold_left all_systems_rec acc (TransSys.get_subsystems sys) in
+    let acc = if List.exists (eq_sys sys) acc then acc
+      else sys :: acc in
+    acc
+  in
+  all_systems_rec [] sys |> List.rev
+
+let pp_print_one_native ppf sys = 
   
   Format.fprintf 
     ppf
@@ -590,7 +604,7 @@ let rec pp_print_native ppf sys =
      %a\
      @]\
      )@]\
-     @."
+     \n@."
     (String.concat "." (TransSys.get_scope sys))
     (pp_print_list pp_print_state_var "@ ") (TransSys.state_vars sys)
     pp_print_term (TransSys.init_term sys)
@@ -599,6 +613,8 @@ let rec pp_print_native ppf sys =
     pp_print_props sys
 
 
+let pp_print_native ppf sys = 
+  List.iter (pp_print_one_native ppf) (all_systems sys)
 
 let dump_native sys =
   let dirname = Flags.dump_dir () in

--- a/src/nativeInput.mli
+++ b/src/nativeInput.mli
@@ -28,10 +28,10 @@ val of_channel : in_channel -> TransSys.t
 val of_file : string -> TransSys.t
 
 val pp_print_path_pt :
-  Format.formatter -> (StateVar.t * Term.t list) list -> unit
+  Format.formatter -> (StateVar.t * Model.term_or_lambda list) list -> unit
 
 val pp_print_path_xml :
-  Format.formatter -> (StateVar.t * Term.t list) list -> unit
+  Format.formatter -> (StateVar.t * Model.term_or_lambda list) list -> unit
 
 
 (* 

--- a/src/nativeInput.mli
+++ b/src/nativeInput.mli
@@ -18,7 +18,7 @@
 
 (** Parse a file in native input format into a transition system 
 
-    @author Christoph Sticksel
+    @author Christoph Sticksel, Alain Mebsout
 *)
 
 (** Parse from the channel *)
@@ -27,9 +27,11 @@ val of_channel : in_channel -> TransSys.t
 (** Parse from the file *)
 val of_file : string -> TransSys.t
 
-val pp_print_path_pt : Format.formatter -> (StateVar.t * Term.t list) list -> unit
+val pp_print_path_pt :
+  Format.formatter -> (StateVar.t * Term.t list) list -> unit
 
-val pp_print_path_xml : Format.formatter -> (StateVar.t * Term.t list) list -> unit
+val pp_print_path_xml :
+  Format.formatter -> (StateVar.t * Term.t list) list -> unit
 
 
 (* 

--- a/src/nativeInput.mli
+++ b/src/nativeInput.mli
@@ -21,12 +21,26 @@
     @author Christoph Sticksel, Alain Mebsout
 *)
 
+
+(** {2 Printing from native input format } *)
+  
 (** Parse from the channel *)
 val of_channel : in_channel -> TransSys.t
 
 (** Parse from the file *)
 val of_file : string -> TransSys.t
 
+
+(** {2 Printing to native format } *)
+  
+(** Print a transition system in native format *)
+val pp_print_native : Format.formatter -> TransSys.t -> unit
+
+(** Dump a transition system to a file in native format *)
+val dump_native : TransSys.t -> unit
+
+(** {2 Pretty printing of counter-examples} *)
+  
 val pp_print_path_pt :
   Format.formatter -> (StateVar.t * Model.term_or_lambda list) list -> unit
 

--- a/src/stateVar.ml
+++ b/src/stateVar.ml
@@ -355,27 +355,12 @@ let state_var_of_string (state_var_name, state_var_scope) =
   Hstate_var.find ht (state_var_name, state_var_scope)
 
 
-(* Split a string at its first dot. Raises {Not_found} if there are not dots *)
-let split_dot s =
-  let open String in
-  let n = (index s '.') in
-  sub s 0 n, sub s (n+1) (length s - n - 1)
-
-
 (* Return a previously declared state variable from a string consisting of the
    concatenation of all scopes and the state variable. Raises {Not_found} if it
    was not previously declared. *)
 let state_var_of_long_string s =
-
-  let rec loop s scope =
-    try state_var_of_string (s, scope)
-    with Not_found ->
-      let s', next_scope = split_dot s in
-      loop s' (scope @ [next_scope])
-  in
-
-  loop s []
-
+  state_var_of_string (Lib.extract_scope_name s)
+    
 
 (* ********************************************************************* *)
 (* Folding and utility functions on state variables                      *)

--- a/src/stateVar.ml
+++ b/src/stateVar.ml
@@ -355,6 +355,28 @@ let state_var_of_string (state_var_name, state_var_scope) =
   Hstate_var.find ht (state_var_name, state_var_scope)
 
 
+(* Split a string at its first dot. Raises {Not_found} if there are not dots *)
+let split_dot s =
+  let open String in
+  let n = (index s '.') in
+  sub s 0 n, sub s (n+1) (length s - n - 1)
+
+
+(* Return a previously declared state variable from a string consisting of the
+   concatenation of all scopes and the state variable. Raises {Not_found} if it
+   was not previously declared. *)
+let state_var_of_long_string s =
+
+  let rec loop s scope =
+    try state_var_of_string (s, scope)
+    with Not_found ->
+      let s', next_scope = split_dot s in
+      loop s' (scope @ [next_scope])
+  in
+
+  loop s []
+
+
 (* ********************************************************************* *)
 (* Folding and utility functions on state variables                      *)
 (* ********************************************************************* *)

--- a/src/stateVar.mli
+++ b/src/stateVar.mli
@@ -82,10 +82,15 @@ val import : t -> t
 (** Return a previously declared state variable *)
 val state_var_of_string : string * string list -> t 
 
+(** Return a previously declared state variable from a string consisting of the
+   concatenation of all scopes and the state variable. Raises {Not_found} if it
+   was not previously declared. *)
+val state_var_of_long_string : string -> t
+
 (** Return the name of the state variable *)
 val name_of_state_var : t -> string
 
-(** Return the name of the state variable *)
+(** Return the scope of the state variable *)
 val scope_of_state_var : t -> string list
 
 (** Return the type of the variable *)

--- a/src/term.ml
+++ b/src/term.ml
@@ -768,6 +768,17 @@ let import = T.import
 (* Import a term from a different instance into this hashcons table *)
 let import_lambda = T.import_lambda 
 
+
+(* Returns true if the lamda expression is the identity, i.e. lambda x.x *)
+let is_lambda_identity l =
+  try
+    let v = Var.mk_fresh_var Type.t_bool in
+    let tv = mk_var v in
+    let lv = eval_lambda l [tv] in
+    equal tv lv
+  with Invalid_argument _ -> false
+
+
 (* Flatten top node of term *)
 let construct = T.construct
 

--- a/src/term.mli
+++ b/src/term.mli
@@ -87,6 +87,9 @@ val import : t -> t
 (** Import a term from a different instance into this hashcons table *)
 val import_lambda : lambda -> lambda
 
+(** Returns true if the lamda expression is the identity, i.e. lambda x.x *)
+val is_lambda_identity : lambda -> bool
+
 (** Create the propositional constant [true] *)
 val mk_true : unit -> t
 

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -635,8 +635,7 @@ let mk_trans_sys scope state_vars init trans subsystems props source =
   let system =
     { scope = scope;
       uf_defs = get_uf_defs [ (init, trans) ] subsystems ;
-      state_vars =
-        List.sort StateVar.compare_state_vars state_vars;
+      state_vars = state_vars;
       init = init ;
       trans = trans ;
       properties =

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -196,7 +196,8 @@ let add_caller callee caller c =
   let rec add_caller' accum = function
     | [] ->  (caller, [c]) :: accum
     | (caller', c') :: tl when 
-        caller'.scope = caller.scope -> (caller', (c :: c')) :: accum
+        caller'.scope = caller.scope ->
+      ((caller', (c :: c')) :: accum) @ tl
     | h :: tl -> add_caller' (h :: accum) tl 
   in
 

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -808,6 +808,8 @@ let invars_of_bound ?(one_state_only = false) t i =
 
 let get_invars { invars } = invars
 
+let get_callers { callers } = callers
+
 
 (* Instantiate terms in association list to the bound *)
 let named_terms_list_of_bound l i = 
@@ -889,6 +891,12 @@ let add_scoped_invariant t scope invar =
 
 (* Add an invariant to the transition system *)
 let add_invariant t invar = add_scoped_invariant t t.scope invar
+
+(* Return all properties *)
+let get_properties t =
+  List.map (fun {prop_name; prop_source; prop_term} ->
+      (prop_name, prop_source, prop_term))
+    t.properties
 
 (* Return current status of all properties *)
 let get_prop_status_all t = 

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -1092,9 +1092,9 @@ let uf_defs_pairs { uf_defs } = uf_defs
   
 
 
-let pp_print_trans_sys 
+let rec pp_print_trans_sys 
     ppf
-    ({ uf_defs;
+    ({ subsystems;
        state_vars;
        properties;
        invars;
@@ -1102,10 +1102,11 @@ let pp_print_trans_sys
        logic;
        callers } as trans_sys) = 
 
+  List.iter (Format.fprintf ppf "%a@." pp_print_trans_sys) subsystems;
+  
   Format.fprintf 
     ppf
     "@[<v>@[<hv 2>(state-vars@ (@[<v>%a@]))@]@,\
-          %a@,\
           @[<hv 2>(init@ (@[<v>%a@]))@]@,\
           @[<hv 2>(trans@ (@[<v>%a@]))@]@,\
           @[<hv 2>(props@ (@[<v>%a@]))@]@,\
@@ -1114,7 +1115,6 @@ let pp_print_trans_sys
           @[<hv 2>(logic %a)@]@,\
           @[<hv 2>(callers@ (@[<v>%a@]))@]@."
     (pp_print_list pp_print_state_var "@ ") state_vars
-    (pp_print_list pp_print_uf_defs "@ ") (uf_defs)
     Term.pp_print_term (init_term trans_sys)
     Term.pp_print_term (trans_term trans_sys)
     (pp_print_list pp_print_property "@ ") properties

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -636,8 +636,7 @@ let mk_trans_sys scope state_vars init trans subsystems props source =
     { scope = scope;
       uf_defs = get_uf_defs [ (init, trans) ] subsystems ;
       state_vars =
-        init_flag_svar :: state_vars
-        |> List.sort StateVar.compare_state_vars ;
+        List.sort StateVar.compare_state_vars state_vars;
       init = init ;
       trans = trans ;
       properties =

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -84,7 +84,8 @@ val mk_trans_sys :
   t
 
 (** Add entry for new system instantiation to the transition system *)
-val add_caller : t -> t -> (StateVar.t * StateVar.t) list * (Term.t -> Term.t) -> unit
+val add_caller : t -> t ->
+  (StateVar.t * StateVar.t) list * (Term.t -> Term.t) -> unit
 
 (** Pretty-print a predicate definition *)
 val pp_print_uf_def : Format.formatter -> pred_def -> unit

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -207,6 +207,10 @@ val invars_of_bound : ?one_state_only:bool -> t -> Numeral.t -> Term.t
 (** The list of invariants and valid properties at zero. *)
 val get_invars : t -> Term.t list
 
+(** The list of callers of this system *)
+val get_callers : t ->
+  (t * (((StateVar.t * StateVar.t) list * (Term.t -> Term.t)) list)) list
+
 (** Return uninterpreted function symbols to be declared in the SMT
     solver *)
 val uf_symbols_of_trans_sys : t -> UfSymbol.t list
@@ -231,6 +235,9 @@ val add_invariant : t -> Term.t -> unit
 
 (** Add an invariant to the transition system *)
 val add_scoped_invariant : t -> string list -> Term.t -> unit
+
+(** Return current status of all properties *)
+val get_properties : t -> (string * TermLib.prop_source * Term.t) list
 
 (** Return current status of all properties *)
 val get_prop_status_all : t -> (string * prop_status) list

--- a/src/type.ml
+++ b/src/type.ml
@@ -185,7 +185,7 @@ let rec pp_print_type_node ppf = function
 
     Format.fprintf
       ppf 
-      "IntRange %a %a" 
+      "(IntRange %a %a)" 
       Numeral.pp_print_numeral i 
       Numeral.pp_print_numeral j
 

--- a/src/var.mli
+++ b/src/var.mli
@@ -90,7 +90,7 @@ val hstring_of_free_var : t -> HString.t
 (** Return true if the variable is an instance of a state variable *)
 val is_state_var_instance : t -> bool
 
-(** Return true if the variable is an instance of a state variable *)
+(** Return true if the variable is a constant state variable *)
 val is_const_state_var : t -> bool
 
 (** Return true if the variable is a free variable *)

--- a/src/yicesDriver.ml
+++ b/src/yicesDriver.ml
@@ -293,7 +293,7 @@ let string_of_symbol ?arity s = string_of_t (pp_print_symbol ?arity) s
 
 
 let pp_print_term ppf t =
-  Term.T.pp_print_term_w pp_print_symbol ppf t
+  Term.T.pp_print_term_w pp_print_symbol Var.pp_print_var ppf t
         
     
 (* Pretty-print an expression *)

--- a/src/yicesNative.ml
+++ b/src/yicesNative.ml
@@ -102,6 +102,7 @@ let smtlib_string_sexpr_conv =
        s_exists = HString.mk_hstring "exists";
        s_div = HString.mk_hstring "/";
        s_minus = HString.mk_hstring "-";
+       prime_symbol = None;
        s_define_fun = HString.mk_hstring "define-fun";
        const_of_atom = GenericSMTLIBDriver.const_of_smtlib_atom;
        symbol_of_atom = GenericSMTLIBDriver.symbol_of_smtlib_atom;


### PR DESCRIPTION
Parsing and dumping of transition systems in native input format.
The input format is detected automatically based on the file extension (```.lus``` for Lustre, ```.kind2``` for native input, ```.smt2``` for Horn clauses, and Lustre otherwise).

The option ```--dump_native``` dumps the transition system into ```<file>.kind2``` after parsing.

[This example](https://github.com/mebsout/kind2/blob/native_input/examples/two_counters.kind2) shows the syntax.

Closes kind2-mc/kind2-dev#30