### PR TITLE
Bugfixes for constant node inputs

### DIFF
--- a/src/lustreExpr.ml
+++ b/src/lustreExpr.ml
@@ -2060,6 +2060,17 @@ let mk_pre
   (* Apply pre to initial state expression *)
   let expr_init', new_vars' = match expr_init with 
 
+    (* Expression is a constant *)
+    | t when 
+        t == Term.t_true || 
+        t == Term.t_false || 
+        (Term.is_free_var t && 
+        Term.free_var_of_term t |> Var.is_const_state_var) ||
+        (match Term.destruct t with 
+          | Term.T.Const c1 when 
+              Symbol.is_numeral c1 || Symbol.is_decimal c1 -> true
+          | _ -> false) -> (expr_init, new_vars)
+
     (* Expression is a variable at the current instant *)
     | t when 
         Term.is_free_var t && 
@@ -2067,15 +2078,6 @@ let mk_pre
                  base_offset)  -> 
       
       (Term.bump_state Numeral.(- one) t, new_vars)
-
-    (* Expression is a constant *)
-    | t when 
-        t == Term.t_true || 
-        t == Term.t_false || 
-        (match Term.destruct t with 
-          | Term.T.Const c1 when 
-              Symbol.is_numeral c1 || Symbol.is_decimal c1 -> true
-          | _ -> false) -> (expr_init, new_vars)
 
     (* Expression is not constant and not a variable at the current
        instant *)
@@ -2187,6 +2189,22 @@ let is_var expr = is_var_at_offset expr (base_offset, cur_offset)
 (* Return true if expression is a previous state variable *)
 let is_pre_var expr = is_var_at_offset expr (pre_base_offset, pre_offset)
 
+
+(* Return true if the expression is constant *)
+let is_const { expr_init; expr_step } = 
+
+  (* Are all variables in the expression constant? *)
+  VS.for_all
+    Var.is_const_state_var
+    (Term.vars_of_term expr_init)
+    
+  &&
+
+  (* Are all variables in the expression constant? *)
+  VS.for_all
+    Var.is_const_state_var
+    (Term.vars_of_term expr_step)
+    
 
 (* Return the state variable of a variable *)
 let state_var_of_expr ({ expr_init; expr_step } as expr) = 

--- a/src/lustreExpr.mli
+++ b/src/lustreExpr.mli
@@ -364,6 +364,9 @@ val is_var : t -> bool
 (** Return true if expression is a previous state variable *)
 val is_pre_var : t -> bool
 
+(** Return true if the expression is constant *)
+val is_const : t -> bool
+
 (* 
    Local Variables:
    compile-command: "make -k -C .."

--- a/src/lustreSimplify.ml
+++ b/src/lustreSimplify.ml
@@ -1788,7 +1788,11 @@ and eval_node_call
             (* Expression must be of a subtype of input type *)
             Type.check_type 
               expr_type
-              (StateVar.type_of_state_var in_var) 
+              (StateVar.type_of_state_var in_var) &&
+
+            (* Expression must be constant if input is *)
+            (not (StateVar.is_const in_var) || 
+             E.is_const expr)
 
           then 
 


### PR DESCRIPTION
Accept ```pre in``` where ```in``` is a constant input, and make it equal to ```in```.

Reject node calls where a non-constant input is given to constant input parameter.