### PR TITLE
Display property statuses on exit

### DIFF
--- a/src/event.ml
+++ b/src/event.ml
@@ -995,6 +995,22 @@ let log_progress mdl level k =
     | F_relay -> ()
   
 
+let log_result trans_sys =
+  let stats = all_stats () in
+  if stats <> [] then begin
+    log L_info "@[<v>%a@, Final statistics:@]" pp_print_hline ();
+  
+    List.iter 
+      (fun (mdl, stat) -> log_stat mdl L_info stat)
+      stats
+  end ;
+  
+  (match trans_sys with | None -> () | Some trans_sys ->
+    log_prop_status 
+      L_fatal
+      (TransSys.get_prop_status_all trans_sys))
+
+
 (* Terminate log output *)
 let terminate_log () = 
   match !log_format with 

--- a/src/event.mli
+++ b/src/event.mli
@@ -72,6 +72,11 @@ val log_prop_status : Lib.log_level -> (string * TransSys.prop_status) list -> u
     {!stat} to send it as a message. *)
 val log_stat : Lib.kind_module -> Lib.log_level -> (string * Stat.stat_item list) list -> unit 
 
+(** Log result
+
+    Log final result as the statuses of all properties. *)
+val log_result : TransSys.t option -> unit 
+
 (** Terminate log
 
     Output closing tags for XML output. *)

--- a/src/invarManager.ml
+++ b/src/invarManager.ml
@@ -19,27 +19,9 @@
 open Lib
 
 let on_exit trans_sys =
-  
-  Event.log
-    L_info
-    "@[<v>%a@,\
-     Final statistics:@]"
-    pp_print_hline ();
-  
-  List.iter 
-    (fun (mdl, stat) -> Event.log_stat mdl L_info stat)
-    (Event.all_stats ());
-  
-  (match trans_sys with | None -> () | Some trans_sys ->
-    Event.log_prop_status 
-      L_fatal
-      (TransSys.get_prop_status_all trans_sys));
-    
   try 
-    
     (* Send termination message to all worker processes *)
     Event.terminate ();
-
   (* Skip if running as a single process *)
   with Messaging.NotInitialized -> ()
 

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -165,7 +165,7 @@ let status_of_trans_sys sys =
       if falsifiable then status_unsafe
       else status_safe
   in
-  Format.printf "status of trans sys@." ;
+
   (* Exit status. *)
   exit_status
 
@@ -324,6 +324,9 @@ let on_exit process sys exn =
     (* Close tags in XML output *)
     Event.terminate_log ();
 
+    (* Log stats and statuses of properties *)
+    Event.log_result sys;
+  
     (* Exit with status *)
     exit status
 
@@ -421,7 +424,7 @@ let on_exit process sys exn =
 
    Give the exception [exn] that was raised or [Exit] on normal
    termination *)
-let on_exit_child messaging_thread process sys_opt exn = 
+let on_exit_child ?(alone=false) messaging_thread process sys_opt exn = 
 
   (* Exit status of process depends on exception *)
   let status = status_of_exn process sys_opt exn in
@@ -444,6 +447,9 @@ let on_exit_child messaging_thread process sys_opt exn =
       pp_print_kind_module process
     in
 
+    (* Log stats and statuses of properties if run as a single process *)
+    if alone then Event.log_result sys_opt;
+    
     (* Exit process with status *)
     exit status )
 
@@ -556,11 +562,13 @@ let run_process messaging_setup process =
             let backtrace = Printexc.get_backtrace () in
 
             Event.log L_fatal
-              "Runtime error: %s" 
+              "[%a] Runtime error: %s"
+              pp_print_kind_module process
               (Printexc.to_string e);
 
             if Printexc.backtrace_status () then
-              Event.log L_debug "Backtrace:@\n%s" backtrace;
+              Event.log L_debug "[%a] Backtrace:@\n%s"
+                pp_print_kind_module process backtrace;
 
             (* Cleanup and exit *)
             on_exit_child None process None e
@@ -977,7 +985,7 @@ let main () =
           Sys.set_signal Sys.sigalrm Sys.Signal_ignore;
 
           (* Cleanup before exiting process *)
-          on_exit_child None p (Some (get !trans_sys)) Exit
+          on_exit_child ~alone:true None p (Some (get !trans_sys)) Exit
             
         )
         
@@ -1043,7 +1051,7 @@ let main () =
         | [p] -> 
           
           (* Cleanup before exiting process *)
-          on_exit_child None p !trans_sys e
+          on_exit_child ~alone:true None p !trans_sys e
             
        
         (* Run some modules in parallel *)

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -893,6 +893,11 @@ let main () =
     Sys.sigquit 
     (Sys.Signal_handle exception_on_signal);
 
+  (* Install generic signal handler for SIGPIPE *)
+  Sys.set_signal 
+    Sys.sigpipe 
+    (Sys.Signal_handle exception_on_signal);
+
   Stat.start_timer Stat.total_time;
 
   try 

--- a/src/yicesNative.ml
+++ b/src/yicesNative.ml
@@ -1241,7 +1241,13 @@ let delete_instance
      command. Hence, ignore these stale respones on the output
      channel *)
 
-  ignore (execute_command_no_response solver "(exit)" 0);
+  begin
+    try ignore(execute_command_no_response solver "(exit)" 0)
+    with Signal s when s = Sys.sigpipe ->
+      Event.log L_fatal
+        "[Warning] Got broken pipe when trying to exit %s instance PID %d."
+        solver.solver_config.solver_cmd.(0) solver_pid
+  end;
 
   (* Reset internal state of yices *)
   solver.solver_last_id <- YicesResponse.yices_id_of_int 0;


### PR DESCRIPTION
Properties will now be shown if:
- Kind 2 was run with a single engine (in single process mode)
- if it exited due to an error