### PR TITLE
Fix IC3 with simulated check-sat with assumptions

### DIFF
--- a/src/CVC4Driver.ml
+++ b/src/CVC4Driver.ml
@@ -21,15 +21,20 @@ open Lib
 include GenericSMTLIBDriver
 
 (* Configuration for CVC4 *)
-let cmd_line () = 
-
+let cmd_line
+    logic
+    produce_assignments
+    produce_proofs
+    produce_cores
+    produce_interpolants =
+  
   (* Path and name of CVC4 executable *)
   let cvc4_bin = Flags.cvc4_bin () in
 
   (* Use unsat cores *)
-  if true then 
+  if produce_cores then 
 
-    (* Use unsat core option *)
+    (* Need to use tear-down incremental mode for unsat cores *)
     [| cvc4_bin; 
        "--lang"; "smt2";
        "--rewrite-divk";
@@ -37,7 +42,7 @@ let cmd_line () =
 
   else
 
-    (* Omit unsat core option for version older than 1.5 *)
+    (* Use normal incremental mode if unsat cores not needed *)
     [| cvc4_bin; 
        "--lang"; "smt2";
        "--rewrite-divk";

--- a/src/IC3.ml
+++ b/src/IC3.ml
@@ -2961,21 +2961,12 @@ let main trans_sys =
 
   match Flags.smtsolver () with 
 
-    (* CVC4 does not support check-sat-assume *)
-    (* | `CVC4_SMTLIB *)
-
     (* Yices with SMTLIB input does not work *)
     | `Yices_SMTLIB -> 
 
       Event.log L_error
         "Cannot use this solver in IC3."
-(*
-    (* Must use check-sat assume for now *)
-    | `Z3_SMTLIB when not (Flags.z3_check_sat_assume_assume ()) -> 
 
-      Event.log L_error
-        "Cannot use Z3 without check-sat-assume in IC3."
-*)
     (* Else is fine or will break without unsound results *)
     | _ -> 
 

--- a/src/IC3.ml
+++ b/src/IC3.ml
@@ -128,49 +128,51 @@ let handle_events
      instances *)
   let add_invariant inv = 
 
-    match Term.var_offsets_of_term inv with
-        
-      (* Skip invariants without variables *)
-      | None, None ->
+    if Flags.ic3_use_invgen () then 
 
-        SMTSolver.trace_comment 
-          solver
-          "handle_event: Skipping constant invariant"
+      match Term.var_offsets_of_term inv with
 
-      (* One-state invariants *)
-      | Some i, Some j when Numeral.equal i j ->
+        (* Skip invariants without variables *)
+        | None, None ->
 
-        SMTSolver.trace_comment 
-          solver
-          "handle_event: Asserting one-state invariant at zero and one";
+          SMTSolver.trace_comment 
+            solver
+            "handle_event: Skipping constant invariant"
 
-        (* Assert at offset zero *)
-        Term.bump_state Numeral.(- i) inv
-        |> SMTSolver.assert_term solver;
-        
-        (* Assert at offset one *)
-        Term.bump_state Numeral.(- i + one) inv
-        |> SMTSolver.assert_term solver
+        (* One-state invariants *)
+        | Some i, Some j when Numeral.equal i j ->
 
-      (* Two-state invariant *)
-      | Some i, Some j when Numeral.(j - i = one) ->
+          SMTSolver.trace_comment 
+            solver
+            "handle_event: Asserting one-state invariant at zero and one";
 
-        SMTSolver.trace_comment 
-          solver
-          "handle_event: Asserting two-state invariant at one";
+          (* Assert at offset zero *)
+          Term.bump_state Numeral.(- i) inv
+          |> SMTSolver.assert_term solver;
 
-        (* Assert at offset one *)
-        Term.bump_state Numeral.(- i) inv |> SMTSolver.assert_term solver
+          (* Assert at offset one *)
+          Term.bump_state Numeral.(- i + one) inv
+          |> SMTSolver.assert_term solver
 
-      (* Invariant over more than two states *)
-      | _ ->
+        (* Two-state invariant *)
+        | Some i, Some j when Numeral.(j - i = one) ->
 
-        SMTSolver.trace_comment 
-          solver
-          "handle_event: Invariant is over more than two states";
-        
-        assert false
-        
+          SMTSolver.trace_comment 
+            solver
+            "handle_event: Asserting two-state invariant at one";
+
+          (* Assert at offset one *)
+          Term.bump_state Numeral.(- i) inv |> SMTSolver.assert_term solver
+
+        (* Invariant over more than two states *)
+        | _ ->
+
+          SMTSolver.trace_comment 
+            solver
+            "handle_event: Invariant is over more than two states";
+
+          assert false
+
   in
 
   (* Assert all received invariants *)

--- a/src/IC3.ml
+++ b/src/IC3.ml
@@ -2502,7 +2502,13 @@ let extract_cex_path solver trans_sys trace =
                state *)
             let path', state = 
               add_to_path
-                (SMTSolver.get_model solver)
+                (* SMTSolver.get_model solver *)
+                (SMTSolver.get_var_values
+                   solver
+                   (TransSys.vars_of_bounds
+                      trans_sys
+                      Numeral.zero
+                      Numeral.one))
                 path
                 (TransSys.state_vars trans_sys)
                 Numeral.one
@@ -2560,7 +2566,13 @@ let extract_cex_path solver trans_sys trace =
               (* Add unprimed state to empty path, get equational
                  constraint for state *)
               add_to_path
-                (SMTSolver.get_model solver)
+                (* SMTSolver.get_model solver *)
+                (SMTSolver.get_var_values
+                   solver
+                   (TransSys.vars_of_bounds
+                      trans_sys
+                      Numeral.zero
+                      Numeral.one))
                 []
                 (TransSys.state_vars trans_sys)
                 Numeral.zero)

--- a/src/IC3.ml
+++ b/src/IC3.ml
@@ -24,7 +24,7 @@ module C = Clause
 module F = Clause.ClauseTrie
 
 (* Check to make sure invariants of IC3 hold *)
-let debug_assert = false
+let debug_assert = true
 
 (* ********************************************************************** *)
 (* Solver instances and cleanup                                           *)
@@ -248,46 +248,54 @@ let rec check_frames' solver prop_set accum = function
           (List.map
              C.term_of_clause
              ((C.clause_of_prop_set prop_set) :: (F.values r_i) @ accum)
-           |> Term.mk_and)
+              |> Term.mk_and)
           C.Actlit_n1
       in
 
-      (* Check P[x] & R_i-1[x] & T[x,x'] |= R_i[x'] & P[x'] *)
-      SMTSolver.check_sat_assuming solver
+      if
+        
+        (* Check P[x] & R_i-1[x] & T[x,x'] |= R_i[x'] & P[x'] *)
+        SMTSolver.check_sat_assuming_tf
+          solver
+          
+          ((* Clauses of R_i are on rhs of entailment *)
+            actlit_n1 ::
+
+              (match tl with 
+
+                (* Preceding frame is not R_0 *)
+                | r_pred_i :: _ -> 
+
+                  C.actlit_p0_of_prop_set solver prop_set :: 
+                    
+                    List.map (C.actlit_p0_of_clause solver) accum @ 
+
+                    (* Clauses of R_i are in R_i-1, assert on lhs of entailment *)     
+                    List.map (C.actlit_p0_of_clause solver) (F.values r_i) @ 
+
+                    (* Assert clauses of R_i-1 on lhs of entailment *)
+                    List.map (C.actlit_p0_of_clause solver) (F.values r_pred_i)
+
+                (* Preceding frame is R_0, assert initial state only *)
+                | [] -> [C.actlit_of_frame 0]))
+
+      then
 
         (* Fail if entailment does not hold *)
-        (fun () -> false)
+        false
 
-        (* Check preceding frames if entailment holds *)
-        (fun () ->
+      else
+        
+        (
 
           (* Deactivate activation literal *)
           Term.mk_not actlit_n1 |> SMTSolver.assert_term solver;
           Stat.incr Stat.ic3_stale_activation_literals;
           
-          check_frames' solver prop_set ((F.values r_i) @ accum) tl)
+          (* Check preceding frames if entailment holds *)
+          check_frames' solver prop_set ((F.values r_i) @ accum) tl
 
-
-        ((* Clauses of R_i are on rhs of entailment *)
-          actlit_n1 ::
-
-          (match tl with 
-
-            (* Preceding frame is not R_0 *)
-            | r_pred_i :: _ -> 
-
-              C.actlit_p0_of_prop_set solver prop_set :: 
-              
-              List.map (C.actlit_p0_of_clause solver) accum @ 
-
-              (* Clauses of R_i are in R_i-1, assert on lhs of entailment *)     
-              List.map (C.actlit_p0_of_clause solver) (F.values r_i) @ 
-
-              (* Assert clauses of R_i-1 on lhs of entailment *)
-              List.map (C.actlit_p0_of_clause solver) (F.values r_pred_i)
-
-            (* Preceding frame is R_0, assert initial state only *)
-            | [] -> [C.actlit_of_frame 0]))
+        )
 
     in
 
@@ -303,19 +311,25 @@ let rec check_frames' solver prop_set accum = function
              "check_frames: Does I |= C for C in R_%d hold?"
              (List.length tl |> succ));
 
-        (* Check if clause is initial *)
-        SMTSolver.check_sat_assuming 
-          solver
+        if
+          
+          (* Check if clause is initial *)
+          SMTSolver.check_sat_assuming_tf 
+            solver
 
+            (* Check I |= C *)
+            ((C.actlit_of_frame 0) :: C.actlits_n0_of_clause solver c)
+
+        then
+          
           (* If sat: Clause is not initial *)
-          (fun () -> false)
+          false
 
+        else
+          
           (* If unsat: continue with next clause *)
-          (fun () -> is_initial ctl)
-
-          (* Check I |= C *)
-          ((C.actlit_of_frame 0) :: C.actlits_n0_of_clause solver c)
-
+          is_initial ctl
+            
       (* All clauses are initial, now check if frame successors of
          frame are in the next frame *)
       | [] -> is_rel_ind ()
@@ -330,17 +344,18 @@ let rec check_frames' solver prop_set accum = function
 
     SMTSolver.check_sat_assuming
       solver
-
-      (* If sat: property is not implied by frame *)
-      (fun () -> is_initial (F.values r_i))
-
-      (* If unsat: Check if clauses are initial, then check if
-         successors of frame are in the next frame *)
-      (fun () -> is_initial (F.values r_i))
+      (fun _ -> ())
+      (fun _ -> ())
 
       (* Check R_i |= P *)
       (C.actlits_n0_of_prop_set solver prop_set @
-         List.map (C.actlit_p0_of_clause solver) ((F.values r_i) @ accum))
+         List.map (C.actlit_p0_of_clause solver) ((F.values r_i) @ accum));
+          
+      (* Property may or may not be implied by frame, keep on
+         checking *)
+      is_initial (F.values r_i)
+
+
 
 
 let check_frames solver prop_set clauses frames =
@@ -475,10 +490,10 @@ let ind_generalize solver prop_set frame clause literals =
 
           (* Deactivate activation literal of parent clause *)
           C.deactivate_clause solver clause;
-            
+          
           (* New clause with generalized clause as parent *)
           let clause' = C.mk_clause_of_literals (C.IndGen clause) kept in
-            
+          
           SMTSolver.trace_comment solver
             (Format.asprintf 
                "@[<hv>New clause from inductive generalization of #%d:@ #%d @[<hv 1>{%a}@]@]"
@@ -514,7 +529,7 @@ let ind_generalize solver prop_set frame clause literals =
         Term.mk_not clause'_actlit_n0 |> SMTSolver.assert_term solver;
         Term.mk_not clause'_actlit_n1 |> SMTSolver.assert_term solver;
         Stat.incr ~by:3 Stat.ic3_stale_activation_literals;
-          
+        
         linear_search (l :: kept) tl
 
       in
@@ -527,7 +542,7 @@ let ind_generalize solver prop_set frame clause literals =
         Term.mk_not clause'_actlit_n0 |> SMTSolver.assert_term solver;
         Term.mk_not clause'_actlit_n1 |> SMTSolver.assert_term solver;
         Stat.incr ~by:3 Stat.ic3_stale_activation_literals;
-          
+        
         linear_search kept tl
 
       in
@@ -539,37 +554,49 @@ let ind_generalize solver prop_set frame clause literals =
           "ind_generalize: Checking if clause without literal is \
            relatively inductive.";
 
-        SMTSolver.check_sat_assuming 
-          solver
+        if 
+          
+          SMTSolver.check_sat_assuming_tf 
+            solver
+            
+            (* Check P[x] & R[x] & C[x] & T[x,x'] |= C[x'] *)
+            (C.actlit_p0_of_prop_set solver prop_set ::
+               clause'_actlit_p0 ::
+               clause'_actlit_n1 ::
+               frame)
 
+        then
+          
           (* If sat: Clause without literal is not relatively inductive *)
-          keep_literal
+          keep_literal ()
 
+        else
+          
           (* If unsat: Clause without literal is relatively inductive *)
-          drop_literal
-
-          (* Check P[x] & R[x] & C[x] & T[x,x'] |= C[x'] *)
-          (C.actlit_p0_of_prop_set solver prop_set ::
-             clause'_actlit_p0 ::
-             clause'_actlit_n1 ::
-             frame)
+          drop_literal ()
 
       in
 
       SMTSolver.trace_comment solver
         "ind_generalize: Checking if clause without literal is initial.";
 
-      SMTSolver.check_sat_assuming 
-        solver
+      if
+        
+        SMTSolver.check_sat_assuming_tf 
+          solver
 
+          (* Check I |= C *)
+          ([clause'_actlit_n0; C.actlit_of_frame 0])
+
+      then
+        
         (* If sat: Clause without literal is not initial *)
-        keep_literal
+        keep_literal ()
 
+      else
+        
         (* If unsat: Clause without literal is initial *)
-        is_initial 
-
-        (* Check I |= C *)
-        ([clause'_actlit_n0; C.actlit_of_frame 0])
+        is_initial ()
 
 
   in
@@ -932,96 +959,6 @@ let rec block solver trans_sys prop_set term_tbl predicates =
         (* Head of frames is the last frame *)
         | r_k :: frames_tl as frames -> 
 
-          (* All successors of R_k are safe *)
-          let r_k_is_safe () = 
-
-            SMTSolver.trace_comment 
-              solver
-              (Format.sprintf 
-                 "block: All successors of R_%d are safe."
-                 (List.length frames));
-
-            (* Return frames *)
-            frames , predicates
-
-          in
-
-          (* We can violate the property in one step from R_k *)
-          let block_in_r_k () = 
-
-            (* Get counterexample as a pair of states from satisfiable
-               query *)
-            let cti =
-
-              (* This is expensive due to the many activation literals *)
-              (* SMTSolver.get_model solver *)
-
-              SMTSolver.get_var_values
-                solver
-                (TransSys.vars_of_bounds trans_sys Numeral.zero Numeral.one)
-
-            in
-
-            (* Extrapolate from counterexample to a cube in R_k
-
-               P[x] & R_k[x] & T[x,x'] & ~P[x'] is sat
-
-               R_k does not imply P[x] yet *)
-            let cti_gen = 
-              match Flags.ic3_abstr () with
-                | `None ->
-                  extrapolate 
-                    trans_sys 
-                    cti 
-                    (C.term_of_prop_set prop_set :: 
-                     List.map C.term_of_clause (F.values r_k)
-                     |> Term.mk_and)
-                    (C.term_of_prop_set prop_set |> Term.negate) 
-
-                | `IA ->
-
-                  List.map 
-                    (fun p ->match  Eval.eval_term
-                                      (TransSys.uf_defs trans_sys)
-                                      cti
-                                      p
-                      with
-
-                        | Eval.ValBool true -> p
-
-                        | Eval.ValBool false -> Term.negate p
-
-                        | _ -> raise (Invalid_argument "abstract cex evaluation")
-
-                    )
-                    predicates
-            in
-            (* Create a clause with activation literals from generalized
-               counterexample *)
-            let clause = 
-              C.mk_clause_of_literals C.BlockFrontier (List.map Term.negate cti_gen) 
-            in
-
-            SMTSolver.trace_comment solver
-              (Format.asprintf 
-                 "@[<hv>New clause at frontier:@ #%d @[<hv 1>{%a}@]@]"
-                 (C.id_of_clause clause)
-                 (pp_print_list Term.pp_print_term ";@ ")
-                 (C.literals_of_clause clause));
-
-            (* Recursively block cube by showing that clause is
-               relatively inductive *)
-            block 
-              solver
-              trans_sys 
-              prop_set
-              ()
-              predicates
-              [([clause, [C.clause_of_prop_set prop_set]], r_k)] 
-              frames_tl
-
-          in
-
           (* Receive and assert new invariants *)
           handle_events solver trans_sys (C.props_of_prop_set prop_set);
 
@@ -1031,24 +968,137 @@ let rec block solver trans_sys prop_set term_tbl predicates =
                "block: Check if all successors of frontier R_%d are safe."
                (List.length frames));
 
-          SMTSolver.check_sat_assuming 
-            solver 
-
-            (* If sat: we have a state in R_k that has a successor
-               outside the property *)
-            block_in_r_k
-
-            (* If unsat: Frames are safe, cannot get outside property
-               in one step in all frames up to R_k *)
-            r_k_is_safe
-
+          match
+            
             (* Check P[x] & R_k[x] & T[x,x'] |= P[x']
 
                R_k does not imply P[x] yet *)
-            (C.actlit_p0_of_prop_set solver prop_set :: 
-             C.actlits_n1_of_prop_set solver prop_set @
-             List.map (C.actlit_p0_of_clause solver) (F.values r_k))
+            SMTSolver.check_sat_assuming_ab 
+              solver 
+              (fun _ -> 
+                
+                (* Get counterexample as a pair of states from satisfiable
+                   query 
+                   
+                   Don't use SMTSolver.get_model, because it is
+                   expensive due to the many activation literals. *)
+                SMTSolver.get_var_values
+                  solver
+                  (TransSys.vars_of_bounds trans_sys Numeral.zero Numeral.one))
 
+              (fun _ -> ())
+
+              (C.actlit_p0_of_prop_set solver prop_set :: 
+                 C.actlits_n1_of_prop_set solver prop_set @
+                 List.map (C.actlit_p0_of_clause solver) (F.values r_k))
+
+          (* If sat: we have a state in R_k that has a successor
+             outside the property *)
+          with
+
+            | SMTSolver.Sat cti ->
+
+              (
+                
+                (* Extrapolate from counterexample to a cube in R_k *)
+                let cti_gen = 
+
+                  (* Abstraction used? *)
+                  match Flags.ic3_abstr () with
+
+                    (* No abstraction *)
+                    | `None ->
+
+                      (* Compute preimage with quantifier elimination
+
+                         P[x] & R_k[x] & T[x,x'] & ~P[x'] is sat
+
+                         R_k does not imply P[x] yet *)
+                      extrapolate 
+                        trans_sys 
+                        cti 
+                        (C.term_of_prop_set prop_set :: 
+                           List.map C.term_of_clause (F.values r_k)
+                            |> Term.mk_and)
+                        (C.term_of_prop_set prop_set |> Term.negate) 
+
+                    (* Implicit abstraction *)
+                    | `IA ->
+
+                      (* Evaluate all predicates on CTI *)
+                      List.map 
+
+                        (fun p ->
+
+                          match
+
+                            (* Evaluate predicate *)
+                            Eval.eval_term
+                              (TransSys.uf_defs trans_sys)
+                              cti
+                              p
+                              
+                          with
+
+                            (* Predicate evaluates to true, use positively *)
+                            | Eval.ValBool true -> p
+
+                            (* Predicate evaluates to true, use negatively *)
+                            | Eval.ValBool false -> Term.negate p
+
+                            (* Predicate must evaluate to either true or
+                               false, we cannot have a partial model *)
+                            | _ -> assert false)
+                        
+                        predicates
+                        
+                in
+
+                (* Create a clause with activation literals from
+                   generalized counterexample *)
+                let clause = 
+                  C.mk_clause_of_literals
+                    C.BlockFrontier
+                    (List.map Term.negate cti_gen) 
+                in
+
+                SMTSolver.trace_comment solver
+                  (Format.asprintf 
+                     "@[<hv>New clause at frontier:@ #%d @[<hv 1>{%a}@]@]"
+                     (C.id_of_clause clause)
+                     (pp_print_list Term.pp_print_term ";@ ")
+                     (C.literals_of_clause clause));
+
+                (* Recursively block cube by showing that clause is
+                   relatively inductive *)
+                block 
+                  solver
+                  trans_sys 
+                  prop_set
+                  ()
+                  predicates
+                  [([clause, [C.clause_of_prop_set prop_set]], r_k)] 
+                  frames_tl
+
+              )
+                
+            (* If unsat: Frames are safe, cannot get outside property
+               in one step in all frames up to R_k *)
+            | SMTSolver.Unsat () ->
+
+              (
+                
+                SMTSolver.trace_comment 
+                  solver
+                  (Format.sprintf 
+                     "block: All successors of R_%d are safe."
+                     (List.length frames));
+                
+                (* Return frames *)
+                frames, predicates
+                  
+              )
+                
       )
 
     (* No more cubes to block in R_i *)
@@ -1098,12 +1148,12 @@ let rec block solver trans_sys prop_set term_tbl predicates =
 
                 (* Join lists of clauses *)
                 (fun (ac, al) (_, r) ->
-                   (F.values r) @ ac,
-                   List.map (C.actlit_p0_of_clause solver) (F.values r) @ al)
+                  (F.values r) @ ac,
+                  List.map (C.actlit_p0_of_clause solver) (F.values r) @ al)
 
                 (C.clause_of_prop_set prop_set :: (F.values r_pred_i), 
                  C.actlit_p0_of_prop_set solver prop_set :: 
-                 List.map (C.actlit_p0_of_clause solver) (F.values r_pred_i))
+                   List.map (C.actlit_p0_of_clause solver) (F.values r_pred_i))
 
                 trace
 
@@ -1120,12 +1170,12 @@ let rec block solver trans_sys prop_set term_tbl predicates =
 
               Stat.time_fun Stat.ic3_ind_gen_time
                 (fun () -> 
-                   ind_generalize 
-                     solver
-                     prop_set
-                     actlits_p0_r_pred_i
-                     block_clause_orig
-                     (C.literals_of_clause block_clause_orig))
+                  ind_generalize 
+                    solver
+                    prop_set
+                    actlits_p0_r_pred_i
+                    block_clause_orig
+                    (C.literals_of_clause block_clause_orig))
             in
 
             block_clause, 
@@ -1139,415 +1189,6 @@ let rec block solver trans_sys prop_set term_tbl predicates =
 
         in
 
-        (* Clause is relative inductive to this frame *)
-        let is_rel_inductive () = 
-
-          (* Activation literals in unsat core of query *)
-          let core_actlits_trans = SMTSolver.get_unsat_core_lits solver in
-
-          SMTSolver.trace_comment 
-            solver
-            "block: Check I |= C to get unsat core.";
-
-          (* Activation literals in unsat core of I |= C *)
-          let core_actlits_init = 
-            SMTSolver.check_sat_assuming
-              solver
-
-              (* Must be unsat *)
-              (fun () -> 
-
-                 Event.log L_info "Query is satisfiable, waiting for BMC";
-
-                 (* This should only happen when we are faster than
-                    BMC, who has not yet discovered at one-step
-                    violation of a property. We wait for messages *)
-                 let rec wait () = 
-                   handle_events 
-                     solver
-                     trans_sys
-                     (C.props_of_prop_set prop_set);
-                   minisleep 0.01;
-                   wait ()
-                 in
-                 ignore (wait ()); 
-
-                 (* We won't return from waiting *)
-                 assert false)
-
-              (* Get literals in unsat core *)
-              (fun () -> SMTSolver.get_unsat_core_lits solver)
-
-              (* Check I |= C *)
-              ((C.actlit_of_frame 0) :: C.actlits_n0_of_clause solver block_clause)
-
-          in
-
-          (* Reduce clause to unsat core of R & T |= C *)
-          let block_clause_literals_core_n1 = 
-
-            List.fold_left2 
-
-              (fun a t l ->
-
-                 if 
-
-                   (* Keep clause literal [l] if activation literals
-                      [t] is in unsat core *)
-                   List.exists (Term.equal t) core_actlits_trans
-
-                 then
-
-                   l :: a
-
-                 else
-
-                   a)
-
-              (* Start with empty clause *)
-              []
-
-              (* Fold over clause literals and their activation literals *)
-              (C.actlits_n1_of_clause solver block_clause)
-              (C.literals_of_clause block_clause)
-
-          in
-
-          (* Reduce clause to unsat core of I |= C *)
-          let block_clause_literals_core = 
-
-            List.fold_left2 
-
-              (fun a t l ->
-
-                 if 
-
-                   (* Keep clause literal [l] if activation literal [t]
-                      is in unsat core *)
-                   List.exists (Term.equal t) core_actlits_init
-
-                 then
-
-                   (* Drop clause literal [l] if it is in accumulator
-                      to prevent duplicates *)
-                   if List.exists (Term.equal l) a then a else l :: a
-
-                 else
-
-                   a)
-
-              (* Start with literal in core of consecution query *)
-              block_clause_literals_core_n1
-
-              (* Fold over clause literals and their activation literals *)
-              (C.actlits_n0_of_clause solver block_clause)
-              (C.literals_of_clause block_clause)
-
-          in
-
-          SMTSolver.trace_comment
-            solver
-            (Format.asprintf
-               "@[<hv>block: Reduced clause@ %a@ with unsat core to@ %a@]"
-               Term.pp_print_term (C.term_of_clause block_clause)
-               Term.pp_print_term (Term.mk_or block_clause_literals_core));
-
-          (* Inductively generalize clause *)
-          let block_clause_gen =
-            Stat.time_fun Stat.ic3_ind_gen_time
-              (fun () -> 
-                 ind_generalize 
-                   solver
-                   prop_set
-                   actlits_p0_r_pred_i
-                   block_clause
-                   block_clause_literals_core)
-          in
-
-          SMTSolver.trace_comment
-            solver
-            (Format.asprintf
-               "@[<hv>block: Reduced clause@ %a@ with ind. gen. to@ %a@]"
-               Term.pp_print_term (Term.mk_or block_clause_literals_core)
-               Term.pp_print_term (C.term_of_clause block_clause_gen));
-
-          (* Add blocking clause to all frames up to where it has to
-             be blocked *)
-          let r_i', frames', block_tl' =
-
-            (* Literals of clause as key for trie *)
-            let block_clause_gen_literals = C.literals_of_clause block_clause_gen in
-
-            (try
-
-               (* Adding a clause may fail if it a prefix of a clause
-                  in the trie, or if a clause in the trie is a
-                  prefix of this clause *)
-               F.add block_clause_gen_literals block_clause_gen r_i
-
-             with Invalid_argument _ ->
-
-               (SMTSolver.trace_comment
-                  solver
-                  (Format.asprintf
-                     "@[<v>Clause@ @[<hv>{%a@}@]@ subsumes a clause in frame, \
-                      must do subsumption before adding@ @[<hv>%a@]@]"
-                     (pp_print_list Term.pp_print_term ";@ ")
-                     block_clause_gen_literals
-                     (pp_print_list
-                        (fun ppf (k, c) ->
-                           Format.fprintf ppf
-                             "@[<hv 1>{%a}@ =@ %a"
-                             (pp_print_list Term.pp_print_term ";@ ") k
-                             Term.pp_print_term (C.term_of_clause c))
-                        ",@ ")
-                     (F.bindings r_i));
-
-                (* The new blocking clause is not subsumed, because
-                   otherwise we would not get the counterexample *)
-                (* if F.is_subsumed r_i block_clause_gen_literals then r_i else *)
-
-                (* Subsume in this frame and add *)
-                F.subsume r_i block_clause_gen_literals
-
-                (* Count number of subsumed clauses *)
-                |> count_subsumed solver
-
-                (* Deactivate activation literals of subsumed clauses *)
-                |> deactivate_subsumed solver
-
-                |> snd
-
-                (* Add clause to frame after subsumption *)
-                |> F.add block_clause_gen_literals block_clause_gen)),
-
-            frames,
-
-            (* Add cube to block to next higher frame if flag is set *)
-            if Flags.ic3_block_in_future () then
-
-              add_to_block_tl
-                solver
-                block_clause_orig
-                block_trace
-                block_tl
-
-            else
-
-              block_tl
-
-          in
-
-          (* Combine clauses from higher frames to get the actual
-             clauses of the delta-encoded frame R_i-1
-
-             Get clauses in R_i..R_k from [trace], R_i-1 is first frame
-             in [frames]. *)
-          let clauses_r_succ_i, actlits_p0_r_succ_i = 
-            List.fold_left
-              (fun (ac, al) (_, r) ->
-                 (F.values r) @ ac,
-                 List.map (C.actlit_p0_of_clause solver) (F.values r) @ al)
-              ([], [])
-              ((block_clauses_tl, r_i') :: block_tl') 
-          in
-
-          (* DEBUG *)
-          if debug_assert then
-            assert
-              (check_frames solver prop_set clauses_r_succ_i (r_i' :: frames'));
-
-          (* Update frame size statistics *)
-          Stat.set_int_list
-            (frame_sizes_block frames' trace) 
-            Stat.ic3_frame_sizes; 
-
-          (* TODO: If clause was propagated from preceding frame,
-             remove from there *)
-
-          (* Add clause to frame and continue with next clauses in
-             this frame *)
-          block 
-            solver
-            trans_sys 
-            prop_set
-            term_tbl
-            predicates
-            (if
-
-              (* Block in higher frames first? *)
-              true &&
-
-              (* Only if not in the highest frame *)
-              (match block_tl' with
-                | [] -> false
-                | _ -> true) 
-
-             then
-
-               (* Remove all clauses to block and go to the next
-                  higher frame *)
-               (([], r_i') :: block_tl')
-
-             else
-
-               (* Block clauses in this frame first *)
-               ((block_clauses_tl, r_i') :: block_tl'))
-
-            frames'
-
-        in
-
-        (* Clause is not relative inductive to this frame *)
-        let block_in_r_i () =
-
-          (* Are there frames below R_i? *)
-          match frames with 
-
-            (* Bad state is reachable from R_0, we have found a
-               counterexample path *)
-            | [] ->
-
-              SMTSolver.trace_comment
-                solver
-                (Format.asprintf
-                   "@[<hv>~P reachable from I:@ @[<hv>%a@]@]"
-                   (pp_print_list
-                      (fun ppf c ->
-                         Format.fprintf ppf
-                           "%d"
-                           (C.id_of_clause c))
-                      ",@ ")
-                   (block_clause :: block_trace));
-
-
-              let raise_cex () = 
-                raise (Counterexample (block_clause :: block_trace))
-              in
-
-              (match Flags.ic3_abstr () with
-                | `None ->
-                  raise_cex ()
-
-                | `IA ->
-                  SMTSolver.trace_comment 
-                    solver
-                    (Format.sprintf
-                       "block: generating interpolants."
-                    );
-
-                  let cex_trace =
-                    List.map
-                      (fun bcl -> Term.mk_and (List.map Term.negate (Clause.literals_of_clause bcl)))
-                      (block_clause :: block_trace)
-                  in
-
-                  let interpolants = abstr_simulate cex_trace trans_sys raise_cex in
-
-
-
-                  List.iteri
-                    (fun i t ->
-                       SMTSolver.assert_term
-                         solver
-                         (Term.mk_eq
-                            [t;
-                             Term.bump_state (Numeral.of_int 2) t]);
-
-                       SMTSolver.assert_term
-                         solver
-                         (Term.mk_eq
-                            [Term.bump_state (Numeral.one) t;
-                             Term.bump_state (Numeral.of_int 3) t]);
-                    )
-                    interpolants;
-
-
-                  block
-                    solver
-                    trans_sys
-                    prop_set
-                    term_tbl
-                    (interpolants @ predicates)
-                    []
-                    (List.rev (List.map (fun (f,s) -> s) trace))
-
-              )
-
-            (* i > 1 and bad state is reachable from R_i-1 *)
-            | r_pred_i :: frames_tl -> 
-
-              (* Get counterexample from satisfiable query *)
-              let cti =
-                (* SMTSolver.get_model solver *)
-                SMTSolver.get_var_values
-                  solver
-                  (TransSys.vars_of_bounds trans_sys Numeral.zero Numeral.one)
-              in
-
-              (* Generalize the counterexample to a list of literals
-
-                 R_i-1[x] & C[x] & T[x,x'] & ~C[x'] is sat *)
-              let cti_gen =
-                match Flags.ic3_abstr () with
-                  | `None ->
-
-                    extrapolate 
-                      trans_sys 
-                      cti
-                      ((C.term_of_clause block_clause ::
-                        List.map C.term_of_clause clauses_r_pred_i) 
-                       |> Term.mk_and)
-                      (C.term_of_clause block_clause |> Term.negate)
-
-                  | `IA ->
-                    List.map 
-                      (fun p ->match  Eval.eval_term
-                                        (TransSys.uf_defs trans_sys)
-                                        cti
-                                        p
-                        with
-
-                          | Eval.ValBool true -> p
-
-                          | Eval.ValBool false -> Term.negate p
-
-                          | _ -> raise (Invalid_argument "abstract cex evaluation")
-
-                      )
-                      predicates
-              in
-
-              (* Create a clause with activation literals from generalized
-                 counterexample *)
-              let block_clause' = 
-                C.mk_clause_of_literals
-                  (C.BlockRec block_clause)
-                  (List.map Term.negate cti_gen) 
-              in
-
-              SMTSolver.trace_comment solver
-                (Format.asprintf 
-                   "@[<hv>New clause at depth %d to block #%d:@ #%d @[<hv 1>{%a}@]@]"
-                   (List.length trace)
-                   (C.id_of_clause block_clause)
-                   (C.id_of_clause block_clause')
-                   (pp_print_list Term.pp_print_term ";@ ")
-                   (C.literals_of_clause block_clause'));
-
-
-              block 
-                solver
-                trans_sys 
-                prop_set
-                term_tbl
-                predicates
-                (([block_clause', (block_clause :: block_trace)], 
-                  r_pred_i) :: trace) 
-                frames_tl
-
-        in
-
         (* Receive and assert new invariants *)
         handle_events solver trans_sys (C.props_of_prop_set prop_set);
 
@@ -1557,20 +1198,431 @@ let rec block solver trans_sys prop_set term_tbl predicates =
              "block: Is blocking clause relative inductive to R_%d?"
              (List.length frames));
 
-        SMTSolver.check_sat_assuming 
-          solver
+        (match
+            
+            (* Check P[x] & R_i-1[x] & C[x] & T[x,x'] |= C[x'] *)
+            SMTSolver.check_sat_assuming_ab 
+              solver
 
-          (* If sat: bad state is reachable *)
-          block_in_r_i
+              (* Get counterexample from satisfiable query *)
+              (fun _ ->
 
-          (* If unsat: clause is relative inductive and bad state is
-             not reachable *)
-          is_rel_inductive
+                match frames with
 
-          (* Check P[x] & R_i-1[x] & C[x] & T[x,x'] |= C[x'] *)
-          (C.actlit_p0_of_clause solver block_clause :: 
-           C.actlits_n1_of_clause solver block_clause @
-           actlits_p0_r_pred_i)
+                  (* Need no model when in initial frame *)
+                  | [] -> Model.create 0
+
+                  (* Get model in all other frames *)
+                  | _ ->
+                    SMTSolver.get_var_values
+                      solver
+                      (TransSys.vars_of_bounds trans_sys Numeral.zero Numeral.one))
+
+              (* Get unsat core from unsatisfiable query *)
+              (fun _ -> SMTSolver.get_unsat_core_lits solver)
+
+              (C.actlit_p0_of_clause solver block_clause :: 
+                 C.actlits_n1_of_clause solver block_clause @
+                 actlits_p0_r_pred_i)
+              
+         with
+             
+           (* If unsat: clause is relative inductive and bad state is
+              not reachable *)
+           | SMTSolver.Unsat core_actlits_trans ->
+             
+             SMTSolver.trace_comment 
+               solver
+               "block: Check I |= C to get unsat core.";
+             
+             (* Activation literals in unsat core of I |= C *)
+             let core_actlits_init = 
+               SMTSolver.check_sat_assuming
+                 solver
+                 
+                 (* Must be unsat *)
+                 (fun _ -> 
+                   
+                   Event.log L_info "Query is satisfiable, waiting for BMC";
+                   
+                   (* This should only happen when we are faster than
+                      BMC, who has not yet discovered at one-step
+                      violation of a property. We wait for messages *)
+                   let rec wait () = 
+                     handle_events 
+                       solver
+                       trans_sys
+                       (C.props_of_prop_set prop_set);
+                     minisleep 0.01;
+                     wait ()
+                   in
+                   ignore (wait ()); 
+                   
+                   (* We won't return from waiting *)
+                   assert false)
+                 
+                 (* Get literals in unsat core *)
+                 (fun _ -> SMTSolver.get_unsat_core_lits solver)
+                 
+                 (* Check I |= C *)
+                 ((C.actlit_of_frame 0) :: C.actlits_n0_of_clause solver block_clause)
+                 
+             in
+             
+             (* Reduce clause to unsat core of R & T |= C *)
+             let block_clause_literals_core_n1 = 
+               
+               List.fold_left2 
+                 
+                 (fun a t l ->
+                   
+                   if 
+
+                     (* Keep clause literal [l] if activation literals
+                        [t] is in unsat core *)
+                     List.exists (Term.equal t) core_actlits_trans
+
+                   then
+
+                     l :: a
+
+                   else
+
+                     a)
+
+                 (* Start with empty clause *)
+                 []
+
+                 (* Fold over clause literals and their activation literals *)
+                 (C.actlits_n1_of_clause solver block_clause)
+                 (C.literals_of_clause block_clause)
+
+             in
+
+             (* Reduce clause to unsat core of I |= C *)
+             let block_clause_literals_core = 
+
+               List.fold_left2 
+
+                 (fun a t l ->
+
+                   if 
+
+                     (* Keep clause literal [l] if activation literal [t]
+                        is in unsat core *)
+                     List.exists (Term.equal t) core_actlits_init
+
+                   then
+
+                     (* Drop clause literal [l] if it is in accumulator
+                        to prevent duplicates *)
+                     if List.exists (Term.equal l) a then a else l :: a
+
+                   else
+
+                     a)
+
+                 (* Start with literal in core of consecution query *)
+                 block_clause_literals_core_n1
+
+                 (* Fold over clause literals and their activation literals *)
+                 (C.actlits_n0_of_clause solver block_clause)
+                 (C.literals_of_clause block_clause)
+
+             in
+
+             SMTSolver.trace_comment
+               solver
+               (Format.asprintf
+                  "@[<hv>block: Reduced clause@ %a@ with unsat core to@ %a@]"
+                  Term.pp_print_term (C.term_of_clause block_clause)
+                  Term.pp_print_term (Term.mk_or block_clause_literals_core));
+
+             (* Inductively generalize clause *)
+             let block_clause_gen =
+               Stat.time_fun Stat.ic3_ind_gen_time
+                 (fun () -> 
+                   ind_generalize 
+                     solver
+                     prop_set
+                     actlits_p0_r_pred_i
+                     block_clause
+                     block_clause_literals_core)
+             in
+
+             SMTSolver.trace_comment
+               solver
+               (Format.asprintf
+                  "@[<hv>block: Reduced clause@ %a@ with ind. gen. to@ %a@]"
+                  Term.pp_print_term (Term.mk_or block_clause_literals_core)
+                  Term.pp_print_term (C.term_of_clause block_clause_gen));
+
+             (* Add blocking clause to all frames up to where it has to
+                be blocked *)
+             let r_i', frames', block_tl' =
+
+               (* Literals of clause as key for trie *)
+               let block_clause_gen_literals = C.literals_of_clause block_clause_gen in
+
+               (try
+
+                  (* Adding a clause may fail if it a prefix of a clause
+                     in the trie, or if a clause in the trie is a
+                     prefix of this clause *)
+                  F.add block_clause_gen_literals block_clause_gen r_i
+
+                with Invalid_argument _ ->
+
+                  (SMTSolver.trace_comment
+                     solver
+                     (Format.asprintf
+                        "@[<v>Clause@ @[<hv>{%a@}@]@ subsumes a clause in frame, \
+                      must do subsumption before adding@ @[<hv>%a@]@]"
+                        (pp_print_list Term.pp_print_term ";@ ")
+                        block_clause_gen_literals
+                        (pp_print_list
+                           (fun ppf (k, c) ->
+                             Format.fprintf ppf
+                               "@[<hv 1>{%a}@ =@ %a"
+                               (pp_print_list Term.pp_print_term ";@ ") k
+                               Term.pp_print_term (C.term_of_clause c))
+                           ",@ ")
+                        (F.bindings r_i));
+
+                   (* The new blocking clause is not subsumed, because
+                      otherwise we would not get the counterexample *)
+                   (* if F.is_subsumed r_i block_clause_gen_literals then r_i else *)
+
+                   (* Subsume in this frame and add *)
+                   F.subsume r_i block_clause_gen_literals
+
+                      (* Count number of subsumed clauses *)
+                      |> count_subsumed solver
+
+                      (* Deactivate activation literals of subsumed clauses *)
+                      |> deactivate_subsumed solver
+
+                      |> snd
+
+                      (* Add clause to frame after subsumption *)
+                      |> F.add block_clause_gen_literals block_clause_gen)),
+
+               frames,
+
+               (* Add cube to block to next higher frame if flag is set *)
+               if Flags.ic3_block_in_future () then
+
+                 add_to_block_tl
+                   solver
+                   block_clause_orig
+                   block_trace
+                   block_tl
+
+               else
+
+                 block_tl
+
+             in
+
+             (* Combine clauses from higher frames to get the actual
+                clauses of the delta-encoded frame R_i-1
+
+                Get clauses in R_i..R_k from [trace], R_i-1 is first frame
+                in [frames]. *)
+             let clauses_r_succ_i, actlits_p0_r_succ_i = 
+               List.fold_left
+                 (fun (ac, al) (_, r) ->
+                   (F.values r) @ ac,
+                   List.map (C.actlit_p0_of_clause solver) (F.values r) @ al)
+                 ([], [])
+                 ((block_clauses_tl, r_i') :: block_tl') 
+             in
+
+             (* DEBUG *)
+             if debug_assert then
+               assert
+                 (check_frames solver prop_set clauses_r_succ_i (r_i' :: frames'));
+
+             (* Update frame size statistics *)
+             Stat.set_int_list
+               (frame_sizes_block frames' trace) 
+               Stat.ic3_frame_sizes; 
+
+             (* TODO: If clause was propagated from preceding frame,
+                remove from there *)
+
+             (* Add clause to frame and continue with next clauses in
+                this frame *)
+             block 
+               solver
+               trans_sys 
+               prop_set
+               term_tbl
+               predicates
+               (if
+
+                   (* Block in higher frames first? *)
+                   true &&
+
+                     (* Only if not in the highest frame *)
+                     (match block_tl' with
+                       | [] -> false
+                       | _ -> true) 
+
+                then
+
+                   (* Remove all clauses to block and go to the next
+                      higher frame *)
+                   (([], r_i') :: block_tl')
+
+                else
+
+                   (* Block clauses in this frame first *)
+                   ((block_clauses_tl, r_i') :: block_tl'))
+
+               frames'
+
+           (* If sat: bad state is reachable *)
+           | SMTSolver.Sat cti ->
+             
+             (* Are there frames below R_i? *)
+             match frames with 
+                 
+               (* Bad state is reachable from R_0, we have found a
+                  counterexample path *)
+               | [] ->
+
+                 SMTSolver.trace_comment
+                   solver
+                   (Format.asprintf
+                      "@[<hv>~P reachable from I:@ @[<hv>%a@]@]"
+                      (pp_print_list
+                         (fun ppf c ->
+                           Format.fprintf ppf
+                             "%d"
+                             (C.id_of_clause c))
+                         ",@ ")
+                      (block_clause :: block_trace));
+
+
+                 let raise_cex () = 
+                   raise (Counterexample (block_clause :: block_trace))
+                 in
+
+                 (match Flags.ic3_abstr () with
+                   | `None ->
+                     raise_cex ()
+
+                   | `IA ->
+                     SMTSolver.trace_comment 
+                       solver
+                       (Format.sprintf
+                          "block: generating interpolants."
+                       );
+
+                     let cex_trace =
+                       List.map
+                         (fun bcl -> Term.mk_and (List.map Term.negate (Clause.literals_of_clause bcl)))
+                         (block_clause :: block_trace)
+                     in
+
+                     let interpolants = abstr_simulate cex_trace trans_sys raise_cex in
+
+
+
+                     List.iteri
+                       (fun i t ->
+                         SMTSolver.assert_term
+                           solver
+                           (Term.mk_eq
+                              [t;
+                               Term.bump_state (Numeral.of_int 2) t]);
+
+                         SMTSolver.assert_term
+                           solver
+                           (Term.mk_eq
+                              [Term.bump_state (Numeral.one) t;
+                               Term.bump_state (Numeral.of_int 3) t]);
+                       )
+                       interpolants;
+
+
+                     block
+                       solver
+                       trans_sys
+                       prop_set
+                       term_tbl
+                       (interpolants @ predicates)
+                       []
+                       (List.rev (List.map (fun (f,s) -> s) trace))
+
+                 )
+
+               (* i > 1 and bad state is reachable from R_i-1 *)
+               | r_pred_i :: frames_tl -> 
+
+                 (* Generalize the counterexample to a list of literals
+
+                    R_i-1[x] & C[x] & T[x,x'] & ~C[x'] is sat *)
+                 let cti_gen =
+                   match Flags.ic3_abstr () with
+                     | `None ->
+
+                       extrapolate 
+                         trans_sys 
+                         cti
+                         ((C.term_of_clause block_clause ::
+                             List.map C.term_of_clause clauses_r_pred_i) 
+                             |> Term.mk_and)
+                         (C.term_of_clause block_clause |> Term.negate)
+
+                     | `IA ->
+                       List.map 
+                         (fun p ->match  Eval.eval_term
+                             (TransSys.uf_defs trans_sys)
+                             cti
+                             p
+                           with
+
+                             | Eval.ValBool true -> p
+
+                             | Eval.ValBool false -> Term.negate p
+
+                             | _ -> raise (Invalid_argument "abstract cex evaluation")
+
+                         )
+                         predicates
+                 in
+
+                 (* Create a clause with activation literals from generalized
+                    counterexample *)
+                 let block_clause' = 
+                   C.mk_clause_of_literals
+                     (C.BlockRec block_clause)
+                     (List.map Term.negate cti_gen) 
+                 in
+
+                 SMTSolver.trace_comment solver
+                   (Format.asprintf 
+                      "@[<hv>New clause at depth %d to block #%d:@ #%d @[<hv 1>{%a}@]@]"
+                      (List.length trace)
+                      (C.id_of_clause block_clause)
+                      (C.id_of_clause block_clause')
+                      (pp_print_list Term.pp_print_term ";@ ")
+                      (C.literals_of_clause block_clause'));
+
+
+                 block 
+                   solver
+                   trans_sys 
+                   prop_set
+                   term_tbl
+                   predicates
+                   (([block_clause', (block_clause :: block_trace)], 
+                     r_pred_i) :: trace) 
+                   frames_tl
+
+        )
 
       )
 
@@ -1601,80 +1653,80 @@ let rec partition_inductive
     C.create_and_assert_fresh_actlit solver "is_ind" clauses C.Actlit_n1
   in
 
-  (* All candidate clause are inductive: return clauses show not to be
-     inductive and inductive clauses *)
-  let all_clauses_inductive () =
-
-    (* Deactivate activation literal *)
-    Term.mk_not actlit_n1 |> SMTSolver.assert_term solver;
-    Stat.incr Stat.ic3_stale_activation_literals;
-
-    not_inductive, maybe_inductive
-
-  in
-
-  (* Some candidate clauses are not inductive: filter out the ones
-     that could still be *)
-  let some_clauses_not_inductive () =
-
-    (* Get model for failed entailment check *)
-    let model =
-      SMTSolver.get_var_values
-        solver
-        (TransSys.vars_of_bounds trans_sys Numeral.zero Numeral.one)
-    in
-
-    (* Separate not inductive terms from potentially inductive terms 
-
-       C_1 & ... & C_n & T & ~ (C_1' & ... & C_n') is satisfiable,
-       partition C_1', ..., C_n' by their model value, false terms are
-       certainly not inductive, true terms can be inductive. *)
-    let maybe_inductive', not_inductive_new = 
-      List.partition 
-        (function c -> 
-          C.term_of_clause c
-          |> Term.bump_state Numeral.one
-          |> Eval.eval_term [] model
-          |> Eval.bool_of_value)
-        maybe_inductive
-    in
-
-    (* Clauses found to be not inductive *)
-    let not_inductive' = not_inductive @ not_inductive_new in
-
-    (* Deactivate activation literal *)
-    Term.mk_not actlit_n1 |> SMTSolver.assert_term solver;
-    Stat.incr Stat.ic3_stale_activation_literals;
-
-    (* No clauses are inductive? *)
-    if maybe_inductive = [] then (not_inductive', []) else
-
-      (* Continue checking if remaining clauses are inductive *)
-      partition_inductive 
-        solver
-        trans_sys 
-        frame
-        not_inductive'
-        maybe_inductive'
-
-  in
-
   SMTSolver.trace_comment
     solver
     "Checking for inductiveness of clauses";
-
-  (* Are all clauses inductive? 
-
-     Check R & C_1 & ... & C_n & T |= C_1' & ... & C_n'
-  *)
-  SMTSolver.check_sat_assuming 
-    solver
-    some_clauses_not_inductive 
-    all_clauses_inductive
-    (actlit_n1 :: actlits_p0)
+  
+  match 
     
+    (* Are all clauses inductive? 
+       
+       Check R & C_1 & ... & C_n & T |= C_1' & ... & C_n'
+    *)
+    SMTSolver.check_sat_assuming_ab 
+      solver
+
+      (* Get model for failed entailment check *)
+      (fun solver ->
+        SMTSolver.get_var_values
+          solver
+          (TransSys.vars_of_bounds trans_sys Numeral.zero Numeral.one))
+      
+      (fun _ -> ())
+      
+      (actlit_n1 :: actlits_p0)
+      
+  with
+
+    (* Some candidate clauses are not inductive: filter out the ones
+       that could still be *)
+    | SMTSolver.Sat model -> 
+      
+      (* Separate not inductive terms from potentially inductive terms 
+         
+         C_1 & ... & C_n & T & ~ (C_1' & ... & C_n') is satisfiable,
+         partition C_1', ..., C_n' by their model value, false terms are
+         certainly not inductive, true terms can be inductive. *)
+      let maybe_inductive', not_inductive_new = 
+        List.partition 
+          (function c -> 
+            C.term_of_clause c
+            |> Term.bump_state Numeral.one
+            |> Eval.eval_term [] model
+            |> Eval.bool_of_value)
+          maybe_inductive
+      in
+
+      (* Clauses found to be not inductive *)
+      let not_inductive' = not_inductive @ not_inductive_new in
+
+      (* Deactivate activation literal *)
+      Term.mk_not actlit_n1 |> SMTSolver.assert_term solver;
+      Stat.incr Stat.ic3_stale_activation_literals;
+
+      (* No clauses are inductive? *)
+      if maybe_inductive = [] then (not_inductive', []) else
+        
+        (* Continue checking if remaining clauses are inductive *)
+        partition_inductive 
+          solver
+          trans_sys 
+          frame
+          not_inductive'
+          maybe_inductive'
+
+    (* All candidate clause are inductive: return clauses show not to be
+       inductive and inductive clauses *)
+    | SMTSolver.Unsat () ->
+      
+    (* Deactivate activation literal *)
+      Term.mk_not actlit_n1 |> SMTSolver.assert_term solver;
+      Stat.incr Stat.ic3_stale_activation_literals;
+
+      not_inductive, maybe_inductive
 
 
+      
 (* Split list of clauses into clauses that can be propagated relative
    to the frame and those that cannot be *)
 let partition_fwd_prop
@@ -1693,62 +1745,6 @@ let partition_fwd_prop
      together *)
   let rec partition_fwd_prop' keep maybe_prop = 
 
-    (* All clause can be forward propagated: return clauses to keep and
-       clauses to propagate *)
-    let prop_all actlit_n1 () =
-
-      (* Deactivate activation literal *)
-      Term.mk_not actlit_n1 |> SMTSolver.assert_term solver;
-      Stat.incr Stat.ic3_stale_activation_literals;
-
-      keep, maybe_prop
-
-    in
-
-    (* Some candidate clauses cannot be propagated: filter out the ones
-       that could still be *)
-    let keep_some actlit_n1 () =
-
-      (* Get model for failed entailment check *)
-      let model =
-        SMTSolver.get_var_values
-          solver
-          (TransSys.vars_of_bounds trans_sys Numeral.zero Numeral.one)
-      in
-
-      (* Separate not propagateable terms from potentially propagateable
-         terms
-
-         C_1 & ... & C_n & T & ~ (C_1' & ... & C_n') is satisfiable,
-         partition C_1', ..., C_n' by their model value, false terms are
-         certainly not propagateable, true terms might be propagated. *)
-      let maybe_prop', keep_new = 
-        List.partition 
-          (function c -> 
-            C.term_of_clause c
-            |> Term.bump_state Numeral.one
-            |> Eval.eval_term [] model
-            |> Eval.bool_of_value)
-          maybe_prop
-      in
-
-      (* Clauses found not propagateable *)
-      let keep' = keep @ keep_new in
-
-      (* Deactivate activation literal *)
-      Term.mk_not actlit_n1 |> SMTSolver.assert_term solver;
-      Stat.incr Stat.ic3_stale_activation_literals;
-
-      (* No clauses can be propagated? *)
-      if maybe_prop' = [] then (keep', []) else
-
-        (* Continue checking if remaining clauses are inductive *)
-        partition_fwd_prop' 
-          keep'
-          maybe_prop'
-
-    in
-
     SMTSolver.trace_comment
       solver
       "partition_fwd_prop: Checking for forward propagation of clause set";
@@ -1762,18 +1758,78 @@ let partition_fwd_prop
         C.Actlit_n1
     in
 
-    (* Can all clauses be propagated? 
+    match
+    
+      (* Can all clauses be propagated? 
+         
+         Check P[x] & R[x] & T[x,x'] |= C_1[x'] & ... & C_n[x']
+      *)
+      SMTSolver.check_sat_assuming_ab 
+        solver
 
-       Check P[x] & R[x] & T[x,x'] |= C_1[x'] & ... & C_n[x']
-    *)
-    SMTSolver.check_sat_assuming 
-      solver
-      (keep_some actlit_n1)
-      (prop_all actlit_n1)
-      (C.actlit_p0_of_prop_set solver prop_set :: actlit_n1 :: actlits_p0)
+        (* Get model for failed entailment check *)
+        (fun solver ->
+          SMTSolver.get_var_values
+            solver
+            (TransSys.vars_of_bounds trans_sys Numeral.zero Numeral.one))
 
+        (fun _ -> ())
+
+        (C.actlit_p0_of_prop_set solver prop_set :: actlit_n1 :: actlits_p0)
+
+    with
+        
+      (* Some candidate clauses cannot be propagated: filter out the ones
+         that could still be *)
+      | SMTSolver.Sat model -> 
+
+        (* Separate not propagateable terms from potentially propagateable
+           terms
+           
+           C_1 & ... & C_n & T & ~ (C_1' & ... & C_n') is satisfiable,
+           partition C_1', ..., C_n' by their model value, false terms are
+           certainly not propagateable, true terms might be propagated. *)
+        let maybe_prop', keep_new = 
+          List.partition 
+            (function c -> 
+              C.term_of_clause c
+              |> Term.bump_state Numeral.one
+              |> Eval.eval_term [] model
+              |> Eval.bool_of_value)
+            maybe_prop
+        in
+        
+        (* Clauses found not propagateable *)
+        let keep' = keep @ keep_new in
+
+        (* Deactivate activation literal *)
+        Term.mk_not actlit_n1 |> SMTSolver.assert_term solver;
+        Stat.incr Stat.ic3_stale_activation_literals;
+        
+        (* No clauses can be propagated? *)
+        if maybe_prop' = [] then (keep', []) else
+          
+          (* Continue checking if remaining clauses are inductive *)
+          partition_fwd_prop' 
+            keep'
+            maybe_prop'
+            
+      (* All clause can be forward propagated: return clauses to keep and
+         clauses to propagate *)
+      | SMTSolver.Unsat () ->
+
+        (* Deactivate activation literal *)
+        Term.mk_not actlit_n1 |> SMTSolver.assert_term solver;
+        Stat.incr Stat.ic3_stale_activation_literals;
+        
+        keep, maybe_prop
+
+
+            
+            
   in
 
+            
   (* Check if all clauses can be propagated *)
   partition_fwd_prop' [] clauses
 
@@ -2112,22 +2168,22 @@ let fwd_propagate solver trans_sys prop_set frames predicates =
                Check if inductive invariant is initial *)
             if debug_assert then
               assert
-                (SMTSolver.check_sat_assuming
-                   solver
-                   (function _ -> false)
-                   (function _ -> true)
-                   [C.actlit_of_frame 0; ind_inv_n0]); 
+                (not
+                   (SMTSolver.check_sat_assuming_tf
+                      solver
+                      [C.actlit_of_frame 0; ind_inv_n0]));
 
             (* DEBUG
 
                Check if inductive invariant is inductive *)
             if debug_assert then
               assert
-                (SMTSolver.check_sat_assuming
-                   solver
-                   (function _ -> false)
-                   (function _ -> true)
-                   [C.actlit_p0_of_prop_set solver prop_set; ind_inv_p0; ind_inv_n1]); 
+                (not
+                   (SMTSolver.check_sat_assuming_tf
+                      solver
+                      [C.actlit_p0_of_prop_set solver prop_set;
+                       ind_inv_p0;
+                       ind_inv_n1])); 
 
             (* Fixpoint found, this frame is equal to the next *)
             raise (Success (List.length frames))
@@ -2433,42 +2489,52 @@ let extract_cex_path solver trans_sys trace =
     (* Take first blocking clause *)
     | r_i :: tl -> 
 
-      (* Find a state in the blocking clause, starting from the given
-         state *)
-      SMTSolver.check_sat_assuming
-        solver
+      match 
+        
+        (* Find a state in the blocking clause, starting from the
+           given state *)
+        SMTSolver.check_sat_assuming_ab
+          solver
+          
+          (fun solver -> 
 
-        (fun () -> 
+            (* Add primed state to path, get equational constraint for
+               state *)
+            let path', state = 
+              add_to_path
+                (SMTSolver.get_model solver)
+                path
+                (TransSys.state_vars trans_sys)
+                Numeral.one
+            in
 
-           (* Add primed state to path, get equational constraint for
-              state *)
-           let path', state = 
-             add_to_path
-               (SMTSolver.get_model solver)
-               path
-               (TransSys.state_vars trans_sys)
-               Numeral.one
-           in
+            (* Activation literal for state *)
+            let actlit_p0_state =
+              C.create_and_assert_fresh_actlit
+                solver
+                "cex_path"
+                state
+                C.Actlit_p0
+            in
+            
+            path', actlit_p0_state)
 
-           (* Activation literal for state *)
-           let actlit_p0_state =
-             C.create_and_assert_fresh_actlit
-               solver
-               "cex_path"
-               state
-               C.Actlit_p0
-           in
+          (fun _ -> ())
 
-           (* Recurse to continue path out of succeeding blocking
-              clause *)
-           extract_cex_path' path' actlit_p0_state tl)
+          (* Assume previous state and blocking clause *)
+          (pre_state :: C.actlits_n1_of_clause solver r_i)
+
+      with
+          
+        (* Recurse to continue path out of succeeding blocking
+           clause *)
+        | SMTSolver.Sat (path', actlit_p0_state) -> 
+          
+          extract_cex_path' path' actlit_p0_state tl
 
         (* Counterexample trace must be satisfiable *)
-        (fun _ -> assert false)
-
-        (* Assume previous state and blocking clause *)
-        (pre_state :: C.actlits_n1_of_clause solver r_i)
-
+        | SMTSolver.Unsat _ -> assert false
+          
   in
 
   (* Start path from initial state into first blocking clause, get
@@ -2482,27 +2548,35 @@ let extract_cex_path solver trans_sys trace =
       (* First blocking clause is successor of initial state *)
       | r_1 :: _ -> 
 
-        (* Find an initial state with the first blocking clause as
-           successor *)
-        SMTSolver.check_sat_assuming 
-          solver
+        match
+          
+          (* Find an initial state with the first blocking clause as
+             successor *)
+          SMTSolver.check_sat_assuming_ab
+            solver
 
-          (fun () ->
+            (fun solver ->
+              
+              (* Add unprimed state to empty path, get equational
+                 constraint for state *)
+              add_to_path
+                (SMTSolver.get_model solver)
+                []
+                (TransSys.state_vars trans_sys)
+                Numeral.zero)
 
-             (* Add unprimed state to empty path, get equational
-                constraint for state *)
-             add_to_path
-               (SMTSolver.get_model solver)
-               []
-               (TransSys.state_vars trans_sys)
-               Numeral.zero)
+            (fun _ -> ())
+            
+            (* Assume initial state and blocking clause *)
+            ((C.actlit_of_frame 0) ::
+                C.actlits_n1_of_clause solver r_1)
 
+        with
+
+          | SMTSolver.Sat r -> r 
+            
           (* Counterexample trace must be satisfiable *)
-          (fun _ -> assert false)
-
-          (* Assume initial state and blocking clause *)
-          ((C.actlit_of_frame 0) ::
-           C.actlits_n1_of_clause solver r_1)
+          | SMTSolver.Unsat _ -> assert false
 
   in
 
@@ -2736,7 +2810,7 @@ let rec bmc_checks solver trans_sys props =
 
   (* Entailment does not hold: split properties in not falsified and
      falsifiable properties *)
-  let not_entailed props k () = 
+  let not_entailed props k _ = 
 
     (* Get model for all variables of transition system *)
     let model =
@@ -2775,7 +2849,7 @@ let rec bmc_checks solver trans_sys props =
 
   (* Entailment does hold: return all properties as not falsified and
      none as falsifiable *)
-  let all_entailed props () = (props, None) in
+  let all_entailed props _ = (props, None) in
 
   (* Check I |= P for given list of properties *)
   let rec bmc_check check_primed = function 
@@ -2895,13 +2969,13 @@ let main trans_sys =
 
       Event.log L_error
         "Cannot use this solver in IC3."
-
+(*
     (* Must use check-sat assume for now *)
-    | `Z3_SMTLIB when not (Flags.z3_check_sat_assume ()) -> 
+    | `Z3_SMTLIB when not (Flags.z3_check_sat_assume_assume ()) -> 
 
       Event.log L_error
         "Cannot use Z3 without check-sat-assume in IC3."
-
+*)
     (* Else is fine or will break without unsound results *)
     | _ -> 
 

--- a/src/IC3.ml
+++ b/src/IC3.ml
@@ -2508,16 +2508,7 @@ let extract_cex_path solver trans_sys trace =
                 Numeral.one
             in
 
-            (* Activation literal for state *)
-            let actlit_p0_state =
-              C.create_and_assert_fresh_actlit
-                solver
-                "cex_path"
-                state
-                C.Actlit_p0
-            in
-            
-            path', actlit_p0_state)
+            path', state)
 
           (fun _ -> ())
 
@@ -2528,7 +2519,16 @@ let extract_cex_path solver trans_sys trace =
           
         (* Recurse to continue path out of succeeding blocking
            clause *)
-        | SMTSolver.Sat (path', actlit_p0_state) -> 
+        | SMTSolver.Sat (path', state) -> 
+          
+            (* Activation literal for state *)
+          let actlit_p0_state =
+            C.create_and_assert_fresh_actlit
+              solver
+              "cex_path"
+              state
+              C.Actlit_p0
+          in
           
           extract_cex_path' path' actlit_p0_state tl
 
@@ -2962,7 +2962,7 @@ let main trans_sys =
   match Flags.smtsolver () with 
 
     (* CVC4 does not support check-sat-assume *)
-    | `CVC4_SMTLIB
+    (* | `CVC4_SMTLIB *)
 
     (* Yices with SMTLIB input does not work *)
     | `Yices_SMTLIB -> 

--- a/src/MathSAT5Driver.ml
+++ b/src/MathSAT5Driver.ml
@@ -19,7 +19,12 @@
 include GenericSMTLIBDriver
 
 (* Configuration for MathSAT5 *)
-let cmd_line () = 
+let cmd_line 
+    logic
+    produce_assignments
+    produce_proofs
+    produce_cores
+    produce_interpolants = 
   
   (* Path and name of MathSAT5 executable *)
   let mathsat5_bin = Flags.mathsat5_bin () in

--- a/src/SMTLIBSolver.ml
+++ b/src/SMTLIBSolver.ml
@@ -178,14 +178,25 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
        (* Get name of variable and its assignment *)
        let s, t_or_l = expr_or_lambda_of_string_sexpr e in
 
-       (* Get uninterpreted function symbol by name *)
-       let u =
-         UfSymbol.uf_symbol_of_string (HString.string_of_hstring s) 
-       in
+       try
+         
+         (* Get uninterpreted function symbol by name *)
+         let u =
+           UfSymbol.uf_symbol_of_string (HString.string_of_hstring s) 
+         in
 
-       (* Continue with next model assignment *)
-       get_model_response_of_sexpr' ((u, t_or_l) :: accum) tl)
+         (* Continue with next model assignment *)
+         get_model_response_of_sexpr' ((u, t_or_l) :: accum) tl
 
+       (* No symbol of that name
+
+          May happen if named terms have been asserted *)
+       with Not_found ->
+
+         (* Continue with next model assignment *)
+         get_model_response_of_sexpr' accum tl)
+                    
+    
 
   (* Return a solver response to a get-value command as expression pairs *)
   let get_value_response_of_sexpr = function 

--- a/src/Yices2SMT2Driver.ml
+++ b/src/Yices2SMT2Driver.ml
@@ -20,7 +20,12 @@ include GenericSMTLIBDriver
 
 
 (* Configuration for Yices *)
-let cmd_line () = 
+let cmd_line
+    logic
+    produce_assignments
+    produce_proofs
+    produce_cores
+    produce_interpolants = 
 
   (* Path and name of Yices executable *)
   let yices2smt2_bin = Flags.yices2smt2_bin () in

--- a/src/Z3Driver.ml
+++ b/src/Z3Driver.ml
@@ -32,17 +32,12 @@ let check_sat_limited_cmd ms =
   Format.sprintf "(check-sat-using (try-for smt %d))" ms
 
 
-let check_sat_assuming_supported () = Flags.z3_check_sat_assume ()
+let check_sat_assuming_supported () = Flags.smt_check_sat_assume ()
 
 let check_sat_assuming_cmd () = "check-sat"
 
 let headers () = 
-  "(set-option :interactive-mode true)" :: 
-  (if Flags.z3_check_sat_assume () then
-     [] 
-   else
-     ["(set-option :global-decls true)"])
-
+  ["(set-option :interactive-mode true)"]
 
 let string_of_logic l =
   let open TermLib in

--- a/src/Z3Driver.ml
+++ b/src/Z3Driver.ml
@@ -19,7 +19,12 @@
 include GenericSMTLIBDriver
 
 (* Configuration for Z3 *)
-let cmd_line () = 
+let cmd_line 
+    logic
+    produce_assignments
+    produce_proofs
+    produce_cores
+    produce_interpolants = 
 
   (* Path and name of Z3 executable *)
   let z3_bin = Flags.z3_bin () in

--- a/src/base.ml
+++ b/src/base.ml
@@ -64,7 +64,7 @@ let shall_keep trans (s,_) =
 let split trans solver k falsifiable to_split actlits =
 
   (* Function to run if sat. *)
-  let if_sat () =
+  let if_sat _ =
 
     (* Get the full model *)
     let model = SMTSolver.get_model solver in
@@ -88,7 +88,7 @@ let split trans solver k falsifiable to_split actlits =
   in
 
   (* Function to run if unsat. *)
-  let if_unsat () =
+  let if_unsat _ =
     None
   in
 

--- a/src/event.ml
+++ b/src/event.ml
@@ -1010,6 +1010,9 @@ let terminate_log () =
 
 (* Broadcast a scoped invariant *)
 let invariant scope term = 
+
+  (* Update time in case we are not running in parallel mode *)
+  Stat.update_time Stat.total_time;
   
   try
     
@@ -1022,6 +1025,9 @@ let invariant scope term =
 
 (* Broadcast a property status *)
 let prop_status status trans_sys prop = 
+  
+  (* Update time in case we are not running in parallel mode *)
+  Stat.update_time Stat.total_time;
   
   let mdl = get_module () in
 
@@ -1045,6 +1051,9 @@ let prop_status status trans_sys prop =
 (* Broadcast a counterexample for some properties *)
 let execution_path trans_sys path = 
 
+  (* Update time in case we are not running in parallel mode *)
+  Stat.update_time Stat.total_time;
+  
   let mdl = get_module () in
 
   log_execution_path mdl L_warn trans_sys path
@@ -1053,6 +1062,9 @@ let execution_path trans_sys path =
 (* Send progress indicator *)
 let progress k =
 
+  (* Update time in case we are not running in parallel mode *)
+  Stat.update_time Stat.total_time;
+  
   let mdl = get_module () in
 
   log_progress mdl L_info k;
@@ -1070,6 +1082,8 @@ let progress k =
 (* Send statistics *)
 let stat stats = 
 
+  Stat.update_time Stat.total_time;
+  
   let mdl = get_module () in
 
   log_stat mdl L_info stats;

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -203,13 +203,13 @@ let z3_bin_default = "z3"
 
 (* ********** *) 
 
-type z3_check_sat_assume = bool
+type smt_check_sat_assume = bool
 
-let z3_check_sat_assume_of_string s = s
+let smt_check_sat_assume_of_string s = s
 
-let string_of_z3_check_sat_assume s = s 
+let string_of_smt_check_sat_assume s = s 
 
-let z3_check_sat_assume_default = true
+let smt_check_sat_assume_default = true
 
 (* ********** *) 
 
@@ -588,7 +588,7 @@ type flags =
     mutable smtsolver : smtsolver;
     mutable smtlogic : smtlogic;
     mutable z3_bin : z3_bin;
-    mutable z3_check_sat_assume : z3_check_sat_assume;
+    mutable smt_check_sat_assume : smt_check_sat_assume;
     mutable cvc4_bin : cvc4_bin;
     mutable mathsat5_bin : mathsat5_bin;
     mutable yices_bin : yices_bin;
@@ -639,7 +639,7 @@ let flags =
     smtsolver = smtsolver_default;
     smtlogic = smtlogic_default;
     z3_bin = z3_bin_default;
-    z3_check_sat_assume = z3_check_sat_assume_default;
+    smt_check_sat_assume = smt_check_sat_assume_default;
     cvc4_bin = cvc4_bin_default;
     mathsat5_bin = mathsat5_bin_default;
     yices_bin = yices_bin_default;
@@ -734,12 +734,15 @@ let z3_bin_spec =
 
 (* ********** *) 
 
-let z3_check_sat_assume_action o = flags.z3_check_sat_assume <- o
+let smt_check_sat_assume_action o = flags.smt_check_sat_assume <- o
   
-let z3_check_sat_assume_spec = 
-  ("--z3_check_sat_assume", 
-   Arg.Bool z3_check_sat_assume_action, 
-   Format.sprintf "use check-sat with assumptions in Z3 (default: %B)" z3_check_sat_assume_default)
+let smt_check_sat_assume_spec = 
+  ("--smt_check_sat_assume", 
+   Arg.Bool smt_check_sat_assume_action, 
+   Format.sprintf
+     "Use check-sat with assumptions, or simulate with push/pop \
+      when false (default: %B)"
+     smt_check_sat_assume_default)
 
 (* ********** *) 
 
@@ -1194,7 +1197,7 @@ let smtlogic () = flags.smtlogic
 
 let z3_bin () = flags.z3_bin
 
-let z3_check_sat_assume () = flags.z3_check_sat_assume
+let smt_check_sat_assume () = flags.smt_check_sat_assume
 
 let cvc4_bin () = flags.cvc4_bin
 
@@ -1318,8 +1321,8 @@ and speclist =
     (* Set executable for Z3 solver *)
     z3_bin_spec;
 
-    (* Use check-sat with assumptions in Z3 *)
-    z3_check_sat_assume_spec;
+    (* Use check-sat with assumptions or simulate with push/pop *)
+    smt_check_sat_assume_spec;
 
     (* Set executable for CVC4 solver *)
     cvc4_bin_spec;

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -415,11 +415,20 @@ let string_of_ic3_fwd_prop_ind_gen = string_of_bool
 let ic3_fwd_prop_ind_gen_default = true
 
 (* ********** *) 
+
 type ic3_fwd_prop_subsume = bool
     
 let string_of_ic3_fwd_prop_subsume = string_of_bool
 
 let ic3_fwd_prop_subsume_default = true
+
+(* ********** *) 
+
+type ic3_use_invgen = bool
+    
+let string_of_ic3_use_invgen = string_of_bool
+
+let ic3_use_invgen_default = true
 
 (* ********** *) 
 
@@ -614,6 +623,7 @@ type flags =
     mutable ic3_fwd_prop_non_gen : ic3_fwd_prop_non_gen;
     mutable ic3_fwd_prop_ind_gen : ic3_fwd_prop_ind_gen;
     mutable ic3_fwd_prop_subsume : ic3_fwd_prop_subsume;
+    mutable ic3_use_invgen : ic3_use_invgen;
     mutable ic3_abstr : ic3_abstr;
     mutable cooper_order_var_by_elim : cooper_order_var_by_elim;
     mutable cooper_general_lbound : cooper_general_lbound;
@@ -665,6 +675,7 @@ let flags =
     ic3_block_in_future = ic3_block_in_future_default;
     ic3_block_in_future_first = ic3_block_in_future_first_default;
     ic3_fwd_prop_subsume = ic3_fwd_prop_subsume_default;
+    ic3_use_invgen = ic3_use_invgen_default;
     ic3_abstr = ic3_abstr_default;
     cooper_order_var_by_elim = cooper_order_var_by_elim_default;
     cooper_general_lbound = cooper_general_lbound_default;
@@ -1000,6 +1011,16 @@ let ic3_fwd_prop_subsume_spec =
                   (string_of_ic3_fwd_prop_subsume ic3_fwd_prop_subsume_default))
 
 (* ********** *) 
+ 
+let ic3_use_invgen_action o = flags.ic3_use_invgen <- o
+  
+let ic3_use_invgen_spec = 
+  ("--ic3_use_invgen", 
+   Arg.Bool ic3_use_invgen_action, 
+   Format.sprintf "(IC3) Use invariants from invariant generators (default: %s)"
+                  (string_of_ic3_use_invgen ic3_use_invgen_default))
+
+(* ********** *) 
 
 let ic3_abstr_action o = flags.ic3_abstr <- (ic3_abstr_of_string o)
   
@@ -1253,6 +1274,8 @@ let ic3_fwd_prop_ind_gen () = flags.ic3_fwd_prop_ind_gen
 
 let ic3_fwd_prop_subsume () = flags.ic3_fwd_prop_subsume 
 
+let ic3_use_invgen () = flags.ic3_use_invgen 
+
 let ic3_abstr () = flags.ic3_abstr
 
 let set_ic3_abstr f = flags.ic3_abstr <- f
@@ -1399,6 +1422,9 @@ and speclist =
 
     (* Subsumption in forward propagation *)
     ic3_fwd_prop_subsume_spec;
+
+    (* Use invariants from invariant generators *)
+    ic3_use_invgen_spec;
 
     (* Abstraction in IC3 *)
     ic3_abstr_spec;

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -166,6 +166,10 @@ val ic3_fwd_prop_ind_gen : unit -> ic3_fwd_prop_ind_gen
 type ic3_fwd_prop_subsume = bool
 val ic3_fwd_prop_subsume : unit -> ic3_fwd_prop_subsume
 
+(** Use invariants from invariant generators *)
+type ic3_use_invgen = bool
+val ic3_use_invgen : unit -> ic3_use_invgen
+
 (** Abstraction mechanism to use in IC3 *)
 type ic3_abstr = [ `None | `IA ]
 val ic3_abstr : unit -> ic3_abstr

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -60,9 +60,9 @@ val smtlogic : unit -> smtlogic
 type z3_bin = string
 val z3_bin : unit -> z3_bin
 
-(** Use check-sat with assumptions in Z3 *)
-type z3_check_sat_assume = bool
-val z3_check_sat_assume : unit -> z3_check_sat_assume
+(** Use check-sat with assumptions, or simulate with push/pop *)
+type smt_check_sat_assume = bool
+val smt_check_sat_assume : unit -> smt_check_sat_assume
 
 (** Executable of CVC4 solver *)
 type cvc4_bin = string

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -29,6 +29,9 @@ let true_of_unit () = true
 (* Returns false when given unit. *)
 let false_of_unit () = false
 
+(* Returns None when given unit. *)
+let none_of_unit () = None
+
 (* ********************************************************************** *)
 (* Arithmetic functions                                                   *)
 (* ********************************************************************** *)

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -31,6 +31,9 @@ val true_of_unit : unit -> bool
 (** Returns false when given unit. *)
 val false_of_unit : unit -> bool
 
+(** Returns None when given unit. *)
+val none_of_unit : unit -> 'a option
+
 (** {1 Option types} *)
 
 (** Return the value of an option type, raise [Invalid_argument "get"]

--- a/src/lockStepDriver.ml
+++ b/src/lockStepDriver.ml
@@ -64,10 +64,10 @@ let check_consistency_sys solver k sys actlit called_by =
 
     SMTSolver.check_sat_assuming
       solver
-      (fun () ->
+      (fun _ ->
        (* Instance is sat for [sys], fine. *)
        ())
-      (fun () ->
+      (fun _ ->
        (* Instance is unsat, let's crash. *)
        Event.log
          L_info
@@ -453,7 +453,7 @@ let query_base
   |> SMTSolver.assert_term base_solver ;
 
   (* Function to run if sat. *)
-  let if_sat () =
+  let if_sat _ =
 
     let minus_k = Numeral.(~- k) in
 
@@ -471,7 +471,7 @@ let query_base
   in
 
   (* Function to run if unsat. *)
-  let if_unsat () = None in
+  let if_unsat _ = None in
 
   (* Checking if we should terminate before doing anything. *)
   Event.check_termination () ;
@@ -546,7 +546,7 @@ let rec split_closure
             |> Term.mk_not ]) ;
 
      (* Function to run if sat. *)
-     let if_sat () =
+     let if_sat _ =
 
        let minus_kp1 = Numeral.(~- kp1) in
        
@@ -583,7 +583,7 @@ let rec split_closure
      in
 
      (* Function to run if unsat. *)
-     let if_unsat () = None in
+     let if_unsat _ = None in
 
      (* Checking if we should terminate before doing anything. *)
      Event.check_termination () ;
@@ -638,7 +638,7 @@ let rec prune_trivial
          Term.mk_and bumped_terms |> Term.mk_not ]
      |> SMTSolver.assert_term solver ;
 
-     let if_sat () =
+     let if_sat _ =
        Some (
          (* Getting the values of terms@1. *)
          SMTSolver.get_term_values
@@ -658,7 +658,7 @@ let rec prune_trivial
        )
      in
 
-     let if_unsat () = None in
+     let if_unsat _ = None in
 
      match
       SMTSolver.check_sat_assuming

--- a/src/solverDriver.ml
+++ b/src/solverDriver.ml
@@ -22,7 +22,7 @@ module type S = sig
   (** {2 Solver configuration options} *)
 
   (** Command line options *)
-  val cmd_line : unit -> string array
+  val cmd_line : TermLib.logic -> bool -> bool -> bool -> bool -> string array
 
   (** Internal command for check-sat with timeout in milliseconds*)
   val check_sat_limited_cmd : int -> string

--- a/src/solverDriver.mli
+++ b/src/solverDriver.mli
@@ -22,7 +22,7 @@ module type S = sig
   (** {2 Solver configuration options} *)
 
   (** Command line options *)
-  val cmd_line : unit -> string array
+  val cmd_line : TermLib.logic -> bool -> bool -> bool -> bool -> string array
 
   (** Internal command for check-sat with timeout in milliseconds*)
   val check_sat_limited_cmd : int -> string

--- a/src/step.ml
+++ b/src/step.ml
@@ -232,7 +232,7 @@ let eval_terms_assert_first_false trans solver eval k =
 let split trans solver k to_split actlits =
   
   (* Function to run if sat. *)
-  let if_sat () =
+  let if_sat _ =
     
     (* Extract a model *)
     let model = 
@@ -284,7 +284,7 @@ let split trans solver k to_split actlits =
   in
 
   (* Function to run if unsat. *)
-  let if_unsat () = None in
+  let if_unsat _ = None in
 
   (* Appending to the list of actlits. *)
   let all_actlits = path_comp_act_term :: actlits in

--- a/src/term.ml
+++ b/src/term.ml
@@ -196,7 +196,14 @@ let term_of_named t =  match node_of_term t with
 
 (* Return the name of a named term *)
 let name_of_named t =  match node_of_term t with
-  | T.Annot (t, a) when TermAttr.is_named a -> TermAttr.named_of_attr a
+  | T.Annot (t, a) when TermAttr.is_named a ->
+
+    (* Get name of term *)
+    let (s, n) = TermAttr.named_of_attr a in
+
+    (* Fail if not in term namespace, otherwise return integer *)
+    if s <> "t" then invalid_arg "term_of_named" else n
+      
   | _ -> invalid_arg "term_of_named"
 
 
@@ -1079,7 +1086,17 @@ let mk_named t =
   (* Return name and named term
 
      Order pair in this way to put it an association list *)
-  (n, T.mk_annot t (TermAttr.mk_named n))
+  (n, T.mk_annot t (TermAttr.mk_named "t" n))
+
+
+(* Hashcons a named term *)
+let mk_named_unsafe t s n = 
+
+  (* Reject namespace used by mk_named to avoid clashes *)
+  if s = "t" then raise (Invalid_argument "mk_named_unsafe") else
+    
+    (* Return named term *)
+    T.mk_annot t (TermAttr.mk_named s n)
 
 
 (* Hashcons an uninterpreted function or constant *)

--- a/src/term.mli
+++ b/src/term.mli
@@ -188,6 +188,16 @@ val mk_select : t -> t -> t
     its name *)
 val mk_named : t -> int * t
 
+(** Name term with the given integer in a given namespace
+
+    This is a basic function, the caller has to generate the name, and
+    ensure the name is used only once. Use with caution, or better
+    only use {!mk_named}, which will create a unique name.
+
+    The namespace ["t"] will be rejected, because this is the
+    namespace used by {!mk_named}. *)
+val mk_named_unsafe : t -> string -> int -> t 
+
 (** Create an uninterpreted constant or function *)
 val mk_uf : UfSymbol.t -> t list -> t
     

--- a/src/termAttr.ml
+++ b/src/termAttr.ml
@@ -27,7 +27,7 @@ open Lib
 (* An attribute for a term annotation 
 
    Currently we only have names for terms *)
-type attr = Named of int
+type attr = Named of string * int
 
 
 (* A private type that cannot be constructed outside this module
@@ -67,10 +67,10 @@ module Attr_node = struct
   let equal v1 v2 = match v1, v2 with
 
     (* Two name attributes, use equality on integers *)
-    | Named n1, Named n2 -> n1 = n2
+    | Named (s1, n1), Named (s2, n2) -> s1 = s2 && n1 = n2
 
   (* Return hash of a name attribute *)
-  let hash = function Named n -> n
+  let hash = function Named (s, n) -> Hashtbl.hash (s, n)
 
 end
 
@@ -163,8 +163,8 @@ module SMTLIBPrinter : Printer =
     let pp_print_attr_node ppf = function 
 
       (* Pretty-print a name attribute *)
-      | Named n ->
-         Format.fprintf ppf ":named@ t%d" n
+      | Named (s, n) ->
+         Format.fprintf ppf ":named@ %s%d" s n
 
     (* Pretty-print an attribute to the standard formatter *)
     let print_attr_node = pp_print_attr_node Format.std_formatter 
@@ -221,7 +221,7 @@ include SelectedPrinter
 let is_named = function { Hashcons.node = Named _ } -> true
 
 (* Return the name in a name attribute *)
-let named_of_attr = function { Hashcons.node = Named n } -> n
+let named_of_attr = function { Hashcons.node = Named (s, n) } -> (s, n)
 
 (* ********************************************************************* *)
 (* Constructors                                                          *)
@@ -229,10 +229,10 @@ let named_of_attr = function { Hashcons.node = Named n } -> n
 
 
 (* Return a hashconsed attribute which is a name *)    
-let mk_named n = 
+let mk_named s n = 
   
   (* Create and hashcons name attribute *)
-  Hattr.hashcons ht (Named n) ()
+  Hattr.hashcons ht (Named (s, n)) ()
 
 
 (* 

--- a/src/termAttr.mli
+++ b/src/termAttr.mli
@@ -52,7 +52,7 @@ module AttrMap : Map.S with type key = t
 (** {1 Constructor} *)
 
 (** Return a name attribute *)
-val mk_named : int -> t
+val mk_named : string -> int -> t
 
 (** {1 Accessor functions} *)
 
@@ -61,7 +61,7 @@ val is_named : t -> bool
 
 (** Return the name in a name attribute, raises [Invalid_argument] for
     other attributes *)
-val named_of_attr : t -> int
+val named_of_attr : t -> string * int
 
 (** {1 Pretty-printing} *)
 

--- a/src/yicesDriver.ml
+++ b/src/yicesDriver.ml
@@ -20,7 +20,12 @@ open Lib
 
 
 (* Configuration for Yices *)
-let cmd_line () = 
+let cmd_line 
+    logic
+    produce_assignments
+    produce_proofs
+    produce_cores
+    produce_interpolants = 
 
   (* Path and name of Yices executable *)
   let yices_bin = Flags.yices_bin () in

--- a/src/yicesDriver.ml
+++ b/src/yicesDriver.ml
@@ -36,7 +36,7 @@ let check_sat_limited_cmd ms =
 
 (* Indicates whether the solver supports the check-sat-assuming
    command. *)
-let check_sat_assuming_supported () = true
+let check_sat_assuming_supported () = Flags.smt_check_sat_assume ()
 
 
 let check_sat_assuming_cmd _ =

--- a/src/yicesDriver.ml
+++ b/src/yicesDriver.ml
@@ -41,7 +41,7 @@ let check_sat_limited_cmd ms =
 
 (* Indicates whether the solver supports the check-sat-assuming
    command. *)
-let check_sat_assuming_supported () = Flags.smt_check_sat_assume ()
+let check_sat_assuming_supported () = true
 
 
 let check_sat_assuming_cmd _ =

--- a/src/yicesNative.ml
+++ b/src/yicesNative.ml
@@ -1114,7 +1114,15 @@ let create_instance
   
   
   (* Get autoconfigured configuration *)
-  let solver_cmd  = YicesDriver.cmd_line () in
+  let solver_cmd  = 
+    YicesDriver.cmd_line
+      logic
+      produce_assignments
+      produce_proofs
+      produce_cores
+      false
+  in
+
   let config = { solver_cmd = solver_cmd; solver_arith_only = arith_only } in
   
   (* Name of executable is first argument 


### PR DESCRIPTION
Moved code out of the continuations of `check_sat_assume`, IC3 works correctly if `check-sat` with assumptions is simulated by asserting the literals on a new context level that is popped after the `check-sat`. This allows us to use CVC4 for IC3 again.

Extended the interface to `check_sat_assume` and added two convenience functions:

- The continuations now get the solver instance their first argument, so that we can factor out and re-use the functions. 

- `check_sat_ssume_tf` does not take continuations as arguments but returns `true` if the context is satisfiable with the assumptions, and `false` otherwise.

- `check_sat_assume_ab` takes two continuations of different types and returns either `Sat of 'a` or `Unsat of 'b`, where `'a` is the return type of the first continuation and `'b` the type of the second.