### PR TITLE
Bang annotations for properties and main node annotation.

### DIFF
--- a/src/lustreAst.ml
+++ b/src/lustreAst.ml
@@ -198,7 +198,7 @@ type struct_item =
 type node_equation =
   | Assert of position * expr
   | Equation of position * struct_item list * expr 
-  | AnnotMain
+  | AnnotMain of bool
   | AnnotProperty of position * expr
 
 (* A contract requirement. *)
@@ -719,7 +719,8 @@ let pp_print_node_equation ppf = function
       (pp_print_list pp_print_struct_item ",@ ") l
       pp_print_expr e
 
-  | AnnotMain -> Format.fprintf ppf "--%%MAIN;"
+  | AnnotMain(b) ->
+    if b then Format.fprintf ppf "--%%MAIN;" else ()
 
   | AnnotProperty (pos, e) ->
      Format.fprintf ppf "--%%PROPERTY %a;" pp_print_expr e

--- a/src/lustreAst.mli
+++ b/src/lustreAst.mli
@@ -166,7 +166,7 @@ type struct_item =
 type node_equation =
   | Assert of position * expr
   | Equation of position * struct_item list * expr
-  | AnnotMain 
+  | AnnotMain of bool
   | AnnotProperty of position * expr
 
 (** A contract requirement. *)

--- a/src/lustreLexer.mll
+++ b/src/lustreLexer.mll
@@ -469,7 +469,13 @@ and comment = parse
       { match p with
 
         (* Return token, continue with rest of line. *)
-        | "contract" -> ANNOTATIONCONTRACT
+        | "contract" -> BANGCONTRACT
+
+        (* Return token, continue with rest of line. *)
+        | "PROPERTY" -> BANGPROPERTY
+
+        (* Return token, continue with rest of line. *)
+        | "MAIN" -> BANGMAIN
 
         (* Warn and ignore rest of line *)
         | _ -> (Format.printf "Warning: unknown annotation %s skipped@." p; 

--- a/src/lustreNode.ml
+++ b/src/lustreNode.ml
@@ -1068,7 +1068,7 @@ let find_main nodes =
            if a = None then Some name else 
              raise
                (Failure 
-                  "find_main: More than one --%MAIN annotation")
+                  "find_main: More than one MAIN node")
          else
            a)
       None

--- a/src/lustreParser.mly
+++ b/src/lustreParser.mly
@@ -99,9 +99,11 @@ let mk_pos = Lib.position_of_lexing
     
 (* Tokens for annotations *)
 %token PROPERTY
+%token BANGPROPERTY
 %token MAIN
+%token BANGMAIN
 %token COMMENTCONTRACT
-%token ANNOTATIONCONTRACT
+%token BANGCONTRACT
 %token COMMENTGLOBALCONTRACT
 %token COMMENTREQUIRE
 %token COMMENTENSURE
@@ -377,7 +379,7 @@ contract:
         (mk_pos $startpos, n, reqs, enss) }
   | COMMENTCONTRACT; n = ident; SEMICOLON
     { A.ContractCall (mk_pos $startpos, n) }
-  | ANNOTATIONCONTRACT; COLON; n = ident; SEMICOLON
+  | BANGCONTRACT; COLON; n = ident; SEMICOLON
     { A.ContractCall (mk_pos $startpos, n) }
 
 contract_require:
@@ -488,10 +490,15 @@ node_equation:
     { A.Equation (mk_pos $startpos, l, e) }
 
   (* Node annotation *)
-  | MAIN { A.AnnotMain }
+  | MAIN { A.AnnotMain true }
+  | BANGMAIN; COLON; TRUE ; SEMICOLON { A.AnnotMain true }
+  | BANGMAIN; COLON; FALSE ; SEMICOLON { A.AnnotMain false }
 
   (* Property annotation *)
   | PROPERTY; e = expr; SEMICOLON { A.AnnotProperty (mk_pos $startpos, e) }
+  | BANGPROPERTY; COLON; e = expr; SEMICOLON {
+    A.AnnotProperty (mk_pos $startpos, e)
+  }
 
 
 left_side:

--- a/src/lustreSimplify.ml
+++ b/src/lustreSimplify.ml
@@ -4028,12 +4028,12 @@ let rec parse_node_equations
 
 
     (* Annotation for main node *)
-    | A.AnnotMain :: tl -> 
+    | (A.AnnotMain b) :: tl -> 
 
       parse_node_equations 
         context 
         abstractions
-        { node with N.is_main = true }
+        { node with N.is_main = b }
         tl
 
 

