### PR TITLE
Improvements on web-hook testing

### DIFF
--- a/pullrequest_server/pullrequest_server.eliom
+++ b/pullrequest_server/pullrequest_server.eliom
@@ -122,15 +122,16 @@ let pullrequest_test_service_handler () (content_type, raw_content_opt) =
       let pr_user = pr |> member "user" |> member "login" |> to_string in
       let sha = pr |> member "head" |> member "sha" |> to_string in
       let base_sha = pr |> member "base" |> member "sha" |> to_string in
-
+      let body = pr |> member "body" |> to_string in
+      
       (* Execute command on cvc cluster through ssh.
          The user ocsigen must have an ssh key that is only allowed to run 
          the neessary command, here we just pass the arguments. *)
       let cmd = Format.sprintf
           "ssh -i /var/lib/ocsigenserver/.ssh/id_rsa_restricted \
            amebsout@@cvc.cs.uiowa.edu \
-           \"%d %s %s %s %s %s %s\" &"
-          pr_nb base_ref statuses_url html_url clone_url sha base_sha
+           \"%d %s %s %s %s %s %s '%s'\" &"
+          pr_nb base_ref statuses_url html_url clone_url sha base_sha body
       in
 
       log AccessLog

--- a/pullrequest_server/pullrequest_server.eliom
+++ b/pullrequest_server/pullrequest_server.eliom
@@ -120,6 +120,8 @@ let pullrequest_test_service_handler () (content_type, raw_content_opt) =
       let statuses_url = pr |> member "statuses_url" |> to_string in
       let html_url = pr |> member "html_url" |> to_string in
       let pr_user = pr |> member "user" |> member "login" |> to_string in
