### PR TITLE
merge operator and uninterpreted functions

### DIFF
--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -586,6 +586,14 @@ let lustre_main_default = None
 
 (* ********** *) 
 
+type lustre_flatten_arrays = bool
+
+let string_of_lustre_flatten_arrays = string_of_bool
+
+let lustre_flatten_arrays_default = false
+
+(* ********** *) 
+
 let debug_default = []
 
 (* ********** *) 
@@ -648,6 +656,7 @@ type flags =
     mutable interpreter_input_file : interpreter_input_file;
     mutable interpreter_steps : interpreter_steps;
     mutable lustre_main : lustre_main;
+    mutable lustre_flatten_arrays : lustre_flatten_arrays;
     mutable debug : string list;
     mutable debug_log : string option;
     mutable log_level : log_level;
@@ -701,6 +710,7 @@ let flags =
     interpreter_input_file = interpreter_input_file_default;
     interpreter_steps = interpreter_steps_default;
     lustre_main = lustre_main_default;
+    lustre_flatten_arrays = lustre_flatten_arrays_default;
     debug = debug_default;
     debug_log = debug_log_default;
     log_level = log_level_default;
@@ -1145,10 +1155,22 @@ let interpreter_steps_spec =
 let lustre_main_action o = flags.lustre_main <- Some o
                                        
 let lustre_main_spec = 
-  ("--lustre-main", 
+  ("--lustre_main", 
    Arg.String lustre_main_action, 
    Format.sprintf "Use the given node as top node in Lustre input \
                    (default: --%%MAIN annotation)")
+
+(* ********** *) 
+
+let lustre_flatten_arrays_action o = flags.lustre_flatten_arrays <- o
+                                       
+let lustre_flatten_arrays_spec = 
+  ("--lustre_flatten_arrays", 
+   Arg.Bool lustre_flatten_arrays_action, 
+   Format.sprintf
+     "Flatten arrays to one stream per element. If false, use quantified definitions. \
+      (default: %B)"
+     lustre_flatten_arrays_default)
 
 (* ********** *) 
 
@@ -1327,6 +1349,8 @@ let interpreter_steps () = flags.interpreter_steps
 
 let lustre_main () = flags.lustre_main
 
+let lustre_flatten_arrays () = flags.lustre_flatten_arrays
+
 let debug () = flags.debug
 
 let debug_log () = flags.debug_log
@@ -1479,6 +1503,9 @@ and speclist =
 
     (* Main node in Lustre input *)
     lustre_main_spec;
+
+    (* Flatten arrays to one stream per element *)
+    lustre_flatten_arrays_spec;
 
     (* Enable debug output *)
     debug_spec;

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -235,6 +235,10 @@ val input_file : unit -> string
 (** Main node in Lustre file *)
 val lustre_main : unit -> string option
 
+(** Flatten arrays to one stream per element *)
+type lustre_flatten_arrays = bool
+val lustre_flatten_arrays : unit -> lustre_flatten_arrays
+
 (** {1 Parsing of the command line} *)
 
 (** Parse the command line *)

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You
@@ -115,7 +115,7 @@ and lustre_type =
   | EnumType of position * ident list
 
 (** An identifier with a type *)
-and typed_ident = ident * lustre_type
+and typed_ident = position * ident * lustre_type
 
 (** A record field or an array or tuple index *)
 and label_or_index = 
@@ -246,7 +246,8 @@ type contract_node_decl =
     - the list of its outputs 
 *)
 type func_decl =
