### PR TITLE
Contracts

### DIFF
--- a/tests/lustre/contracts/PilotFlying-props-top-lemma.lus
+++ b/tests/lustre/contracts/PilotFlying-props-top-lemma.lus
@@ -1,0 +1,644 @@
+-- |=================================================================|
+--
+-- The Pilot Flying example describes a simple system in which left
+-- and right Flight Guidance Systems (FGS) need to agree on which side
+-- is the Pilot Flying side of the aircraft, where either pilot may
+-- choose to transfer control to the other side at any time.
+--
+-- Requirements:
+--
+-- R1: At least one side is always the pilot flying side.
+--
+-- R2: Both sides shall agree on the pilot flying side, except while
+--   the system is changing sides.
+--
+-- R3: Pressing the transfer switch shall always change the pilot
+--   flying side except while the system is switching sides.
+--
+-- R4: The system shall start with the primary side as the pilot
+--   flying side.
+-- 
+-- R5: The system shall not change the pilot flying side unless the
+--   transfer switch is pressed or when the system is switching
+--   sides.
+--
+-- |=================================================================|
+--
+-- Let `inhibited_count` be an integer constant, part of the
+-- specification. The requirements can be rephrased as:
+--
+-- init: R4.
+--
+-- flying: R1.
+--
+-- inhibited_mode: if the system switched sides less than
+--   `inhibited_count` cycles ago then it cannot switch side. The
+--   system is said to be inhibited. (R2 and R3)
+--
+-- consistent: if the system is not inhibited, then only one side
+--   is flying and both sides agree on who is flying. (R2)
+--
+-- active_change: if the system is not inhibited, and a rising edge of
+--   the transfer switch happens, then the system shall switch sides.
+--   (R3)
+--
+-- active_dual: if no rising edge of the transfer switch happens
+--   the system cannot switch sides. (R5)
+--
+
+
+
+
+-- |=================================================================|
+--
+--                       Specification nodes.
+--
+-- |=================================================================|
+
+
+-- Returns false iff its input has been false in the past.
+node hist (in: bool) returns (out: bool) ;
+let
+  out = in and (true -> pre out) ;
+tel
+
+
+-- Returns true once n cycles have passed since the beginning of
+-- time.
+node cyclesElapsedGT (const n: int) returns (out: bool);
+var count: int ;
+let
+  count = 0 -> if (n < pre count) then pre count else pre count + 1 ;
+  out = n < count ;
+tel
+
+-- Returns true if cond has not been true during the last [delay] cycles.
+node hasNotHappenedFor (cond: bool; const delay: int) returns (out: bool) ;
+var cnt: int ; shall_count: bool ;
+let
+  -- Becomes true when (pre cond) is true and stays that way forever.
+  shall_count = false -> cond or pre shall_count ;
+  -- Counts the number of cycles since pre cond was last true.
+  cnt = if cond then 0 else (
+    delay + 1 -> (if shall_count then pre cnt + 1
+                  else pre cnt)
+  ) ;
+  out = cnt > delay ;
+tel
+
+node hasHappenedSince (cond: bool ; const delay: int) returns (out: bool) ;
+var cnt : int ; shall_count: bool ;
+let
+  shall_count = false -> cond or pre shall_count ;
+  cnt = 0 -> if cond then 0
+        else if shall_count then pre cnt + 1
+	else pre cnt ;
+  out = shall_count and (cnt <= delay) ;
+tel
+
+-- Returns true if the current value of in is different from the previous one.
+node valueChange (in: bool) returns (out: bool) ;
+let out = false -> (not in and pre in) or (in and not pre in) ; tel
+
+node Rise 
+  (I : bool)
+returns 
+  (O : bool);
+let 
+  O = false -> (not pre I) and I;
+tel;
+
+
+
+
+
+-- |=================================================================|
+--
+--                            System nodes.
+--
+-- |=================================================================|
+
+-- Inihibited mode constant.
+const inhibit_count_max = 2;
+
+node PFS_Logic
+  (riseTS, riseOSPF : bool;
+   const Primary_Side : bool; 
+   const PFS_Initial_Value : bool)
+
+returns 
+  (PFS : bool);
+
+var
+  pfs_change, has_happened,
+  Start_to_Pilot_Flying, 
+  Start_to_Inhibited, 
+  Inhibited_to_Listening, 
+  Inhibited_to_Inhibited, 
+  Listening_to_Pilot_Flying, 
+  Pilot_Flying_to_Inhibited : bool;
+
+  state : subrange [1,5] of int;
+  -- enum { St_Start, St_Inhibited,  St_Listening, St_Pilot_Flying};
+
+  inhibit_count : subrange [0, inhibit_count_max] of int;
+
+  inhibit_count_bounded : bool;
+  pfs_state_consistency : bool;
+
+  state_bounded : bool;
+  
+  -- req_glb_R1, req_inh_R2_R3, req_inh_init,
+  -- req_act_chg_R3, req_inact_chg_R3, req_act_dual_R5,
+  -- ens_glb_R1, ens_inh_R2_R3, ens_inh_init,
+  -- ens_act_chg_R3, ens_inact_chg_R3, ens_act_dual_R5,
+  -- req, ens: bool;
+
+  const St_Inhibited = 2;
+  const St_Listening = 3;
+  const St_Pilot_Flying = 4;
+  const St_Start = 1;
+  const St_Stop = 5;
+
+
+-- const St_Inhibited = 2;
+-- const St_Listening = 3;
+-- const St_Pilot_Flying = 4;
+-- const St_Start = 1;
+-- const St_Stop = 5;
+
+let
+
+  -- MAIN;
+ 
+  Start_to_Pilot_Flying = 
+    ((St_Start -> pre(state)) = St_Start) and Primary_Side;
+
+  Start_to_Inhibited = 
+    ((St_Start -> pre(state)) = St_Start) and (not Primary_Side);
+
+  Inhibited_to_Listening = 
+    ((St_Start -> pre(state)) = St_Inhibited) and 
+      (0 -> pre(inhibit_count)) >= inhibit_count_max;
+  
+  Inhibited_to_Inhibited = 
+    ((St_Start -> pre(state)) = St_Inhibited) and 
+      not Inhibited_to_Listening;
+
+  Listening_to_Pilot_Flying = 
+    ((St_Start -> pre(state)) = St_Listening) and riseTS;
+
+  Pilot_Flying_to_Inhibited = 
+    ((St_Start -> pre(state)) = St_Pilot_Flying) and riseOSPF;
+
+  state =
+    if
+      Inhibited_to_Inhibited or 
+      Pilot_Flying_to_Inhibited or 
+      Start_to_Inhibited
+    then 
+      St_Inhibited 
+    else if 
+      Inhibited_to_Listening 
+    then 
+      St_Listening
+    else if 
+      Listening_to_Pilot_Flying or 
+      Start_to_Pilot_Flying 
+    then 
+      St_Pilot_Flying 
+    else 
+      (St_Start -> pre(state));
+  
+  PFS = 
+    if 
+      Listening_to_Pilot_Flying 
+    then 
+      true
+    else if 
+      Pilot_Flying_to_Inhibited 
+    then 
+      false
+    else if 
+      Start_to_Pilot_Flying 
+    then 
+      true
+    else if 
+      Start_to_Inhibited 
+    then 
+      false
+    else 
+      PFS_Initial_Value -> pre(PFS);
+  
+  inhibit_count = 
+    if 
+      Inhibited_to_Inhibited 
+    then 
+      (0 -> pre(inhibit_count)) + 1
+    else if 
+      Pilot_Flying_to_Inhibited 
+    then 
+      0
+    else if 
+      Start_to_Inhibited 
+    then 
+      0
+    else 
+      0 -> pre(inhibit_count);
+  
+  pfs_state_consistency = 
+    not (state = St_Start) => (PFS = (state = St_Pilot_Flying));
+  
+  -- PROPERTY pfs_state_consistency;
+
+  -- Proved as property before 
+  assert pfs_state_consistency;
+       
+  inhibit_count_bounded = 
+    inhibit_count >= 0 and inhibit_count <= inhibit_count_max;
+  
+  -- PROPERTY inhibit_count_bounded;
+
+  -- Proved as property before 
+  assert inhibit_count_bounded;
+
+  state_bounded = state >= St_Start and state < St_Stop;
+
+  -- -- PROPERTY state_bounded;
+
+  -- Proved as property before 
+  assert state_bounded;
+
+  -- req_glb_R1 =
+  --   Primary_Side = PFS_Initial_Value ;
+  -- req_inh_R2_R3 =
+  --   true -> (
+  --     (not pre PFS) and
+  --     (pre hasHappenedSince(valueChange(PFS), inhibit_count_max))
+  --   ) ;
+  -- req_inh_init =
+  --   (not Primary_Side) and
+  --   (not cyclesElapsedGT(inhibit_count_max + 1)) ;
+  -- req_act_chg_R3 =
+  --   riseOSPF and (false -> pre PFS) ;
+  -- req_inact_chg_R3 =
+  --   riseTS and (false -> not pre PFS) and
+  --   cyclesElapsedGT(inhibit_count_max + 1) and
+  --   (false -> pre hasNotHappenedFor(valueChange(PFS), inhibit_count_max)) ;
+  -- req_act_dual_R5 =
+  --   true -> (
+  --     ( (not pre PFS) and not riseTS ) or
+  --     ( (pre PFS) and not riseOSPF )
+  --   ) ;
+
+  -- req =
+  --   req_glb_R1 and
+  --   ( req_inh_R2_R3 or
+  --     req_inh_init or
+  --     req_act_chg_R3 or
+  --     req_inact_chg_R3 or
+  --     req_act_dual_R5 ) ;
+
+  -- ens_glb_R1 =
+  --   (PFS = Primary_Side) -> true ;
+  -- ens_inh_R2_R3 =
+  --   true -> (PFS = pre PFS) ;
+  -- ens_inh_init =
+  --   true -> (PFS = pre PFS) ;
+  -- ens_act_chg_R3 =
+  --   not PFS ;
+  -- ens_inact_chg_R3 =
+  --   PFS ;
+  -- ens_act_dual_R5 =
+  --   true -> (pre PFS = PFS) ;
+
+  -- ens =
+  --   ens_glb_R1 and
+  --   ( req_inh_R2_R3 => ens_inh_R2_R3 ) and
+  --   ( req_inh_init => ens_inh_init ) and
+  --   ( req_act_chg_R3 => ens_act_chg_R3 ) and
+  --   ( req_inact_chg_R3 => ens_inact_chg_R3 ) and
+  --   ( req_act_dual_R5 => ens_act_dual_R5 ) ;
+
+  -- --%PROPERTY hist(req) => ens ;
+  	
+tel;
+
+node PFS_Side
+  (TS, OSPF : bool;
+   const Primary_Side : bool; 
+   const PFS_Initial_Value : bool)
+
+returns 
+  (PFS : bool);
+
+var
+  PFSL_PFS : bool;
+  riseTS_O : bool;
+  riseOSPF_O : bool;
+  -- req_glb_R1, req_inh_R2_R3, req_inh_init,
+  -- req_act_chg_R3, req_inact_chg_R3, req_act_dual_R5,
+  -- ens_glb_R1, ens_inh_R2_R3, ens_inh_init,
+  -- ens_act_chg_R3, ens_inact_chg_R3, ens_act_dual_R5,
+  -- req, ens: bool;
+  
+let
+
+
+  -- MAIN;
+
+  PFSL_PFS =
+    PFS_Logic(riseTS_O, riseOSPF_O, Primary_Side, PFS_Initial_Value);
+
+  riseTS_O = Rise(TS);
+
+  riseOSPF_O = Rise(OSPF);
+
+  PFS = PFSL_PFS;
+
+  -- req_glb_R1 =
+  --   ( Primary_Side = PFS_Initial_Value ) ;
+  -- req_inh_R2_R3 =
+  --   (true -> not pre PFS) and
+  --   (true -> pre hasHappenedSince(valueChange(PFS), inhibit_count_max)) ;
+  -- req_inh_init =
+  --   (not Primary_Side) and
+  --   (not cyclesElapsedGT(inhibit_count_max + 1)) ;
+  -- req_act_chg_R3 =
+  --   Rise(OSPF) and (false -> (pre PFS)) ;
+  -- req_inact_chg_R3 =
+  --   Rise(TS) and (false -> (not pre PFS)) and
+  --   cyclesElapsedGT(inhibit_count_max + 1) and
+  --   (false -> pre hasNotHappenedFor(valueChange(PFS), inhibit_count_max)) ;
+  -- req_act_dual_R5 =
+  --   true -> (
+  --     ( (not pre PFS) and not Rise(TS) ) or
+  --     ( (pre PFS) and not Rise(OSPF) )
+  --   ) ;
+
+  -- req =
+  --   req_glb_R1 and
+  --   ( req_inh_R2_R3 or
+  --     req_inh_init or
+  --     req_act_chg_R3 or
+  --     req_inact_chg_R3 or
+  --     req_act_dual_R5 ) ;
+
+  -- ens_glb_R1 =
+  --   (PFS = Primary_Side) -> true ;
+  -- ens_inh_R2_R3 =
+  --   true -> (PFS = pre PFS) ;
+  -- ens_inh_init =
+  --   true -> (PFS = pre PFS) ;
+  -- ens_act_chg_R3 =
+  --   not PFS ;
+  -- ens_inact_chg_R3 =
+  --   PFS ;
+  -- ens_act_dual_R5 =
+  --   true -> (pre PFS = PFS) ;
+
+  -- ens =
+  --   ens_glb_R1 and
+  --   ( req_inh_R2_R3 => ens_inh_R2_R3 ) and
+  --   ( req_inh_init => ens_inh_init ) and
+  --   ( req_act_chg_R3 => ens_act_chg_R3 ) and
+  --   ( req_inact_chg_R3 => ens_inact_chg_R3 ) and
+  --   ( req_act_dual_R5 => ens_act_dual_R5 ) ;
+
+  -- --%PROPERTY hist(req) => ens ;
+
+tel;
+
+node Cross_Channel_Bus
+  (I : bool;
+   const O_Initial_Value : bool; 
+   const prev_I_Initial_Value : bool)
+
+returns
+  (O : bool);
+
+var
+  prev_I : bool;
+  Start_to_Step : bool;
+  Step_to_Step : bool;
+  state_bounded : bool;
+
+  state : subrange [1,3] of int;
+  -- state : enum { St_Step, St_Start };
+
+const St_Step = 2;
+const St_Start = 1;
+const St_Stop = 3;
+
+let
+
+  Start_to_Step = (St_Start -> pre(state)) = St_Start;
+
+  Step_to_Step = (St_Start -> pre(state)) = St_Step;
+
+  state = 
+    if 
+      Start_to_Step or Step_to_Step 
+    then 
+      St_Step 
+    else 
+      (St_Start -> pre(state));
+
+  prev_I = 
+    if Start_to_Step then I
+    else if Step_to_Step then I
+    else prev_I_Initial_Value -> pre(prev_I);
+
+  O = 
+    if
+      Start_to_Step 
+    then 
+      prev_I_Initial_Value -> pre(prev_I)
+    else if 
+      Step_to_Step 
+    then 
+      prev_I_Initial_Value -> pre(prev_I)
+    else 
+      O_Initial_Value -> pre(O);
+      
+  state_bounded = state >= St_Start and state < St_Stop;
+
+  assert state_bounded ;
+  
+  -- PROPERTY ( (O = prev_I_Initial_Value) -> true) and (true -> O = pre I) ;
+  
+tel;
+
+
+
+-- |=================================================================|
+--
+--                   Top level environment nodes.
+--
+-- |=================================================================|
+
+
+
+node qs_dfa (p, q : bool) returns (ok : bool);
+
+var
+  r : int;
+
+let
+
+  ok = not (((0 -> pre r) = 2 and p) or ((0 -> pre r) = -2 and q));
+  
+  r = if p and q then 0 
+      else if p then
+        (if (0 -> pre r) < 0 then 1 else ((0 -> pre r)) + 1)
+      else if q then
+        (if (0 -> pre r) > 0 then -1 else ((0 -> pre r)) - 1)
+      else (0 -> pre r);
+
+tel;
+
+node calendar
+  (CLK1 : bool; CLK3 : bool; CLK2 : bool; CLK4 : bool)
+returns
+  (ok : bool);
+let
+  ok = qs_dfa(CLK1, CLK3) and
+       qs_dfa(CLK1, CLK2) and
+       qs_dfa(CLK1, CLK4) and
+       qs_dfa(CLK3, CLK2) and
+       qs_dfa(CLK3, CLK4) and
+       qs_dfa(CLK2, CLK4);
+tel;
+
+
+node PRESSED (p : bool) returns (b : bool);
+let
+  b = false -> (not pre p and p);
+tel;
+
+node PRESSED_SEEN (p, c : bool) returns (b : bool);
+let
+  b = false -> (not pre p and pre c) and (p and c);
+tel;
+
+node CHANGED (p : bool) returns (b : bool);
+let
+  b = false ->  not (p = pre p);
+tel;
+  
+node ticked(c: bool) returns (b: bool);
+let 
+  b = (false -> pre b) or c;
+tel;
+  
+node false_longer_than (p: bool; const n: int) returns (ok: bool);
+
+var
+  c: int;
+
+let
+
+  c = if p then 0 else (1 -> pre c + 1);
+  
+  ok = c > n;
+
+tel;
+
+node quiescent
+  (TS, CLK1, CLK3, CLK2, CLK4 : bool)
+returns
+  (out : bool) ;
+let
+  out =
+    condact(CLK1, false_longer_than(PRESSED(TS), 46), false) and
+    condact(CLK2, false_longer_than(PRESSED(TS), 46), false) and
+    condact(CLK3, false_longer_than(PRESSED(TS), 46), false) and
+    condact(CLK4, false_longer_than(PRESSED(TS), 46), false) ;
+tel
+
+
+
+-- |=================================================================|
+--
+--                           Top level node.
+--
+-- |=================================================================|
+
+
+
+node PFS
+  (TS, CLK1, CLK3, CLK2, CLK4 : bool) 
+returns 
+  (LPFS, RPFS : bool) ;
+
+-- --@global_contract PFS_global_spec_R1_R4 ;
+-- --@contract PFS_contract_R2 ;
+-- --@contract PFS_contract_R3 ;
+-- --@contract PFS_contract_R5 ;
+
+var
+  RL_O : bool;
+  RS_PFS : bool;
+  LR_O : bool;
+  LS_PFS : bool;
+  req_glb_R1_R4, req_R2_R5, req_R3,
+  ens_glb_R1_R4, ens_R2, ens_R3, ens_R5,
+  req, ens: bool ;
+
+let
+
+  --%MAIN;
+
+  LS_PFS = 
+    condact(CLK1, PFS_Side(TS, RL_O, true, true), true);
+    -- PFS_Side(TS, RL_O, true, true);
+
+  RS_PFS = 
+    condact(CLK3, PFS_Side(TS, LR_O, false, false), false);
+    -- PFS_Side(TS, LR_O, false, false);
+
+  LR_O = 
+    condact(CLK2, Cross_Channel_Bus (LS_PFS, true, true), true);
+    -- Cross_Channel_Bus (LS_PFS, true, true);
+
+  RL_O = 
+    condact(CLK4, Cross_Channel_Bus (RS_PFS, false, false), false);
+    -- Cross_Channel_Bus (RS_PFS, false, false);
+
+  LPFS = LS_PFS;
+
+  RPFS = RS_PFS;
+
+  req_glb_R1_R4 =
+    calendar(CLK1, CLK3, CLK2, CLK4) and
+    (CLK1 or CLK2 or CLK3 or CLK4) ;
+  req_R2_R5 =
+    quiescent(TS,CLK1,CLK2,CLK3,CLK4) ;
+  req_R3 =
+    true -> pre quiescent(TS,CLK1,CLK2,CLK3,CLK4) ;
+  req =
+    req_glb_R1_R4 and
+    ( req_R2_R5 or req_R3 ) ;
+
+  ens_glb_R1_R4 =
+      (LPFS or RPFS) and
+      (LPFS -> true) ;
+  ens_R2 =
+    LPFS = not RPFS ;
+  ens_R3 =
+    true -> (
+      ( (not pre LPFS and PRESSED_SEEN(TS,CLK1)) => LPFS ) and
+      ( (not pre RPFS and PRESSED_SEEN(TS,CLK3)) => RPFS )
+    ) ;
+  ens_R5 =
+    not ( CHANGED(RPFS) or CHANGED(LPFS) ) ;
+  ens =
+    ens_glb_R1_R4 and
+    ( req_R2_R5 => ens_R2 ) and
+    ( req_R3 => ens_R3 ) and
+    ( req_R2_R5 => ens_R5 ) ;
+
+  --%PROPERTY hist(req) => ens ;
+  
+tel;
+


### PR DESCRIPTION
Added variations of the pilot flying system where contracts are rewritten as properties in `tests/lustre/contracts/`. The new systems are `PilotFlying-props-*.lus`:

* `PilotFlying-props-top-no-lemma.lus` -- only the top node is specified, no lemmas (asserts);
* `PilotFlying-props-top-lemma.lus` -- only the top node is specified, with lemmas (asserts);
* the other systems (without `-top-`) differ in that all subnodes are specified.