+      let sha = pr |> member "head" |> member "sha" |> to_string in
+      let base_sha = pr |> member "base" |> member "sha" |> to_string in
 
       (* Execute command on cvc cluster through ssh.
          The user ocsigen must have an ssh key that is only allowed to run 
@@ -127,8 +129,8 @@ let pullrequest_test_service_handler () (content_type, raw_content_opt) =
       let cmd = Format.sprintf
           "ssh -i /var/lib/ocsigenserver/.ssh/id_rsa_restricted \
            amebsout@@cvc.cs.uiowa.edu \
-           \"%d %s %s %s %s\" &"
-          pr_nb base_ref statuses_url html_url clone_url
+           \"%d %s %s %s %s %s %s\" &"
+          pr_nb base_ref statuses_url html_url clone_url sha base_sha
       in
 
       log AccessLog

--- a/pullrequest_server/pullrequest_server.eliom
+++ b/pullrequest_server/pullrequest_server.eliom
@@ -122,7 +122,7 @@ let pullrequest_test_service_handler () (content_type, raw_content_opt) =
       let pr_user = pr |> member "user" |> member "login" |> to_string in
       let sha = pr |> member "head" |> member "sha" |> to_string in
       let base_sha = pr |> member "base" |> member "sha" |> to_string in
-      let body = pr |> member "body" |> to_string in
+      let body = pr |> member "body" |> to_string |> String.escaped in
       
       (* Execute command on cvc cluster through ssh.
          The user ocsigen must have an ssh key that is only allowed to run 
@@ -130,7 +130,7 @@ let pullrequest_test_service_handler () (content_type, raw_content_opt) =
       let cmd = Format.sprintf
           "ssh -i /var/lib/ocsigenserver/.ssh/id_rsa_restricted \
            amebsout@@cvc.cs.uiowa.edu \
-           \"%d %s %s %s %s %s %s '%s'\" &"
+           \"%d %s %s %s %s %s %s \\\"%s\\\"\" &"
           pr_nb base_ref statuses_url html_url clone_url sha base_sha body
       in
 

--- a/pullrequest_server/test_pr
+++ b/pullrequest_server/test_pr
@@ -54,13 +54,16 @@ base=$2
 statuses_url=$3
 pr_url=$4
 clone_url=$5
+sha=$6
+base_sha=$7
+
 
 # unique sha for the pull request's head
-sha=$(echo ${statuses_url##*/})
-
+#sha=$(echo ${statuses_url##*/})
+uniq="$sha$base_sha"
 
 # everything will be run in $workdir
-workdir="$HOME/$sha"
+workdir="$HOME/$uniq"
 mkdir -p $workdir
 
 # the variable $OK contains the status of the build/tests:
@@ -71,7 +74,7 @@ mkdir -p $workdir
 OK=0
 
 # append both stdout and stderr of this script to $log_file
-log_file=$workdir/$sha.log
+log_file=$workdir/$uniq.log
 echo "" > $log_file
 exec >> $log_file
 exec 2>&1
@@ -86,8 +89,11 @@ token="$(cat .github_token)"
 #==============================================================================
 
 # update status on github
+
+status_data=$(printf '{"state":"pending","description":"Fetching and compiling","context":"%s"}' "$base")
+
 curl -H "Authorization: token $token" -H "Content-Type: application/json"\
-     -X POST --data '{"state":"pending","description":"Fetching and compiling"}' $statuses_url
+     -X POST --data "$status_data" $statuses_url
 
 #==============================================================================
 
@@ -203,8 +209,11 @@ else
 
 
         # update status on github
+
+        status_data=$(printf '{"state":"pending","description":"Queuing tests","context":"%s"}' "$base")
+        
         curl -H "Authorization: token $token" -H "Content-Type: application/json"\
-             -X POST --data '{"state":"pending","description":"Queuing tests"}' $statuses_url
+             -X POST --data "$status_data" $statuses_url
 
 
         cd $workdir
@@ -264,7 +273,7 @@ else
 
                 if [ $percentage != $old_percentage ]; then
 
-                    progress_data=$(printf '{"state":"pending","description":"Running tests: %s %%"}' "$percentage")
+                    progress_data=$(printf '{"state":"pending","description":"Running tests: %s %%","context":"%s"}' "$percentage"  "$base")
 
                     echo "send progress_data= $progress_data"
 
@@ -282,8 +291,10 @@ else
         # At this point, all jobs are finished
         
         # update status on github
+        status_data=$(printf '{"state":"pending","description":"Analyzing tests results","context":"%s"}' "$base")
+
         curl -H "Authorization: token $token" -H "Content-Type: application/json"\
-             -X POST --data '{"state":"pending","description":"Analyzing tests results"}' $statuses_url
+             -X POST --data "$status_data" $statuses_url
 
 
         # Create scatterplot to compare performances
@@ -609,7 +620,7 @@ echo '</html>' >> $html_report
 
 
 # create dir for report export
-export_dir=$sha
+export_dir=$uniq
 mkdir -p $export_dir/
 mv $image $export_dir/
 mv $html_report $export_dir/index.html
@@ -628,7 +639,7 @@ report_url="http://kind.cs.uiowa.edu/kind2_reports/$export_dir"
 
 # Send final status update to github
 
-status_data=$(printf '{"state":"%s","description":"%s","target_url":"%s"}' "$state" "$description" "$report_url")
+status_data=$(printf '{"state":"%s","description":"%s","target_url":"%s","context":"%s"}' "$state" "$description" "$report_url" "$base")
 
 echo "send status_data= $status_data"
 

--- a/pullrequest_server/test_pr
+++ b/pullrequest_server/test_pr
@@ -56,15 +56,6 @@ pr_url=$4
 clone_url=$5
 sha=$6
 base_sha=$7
-body=$8
-
-
-
-# Do nothing if the PR body contains %notest
-if echo "$body" | grep -q "%notest"; then
-    exit 0
-fi
-
 
 
 # unique sha for the pull request's head

--- a/pullrequest_server/test_pr
+++ b/pullrequest_server/test_pr
@@ -56,6 +56,15 @@ pr_url=$4
 clone_url=$5
 sha=$6
 base_sha=$7
+body=$8
+
+
+
+# Do nothing if the PR body contains %notest
+if echo "$body" | grep -q "%notest"; then
+    exit 0
+fi
+
 
 
 # unique sha for the pull request's head


### PR DESCRIPTION
Fixes a problem that would occur when a pull request was made to a branch that would update another already opened pull request to a different branch at the same time.
The status message for the pull request will in this case contain as many status reports as there are base branches for this pull request, like the following:
![screen shot 2015-06-18 at 17 32 48](https://cloud.githubusercontent.com/assets/5435080/8243819/31ab01b8-15e0-11e5-8305-7bb81acbdbfe.png)


Also now if the pull request contains the string `%notest`, then nothing will be triggered on the integration server (useful for small updates outside of `src`).
For instance this pull request won't trigger any tests.