-    ident * (ident * lustre_type) list * (ident * lustre_type) list
+    ident * typed_ident list * typed_ident list  * contract_spec 
+
 
 (** An instance of a parametric node as a tuple of the identifier for
     the instance, the identifier of the parametric node and the list of

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1967,10 +1967,6 @@ let add_function_to_context ctx func_ctx =
   
   let func = function_of_context func_ctx in
 
-  Format.printf 
-    "%a@."
-    (F.pp_print_function false) func;
-
   { ctx with funcs = func :: ctx.funcs }
 
 (* 

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You
@@ -32,6 +32,7 @@ module E = LustreExpr
 module ET = E.LustreExprHashtbl
 
 module N = LustreNode
+module F = LustreFunction
 
 module SVT = StateVar.StateVarHashtbl
 
@@ -43,7 +44,7 @@ module VS = Var.VarSet
    This is just failing at the moment, we'd need some dependency
    analysis to recognize cycles to fully support forward
    referencing. *)
-exception Node_not_found of I.t * position
+exception Node_or_function_not_found of I.t * position
 
 
 (* Context for typing, flattening of indexed types and constant
@@ -60,6 +61,12 @@ type t =
 
     (* Visible nodes *)
     nodes : N.t list;
+
+    (* Definitions for function so far *)
+    func : F.t option;
+
+    (* Visible function *)
+    funcs : F.t list;
 
     (* Node dependencies *)
     deps : I.Set.t I.Map.t;
@@ -115,6 +122,8 @@ let mk_empty_context () =
   { scope = [];
     node = None;
     nodes = [];
+    func = None;
+    funcs = [];
     deps = I.Map.empty;
     contract_nodes = [];
     ident_type_map = IT.create 7;
@@ -178,10 +187,13 @@ let fail_on_new_definition ctx pos msg =
 
 
 (* Return the scope of the current context *)
-let scope_of_node = function 
+let scope_of_node_or_func = function 
 
   (* Within a node: add node name to scope *)
   | { node = Some node } -> N.scope_of_node node
+
+  (* Within a function: add function name to scope *)
+  | { func = Some func } -> F.scope_of_function func
 
   (* Outside a node: return empty scope *)
   | { node = None } -> []
@@ -192,7 +204,7 @@ let scope_of_node = function
 let scope_of_context ({ scope } as ctx) = 
 
   (* Start with scope of node *)
-  scope_of_node ctx @ List.rev scope
+  scope_of_node_or_func ctx @ List.rev scope
 
 
 (* Add scope to context *)
@@ -224,14 +236,15 @@ let pop_scope = function
 (* Create an empty node in the context *)
 let create_node = function 
 
-  (* Already in a node *)
-  | { node = Some _ } -> 
+  (* Already in a node or function *)
+  | { node = Some _ } 
+  | { func = Some _ } -> 
 
     (* Fail *)
     (function _ -> raise (Invalid_argument "create_node"))
 
-  (* Not in a node *)
-  | { node = None; ident_type_map; ident_expr_map; expr_state_var_map } as ctx -> 
+  (* Not in a node or function *)
+  | { ident_type_map; ident_expr_map; expr_state_var_map } as ctx -> 
 
     (function ident -> 
 
@@ -243,6 +256,31 @@ let create_node = function
           ident_expr_map = List.map IT.copy ident_expr_map;
           expr_state_var_map = ET.copy expr_state_var_map;
           node = Some (N.empty_node ident) } )
+
+
+(* Create an empty function in the context *)
+let create_function = function 
+
+  (* Already in a node or function *)
+  | { node = Some _ } 
+  | { func = Some _ } -> 
+
+    (* Fail *)
+    (function _ -> raise (Invalid_argument "create_function"))
+
+  (* Not in a node or function *)
+  | { ident_type_map; ident_expr_map; expr_state_var_map } as ctx -> 
+
+    (function ident -> 
+
+      (* Add empty function to context *)
+      { ctx with 
+
+          (* Make deep copies of hash tables *)
+          ident_type_map = IT.copy ident_type_map;
+          ident_expr_map = List.map IT.copy ident_expr_map;
+          expr_state_var_map = ET.copy expr_state_var_map;
+          func = Some (F.empty_function ident) } )
 
 
 (* Add a binding of an identifier to an expression to context *)
@@ -423,8 +461,11 @@ let set_state_var_source = function
 
        (* Return modified context *)
        { ctx with node = Some n'})
+
+  (* No sources in function *)
+  | { func = Some _ } as ctx -> (fun _ _ -> ctx)
         
-  (* Fil if not in a node *)
+  (* Fail if not in a node *)
   | { node = None } -> 
 
     function _ -> function _ -> 
@@ -631,11 +672,12 @@ let type_in_context { ident_type_map } ident =
 
 
 (* Return true if node has been declared in the context *)
-let node_in_context { nodes } ident = 
+let node_or_function_in_context { nodes; funcs } ident = 
   
   (* Return if identifier is in context *)
-  N.exists_node_of_name ident nodes 
-  
+  N.exists_node_of_name ident nodes ||
+  F.exists_function_of_name ident funcs
+    
 
 (* Add newly created variable to locals *)
 let add_state_var_to_locals = function 
@@ -654,45 +696,53 @@ let mk_fresh_oracle
     ?is_input
     ?is_const
     ?for_inv_gen
-    ({ node; fresh_oracle_index } as ctx) 
+    ({ node; definitions_allowed; fresh_oracle_index } as ctx) 
     state_var_type =
 
-  (* Are we in a node? *)
-  match node with 
+  match definitions_allowed with 
 
-    (* Fail if not inside a node *)
-    | None -> raise (Invalid_argument "mk_fresh_oracle")
+    (* Fail with error if no new definitions allowed *)
+    | Some (pos, msg) -> fail_at_position pos msg
 
-    (* Add to oracles *)
-    | Some { N.oracles } ->
+    (* Continue if definitions allowed *)
+    | _ -> 
 
-      (* Create state variable for abstraction *)
-      let state_var, ctx = 
-        mk_state_var 
-          ?is_input:is_input
-          ?is_const:is_const
-          ?for_inv_gen:for_inv_gen
-          ctx
-          (scope_of_node ctx @ I.reserved_scope)
-          (I.push_index I.oracle_ident fresh_oracle_index)
-          D.empty_index
-          state_var_type
-          (Some N.Oracle)
-      in
+      (* Are we in a node? *)
+      match node with 
 
-      (* Increment index of fresh oracle *)
-      let ctx = 
-        match ctx with
-          | { node = None } -> assert false
-          | { node = Some node } ->
-            { ctx with 
-                node = Some { node with 
-                                N.oracles = state_var :: oracles}; 
-                fresh_oracle_index = succ fresh_oracle_index }
-      in
+        (* Fail if not inside a node *)
+        | None -> raise (Invalid_argument "mk_fresh_oracle")
 
-      (* Return variable and changed context *)
-      (state_var, ctx)
+        (* Add to oracles *)
+        | Some { N.oracles } ->
+
+          (* Create state variable for abstraction *)
+          let state_var, ctx = 
+            mk_state_var 
+              ?is_input:is_input
+              ?is_const:is_const
+              ?for_inv_gen:for_inv_gen
+              ctx
+              (scope_of_node_or_func ctx @ I.reserved_scope)
+              (I.push_index I.oracle_ident fresh_oracle_index)
+              D.empty_index
+              state_var_type
+              (Some N.Oracle)
+          in
+
+          (* Increment index of fresh oracle *)
+          let ctx = 
+            match ctx with
+              | { node = None } -> assert false
+              | { node = Some node } ->
+                { ctx with 
+                    node = Some { node with 
+                                    N.oracles = state_var :: oracles}; 
+                    fresh_oracle_index = succ fresh_oracle_index }
+          in
+
+          (* Return variable and changed context *)
+          (state_var, ctx)
 
 
 (* Create a fresh state variable as an oracle input for the state variable *)
@@ -794,9 +844,85 @@ let mk_state_var_for_expr
     ?(is_const = false)
     ?(for_inv_gen = true)
     ({ expr_state_var_map; 
-       fresh_local_index;
-       definitions_allowed } as ctx)
+       fresh_local_index } as ctx)
     after_mk
+    ({ E.expr_type } as expr) = 
+
+  try 
+
+    (* Find previous definition of expression
+
+       Use [find_all] to get all state variables that define the
+       expression. *)
+    let state_var_list =
+      ET.find_all
+        expr_state_var_map
+        expr
+    in
+
+    (* Find state variable with same properties *)
+    let state_var = 
+      List.find
+        (fun sv -> 
+           StateVar.is_input sv = is_input && 
+           StateVar.is_const sv = is_const && 
+           StateVar.for_inv_gen sv = for_inv_gen)
+        state_var_list
+    in
+
+    (* Return state variable used before *)
+    (state_var, ctx)
+
+  (* Expresssion has not been abstracted before *)
+  with Not_found ->
+
+    (* Create state variable for abstraction *)
+    let state_var, ctx = 
+      mk_state_var 
+        ~is_input:is_input
+        ~is_const:is_const
+        ~for_inv_gen:for_inv_gen
+        ctx
+        (scope_of_node_or_func ctx @ I.reserved_scope)
+        (I.push_index I.abs_ident fresh_local_index)
+        D.empty_index
+        expr_type
+        None
+    in
+
+    (* Record mapping of expression to state variable
+
+       This will shadow but not replace a previous definition. Use
+       [find_all] to retrieve the definitions, and the usual
+       [fold] to iterate over all definitions. *)
+    ET.add
+      expr_state_var_map
+      expr
+      state_var;
+
+    (* Evaluate continuation after creating new variable *)
+    let ctx = after_mk ctx state_var in
+
+    (* Hash table is modified in place, increment index of fresh state
+       variable *)
+    let ctx = 
+      { ctx with 
+          fresh_local_index = succ fresh_local_index }
+    in
+
+    (* Return variable and changed context *)
+    (state_var, ctx)
+
+
+(* Define the expression with a state variable *)
+let mk_local_for_expr
+    ?is_input
+    ?is_const
+    ?for_inv_gen
+    pos
+    ({ node; 
+       definitions_allowed;
+       fresh_local_index } as ctx)
     ({ E.expr_type } as expr) = 
 
   match definitions_allowed with 
@@ -807,108 +933,31 @@ let mk_state_var_for_expr
     (* Continue if definitions allowed *)
     | _ -> 
 
-      try 
+      (* Are we in a node? *)
+      match node with 
 
-        (* Find previous definition of expression
+        (* Fail if not inside a node *)
+        | None -> raise (Invalid_argument "mk_local_for_expr")
 
-           Use [find_all] to get all state variables that define the
-           expression. *)
-        let state_var_list =
-          ET.find_all
-            expr_state_var_map
-            expr
-        in
+        (* Add to locals *)
+        | Some _ ->
 
-        (* Find state variable with same properties *)
-        let state_var = 
-          List.find
-            (fun sv -> 
-               StateVar.is_input sv = is_input && 
-               StateVar.is_const sv = is_const && 
-               StateVar.for_inv_gen sv = for_inv_gen)
-            state_var_list
-        in
+          (* Guard unguarded pres before adding definition *)
+          let expr', ctx = close_expr pos (expr, ctx) in
 
-        (* Return state variable used before *)
-        (state_var, ctx)
+          (* Define the expresssion with a fresh state variable *)
+          let state_var, ctx = 
+            mk_state_var_for_expr
+              ?is_input
+              ?is_const
+              ?for_inv_gen
+              ctx
+              add_state_var_to_locals
+              expr'
+          in
 
-      (* Expresssion has not been abstracted before *)
-      with Not_found ->
-
-        (* Create state variable for abstraction *)
-        let state_var, ctx = 
-          mk_state_var 
-            ~is_input:is_input
-            ~is_const:is_const
-            ~for_inv_gen:for_inv_gen
-            ctx
-            (scope_of_node ctx @ I.reserved_scope)
-            (I.push_index I.abs_ident fresh_local_index)
-            D.empty_index
-            expr_type
-            None
-        in
-
-        (* Record mapping of expression to state variable
-
-           This will shadow but not replace a previous definition. Use
-           [find_all] to retrieve the definitions, and the usual
-           [fold] to iterate over all definitions. *)
-        ET.add
-          expr_state_var_map
-          expr
-          state_var;
-
-        (* Evaluate continuation after creating new variable *)
-        let ctx = after_mk ctx state_var in
-
-        (* Hash table is modified in place, increment index of fresh state
-           variable *)
-        let ctx = 
-          { ctx with 
-              fresh_local_index = succ fresh_local_index }
-        in
-
-        (* Return variable and changed context *)
-        (state_var, ctx)
-
-
-(* Define the expression with a state variable *)
-let mk_local_for_expr
-    ?is_input
-    ?is_const
-    ?for_inv_gen
-    pos
-    ({ node;
-       fresh_local_index;
-       definitions_allowed } as ctx)
-    ({ E.expr_type } as expr) = 
-
-  (* Are we in a node? *)
-  match node with 
-
-    (* Fail if not inside a node *)
-    | None -> raise (Invalid_argument "mk_local_for_expr")
-
-    (* Add to locals *)
-    | Some _ ->
-
-      (* Guard unguarded pres before adding definition *)
-      let expr', ctx = close_expr pos (expr, ctx) in
-
-      (* Define the expresssion with a fresh state variable *)
-      let state_var, ctx = 
-        mk_state_var_for_expr
-          ?is_input
-          ?is_const
-          ?for_inv_gen
-          ctx
-          add_state_var_to_locals
-          expr'
-      in
-
-      (* Return variable and changed context *)
-      (state_var, ctx)
+          (* Return variable and changed context *)
+          (state_var, ctx)
 
 
 (* Create a fresh state variable as an oracle input *)
@@ -935,7 +984,7 @@ let mk_fresh_local
           ?is_const:is_const
           ?for_inv_gen:for_inv_gen
           ctx
-          (scope_of_node ctx @ I.reserved_scope)
+          (scope_of_node_or_func ctx @ I.reserved_scope)
           (I.push_index I.abs_ident fresh_local_index)
           D.empty_index
           state_var_type
@@ -959,6 +1008,10 @@ let mk_fresh_local
 
 (* Return the node of the given name from the context*)
 let node_of_name { nodes } ident = N.node_of_name ident nodes
+
+
+(* Return the node of the given name from the context*)
+let function_of_name { funcs } ident = F.function_of_name ident funcs
 
 
 (* Return the output variables of a node call in the context with the
@@ -1061,7 +1114,7 @@ let add_node_input ?is_const ctx ident index_types =
                  ~is_input:true
                  ?is_const
                  ctx
-                 (scope_of_node ctx @ I.user_scope)
+                 (scope_of_node_or_func ctx @ I.user_scope)
                  ident
                  index
                  index_type
@@ -1103,7 +1156,7 @@ let add_node_output ?(is_single = false) ctx ident index_types =
                mk_state_var
                  ~is_input:false
                  ctx
-                 (scope_of_node ctx @ I.user_scope)
+                 (scope_of_node_or_func ctx @ I.user_scope)
                  ident
                  index
                  index_type
@@ -1613,6 +1666,192 @@ let add_dep ({ deps } as ctx) ident called_ident =
   (* Return changed context *)
   { ctx with deps }
 
+
+(* ********************************************************************** *)
+(* Functions                                                              *)
+(* ********************************************************************** *)
+
+(* Add function input to context *)
+let add_function_input ctx ident index_types = 
+
+  match ctx with 
+
+    | { func = None } -> raise (Invalid_argument "add_function_input")
+
+    | { func = Some { F.inputs } } -> 
+
+      (* Get next index at root of trie *)
+      let next_top_idx = D.top_max_index inputs |> succ in
+
+      (* Add state variables for all indexes of input *)
+      let inputs', ctx = 
+        D.fold
+          (fun index index_type (accum, ctx) ->
+         
+             (* Create state variable as input and contant *)
+             let state_var, ctx = 
+               mk_state_var
+                 ~is_input:true
+                 ctx
+                 (scope_of_node_or_func ctx @ I.user_scope)
+                 ident
+                 index
+                 index_type
+                 (Some N.Input)
+             in
+             
+             (* Add expression to trie of identifier *)
+             (D.add (D.ListIndex next_top_idx :: index) state_var accum, ctx))
+             
+          index_types
+          (inputs, ctx)
+      in
+
+      (* Return node with input added *)
+      match ctx with
+        | { func = None } -> assert false
+        | { func = Some func } ->
+          { ctx with func = Some { func with F.inputs = inputs' } }
+
+
+(* Add function output to context *)
+let add_function_output ?(is_single = false) ctx ident index_types = 
+
+  match ctx with 
+
+    | { func = None } -> raise (Invalid_argument "add_function_output")
+
+    | { func = Some { F.outputs } } -> 
+
+      (* Get next index at root of trie *)
+      let next_top_idx = D.top_max_index outputs |> succ in
+
+      let outputs', ctx = 
+        D.fold
+          (fun index index_type (outputs', ctx) ->
+         
+             (* Create state variable as input and contant *)
+             let state_var, ctx = 
+               mk_state_var
+                 ~is_input:false
+                 ctx
+                 (scope_of_node_or_func ctx @ I.user_scope)
+                 ident
+                 index
+                 index_type
+                 (Some N.Output)
+             in
+
+             let index' = 
+               if is_single then index else 
+                 D.ListIndex next_top_idx :: index
+             in
+
+             (* Add expression to trie of identifier *)
+             (D.add index' state_var outputs', ctx))
+             
+          index_types
+          (outputs, ctx)
+      in
+
+      (* Return node with outputs added *)
+      match ctx with
+        | { func = None } -> assert false
+        | { func = Some func } ->
+          { ctx with 
+              func = 
+                Some { func with F.outputs = outputs' } }
+
+
+(* Add function contract to context *)
+let add_function_global_contract ctx pos contract = 
+
+  match ctx with 
+
+    | { func = None } -> raise (Invalid_argument "add_function_global_contract")
+
+    | { func = Some ({ F.global_contracts } as func) } -> 
+
+      (* Return function with contract added *)
+      { ctx with 
+          func = 
+            Some
+              { func with 
+                  F.global_contracts = 
+                    contract :: global_contracts } }
+
+
+(* Add function contract to context *)
+let add_function_mode_contract ctx pos contract_name contract = 
+
+  match ctx with 
+
+    | { func = None } -> raise (Invalid_argument "add_function_mode_contract")
+
+    | { func = Some ({ F.mode_contracts } as func) } -> 
+
+      (* Return node with contract added *)
+      { ctx with 
+          func = 
+            Some
+              { func with 
+                  F.mode_contracts = 
+                    contract :: mode_contracts } }
+
+
+(* Create a node from the context *)
+let function_of_context = function
+
+  (* Fail if not in a function *)
+  | { func = None } -> 
+
+    raise (Invalid_argument "function_of_context")
+
+  (* Return function 
+
+     We don't need to add abstractions, because they have been
+     inlined, and functions have no body *)
+  | { func = Some ({ F.inputs; F.outputs } as func) } -> 
+
+    let input_types = 
+      D.fold 
+        (fun _ sv a -> StateVar.type_of_state_var sv :: a)
+        inputs
+        []
+    in
+
+    let output_ufs = 
+      D.fold
+        (fun i sv a -> 
+           let u = 
+             (if Flags.smt_short_names () then 
+                UfSymbol.mk_fresh_uf_symbol
+              else
+                UfSymbol.mk_uf_symbol
+                  (Format.asprintf 
+                     "%s.uf"
+                     (StateVar.string_of_state_var sv)))
+               input_types
+               (StateVar.type_of_state_var sv)
+           in
+           D.add i u a)
+        outputs
+        D.empty
+    in
+      
+    { func with F.output_ufs } 
+
+
+(* Add node from second context to nodes of first *)
+let add_function_to_context ctx func_ctx = 
+  
+  let func = function_of_context func_ctx in
+
+  Format.printf 
+    "%a@."
+    (F.pp_print_function false) func;
+
+  { ctx with funcs = func :: ctx.funcs }
 
 (* 
    Local Variables:

--- a/src/lustre/lustreContext.mli
+++ b/src/lustre/lustreContext.mli
@@ -107,6 +107,15 @@ val contract_node_decl_of_ident : t -> string -> Lib.position * LustreAst.contra
     as arguments *)
 val fail_on_new_definition : t -> Lib.position -> string -> t
 
+(** Raise exception if no new definitions allowed 
+
+    Raise {!A.ParseError} with the message and position set by
+    {!fail_on_new_definition}. Raise an assertion failure if the
+    context does allow new definitions.
+*)
+
+val raise_no_new_definition_exc : t -> 'a
+
 (** Resolve an indentifier to an expression. *)
 val expr_of_ident : t -> LustreIdent.t -> LustreExpr.t LustreIndex.t
 

--- a/src/lustre/lustreContext.mli
+++ b/src/lustre/lustreContext.mli
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You
@@ -27,8 +27,8 @@ open Lib
 type t
 
 
-(** Node not found, possible forward reference *)
-exception Node_not_found of LustreIdent.t * Lib.position
+(** Node or function not found, possible forward reference *)
+exception Node_or_function_not_found of LustreIdent.t * Lib.position
 
 (** {1 Scopes and Nodes} *)
 
@@ -45,15 +45,21 @@ val push_scope : t -> string -> t
 val pop_scope : t -> t
 
 (** Return a copy of the context with an empty node of the given name
-    in the context. *)
+    in the context *)
 val create_node : t -> LustreIdent.t -> t 
 
+(** Return a copy of the context with an empty function of the given name
+    in the context *)
+val create_function : t -> LustreIdent.t -> t 
+
 (** Return a context that is identical to the first context with the
-    node constructed in the second context added. *)
+    node constructed in the second context added *)
 val add_node_to_context : t -> t -> t
 
-(** Create a new node from the context *)
-val node_of_context : t -> LustreNode.t 
+(** Return a context that is identical to the first context with the
+    function constructed in the second context added *)
+val add_function_to_context : t -> t -> t
+
 
 (** Return forward referenced subnodes of node *)
 val deps_of_node : t -> LustreIdent.t -> LustreIdent.Set.t
@@ -117,7 +123,7 @@ val expr_in_context : t -> LustreIdent.t -> bool
 val type_in_context : t -> LustreIdent.t -> bool
 
 (** Return [true] if the identifier denotes a node in the context *)
-val node_in_context : t -> LustreIdent.t -> bool
+val node_or_function_in_context : t -> LustreIdent.t -> bool
 
 (** Create a fresh local state variable in the context. *)
 val mk_fresh_local : ?is_input:bool -> ?is_const:bool -> ?for_inv_gen:bool -> t -> Type.t -> StateVar.t * t
@@ -145,6 +151,9 @@ val mk_fresh_oracle_for_state_var : t -> StateVar.t -> StateVar.t * t
 
 (** Return the node of the given name from the context*)
 val node_of_name : t -> LustreIdent.t -> LustreNode.t
+
+(** Return the function of the given name from the context *)
+val function_of_name : t -> LustreIdent.t -> LustreFunction.t
 
 (** Return variables capturing outputs of node call if a node call
     with the same input parameters and activation condition is in the
@@ -201,6 +210,25 @@ val set_node_main : t -> t
     The second argument is a pair so that it can take the output of
     {!LustreSimplify.eval_ast_expr} directly. *)
 val close_expr : Lib.position -> (LustreExpr.t * t) -> (LustreExpr.t * t)
+
+
+(** {1 Functions} *)
+
+(** Add function input to context *)
+val add_function_input : t -> LustreIdent.t -> Type.t LustreIndex.t -> t
+
+(** Add function output to context *)
+val add_function_output : ?is_single:bool -> t -> LustreIdent.t -> Type.t LustreIndex.t -> t
+
+(** Add global contract to function
+
+    The function must not have a global contract defined, otherwise a
+    parse error will be raised. *)
+val add_function_global_contract : t -> position -> LustreFunction.contract -> t
+
+(** Add mode contract to node *)
+val add_function_mode_contract : t -> position -> string -> LustreFunction.contract -> t
+
 
 
 (** {1 Helpers} *)

--- a/src/lustre/lustreContext.mli
+++ b/src/lustre/lustreContext.mli
@@ -90,6 +90,9 @@ val add_type_for_ident : t -> LustreIdent.t -> Type.t LustreIndex.t -> t
 (** Return the nodes in the context *)
 val get_nodes : t -> LustreNode.t list
 
+(** Return the functions in the context *)
+val get_functions : t -> LustreFunction.t list
+
 (** Add a contract node to the context for inlining later *)
 val add_contract_node_decl_to_context : t -> Lib.position * LustreAst.contract_node_decl -> t
 
@@ -219,6 +222,11 @@ val add_function_input : t -> LustreIdent.t -> Type.t LustreIndex.t -> t
 
 (** Add function output to context *)
 val add_function_output : ?is_single:bool -> t -> LustreIdent.t -> Type.t LustreIndex.t -> t
+
+val call_outputs_of_function_call : t -> LustreIdent.t -> LustreExpr.t LustreIndex.t -> StateVar.t LustreIndex.t option
+
+(** Add function call to context *)
+val add_function_call : t -> Lib.position -> LustreNode.function_call -> t
 
 (** Add global contract to function
 

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1624,7 +1624,7 @@ let eval_func_contract ctx contract_pos contract_name reqs enss =
   in
 
   (* Introduce state variable for conjunction of requirements *)
-  let contract_ens = function_expr_of_expr reqs' in
+  let contract_ens = function_expr_of_expr ens' in
   
   (* Return a contract *)
   ({ F.contract_name;

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You
@@ -29,6 +29,7 @@ module E = LustreExpr
 module ET = E.LustreExprHashtbl
 
 module N = LustreNode
+module F = LustreFunction
 
 module C = LustreContext
 
@@ -114,13 +115,22 @@ let eval_const_decl ?(ghost = false) ctx = function
       (* No type check for untyped or free constant *)
       | _ -> ());
 
+    (* Ensure expression is constant *)
+    D.iter 
+      (fun _ e -> 
+         if not (E.is_const e) then 
+           (C.fail_at_position
+              pos
+              "Invalid constant expression"))
+      res;
+
 
     (* Return context with new mapping of identifier to expression *)
     C.add_expr_for_ident ~shadow:ghost ctx ident res
 
 
 (* ********************************************************************** *)
-(* Parse signature                                                        *)
+(* Parse node                                                             *)
 (* ********************************************************************** *)
 
 (* Add all node inputs to contexts *)
@@ -852,9 +862,11 @@ let rec eval_node_equations ctx = function
 (* Parse contracts                                                        *)
 (* ********************************************************************** *)
 
+(* Parse a ghost variable declaration and evaluate continuation 
 
-(* Add ghost declaration and definition to context *)
-let eval_ghost_var ctx = function
+   This function is shared between nodes and functions, each has a
+   different way to deal with ghost variables. *)
+let eval_ghost_var ?(no_defs = false) f ctx = function
 
   (* Declaration of a free variable *)
   | A.FreeConst (pos, _, _) ->
@@ -889,7 +901,19 @@ let eval_ghost_var ctx = function
            (I.pp_print_ident false) ident);
 
     (* Evaluate ghost expression *)
-    let expr', ctx = S.eval_ast_expr ctx expr in
+    let expr', ctx = 
+      S.eval_ast_expr
+
+        (* Change context to fail on new definitions *)
+        (if no_defs then 
+           C.fail_on_new_definition
+             ctx
+             pos
+             "Invalid expression for variable"
+         else 
+           ctx)
+        expr
+    in
 
     let type_expr' = 
 
@@ -926,17 +950,12 @@ let eval_ghost_var ctx = function
 
     in
 
-    (* Add local declaration for ghost stream *)
-    let ctx = C.add_node_local ~ghost:true ctx ident type_expr' in
+    (* Pass to continuation *)
+    f ctx pos ident type_expr' expr expr' 
 
-    (* Add equation for ghost stream *)
-    eval_node_equations 
-      ctx
-      [A.Equation (pos, (A.StructDef (pos, [A.SingleIdent (pos, i)])), expr)]
-  
 
 (* Introduce fresh state variable for each ensures expression *)
-let eval_ens (accum, ctx) (pos, expr) = 
+let eval_node_ens (accum, ctx) (pos, expr) = 
 
   (* Evaluate expression to a Boolean expression, may change
      context *)
@@ -956,7 +975,7 @@ let eval_ens (accum, ctx) (pos, expr) =
 
 
 (* Form conjunction of requires expressions *)
-let eval_req (accum, ctx) (pos, expr) =
+let eval_node_req (accum, ctx) (pos, expr) =
 
   (* Evaluate expression to a Boolean expression, may change
      context *)
@@ -971,11 +990,11 @@ let eval_req (accum, ctx) (pos, expr) =
 
 (* Declare and define ghost streams, requires and ensures expressions
    and return contract *)
-let eval_contract ctx contract_pos contract_name reqs enss =
+let eval_node_contract ctx contract_pos contract_name reqs enss =
 
   (* Evaluate require clauses to a conjunction *)
   let reqs', ctx =
-    List.fold_left eval_req (E.t_true, ctx) reqs 
+    List.fold_left eval_node_req (E.t_true, ctx) reqs 
   in
 
   (* Introduce state variable for conjunction of requirements *)
@@ -984,7 +1003,7 @@ let eval_contract ctx contract_pos contract_name reqs enss =
   in
   
   (* Evaluate ensure clauses separately *)
-  let contract_enss, ctx = List.fold_left eval_ens ([], ctx) enss in
+  let contract_enss, ctx = List.fold_left eval_node_ens ([], ctx) enss in
 
   (* Return a contract *)
   ({ N.contract_name;
@@ -1241,7 +1260,7 @@ let rec inline_contract_of_contract_node
     
 
 (* Lookup definition of contract from contract node, or return inline contract *)
-let resolve_contract ctx node_inputs node_outputs = function 
+let resolve_contract node_inputs node_outputs ctx = function 
 
   (* Inline contract *)
   | A.InlinedContract (pos, ident, reqs, enss) -> 
@@ -1283,7 +1302,7 @@ let resolve_contract ctx node_inputs node_outputs = function
 
 
 (* Add mode contracts from list to context *)
-let rec eval_mode_contracts ctx node_inputs node_outputs = function 
+let rec eval_node_mode_contracts resolve_contract ctx = function 
 
   (* No more mode contracts, return *)
   | [] -> ctx
@@ -1302,12 +1321,12 @@ let rec eval_mode_contracts ctx node_inputs node_outputs = function
 
     (* Inline if necessary *)
     let (ctx, pos, ident, reqs, enss) = 
-      resolve_contract ctx node_inputs node_outputs mode_contract 
+      resolve_contract ctx mode_contract 
     in
 
     (* Evaluate *)
     let (contract, ctx) = 
-      eval_contract
+      eval_node_contract
         ctx
         pos
         (I.mk_string_ident ident)
@@ -1324,24 +1343,41 @@ let rec eval_mode_contracts ctx node_inputs node_outputs = function
     let ctx = C.pop_scope ctx in
 
     (* Continue with next contracts *)
-    eval_mode_contracts ctx node_inputs node_outputs tl 
+    eval_node_mode_contracts resolve_contract ctx tl 
 
 
 (* Add all node contracts to contexts *)
 let eval_node_contract_spec 
+  resolve_contract
     ctx
-    node_inputs
-    node_outputs
     (ghost_consts,
      ghost_vars,
      global_contract,
      mode_contracts) =
 
   (* Add constants to context *)
-  let ctx = List.fold_left eval_const_decl ctx ghost_consts in
+  let ctx = List.fold_left (eval_const_decl ~ghost:true) ctx ghost_consts in
+
+  (* Add declaration and equation for ghost stream *)
+  let f ctx pos ident type_expr ast_expr expr = 
+    
+    (* Add local declaration for ghost stream *)
+    let ctx = C.add_node_local ~ghost:true ctx ident type_expr in
+
+    (* Add equation for ghost stream *)
+    eval_node_equations 
+      ctx
+      [A.Equation
+         (pos, 
+          (A.StructDef 
+             (pos,
+              [A.SingleIdent (pos, I.string_of_ident false ident)])), 
+          ast_expr)]
+      
+  in
 
   (* Add ghost variables to context *)
-  let ctx = List.fold_left eval_ghost_var ctx ghost_vars in
+  let ctx = List.fold_left (eval_ghost_var f) ctx ghost_vars in
 
   (* Add global contract to context *)
 
@@ -1358,12 +1394,12 @@ let eval_node_contract_spec
       
       (* Inline if necessary *)
       let (ctx, pos, ident, reqs, enss) = 
-        resolve_contract ctx node_inputs node_outputs c
+        resolve_contract ctx c
       in
       
       (* Evaluate *)
       let (contract, ctx) = 
-        eval_contract 
+        eval_node_contract 
           ctx
           pos
           (I.mk_string_ident ident)
@@ -1382,7 +1418,7 @@ let eval_node_contract_spec
   in
   
   (* Continue with mode contracts *)
-  eval_mode_contracts ctx node_inputs node_outputs mode_contracts
+  eval_node_mode_contracts resolve_contract ctx mode_contracts
 
 
 (* Add declarations of node to context *)
@@ -1406,7 +1442,9 @@ let eval_node_decl
   let ctx = C.push_scope ctx "contract" in
 
   (* Parse contracts and add to context in contracts *)
-  let ctx = eval_node_contract_spec ctx inputs outputs contract_spec in
+  let ctx = 
+    eval_node_contract_spec (resolve_contract inputs outputs) ctx contract_spec 
+  in
 
   (* Remove scope for local declarations in implementation *)
   let ctx = C.pop_scope ctx in
@@ -1427,6 +1465,349 @@ let eval_node_decl
   (* Create node from current context and return *)
   ctx 
   
+
+(* ********************************************************************** *)
+(* Parse function declarations                                            *)
+(* ********************************************************************** *)
+
+(* Return true if the expression is functional, i.e. without temporal
+   operators *)
+let is_function_expr ({ E.expr_init; E.expr_step } as expr) =
+
+  (* Must not have a variable at the previous state *)
+  not (E.has_pre_var E.cur_offset expr) &&
+
+  (* Expressions must be equal *)
+  (E.equal_expr expr_init expr_step)
+  
+
+(* Return an expression for a stateless function from an expression *)
+let function_expr_of_expr ({ E.expr_init; E.expr_step } as expr) =
+
+  if 
+
+    (* Check if expression does not contain temporal operators *)
+    is_function_expr expr
+  
+  then
+
+    (* Return one of the two (equal) expressions *)
+    expr_step
+
+  else
+    
+    (* Fail *)
+    raise (Invalid_argument "func_expr_of_expr")
+
+
+
+(* Add all node inputs to contexts *)
+let rec eval_func_inputs ctx = function
+
+  (* All inputs parsed *)
+  | [] -> ctx
+
+  (* Input on the base clock *)
+  | (pos, i, ast_type) :: tl -> 
+
+    (* Identifier of AST identifier *)
+    let ident = I.mk_string_ident i in
+
+    if 
+      
+      try 
+        C.expr_in_context ctx ident 
+      with Invalid_argument e -> 
+        C.fail_at_position pos e
+      
+    then
+      
+      C.fail_at_position 
+        pos
+        (Format.asprintf 
+           "Function input %a already declared" 
+           (I.pp_print_ident false) ident);
+    
+    (* Evaluate type expression *)
+    let index_types = S.eval_ast_type ctx ast_type in
+  
+    (* Add declaration of possibly indexed type to contexts *)
+    let ctx = 
+      C.add_function_input
+        ctx
+        ident
+        index_types
+    in
+
+    (* Continue with following inputs *)
+    eval_func_inputs ctx tl
+
+
+(* Add all function inputs to contexts *)
+let rec eval_func_outputs ?is_single ctx = function
+
+  (* All outputs parsed *)
+  | [] -> ctx
+
+  (* Output on the base clock *)
+  | (pos, i, ast_type) :: tl -> 
+
+    (* Identifier of AST identifier *)
+    let ident = I.mk_string_ident i in
+
+    if 
+      
+      try 
+        C.expr_in_context ctx ident 
+      with Invalid_argument e -> 
+        C.fail_at_position pos e
+      
+    then
+      
+      C.fail_at_position 
+        pos
+        (Format.asprintf 
+           "Function output %a already declared" 
+           (I.pp_print_ident false) ident);
+    
+    (* Evaluate type expression *)
+    let ident_types = S.eval_ast_type ctx ast_type in
+  
+    (* Add declaration of possibly indexed type to contexts *)
+    let ctx = C.add_function_output ?is_single ctx ident ident_types in
+
+    (* Continue with following inputs *)
+    eval_func_outputs ctx tl
+
+
+(* Form conjunction of requires expressions *)
+let eval_func_req_ens (accum, ctx) (pos, expr) =
+
+  (* Evaluate expression to a Boolean expression, may change
+     context *)
+  let expr', ctx = 
+    S.eval_bool_ast_expr 
+      (C.fail_on_new_definition
+         ctx
+         pos
+         "Invalid expression in contract for function")
+      pos 
+      expr 
+    |> C.close_expr pos
+  in
+
+  if not (is_function_expr expr') then
+    C.fail_at_position
+      pos
+      "Invalid temporal expression in contract of function";
+
+  (* Add to conjunction of requirements *)
+  (E.mk_and accum expr' , ctx)
+
+
+(* Declare and define ghost streams, requires and ensures expressions
+   and return contract *)
+let eval_func_contract ctx contract_pos contract_name reqs enss =
+
+  (* Evaluate require clauses to a conjunction *)
+  let reqs', ctx =
+    List.fold_left eval_func_req_ens (E.t_true, ctx) reqs 
+  in
+
+  (* Introduce state variable for conjunction of requirements *)
+  let contract_req = function_expr_of_expr reqs' in
+  
+  (* Evaluate require clauses to a conjunction *)
+  let ens', ctx =
+    List.fold_left eval_func_req_ens (E.t_true, ctx) enss
+  in
+
+  (* Introduce state variable for conjunction of requirements *)
+  let contract_ens = function_expr_of_expr reqs' in
+  
+  (* Return a contract *)
+  ({ F.contract_name;
+     F.contract_pos; 
+     F.contract_req; 
+     F.contract_ens },
+   ctx)
+
+
+(* Add mode contracts from list to context *)
+let rec eval_func_mode_contracts resolve_contract ctx = function 
+
+  (* No more mode contracts, return *)
+  | [] -> ctx
+
+  (* Take the first contract *)
+  | mode_contract :: tl -> 
+
+    (* Peek at contract to get identifier for scoping *)
+    let ident = match mode_contract with
+      | A.InlinedContract (_, ident, _, _) 
+      | A.ContractCall (_, ident) -> ident
+    in
+
+    (* New scope for local declarations *)
+    let ctx = C.push_scope ctx ident in
+
+    (* Inline if necessary *)
+    let (ctx, pos, ident, reqs, enss) = 
+      resolve_contract ctx mode_contract 
+    in
+
+    (* Evaluate *)
+    let (contract, ctx) = 
+      eval_func_contract
+        ctx
+        pos
+        (I.mk_string_ident ident)
+        reqs
+        enss 
+    in
+
+    (* Add to context *)
+    let ctx = 
+      C.add_function_mode_contract ctx pos ident contract
+    in
+
+    (* Remove scope for local declarations *)
+    let ctx = C.pop_scope ctx in
+
+    (* Continue with next contracts *)
+    eval_func_mode_contracts resolve_contract ctx tl 
+
+
+(* Add all node contracts to contexts *)
+let eval_func_contract_spec 
+    ctx
+    func_inputs
+    func_outputs
+    (ghost_consts,
+     ghost_vars,
+     global_contract,
+     mode_contracts) =
+
+  (* Add constants to context *)
+  let ctx = 
+    List.fold_left
+      (eval_const_decl ~ghost:true)
+      ctx
+      ghost_consts 
+  in
+
+  (* Add expresson for identifier for ghost stream *)
+  let f ctx pos ident _ _ expr = 
+
+    (* Check expressions for all indexes *)
+    D.iter
+      (fun _ e -> 
+         if not (is_function_expr e) then 
+           C.fail_at_position
+             pos
+             "Invalid temporal expression in contract of function")
+      expr;
+
+    (* Bind identifier to expression in context *)
+    C.add_expr_for_ident ctx ident expr
+
+  in
+
+  (* Fail on contract calls *)
+  let inlined_contract_only ctx = function 
+
+    (* Return paramters of inline contract *)
+    | A.InlinedContract (pos, ident, reqs, enss) -> 
+      (ctx, pos, ident, reqs, enss)
+      
+    (* Contract must be inlined *)
+    | A.ContractCall (pos, _) -> 
+      C.fail_at_position 
+        pos
+        "Only inline contracts supported for functions" 
+
+  in
+
+  (* Add ghost variables to context *)
+  let ctx = 
+    List.fold_left
+      (eval_ghost_var ~no_defs:true f)
+      ctx
+      ghost_vars 
+  in
+
+  (* Add global contract to context *)
+  let ctx = match global_contract with
+    
+    (* No global contract for nodex *)
+    | None -> ctx
+
+    (* Global contract for node *)
+    | Some c -> 
+      
+      (* New scope for local declarations in contract *)
+      let ctx = C.push_scope ctx "__global" in
+      
+      (* Inline if necessary *)
+      let (ctx, pos, ident, reqs, enss) = inlined_contract_only ctx c in
+      
+      (* Evaluate *)
+      let (contract, ctx) = 
+        eval_func_contract 
+          ctx
+          pos
+          (I.mk_string_ident ident)
+          reqs
+          enss 
+      in
+      
+      (* Add to context *)
+      let ctx = 
+        C.add_function_global_contract ctx pos contract
+      in
+      
+      (* Remove scope for local declarations in contract *)
+      C.pop_scope ctx
+      
+  in
+  
+  (* Continue with mode contracts *)
+  eval_func_mode_contracts inlined_contract_only ctx mode_contracts
+
+
+(* Add declarations of node to context *)
+let eval_func_decl
+    ctx
+    inputs
+    outputs
+    contract_spec = 
+
+  (* Add inputs to context: as state variable to ident_expr_map, and
+     to inputs *)
+  let ctx = eval_func_inputs ctx inputs in
+
+  (* Add outputs to context: as state variable to ident_expr_map, and
+     to outputs *)
+  let ctx = eval_func_outputs ~is_single:(List.length outputs = 1) ctx outputs in
+
+  (* New scope for local declarations in contracts *)
+  let ctx = C.push_scope ctx "contract" in
+
+  (* Parse contracts and add to context in contracts *)
+  let ctx = eval_func_contract_spec ctx inputs outputs contract_spec in
+
+  (* Remove scope for local declarations in implementation *)
+  let ctx = C.pop_scope ctx in
+
+  (* New scope for local declarations in implementation *)
+  let ctx = C.push_scope ctx "impl" in
+
+  (* Remove scope for local declarations in implementation *)
+  let ctx = C.pop_scope ctx in
+
+  (* Create node from current context and return *)
+  ctx 
+
 
 (* ********************************************************************** *)
 (* Parse declarations                                                     *)
@@ -1492,7 +1873,7 @@ let rec declarations_to_context ctx =
       let ident = I.mk_string_ident i in
 
       (* Identifier must not be declared *)
-      if C.node_in_context ctx ident then
+      if C.node_or_function_in_context ctx ident then
 
         (* Fail if identifier already declared *)
         C.fail_at_position 
@@ -1524,7 +1905,7 @@ let rec declarations_to_context ctx =
          declarations_to_context ctx decls
 
        (* Node may be forward referenced *)
-       with C.Node_not_found (called_ident, pos) -> 
+       with C.Node_or_function_not_found (called_ident, pos) -> 
 
          if 
 
@@ -1587,8 +1968,8 @@ let rec declarations_to_context ctx =
            C.fail_at_position
              pos
              (Format.asprintf 
-                "Node %a is not defined" 
-                (I.pp_print_ident false) ident))
+                "Node or function %a is not defined" 
+                (I.pp_print_ident false) called_ident))
 
     (* Declaration of a contract node *)
     | A.ContractNodeDecl (pos, node_decl) :: decls -> 
@@ -1599,6 +1980,115 @@ let rec declarations_to_context ctx =
       (* Recurse for next declarations *)
       declarations_to_context ctx decls
 
+
+    (* Uninterpreted function declaration *)
+    | (A.FuncDecl 
+         (pos, 
+          (i, 
+           inputs, 
+           outputs,
+           contracts))) as curr_decl :: decls ->
+
+      (* Identifier of AST identifier *)
+      let ident = I.mk_string_ident i in
+
+      (* Identifier must not be declared *)
+      if C.node_or_function_in_context ctx ident then
+
+        (* Fail if identifier already declared *)
+        C.fail_at_position 
+          pos 
+          (Format.asprintf 
+             "Function %a is redeclared" 
+             (I.pp_print_ident false) ident);
+
+      (try
+
+         (* Create separate context for function *)
+         let func_ctx = C.create_function ctx ident in
+
+         (* Evaluate node declaration in separate context *)
+         let func_ctx = 
+           eval_func_decl
+             func_ctx
+             inputs
+             outputs
+             contracts 
+         in  
+
+         (* Add node to context *)
+         let ctx = C.add_function_to_context ctx func_ctx in
+
+         (* Recurse for next declarations *)
+         declarations_to_context ctx decls
+
+       (* Node may be forward referenced *)
+       with C.Node_or_function_not_found (called_ident, pos) -> 
+
+         if 
+
+           (* Is the referenced node declared later? *)
+           List.exists 
+             (function 
+               | A.NodeDecl (_, (i, _, _, _, _, _, _)) 
+                 when i = (I.string_of_ident false) called_ident -> true 
+               | _ -> false)
+             decls
+
+         then
+
+           (
+
+             (* Check circularity *)
+             (try
+
+                (* Get nodes that this forward references *)
+                let called_deps = C.deps_of_node ctx called_ident in
+
+                (* Is the reference circular? *)
+                if I.Set.mem ident called_deps then 
+
+                  C.fail_at_position
+                    pos
+                    (Format.asprintf 
+                       "Circular dependecy between nodes %a and %a" 
+                       (I.pp_print_ident false) ident
+                       (I.pp_print_ident false) called_ident)
+
+              with Not_found -> ());
+
+             (* Add new dependency *)
+             let ctx = C.add_dep ctx ident called_ident in
+
+             (* Move declaration to correct position.  
+
+                Inefficient: might be better to do a topological sort
+                beforehand *)
+             let decls =
+               List.fold_left 
+                 (fun acc d -> match d with 
+                    | A.NodeDecl (_, (i, _, _, _, _, _, _)) 
+                      when i = (I.string_of_ident false) called_ident ->
+                      curr_decl :: d :: acc
+                    | _ -> d :: acc)
+                 [] 
+                 decls
+               |> List.rev
+             in
+
+             (* Continue *)
+             declarations_to_context ctx decls
+
+           )
+
+         else
+
+           C.fail_at_position
+             pos
+             (Format.asprintf 
+                "Node or function %a is not defined" 
+                (I.pp_print_ident false) called_ident))
+
     (* ******************************************************************** *)
     (* Unsupported below                                                    *)
     (* ******************************************************************** *)
@@ -1608,10 +2098,6 @@ let rec declarations_to_context ctx =
 
       C.fail_at_position pos "Free types not supported"
 
-    (* External function declaration *)
-    | (A.FuncDecl (pos, _)) :: _ ->
-
-      C.fail_at_position pos "Functions not supported"
 
     (* Parametric node declaration *)
     | (A.NodeParamInst (pos, _)) :: _

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -30,6 +30,7 @@ module ET = E.LustreExprHashtbl
 
 module N = LustreNode
 module F = LustreFunction
+module G = LustreGlobals
 
 module C = LustreContext
 
@@ -2121,7 +2122,7 @@ let declarations_to_nodes decls =
   let ctx = declarations_to_context ctx decls in
 
   (* Return nodes in context *)
-  C.get_nodes ctx
+  C.get_nodes ctx, { G.functions = C.get_functions ctx }
 
 
 

--- a/src/lustre/lustreDeclarations.mli
+++ b/src/lustre/lustreDeclarations.mli
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You

--- a/src/lustre/lustreDeclarations.mli
+++ b/src/lustre/lustreDeclarations.mli
@@ -20,7 +20,7 @@
 
     @author Christoph Sticksel *)
 
-val declarations_to_nodes : LustreAst.t -> LustreNode.t list
+val declarations_to_nodes : LustreAst.t -> LustreNode.t list * LustreGlobals.t
 
 (* 
    Local Variables:

--- a/src/lustre/lustreFunction.ml
+++ b/src/lustre/lustreFunction.ml
@@ -1,0 +1,208 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+open Lib
+
+(* Module abbreviations *)
+module I = LustreIdent 
+module D = LustreIndex
+module E = LustreExpr
+
+type contract =
+  { 
+
+    (* Identifier of contract *)
+    contract_name : LustreIdent.t;
+
+    (* Position of the contract in the input *)
+    contract_pos: position;
+
+    (* Invariant from requirements of contract *)
+    contract_req : LustreExpr.expr;
+
+    (* Invariant from ensures of contract *)
+    contract_ens : LustreExpr.expr
+
+  }
+
+
+type t = 
+
+  {
+
+    name : LustreIdent.t;
+
+    inputs : StateVar.t LustreIndex.t;
+
+    outputs : StateVar.t LustreIndex.t;
+
+    output_ufs : UfSymbol.t LustreIndex.t;
+
+    global_contracts : contract list;
+
+    mode_contracts : contract list;
+
+  }
+
+
+(* An empty function *)
+let empty_function name = 
+  { name = name;
+    inputs = D.empty;
+    outputs = D.empty;
+    output_ufs = D.empty;
+    global_contracts = [];
+    mode_contracts = [] }
+
+
+
+(* Pretty-print array bounds of index *)
+let pp_print_array_dims safe ppf idx = 
+
+  match D.array_bounds_of_index idx with 
+
+    (* Print only if not empty *)
+    | [] -> ()
+
+    | bounds -> 
+
+      Format.fprintf 
+        ppf
+        "^%a"
+        (pp_print_list (E.pp_print_expr safe) "^")
+        bounds
+
+
+(* Pretty-print a function input or output *)
+let pp_print_input_output safe ppf (idx, var) =
+
+  Format.fprintf ppf
+    "%a: %a%a"
+    (E.pp_print_lustre_var safe) var
+    (E.pp_print_lustre_type safe) (StateVar.type_of_state_var var)
+    (pp_print_array_dims safe) idx
+
+
+
+(* Pretty-print an assumption *)
+let pp_print_require safe ppf expr =
+  Format.fprintf ppf
+    "@[<hv 2>--@@require@ @[<h>%a@];@]"
+    (E.pp_print_expr safe) expr
+
+
+(* Pretty-print a guarantee *)
+let pp_print_ensure safe ppf sv =
+  Format.fprintf ppf
+    "@[<hv 2>--@@ensure @[<h>%a@];@]"
+    (E.pp_print_expr safe) sv
+
+
+(* Pretty-print a named mode contract. *)
+let pp_print_mode_contract safe ppf { contract_name; contract_req; contract_ens } =
+  Format.fprintf
+    ppf
+    "@[<v>--@@contract %a;@,%a@,%a@]"
+    (I.pp_print_ident false) contract_name
+    (pp_print_require safe) contract_req
+    (pp_print_ensure safe) contract_ens
+
+
+(* Pretty-print an anonymous global contract. *)
+let pp_print_global_contract 
+    safe
+    ppf
+    { contract_name; contract_req; contract_ens } =
+
+    Format.fprintf
+      ppf
+      "@[<v>-- %a@,%a@,%a@]"
+      (I.pp_print_ident false) contract_name
+      (pp_print_require safe) contract_req
+      (pp_print_ensure safe) contract_ens
+
+
+(* Pretty-print a node *)
+let pp_print_function 
+    safe
+    ppf 
+    { name;
+      inputs; 
+      outputs; 
+      output_ufs;
+      global_contracts;
+      mode_contracts } = 
+
+  Format.fprintf ppf 
+    "@[<hv>@[<hv 2>function %a@ @[<hv 1>(%a)@]@;<1 -2>\
+     returns@ @[<hv 1>(%a)@];@]@ \
+     @[<v>%a@]%t@[<v>%a@]@\n%a"
+
+    (* %a *)
+    (I.pp_print_ident safe) name
+
+    (* %a *)
+    (pp_print_list (pp_print_input_output safe) ";@ ") 
+    (List.map
+       (* Remove first index of input argument for printing *)
+       (function ([], e) -> ([], e) | (_ :: tl, e) -> (tl, e))
+       (D.bindings inputs))
+
+    (* %a *)
+    (pp_print_list (pp_print_input_output safe) ";@ ") 
+    (List.map
+       (* Remove first index of output argument for printing *)
+       (function ([], e) -> ([], e) | (_ :: tl, e) -> (tl, e))
+       (D.bindings outputs))
+
+    (pp_print_list (pp_print_global_contract safe) "@,") global_contracts
+
+    (function ppf -> 
+      if global_contracts <> [] && mode_contracts <> [] then 
+        Format.pp_print_newline ppf ())
+
+    (pp_print_list (pp_print_mode_contract safe) "@,") mode_contracts
+
+    (pp_print_list UfSymbol.pp_print_uf_symbol "@,") (D.values output_ufs)
+
+(* ********************************************************************** *)
+(* Find functions in lists                                                *)
+(* ********************************************************************** *)
+
+
+(* Return true if a node of the given name exists in the a list of nodes *)
+let exists_function_of_name name functs =
+
+  List.exists
+    (function { name = funct_name } -> name = funct_name)
+    functs
+
+
+(* Return the node of the given name from a list of nodes *)
+let function_of_name name functs =
+
+  List.find
+    (function { name = funct_name } -> name = funct_name)
+    functs
+
+
+(* Return the name of the function *)
+let name_of_function { name } = name
+
+(* Return the scope of the name of the function *)
+let scope_of_function { name } = name |> I.to_scope

--- a/src/lustre/lustreFunction.mli
+++ b/src/lustre/lustreFunction.mli
@@ -1,0 +1,103 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+(** A contract has an identifier and a position in the input. It
+    consists of a state variable stands for the conjunction of its
+    require clauses, and one state variable that stand for each ensure
+    clause.
+
+    The requirement of a global contract may be assumed
+    invariant. Each ensures of a global or mode contract is a separate
+    proof obligation for the node. 
+
+    The conjunction of the requirements of all global contracts, and
+    the disjunction of the requirements of all mode contracts is a
+    proof obligation for all calling nodes. *)
+type contract =
+  { 
+
+    contract_name : LustreIdent.t;
+    (** Identifier of contract *)
+
+    contract_pos: Lib.position;
+    (** Position of the contract in the input *)
+
+    contract_req : LustreExpr.expr;
+    (** Invariant from requirements of contract *)
+
+    contract_ens : LustreExpr.expr
+    (** Invariant from ensures of contract *)
+
+  }
+
+type t = 
+
+  {
+
+    name : LustreIdent.t;
+    (** Name of the function *)
+
+    inputs : StateVar.t LustreIndex.t;
+    (** Input streams to the function
+
+        The inputs are considered as a list with an integer indexes
+        correpsonding to their position in the formal parameters if
+        there is more than one input parameter. If there is only one
+        input parameter, the list index is omitted, the index is empty
+        if there are no input parameters. *)
+
+    outputs : StateVar.t LustreIndex.t;
+    (** Output streams to the function
+
+        The outputs are considered as a list with an integer indexes
+        correpsonding to their position in the formal parameters. *)
+
+    output_ufs : UfSymbol.t LustreIndex.t;
+    (** Uninterpreted function symbol for output stream to enforce
+        functionality constraint *)
+
+    global_contracts : contract list;
+    (** Global contracts *)
+
+    mode_contracts : contract list;
+    (** Mode contracts *)
+
+  }
+
+(** Return a function of the given name without inputs, outputs and
+    contracts *)
+val empty_function : LustreIdent.t -> t
+
+
+(** Return the name of the node *)
+val name_of_function : t -> LustreIdent.t
+
+(** Return the scope of the node *)
+val scope_of_function : t -> Scope.t
+
+
+(** {1 Function Lists} *)
+
+(** Return the function of the given name from a list of functions *)
+val function_of_name : LustreIdent.t -> t list -> t 
+
+(** Return true if a function of the given name exists in the a list of function *)
+val exists_function_of_name : LustreIdent.t -> t list -> bool 
+
+
+val pp_print_function : bool -> Format.formatter -> t -> unit

--- a/src/lustre/lustreGlobals.ml
+++ b/src/lustre/lustreGlobals.ml
@@ -1,0 +1,37 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+open Lib
+
+(* Abbreviations *)
+module I = LustreIdent
+module D = LustreIndex
+module E = LustreExpr
+module N = LustreNode
+module F = LustreFunction
+
+
+type t = 
+
+  { 
+
+    (* Functions *)
+    functions : F.t list;
+
+  }
+

--- a/src/lustre/lustreGlobals.mli
+++ b/src/lustre/lustreGlobals.mli
@@ -1,0 +1,32 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+(** Global declarations for Lustre input 
+
+    @author Christoph Sticksel *)
+
+(** *)
+type t = 
+
+  { 
+
+    (** Functions *)
+    functions : LustreFunction.t list;
+
+  }
+

--- a/src/lustre/lustreIdent.ml
+++ b/src/lustre/lustreIdent.ml
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You

--- a/src/lustre/lustreIdent.mli
+++ b/src/lustre/lustreIdent.mli
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You

--- a/src/lustre/lustreIndex.ml
+++ b/src/lustre/lustreIndex.ml
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You

--- a/src/lustre/lustreIndex.mli
+++ b/src/lustre/lustreIndex.mli
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -62,7 +62,7 @@ let of_channel in_ch =
   in
 
   (* Simplify declarations to a list of nodes *)
-  let nodes = D.declarations_to_nodes declarations in
+  let nodes, globals = D.declarations_to_nodes declarations in
 
   (* Name of main node *)
   let main_node = 
@@ -111,7 +111,7 @@ let of_channel in_ch =
   in
 
   (* Return a subsystem tree from the list of nodes *)
-  N.subsystem_of_nodes nodes'
+  N.subsystem_of_nodes nodes', globals
   
 
 (* Open and parse from file *)

--- a/src/lustre/lustreInput.mli
+++ b/src/lustre/lustreInput.mli
@@ -117,7 +117,7 @@
 
 (** Parse from the file, return an input system for further slicing
     and refinement from analysis strategies. *)
-val of_file : string -> LustreNode.t SubSystem.t
+val of_file : string -> LustreNode.t SubSystem.t * LustreGlobals.t
 
 (* 
    Local Variables:

--- a/src/lustre/lustreLexer.mli
+++ b/src/lustre/lustreLexer.mli
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -402,6 +402,25 @@ let pp_print_call safe ppf = function
        call_oracles)
           
 
+(* Pretty-print a function call *)
+let pp_print_function_call safe ppf = function 
+
+  (* Node call on the base clock *)
+  | { call_function_name; 
+      call_inputs; 
+      call_outputs } ->
+
+    Format.fprintf ppf
+      "@[<hv 2>@[<hv 1>(%a)@] =@ @[<hv 1>%a@,(%a);@]@]"
+      (pp_print_list 
+         (E.pp_print_lustre_var safe)
+         ",@ ") 
+      (D.values call_outputs)
+      (I.pp_print_ident safe) call_function_name
+      (pp_print_list (E.pp_print_lustre_expr safe) ",@ ") 
+      (D.values call_inputs)
+
+
 (* Pretty-print an assertion *)
 let pp_print_assert safe ppf expr = 
 
@@ -488,6 +507,7 @@ let pp_print_node
       locals; 
       equations; 
       calls; 
+      function_calls; 
       asserts; 
       props;
       global_contracts;
@@ -507,6 +527,7 @@ let pp_print_node
      %a%t\
      @[<v>%t@]\
      @[<hv 2>let@ \
+     %a%t\
      %a%t\
      %a%t\
      %a%t\
@@ -549,6 +570,10 @@ let pp_print_node
     (* %a%t *)
     (pp_print_list (pp_print_call safe) "@ ") calls
     (space_if_nonempty calls)
+
+    (* %a%t *)
+    (pp_print_list (pp_print_function_call safe) "@ ") function_calls
+    (space_if_nonempty function_calls)
 
     (* %a%t *)
     (pp_print_list (pp_print_node_equation safe) "@ ") equations

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You
@@ -695,7 +695,7 @@ let node_of_name name nodes =
 (* Return the name of the node *)
 let name_of_node { name } = name
 
-(* Return the name of the node *)
+(* Return the scope of the name of the node *)
 let scope_of_node { name } = name |> I.to_scope
 
     

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -116,6 +116,26 @@ type node_call =
   }
 
 
+(* A call of a function *)
+type function_call = 
+
+  { 
+
+    (* Position of function call in input file *)
+    call_pos : position;
+
+    (* Name of called function *)
+    call_function_name : I.t;
+    
+    (* Expressions for input parameters *)
+    call_inputs : E.t D.t;
+
+    (* Variables capturing the outputs *)
+    call_outputs : StateVar.t D.t;
+
+  }
+
+
 type contract =
   { 
 
@@ -173,11 +193,14 @@ type t =
     (* Equations for local and output variables *)
     equations : equation list;
 
-    (* Node calls with activation condition: variables capturing the
-       outputs, the Boolean activation condition, the name of the
-       called node, expressions for input parameters and expression
-       for initialization *)
+    (* Node calls *)
     calls : node_call list;
+
+    (* Function calls
+
+       Needed to share functions calls with the same input
+       parameters *)
+    function_calls : function_call list;
 
     (* Assertions of node *)
     asserts : E.t list;
@@ -220,6 +243,7 @@ let empty_node name =
     locals = [];
     equations = [];
     calls = [];
+    function_calls = [];
     asserts = [];
     props = [];
     global_contracts = [];

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -99,6 +99,26 @@ type node_call =
   }
 
 
+(** A call of a function *)
+type function_call = 
+
+  { 
+
+    (** Position of function call in input file *)
+    call_pos : position;
+
+    (** Name of called function *)
+    call_function_name : LustreIdent.t;
+    
+    (** Expressions for input parameters *)
+    call_inputs : LustreExpr.t LustreIndex.t;
+
+    (** Variables capturing the outputs *)
+    call_outputs : StateVar.t LustreIndex.t;
+
+  }
+
+
 (** Source of a state variable *)
 type state_var_source =
   | Input   (** Declared input variable *)
@@ -214,6 +234,9 @@ type t =
 
     calls : node_call list;
     (** Node calls inside the node *)
+
+    function_calls : function_call list;
+    (** Function calls in the node *)
 
     asserts : LustreExpr.t list;
     (** Assertions of node *)

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You
@@ -21,7 +21,7 @@
     Nodes are normalized for easy translation into a transition
     system, mainly by introducing new variables. 
 
-    
+
 
     The node equations taken together become a map of state variables
     to expressions. All node calls are factored out with fresh state
@@ -200,7 +200,7 @@ type t =
     outputs : StateVar.t LustreIndex.t;
     (** Output streams defined in the node
 
-        The inputs are considered as a list with an integer indexes
+        The outputs are considered as a list with an integer indexes
         correpsonding to their position in the formal parameters. *)
 
     locals : StateVar.t LustreIndex.t list;
@@ -224,7 +224,7 @@ type t =
     global_contracts : contract list;
     (** Global contracts *)
 
-    mode_contracts :  contract list;
+    mode_contracts : contract list;
     (** Mode contracts *)
 
     is_main : bool;

--- a/src/lustre/lustreSimplify.ml
+++ b/src/lustre/lustreSimplify.ml
@@ -1720,18 +1720,9 @@ and eval_function_call
       (* Return expression and changed context *)
       (res, ctx)
       
-
-
-
-  (* Create constraints for outupts: D.fold output_ufs *)
-
-  (* Add constraints from contract ensures *)
-
-  (* Do not add constraint as assertion yet, must be able to slice
-     away function calls *)
-
-  (* Add property for contract requires *)
-
+    | exception Invalid_argument _ -> 
+      
+      C.raise_no_new_definition_exc ctx
 
 
 

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You

--- a/src/lustre/lustreSlicing.mli
+++ b/src/lustre/lustreSlicing.mli
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You

--- a/src/lustre/lustreSlicing.mli
+++ b/src/lustre/lustreSlicing.mli
@@ -120,9 +120,9 @@ val node_is_abstract : Analysis.param -> LustreNode.t -> bool
     influence together with a state variable not in the cone of
     influence. In this case, both state variables are in the cone of
     influence. We may add a better analysis later. *)
-val slice_to_abstraction : Analysis.param -> LustreNode.t SubSystem.t -> LustreNode.t SubSystem.t
+val slice_to_abstraction : Analysis.param -> LustreNode.t SubSystem.t -> LustreGlobals.t -> LustreNode.t SubSystem.t * LustreGlobals.t
 
-val slice_to_abstraction_and_property : Analysis.param -> Term.t -> LustreNode.t SubSystem.t -> LustreNode.t SubSystem.t
+val slice_to_abstraction_and_property : Analysis.param -> Term.t -> LustreNode.t SubSystem.t -> LustreGlobals.t -> LustreNode.t SubSystem.t * LustreGlobals.t 
 
 (* 
    Local Variables:

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -1934,6 +1934,7 @@ let rec trans_sys_of_node'
 
 let trans_sys_of_nodes 
     subsystem
+    globals
     ({ A.top; A.abstraction_map; A.assumptions } as  analysis_param) = 
   
   (* Make sure top level system is not abstract
@@ -1947,8 +1948,8 @@ let trans_sys_of_nodes
   (* TODO: Find top subsystem by name *)
   let subsystem' = subsystem in
 
-  let { SubSystem.source = { N.name = top_name } as node } as subsystem' = 
-    LustreSlicing.slice_to_abstraction analysis_param subsystem' 
+  let { SubSystem.source = { N.name = top_name } as node } as subsystem', globals' = 
+    LustreSlicing.slice_to_abstraction analysis_param subsystem' globals
   in
 
   let nodes = N.nodes_of_subsystem subsystem' in 
@@ -1989,7 +1990,7 @@ let trans_sys_of_nodes
           Biggest bucket length: %d@]@."
     s1 s2 s3 s4 s5 s6;
 *)
-  trans_sys, subsystem'
+  trans_sys, subsystem', globals'
 
 (*
 

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2014 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You
@@ -1251,6 +1251,10 @@ let rec constraints_of_equations
     (* Array state variable *)
     | (state_var, bounds, { E.expr_init; E.expr_step }) :: tl -> 
 
+      (* TODO: If bounds are not fixed, unroll to fixed bounds and
+         generate equations without quantifiers *)
+
+
       (* Return the i-th index variable *)
       let index_var_of_int i = 
         E.mk_index_var i
@@ -1905,9 +1909,9 @@ let rec trans_sys_of_node'
                 [] (* One-state invariants *)
                 [] (* Two-state invariants *)
             in                
-(*
+
             Format.printf "%a@." TransSys.pp_print_trans_sys trans_sys;
-*)
+
             trans_sys_of_node'
               top_name
               analysis_param
@@ -1948,11 +1952,11 @@ let trans_sys_of_nodes
   in
 
   let nodes = N.nodes_of_subsystem subsystem' in 
-(*
+
   Format.printf
     "@[<v>%a@]@."
     (pp_print_list (N.pp_print_node false) "@,") (List.rev nodes);
-*)
+
   let { trans_sys } =   
 
     try 

--- a/src/lustre/lustreTransSys.mli
+++ b/src/lustre/lustreTransSys.mli
@@ -229,7 +229,7 @@
     @author Adrien Champion *)
 
 
-val trans_sys_of_nodes : LustreNode.t SubSystem.t -> Analysis.param -> TransSys.t * LustreNode.t SubSystem.t
+val trans_sys_of_nodes : LustreNode.t SubSystem.t -> LustreGlobals.t -> Analysis.param -> TransSys.t * LustreNode.t SubSystem.t * LustreGlobals.t
 
 
 (* 

--- a/src/property.ml
+++ b/src/property.ml
@@ -247,7 +247,7 @@ let set_prop_ktrue p k =
 
       (* Fail if property was l-false for l <= k *)
       | PropFalse _ -> 
-        raise (Failure "set_prop_kfalse") 
+        raise (Failure "set_prop_ktrue") 
 
 
 (* Mark property status *)

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -97,6 +97,9 @@ type t =
        different scopes *)
     subsystems : (t * instance list) list;
 
+    (* Other function declarations *)
+    ufs : UfSymbol.t list;
+    
     (* Logic fragment needed to express the transition system 
 
        TODO: Should this go somewhere more global? *)
@@ -175,7 +178,7 @@ let pp_print_property
     { P.prop_name; P.prop_source; P.prop_term; P.prop_status } =
 
   Format.fprintf ppf
-    "(\"%s\" %a %a %a)" 
+    "(\"%s\"@ %a %a %a)" 
     prop_name
     Term.pp_print_term prop_term
     pp_print_property_status prop_status
@@ -209,6 +212,15 @@ let pp_print_subsystem ppf ({ scope }, instances) =
     (pp_print_list pp_print_instance "@ ") instances
 
 
+let pp_print_uf ppf uf =
+  Format.fprintf
+    ppf
+    "@[<hv>%a@ @[<hv 1>(%a)@]@ %a@]"
+    UfSymbol.pp_print_uf_symbol uf
+    (pp_print_list Type.pp_print_type "@ ") (UfSymbol.arg_type_of_uf_symbol uf)
+    Type.pp_print_type (UfSymbol.res_type_of_uf_symbol uf)
+
+    
 let pp_print_trans_sys 
     ppf
     { scope;
@@ -216,6 +228,7 @@ let pp_print_trans_sys
       instance_var_bindings;
       global_state_vars;
       state_vars;
+      ufs;
       init;
       init_formals;
       trans;
@@ -229,6 +242,7 @@ let pp_print_trans_sys
     ppf
     "@[<v 1>(trans-sys %a@,\
      @[<hv 2>(state-vars@ (@[<v>%a@]))@]@,\
+     @[<hv 2>(uf@ (@[<v>%a@]))@]@,\
      @[<hv 2>(init@ @[<hv 1>(%a)@]@ (@[<v>%a@]))@]@,\
      @[<hv 2>(trans@ @[<hv 1>(%a)@]@ (@[<v>%a@]))@]@,\
      @[<hv 2>(prop@ (@[<v>%a@]))@]@,\
@@ -236,6 +250,7 @@ let pp_print_trans_sys
 
     Scope.pp_print_scope scope
     (pp_print_list pp_print_state_var "@ ") state_vars
+    (pp_print_list pp_print_uf "@ ") ufs
     (pp_print_list Var.pp_print_var "@ ") init_formals
     Term.pp_print_term init
     (pp_print_list Var.pp_print_var "@ ") trans_formals
@@ -845,6 +860,11 @@ let declare_init_flag_of_bounds { init_flag_state_var } declare lbound ubound =
   |> Var.declare_vars declare 
 
 
+(* Declare other functions symbols *)
+let declare_ufs { ufs } declare =
+  List.iter declare ufs
+    
+      
 (* Define initial state predicate *)
 let define_init define { init_uf_symbol; init_formals; init } = 
   define init_uf_symbol init_formals init
@@ -884,6 +904,9 @@ let define_and_declare_of_bounds
 
     trans_sys;
   
+  (* Declare other functions of top system *)
+  declare_ufs trans_sys declare;
+       
   (* Declare constant state variables of top system *)
   declare_const_vars trans_sys declare;
        
@@ -1259,6 +1282,7 @@ let mk_trans_sys
     init_flag_state_var
     global_state_vars
     state_vars
+    ufs
     init_uf_symbol
     init_formals
     init
@@ -1400,6 +1424,7 @@ let mk_trans_sys
       global_state_vars;
       state_vars;
       subsystems;
+      ufs;
       init_uf_symbol;
       init_formals;
       init;

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -160,6 +160,9 @@ val mk_trans_sys :
   (** All state variables including globals and instance identifier *)
   StateVar.t list ->
 
+  (** Declarations of other function symbols *)
+  UfSymbol.t list  -> 
+
   (** Predicate symbol for initial state constraint *)
   UfSymbol.t -> 
 

--- a/tests/lustre/test-cycles.lus
+++ b/tests/lustre/test-cycles.lus
@@ -1,0 +1,51 @@
+function sincos(in: real) returns (sin: real; cos: real);
+
+-- Third input is not used to compute output 
+node Xi (in1, in2, in3: int) returns (out: int);
+let
+  out = in1 + in2;
+tel;
+
+-- Implementation is empty 
+node Xc (in1, in2, in3: int) returns (out: int);
+--@ensure out = in1 + in2;
+let tel;
+
+node Y() returns (OK: int);
+var
+  a, b, c,  d: int;
+  s1, s2, s3: int;
+  
+  x1, x2, y1, y2: real; 
+  A, B: int^3;
+
+
+let
+
+  s1 = s2;
+  s2 = s3;
+  -- s3 = s1;
+  
+  d = Xi(a, b, c);
+  -- a = d;
+  
+  -- b = Xi(a, c, b);
+  a = b;
+
+  -- This is a potential cycle, because we don't know the implementation
+  -- c = Xc(a, b, c);
+
+  -- c = a -> pre c;
+
+  -- a = b -> c;
+
+  -- This is a cycle 
+  x1, x2 = sincos(y1);
+  y1, y2 = sincos(x1);
+
+  -- This is a cycle, variable A is defined in more than one equation
+  A = [B[0], B[1], B[2]];
+  B[k] = A[k];
+
+  --%PROPERTY a + b + c + d + s1 + s2 + s3 + A[0] + B[0] > 0 + (int x1) + (int y1);
+tel;

--- a/tests/lustre/test-func.lus
+++ b/tests/lustre/test-func.lus
@@ -27,6 +27,7 @@ function sincos(in: real) returns (sin: real; cos: real);
 
 node X (in: real) returns (OK: bool);
 let
+
   OK = exp(in, in) > 0 or sincos(in) + sincos(in) = (0.0, 0.0);
   --%PROPERTY OK;
 tel;

--- a/tests/lustre/test-func.lus
+++ b/tests/lustre/test-func.lus
@@ -27,7 +27,6 @@ function sincos(in: real) returns (sin: real; cos: real);
 
 node X (in: real) returns (OK: bool);
 let
-
-  OK = exp(in, in) > 0 or sincos(in) + sincos(in) = (0.0, 0.0);
+  OK = exp(0.0 -> in, 1.0 -> in) > 0 or sincos(2.0 -> in) + sincos(2.0 -> in) = (0.0, 0.0);
   --%PROPERTY OK;
 tel;

--- a/tests/lustre/test-func.lus
+++ b/tests/lustre/test-func.lus
@@ -1,13 +1,3 @@
-node id (in: real) returns (out: int);
-let out = (int in); tel;
-
-/*
-node sin(in: real) returns (out: int);
-let tel;
-*/
-
-function exp (x, y: real) returns (out: int);
-
 
 function sincos(in: real) returns (sin: real; cos: real);
 --@const max = 1.0;
@@ -27,6 +17,16 @@ function sincos(in: real) returns (sin: real; cos: real);
 
 node X (in: real) returns (OK: bool);
 let
-  OK = exp(0.0 -> in, 1.0 -> in) > 0 or sincos(2.0 -> in) + sincos(2.0 -> in) = (0.0, 0.0);
+  OK = exp(0.0 -> in, 1.0 -> in) > 0.0 or sincos(2.0 -> in) + sincos(2.0 -> in) = (0.0, 0.0);
   --%PROPERTY OK;
+  --%MAIN
 tel;
+
+node id (in: real) returns (out: int);
+let out = (int in); tel;
+
+function exp (x, y: real) returns (out: real);
+-- --@ensure out >= id(out);
+-- --@ensure out <= sin(out);
+
+function sin(in: real) returns (out: int);

--- a/tests/lustre/test-func.lus
+++ b/tests/lustre/test-func.lus
@@ -1,0 +1,32 @@
+node id (in: real) returns (out: int);
+let out = (int in); tel;
+
+/*
+node sin(in: real) returns (out: int);
+let tel;
+*/
+
+function exp (x, y: real) returns (out: int);
+
+
+function sincos(in: real) returns (sin: real; cos: real);
+--@const max = 1.0;
+--@const pi = 3.14;
+--@const tau = 2.0 * pi;
+--@var min = - max;
+--@require in <= 0.0 or in >= 0.0;
+--@ensure min <= sin and sin <= max;
+
+--@contract pos;
+--@require 0.0 <= in and in <= tau;
+--@ensure sin >= 0.0;
+
+--@contract neg;
+--@require - tau <= in and in <= 0.0;
+--@ensure sin <= 0.0;
+
+node X (in: real) returns (OK: bool);
+let
+  OK = exp(in, in) > 0 or sincos(in) + sincos(in) = (0.0, 0.0);
+  --%PROPERTY OK;
+tel;

--- a/tests/lustre/test-merge.lus
+++ b/tests/lustre/test-merge.lus
@@ -8,7 +8,7 @@ let
   s = e;
 tel
 
-node two_instances (e: int; h: bool) returns (s, t1, t2, t3, t4, t5: int);
+node two_instances (e: int; h: bool) returns (s, t1, t2, t3, t4, t5, t1_k, t2_k, t3_k, t5_k: int);
 let
   s = integr (e);
   -- Need to use activate to clock node calls
@@ -18,8 +18,15 @@ let
   t3 = merge (h; (activate integr every h) (e); (activate id every not h) (e));
   t4 = (activate integr every h initial default (0)) (e);
   t5 = merge (h; e when h; e + 1 when not h);
+
+  -- Our syntax 
+  t1_k = merge (h; integr(e); 0 -> pre t1); 
+  t2_k = merge (h; integr(e); 42);
+  t3_k = merge (h; integr(e); id(e));
+  t5_k = merge (h; e; e + 1);
+
   --%MAIN
-  --%PROPERTY t1+t2+t3+t4 > 0;
+  --%PROPERTY t1 + t2 + t3 + t4 + t5 + t1_k + t2_k + t3_k + t5_k > 0;
 tel
 
 

--- a/tests/regression/success/test-type.lus
+++ b/tests/regression/success/test-type.lus
@@ -9,7 +9,7 @@ type x = int;
 type y = x;
 
 -- Not supported: free type
-type z;
+-- type z;
 
 -- Alias definition of record type
 type t = { one: x; two: real };


### PR DESCRIPTION
# merge

The SCADE6 syntax for merge is

    merge(h; A when c; B when not h);
    merge(h; (activate N every h)(i1,...,in); (activate M every not h)(j1,...,jm));

Since Kind 2 does not support clocked streams, then `when` operator can only occur at the positions in the `merge` above. The arguments `A` and `B` are on the base clock, so are the inputs `i1`,...,`jm` of `N` and `M`.

We therefore support a less redundant syntax by implicitly clocking the arguments of `merge`. The two expressions above are equivalent to

    merge(h; A; B);
    merge(h; N(i1,...,in); M(j1,...,jm));

# function

Stateless uninterpreted functions can be defined as 

    function(i1:t1; ...; iN:tN) returns (o1:t1; ...; oM:tM);

The outputs are only constrained to be functions of the input, that is, for the same inputs the same outputs will be returned. Unlike nodes, functions do not have a body. Functions are called in the same way nodes are, but they cannot occur under a `condact`.

Functions can be annotated with mode or global contracts in the Kind 2 contract language. Functions are stateless, therefore contracts must not use the temporal operators `->` and `pre`.

```
function sincos(in: real) returns (sin: real; cos: real);
--@const max = 1.0;
--@const pi = 3.14;
--@const tau = 2.0 * pi;
--@var min = - max;
--@require in <= 0.0 or in >= 0.0;
--@ensure min <= sin and sin <= max;

--@contract pos;
--@require 0.0 <= in and in <= tau;
--@ensure sin >= 0.0;

--@contract neg;
--@require - tau <= in and in <= 0.0;
--@ensure sin <= 0.0;
```

Two limitations apply: there can be no node or function calls in contracts, and contracts cannot be imported from spec nodes. 
