### PR TITLE
Block comment annotation + oracle generation fix

### DIFF
--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -834,14 +834,14 @@ let close_expr
          Numeral.(Var.offset_of_state_var_instance var < E.base_offset))
       init_vars
   in
-  
+
   (* No unguarded pres in initial state term? *)
   if VS.is_empty init_pre_vars then (expr, ctx) else
-    
+
     (warn_at_position
        pos
        "Unguarded pre in expression, adding new oracle input";
-     
+
      (* New oracle for each state variable *)
      let oracle_substs, ctx =
        VS.fold

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -970,7 +970,7 @@ let eval_req (accum, ctx, count) (pos, expr) =
   in
 
   (* Define expression with a state variable *)
-  let state_var, ctx = 
+  let state_var, ctx =
     C.mk_local_for_expr pos ctx expr' 
   in
 

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -245,8 +245,6 @@ let keyword_table = mk_hashtbl [
   ("MAIN", MAIN) ;
   (* Contract related things. *)
   ("contract", CONTRACT) ;
-  ("@mode", MODE) ;
-  ("@require", REQUIRE) ; ("@ensure", ENSURE) ;
 
   (* Boolean operators *)
   ("true", TRUE) ; ("false", FALSE) ;
@@ -331,6 +329,13 @@ rule token = parse
 
   (* End of slash star (SS). *)
   | "*/" { SSBLOCKEND }
+
+
+  (* |===| Block annotation contract stuff. *)
+
+  | "@mode" { MODE }
+  | "@require" { REQUIRE }
+  | "@ensure" { ENSURE }
 
 
   (* |===| Actual comments. *)

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -208,81 +208,69 @@ let read_from_lexbuf_stack buf n =
 
 
 (* Create and populate a hashtable *)
-let mk_hashtbl size init =
-  let tbl = Hashtbl.create size in
-  List.iter
-    (function (k, v) -> Hashtbl.add tbl k v)
-    init;
+let mk_hashtbl init =
+  let tbl = List.length init |> Hashtbl.create in
+  init |> List.iter (fun (k, v) -> Hashtbl.add tbl k v) ;
   tbl
   
 (* Use hash tables instead of rule matches to keep numer of transition
    of lexer small *)
 
 (* Hashtable of keywords *)
-let keyword_table = 
-  mk_hashtbl 
-    43
-    [
+let keyword_table = mk_hashtbl [
 
-      (* Types *)
-      ("type", TYPE);
-      ("int", INT);
-      ("real", REAL);
-      ("bool", BOOL);
-      ("subrange", SUBRANGE);
-      ("of", OF);
-(*      ("array", ARRAY); *)
-      ("struct", STRUCT);
-      ("enum", ENUM);
+  (* Types *)
+  ("type", TYPE) ;
+  ("int", INT) ; ("real", REAL) ; ("bool", BOOL) ;
+  ("subrange", SUBRANGE) ; ("of", OF) ;
+  (* ("array", ARRAY) ; *)
+  ("struct", STRUCT) ;
+  ("enum", ENUM) ;
 
-      (* Constant declaration *)
-      ("const", CONST);
-      
-      (* Node declaration *)
-      ("node", NODE);
-      ("function", FUNCTION);
-      ("returns", RETURNS);
-      ("var", VAR);
-      ("let", LET);
-      ("tel", TEL);
-      
-      (* Assertion *)
-      ("assert", ASSERT);
+  (* Constant declaration *)
+  ("const", CONST) ;
+  
+  (* Node / function declaration *)
+  ("node", NODE) ; ("function", FUNCTION) ;
+  ("returns", RETURNS) ;
+  ("var", VAR) ;
+  ("let", LET) ;
+  ("tel", TEL) ;
+  
+  (* Assertion *)
+  ("assert", ASSERT) ;
 
-      (* Contract related things. *)
-      ("contract", CONTRACT);
-      ("require", REQUIRE);
-      ("ensure", ENSURE);
+  (* Annotations. *)
+  ("PROPERTY", PROPERTY) ;
+  ("MAIN", MAIN) ;
+  (* Contract related things. *)
+  ("contract", CONTRACT) ;
+  ("mode", MODE) ;
+  ("require", REQUIRE) ; ("ensure", ENSURE) ;
+
+  (* Boolean operators *)
+  ("true", TRUE) ; ("false", FALSE) ;
+  ("not", NOT) ; ("and", AND) ; ("xor", XOR) ; ("or", OR) ;
+  ("if", IF) ;
+  ("then", THEN) ;
+  ("else", ELSE) ;
+  ("with", WITH) ;
+  ("div", INTDIV) ; ("mod", MOD) ;
+  
+  (* Clock operators *)
+  ("when", WHEN) ;
+  ("current", CURRENT) ;
+  ("condact", CONDACT) ;
+  ("activate", ACTIVATE) ;
+  ("initial", INITIAL) ;
+  ("default", DEFAULT) ;
+  ("every", EVERY) ;
+  ("merge", MERGE) ;
+  
+  (* Temporal operators *)
+  ("pre", PRE) ; ("fby", FBY) ;
       
-      (* Boolean operators *)
-      ("true", TRUE);
-      ("false", FALSE);
-      ("not", NOT);
-      ("and", AND);
-      ("xor", XOR);
-      ("or", OR);
-      ("if", IF);
-      ("with", WITH);
-      ("then", THEN);
-      ("else", ELSE);
-      ("div", INTDIV);
-      ("mod", MOD);
-      
-      (* Clock operators *)
-      ("when", WHEN);
-      ("current", CURRENT);
-      ("condact", CONDACT);
-      ("activate", ACTIVATE);
-      ("initial", INITIAL);
-      ("default", DEFAULT);
-      ("every", EVERY);
-      ("merge", MERGE);
-      
-      (* Temporal operators *)
-      ("pre", PRE);
-      ("fby", FBY);
-      
-    ]
+]
     
 }
 
@@ -317,59 +305,82 @@ let newline = '\r'* '\n'
 (* Toplevel function *)
 rule token = parse
 
-  (* Comment until end of line 
+  (* |===| Annotations. *)
 
-     Need to have the '-'* here, otherwise "---" would be matched 
-     as operator *)
-  | "--" '-'* { comment lexbuf }
+  (* Inline. *)
+  | "--%" { PERCENTANNOT }
+  | "--!" { BANGANNOT }
+  | "--@mode" { INLINEMODE }
+  | "--@require" { INLINEREQUIRE }
+  | "--@ensure" { INLINEENSURE }
+  | "--@const" { INLINECONST }
+  | "--@var" { INLINEVAR }
 
-  (* Multi-line comment *)
-  |  "/*" { skip_commented_slashstar lexbuf }
+  (* Parenthesis star (PS) block annotations. *)
+  | "(*%" { PSPERCENTBLOCK }
+  | "(*!" { PSBANGBLOCK }
+  | "(*@" { PSATBLOCK }
 
-  (* Multi-line comment *)
-  |  "(*" { skip_commented_parenstar lexbuf }
+  (* End of parenthesis star (PS). *)
+  | "*)" { PSBLOCKEND }
 
-  (* Include file *)
-  | "include" whitespace* '\"' ([^'\"']* as p) '\"' 
+  (* Slash star (SS) block annotations. *)
+  | "/*%" { SSPERCENTBLOCK }
+  | "/*!" { SSBANGBLOCK }
+  | "/*@" { SSATBLOCK }
 
-      { 
+  (* End of slash star (SS). *)
+  | "*/" { SSBLOCKEND }
 
-        (* Open include file *)
+
+  (* |===| Actual comments. *)
+
+  (* Inline.
+    Need to have the '-'* here, otherwise "---" would be matched 
+    as operator *)
+  | "--" '-'* { skip_to_eol lexbuf }
+
+  (* Multi-line. *)
+  | "/*" { skip_commented_slashstar lexbuf }
+  | "(*" { skip_commented_parenstar lexbuf }
+
+
+  (* |===| Include file. *)
+  | "include" whitespace* '\"' ([^'\"']* as p) '\"' {
+
+    (* Open include file *)
+    let include_channel, include_curdir =
+      try (
         let include_channel, include_curdir = 
-          try 
-
-            let include_channel = 
-              open_in (Filename.concat (curdir_of_lexbuf_stack ()) p) in
-
-            let include_curdir = Filename.dirname p in
-
-            include_channel, include_curdir 
-
-          with 
-            | Sys_error e -> 
-              failwith (Format.sprintf "Error opening include file %s: %s" p e)
-        in
-        
-        (* New lexing buffer from include file *)
-        lexbuf_switch_to_channel lexbuf include_channel include_curdir;
-        
-        Lexing.flush_input lexbuf;
-
-        (* Starting position in new file *)
-        let zero_pos = 
-          { Lexing.pos_fname = p;
-            Lexing.pos_lnum = 1;
-            Lexing.pos_bol = 0;
-            Lexing.pos_cnum = 0 } 
+          open_in (Filename.concat (curdir_of_lexbuf_stack ()) p),
+          Filename.dirname p
         in
 
-        (* Set new position in lexing buffer *)
-        lexbuf.Lexing.lex_curr_p <- zero_pos;
+        include_channel, include_curdir
+      ) with Sys_error e -> 
+        Format.sprintf "Error opening include file %s: %s" p e
+        |> failwith
+    in
+    
+    (* New lexing buffer from include file *)
+    lexbuf_switch_to_channel lexbuf include_channel include_curdir ;
+    
+    Lexing.flush_input lexbuf ;
 
-        (* Continue with included file *)
-        token lexbuf
-          
-      }
+    (* Starting position in new file *)
+    let zero_pos =
+      { Lexing.pos_fname = p ;
+        Lexing.pos_lnum = 1  ;
+        Lexing.pos_bol = 0   ;
+        Lexing.pos_cnum = 0  }
+    in
+
+    (* Set new position in lexing buffer *)
+    lexbuf.Lexing.lex_curr_p <- zero_pos ;
+
+    (* Continue with included file *)
+    token lexbuf
+  }
 
   (* Operators that are not identifiers *)
   | ';' { SEMICOLON }
@@ -389,8 +400,8 @@ rule token = parse
   | '}' { RCURLYBRACKET }
   | ".%" { DOTPERCENT }
   | '|' { PIPE }
-  | "<<" { LPARAMBRACKET } 
-  | ">>" { RPARAMBRACKET } 
+  | "<<" { LPARAMBRACKET }
+  | ">>" { RPARAMBRACKET }
   | "=>" { IMPL }
   | '#' { HASH }
   | "<=" { LTE }
@@ -407,29 +418,29 @@ rule token = parse
   (* Decimal or numeral *)
   | decimal as p { DECIMAL p }
   | exponent_decimal as p { DECIMAL p }
-  | numeral as p { NUMERAL p } 
+  | numeral as p { NUMERAL p }
 
   (* Keyword *)
-  | id as p 
-      { try Hashtbl.find keyword_table p with 
-        | Not_found -> (SYM p) }
+  | id as p {
+    try Hashtbl.find keyword_table p with Not_found -> (SYM p)
+  }
 
   (* Whitespace *)
   | whitespace { token lexbuf }
 
   (* Newline *)
-  | newline { Lexing.new_line lexbuf; token lexbuf }
+  | newline { Lexing.new_line lexbuf ; token lexbuf }
 
   (* End of file *)
-  | eof 
-
-      (* Pop previous lexing buffer form stack if at end of included file *)
-      { try pop_channel_of_lexbuf lexbuf; token lexbuf with End_of_file -> EOF }
+  | eof {
+    (* Pop previous lexing buffer form stack if at end of included file *)
+    try pop_channel_of_lexbuf lexbuf ; token lexbuf with End_of_file -> EOF
+  }
 
   (* Unrecognized character *)
-  | _ as c 
-      { failwith 
-          (Format.sprintf "Unrecognized token %c (0x%X)" c (Char.code c)) }
+  | _ as c {
+    Format.sprintf "Unrecognized token %c (0x%X)" c (Char.code c) |> failwith
+  }
 
 (* Parse until end of comment, count newlines and otherwise discard
    characters *)
@@ -439,10 +450,9 @@ and skip_commented_slashstar = parse
   | "*/" { token lexbuf } 
 
   (* Count new line *)
-  | newline { Lexing.new_line lexbuf; skip_commented_slashstar lexbuf } 
+  | newline { Lexing.new_line lexbuf ; skip_commented_slashstar lexbuf } 
 
-  | eof 
-      { failwith (Format.sprintf "Unterminated comment") }
+  | eof { Format.sprintf "Unterminated comment" |> failwith }
 
   (* Ignore characters in comments *)
   | _ { skip_commented_slashstar lexbuf }
@@ -458,99 +468,10 @@ and skip_commented_parenstar = parse
   (* Count new line *)
   | newline { Lexing.new_line lexbuf; skip_commented_parenstar lexbuf } 
 
-  | eof 
-      { failwith (Format.sprintf "Unterminated comment") }
+  | eof { Format.sprintf "Unterminated comment" |> failwith }
 
   (* Ignore characters in comments *)
   | _ { skip_commented_parenstar lexbuf }
-
-
-(* Parse until end of line and otherwise discard characters *)
-and comment = parse 
-
-  (* Annotation *)
-  | "%" (id as p) {
-    match p with 
-
-    (* Ignore rest of line and return token *)
-    | "MAIN" -> return_at_eol MAIN lexbuf
-
-    (* Return token, continue with rest of line *)
-    | "PROPERTY" -> PROPERTY
-
-    (* Warn and ignore rest of line *)
-    | _ -> (
-      print_warning "Unknown annotation %s skipped" p ;
-      skip_to_eol lexbuf
-    )
-  }
-
-  (* Contract *)
-  | "@" (id as p) {
-    match p with
-
-    (* Ignore rest of line and return token *)
-    | "main" -> return_at_eol MAIN lexbuf
-
-    (* Return token, continue with rest of line *)
-    | "property" -> PROPERTY
-
-    (* Return token, continue with rest of line *)
-    | "var" -> COMMENTGHOSTVAR
-
-    (* Return token, continue with rest of line *)
-    | "const" -> COMMENTGHOSTCONST
-
-    (* Return token, continue with rest of line. *)
-    | "import" -> COMMENTIMPORT
-
-    (* Return token, continue with rest of line. *)
-    | "import_mode" -> COMMENTIMPORTMODE
-
-    (* Return token, continue with rest of line. *)
-    | "mode" -> COMMENTMODE
-
-    (* Return token, continue with rest of line *)
-    | "require" -> COMMENTREQUIRE
-
-    (* Return token, continue with rest of line *)
-    | "ensure" -> COMMENTENSURE
-
-    (* Warn and ignore rest of line *)
-    | _ -> (
-      print_warning "Unknown \"@\" contract annotation %s skipped" p ;
-      skip_to_eol lexbuf
-    )
-  }
-
-  (* Bang annotation *)
-  | "!" (id as p) {
-    match p with
-
-    (* Return token, continue with rest of line. *)
-    | "PROPERTY" -> BANGPROPERTY
-
-    (* Return token, continue with rest of line. *)
-    | "MAIN" -> BANGMAIN
-
-    (* Warn and ignore rest of line *)
-    | _ -> (
-      print_warning "Unknown \"!\" annotation %s skipped" p ;
-      skip_to_eol lexbuf
-    )
-  }
-(*
-  (* Bang annotation *)
-  | "!" (id as p) { BANGCOMMENT p }
-*)
-  (* Count new line and resume *)
-  | newline { Lexing.new_line lexbuf; token lexbuf } 
-
-  (* Line ends at end of file *)
-  | eof { token lexbuf }
-
-  (* Ignore characters *)
-  | _ { skip_to_eol lexbuf }
 
 and skip_to_eol = parse
 

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -245,8 +245,8 @@ let keyword_table = mk_hashtbl [
   ("MAIN", MAIN) ;
   (* Contract related things. *)
   ("contract", CONTRACT) ;
-  ("mode", MODE) ;
-  ("require", REQUIRE) ; ("ensure", ENSURE) ;
+  ("@mode", MODE) ;
+  ("@require", REQUIRE) ; ("@ensure", ENSURE) ;
 
   (* Boolean operators *)
   ("true", TRUE) ; ("false", FALSE) ;

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -102,7 +102,7 @@ let mk_pos = position_of_lexing
 %token CONTRACT
 %token IMPORTCONTRACT
 %token MODE
-%token IMPORTMODE
+(* %token IMPORTMODE *)
 %token REQUIRE
 %token ENSURE
 %token INLINEMODE

--- a/src/lustre/lustreSimplify.ml
+++ b/src/lustre/lustreSimplify.ml
@@ -1563,8 +1563,10 @@ and eval_node_call
     | None  -> 
 
       (* Fresh state variables for oracle inputs of called node *)
-      let ctx, oracle_state_vars = 
-        List.fold_left
+      let ctx, oracle_state_vars =
+        node_oracles
+        |> List.rev (* Preserve order of oracles. *)
+        |> List.fold_left
           (fun (ctx, accum) sv ->
              let sv', ctx = 
                C.mk_fresh_oracle 
@@ -1576,7 +1578,6 @@ and eval_node_call
              (* N.set_state_var_instance ctx sv' pos ident sv; *)
              (ctx, sv' :: accum))
           (ctx, [])
-          node_oracles 
       in
 
       (* Create fresh state variable for each output *)

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -545,27 +545,27 @@ let add_subsystem
 
    This factors out node calls with or without an activation
    condition *)
-let call_terms_of_node_call
-  mk_fresh_state_var
-  { N.call_node_name;
-    N.call_pos;
-    N.call_inputs;
-    N.call_oracles;
-    N.call_outputs }
-  node_locals
-  node_props
-  { init_uf_symbol;
-    trans_uf_symbol;
-    node = { N.init_flag;
-             N.instance;
-             N.inputs;
-             N.oracles;
-             N.outputs;
-             N.locals;
-             N.props };
-    stateful_locals;
-    properties }
-=
+let call_terms_of_node_call mk_fresh_state_var {
+  N.call_node_name ;
+  N.call_pos       ;
+  N.call_inputs    ;
+  N.call_oracles   ;
+  N.call_outputs   ;
+} node_locals node_props {
+  init_uf_symbol  ;
+  trans_uf_symbol ;
+  node = {
+    N.init_flag ;
+    N.instance  ;
+    N.inputs    ;
+    N.oracles   ;
+    N.outputs   ;
+    N.locals    ;
+    N.props     ;
+  }               ;
+  stateful_locals ;
+  properties      ;
+} =
 
   (* Initialize map of state variable in callee to instantiated state
      variable in caller *)

--- a/tests/lustre/PilotFlying.lus
+++ b/tests/lustre/PilotFlying.lus
@@ -1,7 +1,4 @@
-node Rise 
-  (I : bool)
-returns 
-  (O : bool);
+node Rise (I : bool) returns (O : bool) ;
 let 
   O = false -> (not pre I) and I;
 tel;
@@ -9,13 +6,11 @@ tel;
 
 const inhibit_count_max = 2;
 
-node PFS_Logic
-  (riseTS, riseOSPF : bool;
-   const Primary_Side : bool; 
-   const PFS_Initial_Value : bool) 
-
-returns 
-  (PFS : bool);
+node PFS_Logic (
+  riseTS, riseOSPF : bool;
+  const Primary_Side : bool; 
+  const PFS_Initial_Value : bool
+) returns (PFS : bool) ;
 
 var
   Start_to_Pilot_Flying, 
@@ -354,7 +349,7 @@ var
 
 let
 
-  --%MAIN
+  --%MAIN ;
   clocks_are_quasi_synchronous = calendar(CLK1, CLK3, CLK2, CLK4);
   
   assert clocks_are_quasi_synchronous;

--- a/tests/lustre/stopwatch-condact.lus
+++ b/tests/lustre/stopwatch-condact.lus
@@ -31,6 +31,6 @@ let
   time_is_positive = time > 0;
   --%PROPERTY time_is_positive;
 
-  --%MAIN
+  --%MAIN ;
 tel
 

--- a/tests/lustre/stopwatch.lus
+++ b/tests/lustre/stopwatch.lus
@@ -28,5 +28,5 @@ let
   -- --%PROPERTY time_is_positive;
   --%PROPERTY time_is_less_than_three;
 
-  --%MAIN
+  --%MAIN ;
 tel

--- a/tests/lustre/test-condact.lus
+++ b/tests/lustre/test-condact.lus
@@ -8,5 +8,5 @@ let y = 0 -> pre y + 1; tel;
 node CountRise(x: bool) returns (y: int);
 let y = condact(pre Rise(x), Count(), 0); 
 --%PROPERTY y >= 0;
---%MAIN
+--%MAIN ;
 tel;

--- a/tests/lustre/test-func.lus
+++ b/tests/lustre/test-func.lus
@@ -19,7 +19,7 @@ node X (in: real) returns (OK: bool);
 let
   OK = exp(0.0 -> in, 1.0 -> in) > 0.0 or sincos(2.0 -> in) + sincos(2.0 -> in) = (0.0, 0.0);
   --%PROPERTY OK;
-  --%MAIN
+  --%MAIN ;
 tel;
 
 node id (in: real) returns (out: int);

--- a/tests/lustre/test-fwd-ref.lus
+++ b/tests/lustre/test-fwd-ref.lus
@@ -1,6 +1,6 @@
 node X () returns (OK: bool);
 let
-  --%MAIN
+  --%MAIN ;
   OK = Y();
   --%PROPERTY OK;
 tel

--- a/tests/lustre/test-issue-123.lus
+++ b/tests/lustre/test-issue-123.lus
@@ -264,7 +264,7 @@ var
   _THIS_CONTRACT_CONSIST : bool;
   _THIS_CONTRACT_HIST : bool;
 let
-  --%MAIN
+  --%MAIN ;
   _TOTAL_COMP_HIST = ((true and (true and true)) -> ((true and (true and true)) and (pre _TOTAL_COMP_HIST)));
 
   _SYSTEM_ASSUMP_HIST = ((true and true) -> ((true and true) and (pre _SYSTEM_ASSUMP_HIST)));

--- a/tests/lustre/test-issue-127.lus
+++ b/tests/lustre/test-issue-127.lus
@@ -342,7 +342,7 @@ var
   ___kind2_record_access_workaround_26 : ADS__Pitch__Pitch_Impl;
   ___kind2_record_access_workaround_27 : ADS__Pitch__Pitch_Impl;
 let
-  --%MAIN
+  --%MAIN ;
   Flight_Control_System_Flight_Control_System_Impl_Instance__prop2 = ((false -> (pre (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_L__LSO.Valid and (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_L__LSO.Leader = 1)))) => (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_L__LSO.Valid => (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_L__LSO.Leader = 1)));
 
   Flight_Control_System_Flight_Control_System_Impl_Instance__prop1 = ((false -> (pre (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_R__LSO.Valid and (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_R__LSO.Leader = 2)))) => (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_R__LSO.Valid => (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_R__LSO.Leader = 2)));

--- a/tests/lustre/test-merge.lus
+++ b/tests/lustre/test-merge.lus
@@ -25,7 +25,7 @@ let
   t3_k = merge (h; integr(e); id(e));
   t5_k = merge (h; e; e + 1);
 
-  --%MAIN
+  --%MAIN ;
   --%PROPERTY t1 + t2 + t3 + t4 + t5 + t1_k + t2_k + t3_k + t5_k > 0;
 tel
 

--- a/tests/lustre/test-nodes.lus
+++ b/tests/lustre/test-nodes.lus
@@ -30,7 +30,7 @@ let
   v = Z(true);
   y = X(pre x + v.one);
   (flag, value) = if x > 0 then nodecall(x) else (true, 0);
-  --%MAIN
+  --%MAIN ;
   --%PROPERTY y > 0;
 tel; 
 
@@ -67,7 +67,7 @@ let
   x1, y1 = U1(pre x, y);
   xp = pre pre x;
 
-  --%MAIN
+  --%MAIN ;
   --%PROPERTY x > 0; 
 tel;
 

--- a/tests/lustre/test-oracles.lus
+++ b/tests/lustre/test-oracles.lus
@@ -14,5 +14,5 @@ let
   c = condact(clk, X(0), 0);
   d = X(0);
   --%PROPERTY c > 0 or c <= 0;
-  --%MAIN
+  --%MAIN ;
 tel;

--- a/tests/lustre/test-subranges.lus
+++ b/tests/lustre/test-subranges.lus
@@ -53,6 +53,6 @@ node T(in: bool) returns (out1: int; out2: subrange [0, 2] of int);
 let
   out2 = out1;
   out1 = if in then 0 else 1;
-  --%MAIN
+  --%MAIN ;
   --%PROPERTY out1 >= out2;
 tel

--- a/tests/regression/falsifiable/stopwatch-condact.lus
+++ b/tests/regression/falsifiable/stopwatch-condact.lus
@@ -31,6 +31,6 @@ let
   time_is_positive = time > 0;
   --%PROPERTY time_is_positive;
 
-  --%MAIN
+  --%MAIN ;
 tel
 

--- a/tests/regression/falsifiable/stopwatch.lus
+++ b/tests/regression/falsifiable/stopwatch.lus
@@ -28,5 +28,5 @@ let
   -- --%PROPERTY time_is_positive;
   --%PROPERTY time_is_less_than_three;
 
-  --%MAIN
+  --%MAIN ;
 tel

--- a/tests/regression/falsifiable/test-issue-116-2.lus.log
+++ b/tests/regression/falsifiable/test-issue-116-2.lus.log
@@ -1,0 +1,57 @@
+ kind2 v0.8.0-243-gb5bb23a
+
+
+------------------------------------------------------------------------------
+
+Analyzing main
+  with top: "main"
+       subsystems
+         | concrete: main, integ
+
+<Success> Property prop1 is valid by inductive step after 0.070s.
+
+<Error> Runtime error in property directed reachability: Failure("set_prop_ktrue")
+
+<Failure> Property prop2 is invalid by property directed reachability for k=3 after 0.081s.
+
+Counterexample:
+  Node main ()
+    == Inputs ==
+    x         0     2     0
+    y         0     0     0
+    r         0   1/2   1/2
+    == Locals ==
+    prop2  true  true false
+    
+  Node integ (main[l19c32])
+    == Inputs ==
+    x   0 2 0
+    == Outputs ==
+    sum 0 2 2
+    
+  Node integ (main[l19c21])
+    == Inputs ==
+    x   0 0 0
+    == Outputs ==
+    sum 0 0 0
+    
+  Node integ (main[l12c6])
+    == Inputs ==
+    x   0 2 0
+    == Outputs ==
+    sum 0 2 2
+    
+  
+------------------------------------------------------------------------------
+Summary of properties:
+
+prop1: valid
+prop2: true up to 8 steps
+------------------------------------------------------------------------------
+
+<Error> Runtime error in one state invariant generator: Failure("set_prop_false: was 8-true before, now cex of length 3")
+
+<Error> Runtime error in c2i: Failure("set_prop_false: was 8-true before, now cex of length 3")
+
+<Error> Runtime error in bounded model checking: Failure("set_prop_false: was 19-true before, now cex of length 3")
+

--- a/tests/regression/falsifiable/test-issue-123.lus
+++ b/tests/regression/falsifiable/test-issue-123.lus
@@ -264,7 +264,7 @@ var
   _THIS_CONTRACT_CONSIST : bool;
   _THIS_CONTRACT_HIST : bool;
 let
-  --%MAIN
+  --%MAIN ;
   _TOTAL_COMP_HIST = ((true and (true and true)) -> ((true and (true and true)) and (pre _TOTAL_COMP_HIST)));
 
   _SYSTEM_ASSUMP_HIST = ((true and true) -> ((true and true) and (pre _SYSTEM_ASSUMP_HIST)));

--- a/tests/regression/falsifiable/test-issue-127.lus
+++ b/tests/regression/falsifiable/test-issue-127.lus
@@ -342,7 +342,7 @@ var
   ___kind2_record_access_workaround_26 : ADS__Pitch__Pitch_Impl;
   ___kind2_record_access_workaround_27 : ADS__Pitch__Pitch_Impl;
 let
-  --%MAIN
+  --%MAIN ;
   Flight_Control_System_Flight_Control_System_Impl_Instance__prop2 = ((false -> (pre (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_L__LSO.Valid and (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_L__LSO.Leader = 1)))) => (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_L__LSO.Valid => (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_L__LSO.Leader = 1)));
 
   Flight_Control_System_Flight_Control_System_Impl_Instance__prop1 = ((false -> (pre (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_R__LSO.Valid and (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_R__LSO.Leader = 2)))) => (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_R__LSO.Valid => (Flight_Control_System_Flight_Control_System_Impl_Instance__FGS_R__LSO.Leader = 2)));

--- a/tests/regression/falsifiable/test-oracles.lus
+++ b/tests/regression/falsifiable/test-oracles.lus
@@ -1,4 +1,6 @@
 node X(x: int) returns (y: int);
+  --@require pre(x) > 2;
+  --@ensure pre(x > 3);
 let
   assert (pre pre (x + 1) > 0);
   --%PROPERTY 1 > x;

--- a/tests/regression/success/block_annot_syntax.lus
+++ b/tests/regression/success/block_annot_syntax.lus
@@ -1,0 +1,68 @@
+node abs (in: int) returns (out: int) ;
+let
+  out = if in < 0 then -in else in ;
+  (*%PROPERTY out >= 0 ; *)
+  /*!PROPERTY : if in < 0 then (out = -in) else (out = in) ; */
+tel
+
+node has_been_true(in: bool) returns (out: bool) ;
+
+/*@contract
+
+  mode false_so_far (
+    require not (in or (false -> pre out)) ;
+    ensure not out ;
+  ) ;
+
+  mode in_true (
+    require in ;
+    ensure out ;
+  ) ;
+
+  mode always_true (
+    require in -> pre out ;
+    ensure out ;
+  ) ;
+*/
+let
+  out = in or (false -> pre out) ;
+tel
+
+
+node my_node (in: int) returns (out: int) ;
+
+(*@contract
+
+  const bound = 10 ;
+  var in_bounded = abs(in) < bound ;
+
+  require in_bounded ;
+  ensure out >= - bound ;
+
+  mode in_neg (
+    require in < 0 ;
+    ensure out = in ;
+  ) ;
+
+  mode in_pos (
+    require in >= 0 ;
+    ensure out >= 0 ;
+    ensure true -> (
+      (pre has_been_true(in > 0)) => out > in
+    ) ;
+  ) ;
+*)
+var mem: int ;
+let
+  mem = abs(in) + (0 -> pre mem) ;
+  out = if in < 0 then in else mem ;
+
+  (* Old style still works. *)
+  --%PROPERTY out - in >= 0 ;
+
+  (* Doing the same thing using different annotations. *)
+  (*!MAIN: true ; *)
+  (*%MAIN ; *)
+  --%MAIN ;
+  --!MAIN: true ;
+tel

--- a/tests/regression/success/block_annot_syntax.lus
+++ b/tests/regression/success/block_annot_syntax.lus
@@ -9,19 +9,19 @@ node has_been_true(in: bool) returns (out: bool) ;
 
 /*@contract
 
-  mode false_so_far (
-    require not (in or (false -> pre out)) ;
-    ensure not out ;
+  @mode false_so_far (
+    @require not (in or (false -> pre out)) ;
+    @ensure not out ;
   ) ;
 
-  mode in_true (
-    require in ;
-    ensure out ;
+  @mode in_true (
+    @require in ;
+    @ensure out ;
   ) ;
 
-  mode always_true (
-    require in -> pre out ;
-    ensure out ;
+  @mode always_true (
+    @require in -> pre out ;
+    @ensure out ;
   ) ;
 */
 let
@@ -36,18 +36,18 @@ node my_node (in: int) returns (out: int) ;
   const bound = 10 ;
   var in_bounded = abs(in) < bound ;
 
-  require in_bounded ;
-  ensure out >= - bound ;
+  @require in_bounded ;
+  @ensure out >= - bound ;
 
-  mode in_neg (
-    require in < 0 ;
-    ensure out = in ;
+  @mode in_neg (
+    @require in < 0 ;
+    @ensure out = in ;
   ) ;
 
-  mode in_pos (
-    require in >= 0 ;
-    ensure out >= 0 ;
-    ensure true -> (
+  @mode in_pos (
+    @require in >= 0 ;
+    @ensure out >= 0 ;
+    @ensure true -> (
       (pre has_been_true(in > 0)) => out > in
     ) ;
   ) ;

--- a/tests/regression/success/test-alias.lus
+++ b/tests/regression/success/test-alias.lus
@@ -11,7 +11,7 @@ var
 	a : sub;
 	b : real;
 let
-	 --%MAIN 	 
+	 --%MAIN ;
 	 (a,b) = test (in);										
 OK = a <=3;
 tel

--- a/tests/regression/success/test-condact.lus
+++ b/tests/regression/success/test-condact.lus
@@ -8,5 +8,5 @@ let y = 0 -> pre y + 1; tel;
 node CountRise(x: bool) returns (y: int);
 let y = condact(pre Rise(x), Count(), 0); 
 --%PROPERTY y >= 0;
---%MAIN
+--%MAIN ;
 tel;

--- a/tests/regression/success/test-issue-317.lus
+++ b/tests/regression/success/test-issue-317.lus
@@ -2,7 +2,7 @@ type sub = subrange [0, 2] of int;
 
 node test (in : sub) returns (out : bool);
 let
-  --%MAIN
+  --%MAIN ;
   out = in >= 0 and in <= 2;
   --%PROPERTY out;
 tel;


### PR DESCRIPTION
* fixed a bug in oracle generation for unguarded pre-s
* block comment annotations for properties, main, labels and contracts
* *[edit]* prefixed `mode`, `require`, `ensure` in block contracts by `@` so that they're not reserved

Block comment annotations are for writing multi-line expressions (*e.g.* in a property or a require/ensure) while preserving compatibility with annotation-agnostic tools.
Before we would do
```
--%PROPERTY (
  in > 0 => out < 0
) and (
  in = 0 => out = 0
);
```
causing most other tools to fail with a parsing error.

# Warning: backward compatibility

The lexing/parsing was modified substantially for block comment annotations.
Before Kind 2 accepted the `MAIN` annotation in both
```
--%MAIN ;
--%MAIN
```

The latter is now illegal and causes a parse error.

# Block comment annotations

See [here][sample file] for a full example.

With the exception of what's discussed in the section above, all previous annotations still work.
The examples below showcase the

* `(*% ... *)`, `(*! ... *)` and `(*@ ... *)`

syntax but we also support

* `/*% ... */`, `/*! ... */` and `/*@ ... */`.

## Block comment 'Kind 2'-style annotations

```
(*%MAIN ; *)
(*%PROPERTY (
    in > 0 => out < 0
  ) and (
    in = 0 => out = 0
  ) ;
*)
```

## Block comment field/label 'lustreC'-style annotations

```
(*!<label> : <value> ; *)
(*!MAIN : false ; *)
(*!PROPERTY : (
    in > 0 => out < 0
  ) and (
    in = 0 => out = 0
  ) ;
*)
```

## Block comment contract annotations

This is a nice improvement in writability/readability for contracts.
We simply start a contract with `(*@contract`, end it with `*)` and write require, ensure and mode things without `--@`. *[edit]* To avoid having three additional reserved identifiers --especially `mode` which often appears in lustre models-- and keep parsing simple, they must still be prefixed by `@`.

Note that the ensure/require statements of a `mode` are now between parens to ease parsing and readability.

```
(*@contract

  -- Global require/ensure statements.
  @require ... ;
  @ensure ... ;

  -- Modes.
  @mode mode_name (
    @require ... ;
    @ensure ... ;
  ) ;

*)
```

[sample file]: https://github.com/AdrienChampion/kind2/blob/new-contract-syntax/tests/regression/success/block_annot_syntax.lus (Block comment annotation sample file)