--- a/tests/lustre/annotations/stopwatch-multi-mains.lus
+++ b/tests/lustre/annotations/stopwatch-multi-mains.lus
@@ -1,0 +1,37 @@
+node Switch(on, off: bool) returns (s: bool);
+let
+  s = if (false -> pre s) then not off else on; 
+  --!MAIN : false ;
+  --%PROPERTY s or (not s) ;
+tel
+
+node Count(reset, x: bool) returns (c: int);
+let
+  c = if reset then 0
+      else if x then (0 -> pre c) + 1
+      else (0 -> pre c);
+  --!MAIN: true ;
+  --!PROPERTY : c >= 0 ;
+tel
+
+node Stopwatch(on_off, reset, freeze: bool) returns (time: int);
+var
+  running, freezed: bool;
+  cpt: int;
+  time_is_positive, time_is_less_than_three: bool;
+let
+  running = Switch(on_off, on_off);
+  freezed = Switch(freeze and running,
+                   freeze or on_off);
+  cpt = Count(reset and not running, running);
+  time = if freezed then (0 -> pre time) else cpt;
+
+  time_is_positive = time >= 0;
+  time_is_less_than_three = time < 3;
+  -- --%PROPERTY time_is_positive;
+  --%PROPERTY time_is_less_than_three;
+  --!PROPERTY : time_is_positive;
+
+  --!MAIN : true ;
+  --!MAIN : true ;
+tel

--- a/tests/lustre/annotations/stopwatch-sub.lus
+++ b/tests/lustre/annotations/stopwatch-sub.lus
@@ -1,0 +1,36 @@
+node Switch(on, off: bool) returns (s: bool);
+let
+  s = if (false -> pre s) then not off else on; 
+  --!MAIN : false ;
+  --%PROPERTY s or (not s) ;
+tel
+
+node Count(reset, x: bool) returns (c: int);
+let
+  c = if reset then 0
+      else if x then (0 -> pre c) + 1
+      else (0 -> pre c);
+  --!MAIN: true ;
+  --!PROPERTY : c >= 0 ;
+tel
+
+node Stopwatch(on_off, reset, freeze: bool) returns (time: int);
+var
+  running, freezed: bool;
+  cpt: int;
+  time_is_positive, time_is_less_than_three: bool;
+let
+  running = Switch(on_off, on_off);
+  freezed = Switch(freeze and running,
+                   freeze or on_off);
+  cpt = Count(reset and not running, running);
+  time = if freezed then (0 -> pre time) else cpt;
+
+  time_is_positive = time >= 0;
+  time_is_less_than_three = time < 3;
+  -- --%PROPERTY time_is_positive;
+  --%PROPERTY time_is_less_than_three;
+  --!PROPERTY : time_is_positive;
+
+  --!MAIN : false ;
+tel

--- a/tests/lustre/annotations/stopwatch-top.lus
+++ b/tests/lustre/annotations/stopwatch-top.lus
@@ -1,0 +1,36 @@
+node Switch(on, off: bool) returns (s: bool);
+let
+  s = if (false -> pre s) then not off else on; 
+  --!MAIN : false ;
+  --%PROPERTY s or (not s) ;
+tel
+
+node Count(reset, x: bool) returns (c: int);
+let
+  c = if reset then 0
+      else if x then (0 -> pre c) + 1
+      else (0 -> pre c);
+  --!MAIN: false ;
+  --!PROPERTY : c >= 0 ;
+tel
+
+node Stopwatch(on_off, reset, freeze: bool) returns (time: int);
+var
+  running, freezed: bool;
+  cpt: int;
+  time_is_positive, time_is_less_than_three: bool;
+let
+  running = Switch(on_off, on_off);
+  freezed = Switch(freeze and running,
+                   freeze or on_off);
+  cpt = Count(reset and not running, running);
+  time = if freezed then (0 -> pre time) else cpt;
+
+  time_is_positive = time >= 0;
+  time_is_less_than_three = time < 3;
+  -- --%PROPERTY time_is_positive;
+  --%PROPERTY time_is_less_than_three;
+  --!PROPERTY : time_is_positive;
+
+  --!MAIN : true ;
+tel


### PR DESCRIPTION
Support for `--!<key> : <value> ;` for

* `<key>=PROPERTY` and `<value>=<expr>`.

  Equivalent to `--%PROPERTY <expr> ;`

* `<key>=MAIN` and `<value>=<bool>`.

  Sets the value of the `is_main` flag (`lustreNode.ml`) of the node to `<value>`.
  `--%MAIN ;` is equivalent to `--!MAIN : true ;`.
  This means that only the last main annotation (`!` or `%`) matters. 