### PR TITLE
Bug fix in TransSys.add_caller

### DIFF
--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -196,7 +196,8 @@ let add_caller callee caller c =
   let rec add_caller' accum = function
     | [] ->  (caller, [c]) :: accum
     | (caller', c') :: tl when 
-        caller'.scope = caller.scope -> (caller', (c :: c')) :: accum
+        caller'.scope = caller.scope ->
+      ((caller', (c :: c')) :: accum) @ tl
     | h :: tl -> add_caller' (h :: accum) tl 
   in
 


### PR DESCRIPTION
Callers would be removed when adding an extra call to an already existing node call.