### PR TITLE
Support for --! annotation for contracts.

### DIFF
--- a/src/lustreLexer.mll
+++ b/src/lustreLexer.mll
@@ -465,6 +465,17 @@ and comment = parse
                 skip_to_eol lexbuf ) }
 
   (* Contract *)
+  | "!" (id as p) 
+      { match p with
+
+        (* Return token, continue with rest of line. *)
+        | "contract" -> ANNOTATIONCONTRACT
+
+        (* Warn and ignore rest of line *)
+        | _ -> (Format.printf "Warning: unknown annotation %s skipped@." p; 
+                skip_to_eol lexbuf ) }
+
+  (* Contract *)
   | "@" (id as p) 
       { match p with
 

--- a/src/lustreParser.mly
+++ b/src/lustreParser.mly
@@ -101,6 +101,7 @@ let mk_pos = Lib.position_of_lexing
 %token PROPERTY
 %token MAIN
 %token COMMENTCONTRACT
+%token ANNOTATIONCONTRACT
 %token COMMENTGLOBALCONTRACT
 %token COMMENTREQUIRE
 %token COMMENTENSURE
@@ -375,6 +376,8 @@ contract:
       A.InlinedContract
         (mk_pos $startpos, n, reqs, enss) }
   | COMMENTCONTRACT; n = ident; SEMICOLON
+    { A.ContractCall (mk_pos $startpos, n) }
+  | ANNOTATIONCONTRACT; COLON; n = ident; SEMICOLON
     { A.ContractCall (mk_pos $startpos, n) }
 
 contract_require:


### PR DESCRIPTION
Contract calls can be written as

```
--!contract : <contract_node_name> ;
```

It is exactly the same as

```
--@contract <contract_node_name> ;
```
