### PR TITLE
Easier-to-parse XML output

### DIFF
--- a/src/event.ml
+++ b/src/event.ml
@@ -1041,12 +1041,12 @@ let log_analysis_start param =
     in
     (* Opening [analysis] tag and printing info. *)
     Format.fprintf !log_ppf "@.@.\
-      <Analysis \
+      <AnalysisStart \
         top=\"%a\" \
         concrete=\"%a\" \
         abstract=\"%a\" \
         assumptions=\"%a\"\
-      >@.@.\
+      />@.@.\
     "
     Scope.pp_print_scope param.Analysis.top
     (pp_print_list Scope.pp_print_scope ",") concrete
@@ -1066,7 +1066,7 @@ let log_analysis_end result =
   | F_pt -> ()
   | F_xml ->
     (* Closing [analysis] tag. *)
-    Format.fprintf !log_ppf "</Analysis>@.@."
+    Format.fprintf !log_ppf "<AnalysisStop/>@.@."
 
   | F_relay -> failwith "can only be called by supervisor"
 

--- a/src/strategy.ml
+++ b/src/strategy.ml
@@ -224,8 +224,8 @@ module ModularStrategy : Strategy = struct
             ) else (
               match get_params results subs_of_scope result with
               | None -> (* Cannot refine, going up. *)
-                Format.printf "Cannot refine for %a@."
-                  Scope.pp_print_scope sys ;
+                (* Format.printf "Cannot refine for %a@."
+                  Scope.pp_print_scope sys ; *)
                 go_up prefix
               | Some (sub, abs, ass) -> (* Refinement found. *)
                 (* Format.printf "Refined %a for %a@."


### PR DESCRIPTION
* an analysis now starts with `<AnalysisStart .../>` containing the info from the previous `<Analysis ...>`
* it ends with `<AnalysisStop/>`
* silenced a `printf` in refiner
* cleaner xml log termination in case of timeout / error

## Motivation

Previously analyses were wrapped in an `Analysis` tag:

```xml
<Analysis top="..." concrete="..." abstract="..." assumptions="...">
...
</Analysis>
```

The problem is that with most parsers you would not have access to the info in the Analysis tag until you see `</Analysis>`.
So for instance you would not know which system and abstraction the messages output correspond to.
This is a problem for providing real-time info to the user of tool using Kind 2.

With these new tags the parser can first parse
```xml
<AnalysisStart top="..." concrete="..." abstract="..." assumptions="..."/>
```
and have all the info available right away. Eventually,
```xml
<AnalysisStop/>
```
indicates the analysis corresponding to the last `AnalysisStart` is over and a new one can start.