### PR TITLE
Fixed continuation making invgen with push pop unsound (closes #96)

### DIFF
--- a/src/invGenGraph.ml
+++ b/src/invGenGraph.ml
@@ -24,6 +24,241 @@ module CandTerm = InvGenCandTermGen
 module LSD = LockStepDriver
 
 
+(* Module gathering pruning algorithms. *)
+module Pruning = struct
+
+  (* Tests if [rhs] is an [or] containing [lhs], or a negated and
+     containing the complement of [lhs]. *)
+  let trivial_rhs_or lhs rhs =
+
+    (* Returns true if [negated] is an or containing the complement
+       of [lhs]. Used if [rhs] is a not. *)
+    let negated_and negated =
+      if Term.is_node negated
+      then
+      
+        if Term.node_symbol_of_term negated == Symbol.s_and
+        then
+          (* Term is an and. *)
+          Term.node_args_of_term negated
+          |> List.mem (Term.negate lhs)
+
+        else false
+      else false
+    in
+  
+    (* Is rhs an application? *)
+    if Term.is_node rhs
+    then
+
+      ( if Term.node_symbol_of_term rhs == Symbol.s_or
+        then
+          (* Rhs is an or. *)
+          Term.node_args_of_term rhs |> List.mem lhs
+
+        else if Term.node_symbol_of_term rhs == Symbol.s_not
+        then
+          (* Rhs is a not, need to check if there is an and
+             below. *)
+          ( match Term.node_args_of_term rhs with
+
+            (* Well founded not. *)
+            | [ negated ] -> negated_and negated
+
+            (* Dunno what that is. *)
+            | _ -> false )
+
+        else false )
+    else false
+
+
+  (* Tests if [lhs] is an [and] containing [rhs], or a negated or
+     containing the complement of [rhs]. *)
+  let trivial_lhs_and lhs rhs =
+
+    (* Returns true if [negated] is an and containing the complement
+       of [rhs]. Used if [lhs] is a not. *)
+    let negated_or negated =
+      if Term.is_node negated
+      then
+
+        if Term.node_symbol_of_term negated == Symbol.s_or
+        then
+          (* Term is an or. *)
+          Term.node_args_of_term negated
+          |> List.mem (Term.negate rhs)
+
+        else false
+      else false
+    in
+
+    (* Is rhs an application? *)
+    if Term.is_node lhs
+    then
+
+      ( if Term.node_symbol_of_term lhs == Symbol.s_and
+        then
+          (* Lhs is an and. *)
+          Term.node_args_of_term lhs |> List.mem rhs
+
+
+        else if Term.node_symbol_of_term lhs == Symbol.s_not
+        then
+          (* Lhs is a not, need to check if there is an or below. *)
+          ( match Term.node_args_of_term lhs with
+
+            (* Well founded not. *)
+            | [ negated ] -> negated_or negated
+
+            (* Dunno what that is. *)
+            | _ -> false )
+
+        else false )
+
+    else false
+    
+   
+
+
+  (* Tests if [lhs] and [rhs] are arithmetic operators that
+     trivially imply each other, such as [x<=2] and [x<=0]. *)
+  let trivial_impl_arith lhs rhs =
+
+    (* Returns true if the two input terms are arith constants and
+       the first one is greater than or equal to the second one. *)
+    let term_geq t1 t2 =
+      if (Term.is_numeral t1) && (Term.is_numeral t2)
+      then
+        (* Comparing numerals. *)
+        Numeral.(
+          (Term.numeral_of_term t1) >= (Term.numeral_of_term t2)
+        )
+
+      else if (Term.is_decimal t1) && (Term.is_decimal t2)
+      then
+        (* Comparing decimals. *)
+        Decimal.(
+          (Term.decimal_of_term t1) >= (Term.decimal_of_term t2)
+        )
+
+      else
+        (* Uncomparable terms. *)
+        false
+    in
+
+    (* Are lhs and rhs applications? *)
+    if (Term.is_node lhs) && (Term.is_node rhs)
+    then
+
+      (* Are rhs and lhs similar applications? *)
+      if
+        (Term.node_symbol_of_term lhs)
+        == (Term.node_symbol_of_term rhs)
+      then (
+
+        match
+          (Term.node_args_of_term lhs),
+          (Term.node_args_of_term rhs)
+        with
+
+          | [kid1 ; kid2], [kid1' ; kid2'] ->
+
+            (* If lhs and rhs are applications of [symbol], and if
+               [kid1] and [kid1'] are the same variables then return
+               [operator kid2 kid2']. Else, if [kid2] and [kid2']
+               are the same variables then return [operator kid1'
+               kid1]. Otherwise return false. *)
+            let compare symbol operator =
+
+              if (Term.node_symbol_of_term lhs) == symbol
+              then
+
+                ( if
+                    (Term.is_free_var kid1)
+                    && (Term.is_free_var kid1')
+                  then
+
+                    ( (Term.free_var_of_term kid1) ==
+                        (Term.free_var_of_term kid1') )
+                    && ( operator kid2 kid2' )
+
+                  else if
+                      (Term.is_free_var kid2)
+                      && (Term.is_free_var kid2')
+                  then
+
+                    ( (Term.free_var_of_term kid2)
+                      == (Term.free_var_of_term kid2') )
+                    && ( operator kid1' kid1 )
+
+                  else false )
+                  
+              else false
+
+            in
+
+
+            (* Returns true if
+               [x>=n  x>=n' and n  >= n']
+               [n>=x n'>=x  and n' >= n] *)
+            (compare Symbol.s_geq term_geq)
+
+            (* Returns true if
+               [x>n  x>n'   and n  >= n']
+               [n>x n'>x    and n' >= n] *)
+            || (compare Symbol.s_gt term_geq)
+
+            (* Returns true if
+               [x<=n  x<=n' and n  <= n']
+               [n<=x n'<=x  and n' <= n] *)
+            || (compare
+                    Symbol.s_leq (fun t1 t2 -> term_geq t2 t1))
+
+            (* Returns true if
+               [x<n  x<n'   and n  <= n']
+               [n<x n'<x    and n' <= n] *)
+            || (compare
+                  Symbol.s_lt (fun t1 t2 -> term_geq t2 t1))
+
+
+          (* Kid count does not fit the template, returning
+             false. *)
+          | _ -> false
+
+      (* [rhs] and [lhs] are not similar applications, returning
+         false. *)
+      ) else false
+
+    (* [rhs] and [lhs] are not applications, returning false. *)
+    else false
+
+ 
+  
+  let structural_criterion term =
+    if Term.node_symbol_of_term term == Symbol.s_implies then
+        (* Term is indeed an implication. *)
+        ( match Term.node_args_of_term term with
+
+          (* Term is a well founded implication. *)
+          | [ lhs ; rhs ] ->
+             (* Checking if rhs is an and containing lhs, or a
+                negated or containing the negation of lhs. *)
+             (trivial_rhs_or lhs rhs)
+             (* Checking if lhs is an or containing lhs, or a
+                negated or containing the negation of lhs. *)
+             || (trivial_lhs_and lhs rhs)
+             (* Checking if lhs and rhs are arith operator and lhs
+                trivially implies rhs. *)
+             || (trivial_impl_arith lhs rhs)
+
+          (* Implication is not well-founded, crashing. *)
+          | _ -> assert false )
+    else
+      (* Node is not an implication. *)
+      true
+end
+
+
 (* Input signature of a graph-based invariant generation technique. *)
 module type In = sig
 
@@ -235,225 +470,6 @@ module Make (InModule : In) : Out = struct
   (* Filters candidate invariants from a set of term for step. *)
   let filter_step_candidates invariants ignore =
 
-    (* FIXME: Why is this unused?
-
-    (* Tests if [rhs] is an [or] containing [lhs], or a negated and
-       containing the complement of [lhs]. *)
-    let trivial_rhs_or lhs rhs =
-
-      (* Returns true if [negated] is an or containing the complement
-         of [lhs]. Used if [rhs] is a not. *)
-      let negated_and negated =
-        if Term.is_node negated
-        then
-        
-          if Term.node_symbol_of_term negated == Symbol.s_and
-          then
-            (* Term is an and. *)
-            Term.node_args_of_term negated
-            |> List.mem (Term.negate lhs)
-
-          else false
-        else false
-      in
-    
-      (* Is rhs an application? *)
-      if Term.is_node rhs
-      then
-
-        ( if Term.node_symbol_of_term rhs == Symbol.s_or
-          then
-            (* Rhs is an or. *)
-            Term.node_args_of_term rhs |> List.mem lhs
-
-          else if Term.node_symbol_of_term rhs == Symbol.s_not
-          then
-            (* Rhs is a not, need to check if there is an and
-               below. *)
-            ( match Term.node_args_of_term rhs with
-
-              (* Well founded not. *)
-              | [ negated ] -> negated_and negated
-
-              (* Dunno what that is. *)
-              | _ -> false )
-
-          else false )
-      else false
-
-    in
-
-    *)
-    
-    (* FIXME: Why is this unused?
-
-    (* Tests if [lhs] is an [and] containing [rhs], or a negated or
-       containing the complement of [rhs]. *)
-    let trivial_lhs_and lhs rhs =
-
-      (* Returns true if [negated] is an and containing the complement
-         of [rhs]. Used if [lhs] is a not. *)
-      let negated_or negated =
-        if Term.is_node negated
-        then
-
-          if Term.node_symbol_of_term negated == Symbol.s_or
-          then
-            (* Term is an or. *)
-            Term.node_args_of_term negated
-            |> List.mem (Term.negate rhs)
-
-          else false
-        else false
-      in
-
-      (* Is rhs an application? *)
-      if Term.is_node lhs
-      then
-
-        ( if Term.node_symbol_of_term lhs == Symbol.s_and
-          then
-            (* Lhs is an and. *)
-            Term.node_args_of_term lhs |> List.mem rhs
-
-
-          else if Term.node_symbol_of_term lhs == Symbol.s_not
-          then
-            (* Lhs is a not, need to check if there is an or below. *)
-            ( match Term.node_args_of_term lhs with
-
-              (* Well founded not. *)
-              | [ negated ] -> negated_or negated
-
-              (* Dunno what that is. *)
-              | _ -> false )
-
-          else false )
-
-      else false
-
-    in
-    
-    *)
-
-    (* FIXME: Why is this unused?
-
-    (* Tests if [lhs] and [rhs] are arithmetic operators that
-       trivially imply each other, such as [x<=2] and [x<=0]. *)
-    let trivial_impl_arith lhs rhs =
-
-      (* Returns true if the two input terms are arith constants and
-         the first one is greater than or equal to the second one. *)
-      let term_geq t1 t2 =
-        if (Term.is_numeral t1) && (Term.is_numeral t2)
-        then
-          (* Comparing numerals. *)
-          Numeral.(
-            (Term.numeral_of_term t1) >= (Term.numeral_of_term t2)
-          )
-
-        else if (Term.is_decimal t1) && (Term.is_decimal t2)
-        then
-          (* Comparing decimals. *)
-          Decimal.(
-            (Term.decimal_of_term t1) >= (Term.decimal_of_term t2)
-          )
-
-        else
-          (* Uncomparable terms. *)
-          false
-      in
-
-      (* Are lhs and rhs applications? *)
-      if (Term.is_node lhs) && (Term.is_node rhs)
-      then
-
-        (* Are rhs and lhs similar applications? *)
-        if
-          (Term.node_symbol_of_term lhs)
-          == (Term.node_symbol_of_term rhs)
-        then (
-
-          match
-            (Term.node_args_of_term lhs),
-            (Term.node_args_of_term rhs)
-          with
-
-            | [kid1 ; kid2], [kid1' ; kid2'] ->
-
-              (* If lhs and rhs are applications of [symbol], and if
-                 [kid1] and [kid1'] are the same variables then return
-                 [operator kid2 kid2']. Else, if [kid2] and [kid2']
-                 are the same variables then return [operator kid1'
-                 kid1]. Otherwise return false. *)
-              let compare symbol operator =
-
-                if (Term.node_symbol_of_term lhs) == symbol
-                then
-
-                  ( if
-                      (Term.is_free_var kid1)
-                      && (Term.is_free_var kid1')
-                    then
-
-                      ( (Term.free_var_of_term kid1) ==
-                          (Term.free_var_of_term kid1') )
-                      && ( operator kid2 kid2' )
-
-                    else if
-                        (Term.is_free_var kid2)
-                        && (Term.is_free_var kid2')
-                    then
-
-                      ( (Term.free_var_of_term kid2)
-                        == (Term.free_var_of_term kid2') )
-                      && ( operator kid1' kid1 )
-
-                    else false )
-                    
-                else false
-
-              in
-
-
-              (* Returns true if
-                 [x>=n  x>=n' and n  >= n']
-                 [n>=x n'>=x  and n' >= n] *)
-              (compare Symbol.s_geq term_geq)
-
-              (* Returns true if
-                 [x>n  x>n'   and n  >= n']
-                 [n>x n'>x    and n' >= n] *)
-              || (compare Symbol.s_gt term_geq)
-
-              (* Returns true if
-                 [x<=n  x<=n' and n  <= n']
-                 [n<=x n'<=x  and n' <= n] *)
-              || (compare
-                      Symbol.s_leq (fun t1 t2 -> term_geq t2 t1))
-
-              (* Returns true if
-                 [x<n  x<n'   and n  <= n']
-                 [n<x n'<x    and n' <= n] *)
-              || (compare
-                    Symbol.s_lt (fun t1 t2 -> term_geq t2 t1))
-
-
-            (* Kid count does not fit the template, returning
-               false. *)
-            | _ -> false
-
-        (* [rhs] and [lhs] are not similar applications, returning
-           false. *)
-        ) else false
-
-      (* [rhs] and [lhs] are not applications, returning false. *)
-      else false
-
-    in
-
-    *)
-
     (* Function returning false for the candidate invariants to prune
        out. *)
     let filter_candidates term =
@@ -469,33 +485,6 @@ module Make (InModule : In) : Out = struct
         let offset_filter =
           (Lazy.force lazy_offset_criterion) term
         in
-        
-        (* FIXME: Why is this unused?
-        
-        let structural_criterion () =
-          if Term.node_symbol_of_term term == Symbol.s_implies then
-              (* Term is indeed an implication. *)
-              ( match Term.node_args_of_term term with
-
-                (* Term is a well founded implication. *)
-                | [ lhs ; rhs ] ->
-                   (* Checking if rhs is an and containing lhs, or a
-                      negated or containing the negation of lhs. *)
-                   (trivial_rhs_or lhs rhs)
-                   (* Checking if lhs is an or containing lhs, or a
-                      negated or containing the negation of lhs. *)
-                   || (trivial_lhs_and lhs rhs)
-                   (* Checking if lhs and rhs are arith operator and lhs
-                      trivially implies rhs. *)
-                   || (trivial_impl_arith lhs rhs)
-
-                (* Implication is not well-founded, crashing. *)
-                | _ -> assert false )
-          else
-            (* Node is not an implication. *)
-            true
-        in
-        *)
 
         offset_filter
       )
@@ -785,25 +774,10 @@ module Make (InModule : In) : Out = struct
     (* Returning new binding and base instance flag. *)
     (sys, graph', invariants', ignore'), unsat_on_first_check
 
-  let lazy_max_successive =
-    lazy
-      ( (* match *)
-        (*   Flags.invgengraph_max_successive () *)
-        (* with *)
-        (* | n when n > 0 -> *)
-        (*    (fun count -> count > n) *)
-        (* | _ -> *)
-           (fun count -> false) )
-
   (* Iterates on a [sys], [graph], [invariants] until the base
      instance is unsat on the first check or the upper bound given by
      the flags has been reached. *)
   let iterate_on_binding top_sys lsd (binding, cand_count) =
-
-    (* FIXME: Why is this unused?
-
-    let max_successive = Lazy.force lazy_max_successive in
-    *)
 
     let rec loop count ((sys,_,invs,_) as binding) =
       (*
@@ -823,8 +797,6 @@ module Make (InModule : In) : Out = struct
       let binding', base_unsat_on_first_check =
         rewrite_graph_find_invariants top_sys lsd binding
       in
-
-      (* let k' = LSD.get_k lsd sys in *)
 
       if
         base_unsat_on_first_check

--- a/src/lockStepDriver.ml
+++ b/src/lockStepDriver.ml
@@ -324,18 +324,19 @@ let create two_state top_only sys =
     new_inst_sys (), new_inst_sys (), new_inst_sys ()
   in
 
-  let init_solver solver =
+  let init_solver solver title =
+    SMTSolver.trace_comment solver title ;
     TransSys.init_flag_uf Numeral.(~- one)
     |> SMTSolver.declare_fun solver ;
     TransSys.init_flag_uf Numeral.zero
     |> SMTSolver.declare_fun solver ;
   in
 
-  init_solver base_solver ;
-  init_solver step_solver ;
+  init_solver base_solver "|===| Base solver" ;
+  init_solver step_solver "|===| Step solver" ;
   TransSys.init_flag_uf Numeral.one
   |> SMTSolver.declare_fun step_solver ;
-  init_solver pruning_solver ;
+  init_solver pruning_solver "|===| Pruning solver" ; ;
   TransSys.init_flag_uf Numeral.one
   |> SMTSolver.declare_fun pruning_solver ;
 
@@ -489,6 +490,11 @@ let query_base
   (* Returning result. *)
   result
 
+(* Wraps the result of a call to [split_closure]. *)
+type 'a solver_res =
+  | Continuation of (unit -> 'a solver_res)
+  | Result of 'a
+
 (* Splits its input list of terms between the falsifiable and the
    unfalsifiable ones at [k+1]. The terms are asserted from 0 (1 if
    [two_state] is true) up to [k]. *)
@@ -567,35 +573,34 @@ let rec split_closure
               (falsifiable, [])
        in
 
-       (* Deactivating actlit. *)
-       Term.mk_not actlit
-       |> SMTSolver.assert_term solver ;
-
        (* Looping. *)
-       split_closure
-        solver two_state trans_actlit k falsifiable' unknown
+       Some (
+        fun () ->
+          split_closure
+            solver two_state trans_actlit k falsifiable' unknown
+       )
                      
      in
 
      (* Function to run if unsat. *)
-     let if_unsat () =
-       (* Deactivating actlit. *)
-       Term.mk_not actlit
-       |> SMTSolver.assert_term solver ;
-       
-       (* Returning result. *)
-       falsifiable, terms_to_check
-     in
+     let if_unsat () = None in
 
      (* Checking if we should terminate before doing anything. *)
      Event.check_termination () ;
 
-     (* Checksat-ing. *)
-     SMTSolver.check_sat_assuming
-       solver
-       if_sat
-       if_unsat
-       [ actlit ; trans_actlit ]
+     (* Checking. *)
+     let check =
+        SMTSolver.check_sat_assuming
+          solver if_sat if_unsat [ actlit ; trans_actlit ]
+     in
+
+     (* Deactivating actlit. *)
+     Term.mk_not actlit
+     |> SMTSolver.assert_term solver ;
+
+     match check with
+     | Some continue -> continue ()
+     | None -> falsifiable, terms_to_check
 
 
 
@@ -655,8 +660,9 @@ let rec prune_trivial
 
      let if_unsat () = None in
 
-     match SMTSolver.check_sat_assuming
-       solver if_sat if_unsat [actlit ; trivial_actlit]
+     match
+      SMTSolver.check_sat_assuming
+        solver if_sat if_unsat [actlit ; trivial_actlit]
      with
        | None ->
           (* Deactivating actlit. *)

--- a/src/step.ml
+++ b/src/step.ml
@@ -527,12 +527,6 @@ let rec next trans solver k unfalsifiables unknowns =
 
      (* k+1. *)
      let k_p_1 = Numeral.succ k in
-
-     (* FIXME: Why is this unused?
-
-     Printf.sprintf
-       "Unrolling step at %i." Numeral.(to_int k_p_1) ;
-     *)
      
      (* Declaring unrolled vars at k+1. *)
      TransSys.declare_vars_of_bounds

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -258,28 +258,6 @@ let instantiate_term { callers } term =
   |> List.map
        ( fun (sys, maps) ->
 
-        (* FIXME: why is this unused?
-
-         let print_map =
-           (* Turns a map from state vars to terms into a string. *)
-           let string_of_map map =
-             map
-             |> List.map
-                  ( fun (v,t) ->
-                    Printf.sprintf "(%s -> %s)"
-                                   (StateVar.string_of_state_var v)
-                                   (StateVar.string_of_state_var t) )
-             |> String.concat ", "
-           in
-           
-           List.map
-             (fun map ->
-              Printf.printf "  Mapping to [%s]:\n"
-                            (String.concat "/" sys.scope) ;
-              Printf.printf "  > %s\n\n" (string_of_map map) )
-         in
-         *)
-
          (* Building one new term per instantiation mapping for
             sys. *)
          let terms =


### PR DESCRIPTION
Problem was a continuation where the step instance of the invariant generation. When splitting candidate invariants between falsifiable and valid, in the sat case the algorithm did not pop before iterating until it gets unsat.

So check-sat occuring later would end up being unsat because of un-popped asserts.