### PR TITLE
Reuse previous results when refining

### DIFF
--- a/src/analysis.ml
+++ b/src/analysis.ml
@@ -32,29 +32,14 @@ type param = {
 
   (** Properties that can be assumed invariant in subsystems *)
   assumptions : (Scope.t * Term.t) list ;
+
+  (** Result of the previous analysis of the top system if this analysis is a
+      refinement. *)
+  refinement_of : result option
 }
 
-(* Retrieve the assumptions of a [scope] from a [param]. *)
-let param_assumptions_of_scope { assumptions } scope =
-  assumptions |> List.fold_left (fun a (s, t) -> 
-     if Scope.equal s scope then t :: a else a
-  ) []
-
-(* Return [true] if a scope is flagged as abstract in the [abstraction_map] of
-   a [param]. Default to [false] if the node is not in the map. *)
-let param_scope_is_abstract { abstraction_map } scope =
-  try
-    (* Find node in abstraction map by name *)
-    Scope.Map.find scope abstraction_map 
-  (* Assume node to be concrete if not in map *)
-  with Not_found -> false
-
-
-
-
-
 (** Result of analysing a transistion system *)
-type result = {
+and result = {
   (** Parameters of the analysis. *)
   param : param ;
 
@@ -71,6 +56,21 @@ type result = {
       [Some false] if it does and some are unknown / falsified. *)
   requirements_valid : bool option ;
 }
+
+(* Retrieve the assumptions of a [scope] from a [param]. *)
+let param_assumptions_of_scope { assumptions } scope =
+  assumptions |> List.fold_left (fun a (s, t) -> 
+     if Scope.equal s scope then t :: a else a
+  ) []
+
+(* Return [true] if a scope is flagged as abstract in the [abstraction_map] of
+   a [param]. Default to [false] if the node is not in the map. *)
+let param_scope_is_abstract { abstraction_map } scope =
+  try
+    (* Find node in abstraction map by name *)
+    Scope.Map.find scope abstraction_map 
+  (* Assume node to be concrete if not in map *)
+  with Not_found -> false
 
 (* Abstraction of a property source. *)
 type prop_kind = | Contract | Subreq | Prop

--- a/src/analysis.mli
+++ b/src/analysis.mli
@@ -39,37 +39,28 @@
     @author Christoph Sticksel *)
 
 
-(** Parameters of an analysis, also used for the creation of a transition
-    system. *)
+(** Parameters for the creation of a transition system *)
 type param = {
-  (** The top system for the analysis run. *)
+  (** The top system for the analysis run *)
   top : Scope.t ;
 
-  (** UID for this analysis. *)
+  (** UID for the analysis. *)
   uid : int ;
 
   (** Systems flagged [true] are to be represented abstractly, those flagged
       [false] are to be represented by their implementation. *)
   abstraction_map : bool Scope.Map.t ;
 
-  (** Properties that can be assumed invariant in subsystems. *)
+  (** Properties that can be assumed invariant in subsystems *)
   assumptions : (Scope.t * Term.t) list ;
+
+  (** Result of the previous analysis of the top system if this analysis is a
+      refinement. *)
+  refinement_of : result option
 }
 
-(** Return [true] if a scope is flagged as abstract in the [abstraction_map] of
-   a [param]. Default to [false] if the node is not in the map. *)
-val param_scope_is_abstract : param -> Scope.t -> bool
-
-(** Retrieve the assumptions of a [scope] from a [param]. *)
-val param_assumptions_of_scope : param -> Scope.t -> Term.t list
-
-
-
-
-
-
 (** Result of analysing a transistion system *)
-type result = {
+and result = {
   (** Parameters of the analysis. *)
   param : param ;
 
@@ -86,6 +77,17 @@ type result = {
       [Some false] if it does and some are unknown / falsified. *)
   requirements_valid : bool option ;
 }
+
+(** Return [true] if a scope is flagged as abstract in the [abstraction_map] of
+   a [param]. Default to [false] if the node is not in the map. *)
+val param_scope_is_abstract : param -> Scope.t -> bool
+
+(** Retrieve the assumptions of a [scope] from a [param]. *)
+val param_assumptions_of_scope : param -> Scope.t -> Term.t list
+
+
+
+
 
 (** Returns a result from an analysis. *)
 val mk_result : param -> TransSys.t -> result

--- a/src/base.ml
+++ b/src/base.ml
@@ -284,10 +284,8 @@ let rec next (input_sys, aparam, trans, solver, k, invariants, unknowns) =
         Event.log
           L_info
           "BMC @[<v>at k = %i@,\
-                    %i properties ( @[<v>%a@] ).@]"
-          k_int (List.length unknowns_at_k)
-          (pp_print_list Format.pp_print_string "@ ")
-          (unknowns_at_k |> List.map fst) ;
+                    %i properties.@]"
+          k_int (List.length unknowns_at_k) ;
 
         (* Splitting. *)
         let unfalsifiable, falsifiable =

--- a/src/event.ml
+++ b/src/event.ml
@@ -71,7 +71,7 @@ let pp_print_event ppf = function
       ppf
       "@[<hv>Property %s false at step %d@]" 
       p
-      (Property.length_of_cex cex)
+      ((Property.length_of_cex cex) - 1)
 
   | StepCex (p, cex) ->
     Format.fprintf 
@@ -432,7 +432,8 @@ let cex_pt mdl level input_sys analysis trans_sys prop cex disproved =
       )
       (function ppf -> match cex with
          | [] -> ()
-         | ((_, c) :: _) -> Format.fprintf ppf "for k=%d " (List.length c))
+         | ((_, c) :: _) ->
+           (List.length c) - 1 |> Format.fprintf ppf "for k=%d ")
       (Stat.get_float Stat.total_time)
       (pp_print_counterexample_pt
         level input_sys analysis trans_sys prop disproved)
@@ -507,7 +508,7 @@ let prop_status_pt level prop_status =
                  Format.fprintf 
                    ppf
                    "invalid after %d steps"
-                   (Property.length_of_cex cex))
+                   ((Property.length_of_cex cex) - 1))
             s)
        "@,")
     prop_status
@@ -709,7 +710,8 @@ mdl level input_sys analysis trans_sys prop (
       (Stat.get_float Stat.total_time)
       (function ppf -> match cex with 
          | [] -> () 
-         | cex -> Format.fprintf ppf "<K>%d</K>@," (Property.length_of_cex cex))
+         | cex ->
+          (Property.length_of_cex cex) - 1 |> Format.fprintf ppf "<K>%d</K>@,")
       pp_print_kind_module_xml_src mdl
       (pp_print_counterexample_xml input_sys analysis trans_sys prop disproved)
       cex ;
@@ -792,7 +794,7 @@ let prop_status_xml level prop_status =
                    Format.fprintf 
                      ppf 
                      "@,@[<hv 2><FalseAt>@,%d@;<0 -2></FalseAt>@]"
-                     (Property.length_of_cex cex))
+                     ((Property.length_of_cex cex) - 1))
               s)
        "@,")
   (* (ignore_or_fprintf level)

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -286,6 +286,7 @@ let kind_module_of_string = function
   | "IC3" -> `IC3
   | "BMC" -> `BMC
   | "IND" -> `IND
+  | "IND2" -> `IND2
   | "INVGEN" -> `INVGEN
   | "INVGENOS" -> `INVGENOS
   | "C2I" -> `C2I
@@ -298,6 +299,7 @@ let string_of_kind_module = function
   | `IC3 -> "IC3"
   | `BMC -> "BMC"
   | `IND -> "IND"
+  | `IND2 -> "IND2"
   | `INVGEN -> "INVGEN"
   | `INVGENOS -> "INVGENOS"
   | `C2I -> "C2I"
@@ -313,13 +315,13 @@ let string_of_enable = function
   | [] -> "[]"
 
 let enable_values = [
-  `IC3 ; `BMC ; `IND ; `INVGEN ; `INVGENOS ; `C2I ; `Interpreter
+  `IC3 ; `BMC ; `IND ; `IND2 ; `INVGEN ; `INVGENOS ; `C2I ; `Interpreter
 ] |> List.map string_of_kind_module |> String.concat ", "
 
 let enable_default_init = []
 let disable_default_init = []
 
-let enable_default_after = [ `BMC; `IND; `IC3; `INVGEN; `INVGENOS ]
+let enable_default_after = [ `BMC; `IND; `IND2; `IC3; `INVGEN; `INVGENOS ]
 
 (* ********** *) 
 

--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -105,6 +105,7 @@ let maximal_abstraction_for_testgen (type s)
       Analysis.uid = get_testgen_uid () ;
       Analysis.abstraction_map = map ;
       Analysis.assumptions = assumptions ;
+      Analysis.refinement_of = None ;
     }
 
   )

--- a/src/invarManager.ml
+++ b/src/invarManager.ml
@@ -21,13 +21,13 @@ open Lib
 let print_stats trans_sys =
   
   Event.log
-    L_info
+    L_debug
     "@[<v>%a@,\
      Final statistics:@]"
     pp_print_hline ();
   
   List.iter 
-    (fun (mdl, stat) -> Event.log_stat mdl L_info stat)
+    (fun (mdl, stat) -> Event.log_stat mdl L_debug stat)
     (Event.all_stats ());
   
   (match trans_sys with | None -> () | Some trans_sys ->

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -931,6 +931,11 @@ let rec run_loop msg_setup modules results =
     get !cur_aparam, get !cur_input_sys, get !cur_trans_sys
   in
 
+  Format.printf
+    "properties: @[<v>%a@]@.@."
+    (pp_print_list Property.pp_print_property "@ ")
+    (TransSys.get_properties trans_sys) ;
+
   (* Event.log L_fatal "Launching analysis with param %a"
     Analysis.pp_print_param aparam ; *)
   Event.log_analysis_start aparam ;

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -104,7 +104,7 @@ let renice () =
     Event.log L_info
       "Ignoring negative niceness value for invariant generation."
 
-  else
+  else if nice > 0 then
     let nice' = Unix.nice nice in
     Event.log L_info "Renicing invariant generation to %d" nice'
 
@@ -930,11 +930,6 @@ let rec run_loop msg_setup modules results =
   let aparam, input_sys, trans_sys =
     get !cur_aparam, get !cur_input_sys, get !cur_trans_sys
   in
-
-  Format.printf
-    "properties: @[<v>%a@]@.@."
-    (pp_print_list Property.pp_print_property "@ ")
-    (TransSys.get_properties trans_sys) ;
 
   (* Event.log L_fatal "Launching analysis with param %a"
     Analysis.pp_print_param aparam ; *)

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2495,8 +2495,9 @@ let trans_sys_of_nodes subsystem globals (
         
         | name, P.PropFalse cex -> (
           match P.length_of_cex cex with
-          | k when k > 0 -> (* False at k>0 is now (k-1)-true. *)
-            TransSys.set_prop_status trans_sys name (P.PropKTrue (k-1))
+          | l when l > 1 -> (* False at k>0 is now (k-1)-true. *)
+            (* Minus 2 because l = k + 1. *)
+            TransSys.set_prop_status trans_sys name (P.PropKTrue (l-2))
           | _ -> (* False at 0 is now unknown, do nothing. *)
             ()
         )

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2493,8 +2493,8 @@ let trans_sys_of_nodes subsystem globals (
           TransSys.get_prop_term trans_sys name
           |> TransSys.add_invariant trans_sys
         
-        | name, P.PropFalse model -> (
-          match List.length model with
+        | name, P.PropFalse cex -> (
+          match P.length_of_cex cex with
           | k when k > 0 -> (* False at k>0 is now (k-1)-true. *)
             TransSys.set_prop_status trans_sys name (P.PropKTrue (k-1))
           | _ -> (* False at 0 is now unknown, do nothing. *)

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2410,19 +2410,18 @@ let rec trans_sys_of_node'
             tl
           
 
-let trans_sys_of_nodes 
-  subsystem
-  globals
-  ({ A.top; A.abstraction_map; A.assumptions } as  analysis_param)
-=
+let trans_sys_of_nodes subsystem globals (
+  { A.top; A.abstraction_map; A.assumptions; A.refinement_of }
+  as analysis_param
+) =
   
   (* Make sure top level system is not abstract
 
      Contracts would be trivially satisfied otherwise *)
-  (if A.param_scope_is_abstract analysis_param top then
+(*   (if A.param_scope_is_abstract analysis_param top then
      raise
        (Invalid_argument
-          "trans_sys_of_nodes: Top-level system must not be abstract"));
+          "trans_sys_of_nodes: Top-level system must not be abstract")); *)
 
   (* TODO: Find top subsystem by name *)
   let subsystem' = subsystem in
@@ -2474,6 +2473,35 @@ let trans_sys_of_nodes
           Biggest bucket length: %d@]@."
     s1 s2 s3 s4 s5 s6;
 *)
+
+  
+  ( match refinement_of with
+    | None -> ()
+    | Some result ->
+      (* The analysis that's going to run is a refinement. *)
+      TransSys.get_prop_status_all result.sys
+      |> List.iter (function
+        | name, P.PropUnknown -> (* Unknown is still unknown, do nothing. *)
+          ()
+        
+        | name, (P.PropKTrue k as status) -> (* K-true is still k-true. *)
+          TransSys.set_prop_status trans_sys name status
+        
+        | name, P.PropInvariant -> (* Invariant is still invariant. *)
+          TransSys.set_prop_invariant trans_sys name ;
+          (* Adding to invariants of the system. *)
+          TransSys.get_prop_term trans_sys name
+          |> TransSys.add_invariant trans_sys
+        
+        | name, P.PropFalse model -> (
+          match List.length model with
+          | k when k > 0 -> (* False at k>0 is now (k-1)-true. *)
+            TransSys.set_prop_status trans_sys name (P.PropKTrue (k-1))
+          | _ -> (* False at 0 is now unknown, do nothing. *)
+            ()
+        )
+      )
+  ) ;
 
   trans_sys, subsystem', globals'
 

--- a/src/step2.ml
+++ b/src/step2.ml
@@ -84,13 +84,13 @@ type 'a ctx = {
   param: Analysis.param ;
   (* System we're analyzing. *)
   sys: Sys.t ; 
-  (* Property to (positive actlit, negative actlit, prop term) map. *)
-  mutable map: ( string * (term * term * term) ) list ;
+  (* Property to (positive actlit, prop term) map. *)
+  mutable map: ( string * (term * term) ) list ;
 }
 
 (* Creates a solver, memorizes it for clean exit, asserts transition relation
   [(0,1)] and [(1,2)], creates actlits for unknown properties, creates positive
-  and negative activation literals and asserts relevant implications. *)
+  activation literals and asserts relevant implications. *)
 let mk_ctx in_sys param sys =
   let solver =
     Smt.create_instance
@@ -121,16 +121,15 @@ let mk_ctx in_sys param sys =
 
   {
     solver ; in_sys ; param ; sys ;
-    (* Creating map from properties to positive/negative actlit pairs. *)
+    (* Creating map from properties to positive actlit/term pairs. *)
     map = Sys.get_prop_status_all_unknown sys |> List.fold_left (
       fun map (name,_) ->
         (* Getting fresh actlit UFs. *)
-        let pactlit, nactlit = fresh_actlit (), fresh_actlit () in
+        let pactlit = fresh_actlit () in
         (* Declaring them. *)
         Smt.declare_fun solver pactlit ;
-        Smt.declare_fun solver nactlit ;
         (* Building terms. *)
-        let pactlit, nactlit = actlit_term pactlit, actlit_term nactlit in
+        let pactlit = actlit_term pactlit in
         (* Retrieving prop term. *)
         let prop = Sys.get_prop_term sys name in
         (* Positive implications. *)
@@ -138,12 +137,8 @@ let mk_ctx in_sys param sys =
         |> Smt.assert_term solver ;
         Term.mk_implies [ pactlit ; unroll Numeral.one prop ]
         |> Smt.assert_term solver ;
-        (* Negative implication. *)
-        Term.mk_implies [
-          nactlit ; unroll Numeral.(succ one) prop |> Term.mk_not
-        ] |> Smt.assert_term solver ;
         (* Appending mapping. *)
-        (name, (pactlit, nactlit, prop)) :: map
+        (name, (pactlit, prop)) :: map
     ) [] ;
   }
 
@@ -167,18 +162,16 @@ let rec check_new_things ({ solver ; sys ; map } as ctx) =
       let map, invs =
         map |> List.fold_left (
           (* Go through map and inspect property status. *)
-          fun (map,invs) ( (name, (pos,neg,prop)) as p ) ->
+          fun (map,invs) ( (name, (pos,prop)) as p ) ->
             match Sys.get_prop_status sys name with
             | Prop.PropFalse _ ->
               (* Deactivate actlits and remove from map. *)
               deactivate solver pos ;
-              deactivate solver neg ;
               map, invs
 
             | Prop.PropInvariant ->
               (* Deactivate actlits, remove from map, add to invariants. *)
               deactivate solver pos ;
-              deactivate solver neg ;
               map, prop :: invs
 
             | _ ->
@@ -205,25 +198,38 @@ let split ({ solver ; map } as ctx) =
       (* Check if termination was requested. *)
       Event.check_termination () ;
 
-      (* Actlits for unknown properties. *)
-      let actlits =
-        map |> List.fold_left (fun l (prop, (pos,neg,_)) ->
+      (* Positive actlits for unknown properties. *)
+      let actlits, unknowns =
+        map |> List.fold_left (fun (actlits,terms) (prop, (pos,term)) ->
           (* Ignore falsifiable properties. *)
           if List.mem prop falsifiable |> not
-          then pos :: neg :: l else l
-        ) []
+          then pos :: actlits, term :: terms  else actlits, terms
+        ) ([],[])
       in
+
+      (* Negative actlit. *)
+      let nactlit =
+        let nactlit = fresh_actlit () in
+        Smt.declare_fun solver nactlit ;
+        let nactlit = term_of_actlit nactlit in
+        Term.mk_implies [ nactlit ; Term.mk_and unknowns ]
+        |> Smt.assert_term solver ;
+        nactlit
+      in
+
+      (* Deactivation function. *)
+      let deactivate () = Term.mk_not nactlit |> Smt.assert_term solver in
 
       (* Check-sat. *)
       match
-        actlits
+        nactlit :: actlits
         |> Smt.check_sat_assuming
           solver
           (fun _ -> (* If sat. *)
             (* Maps prop terms at 2 to their name. *)
             let props_2 =
               map |> List.map (
-                fun (name, (_,_,t)) -> unroll Numeral.(succ one) t, name
+                fun (name, (_,t)) -> unroll Numeral.(succ one) t, name
               )
             in
             (* Retrieve values. *)
@@ -241,8 +247,10 @@ let split ({ solver ; map } as ctx) =
           )
       with
       | None -> (* Unsat, remaining properties are unfalsifiable. *)
+        deactivate () ;
         map |> List.map fst
       | Some nu_falsifiable ->
+        deactivate () ;
         (* Sat, we need to check the remaining properties. *)
         List.rev_append nu_falsifiable falsifiable |> loop
     )
@@ -277,11 +285,10 @@ let broadcast_if_safe ({ solver ; sys ; map } as ctx) unfalsifiable =
       ) ;
       (* Removing from map and updating solver. *)
       let map =
-        map |> List.filter (fun (name, (pos,neg,t)) ->
+        map |> List.filter (fun (name, (pos,t)) ->
           if List.mem name confirmed then (
             (* Deactivating actlits. *)
             deactivate solver pos ;
-            deactivate solver neg ;
             (* Adding invariant. *)
             add_invariants solver [t] ;
             (* Don't keep. *)

--- a/src/strategy.ml
+++ b/src/strategy.ml
@@ -150,6 +150,7 @@ let first_param_of results all_nodes scope =
     A.uid = A.results_length results ;
     A.abstraction_map = abstraction ;
     A.assumptions = assumptions ;
+    A.refinement_of = None
   }
 
 
@@ -235,7 +236,8 @@ module ModularStrategy : Strategy = struct
                   A.top = sys ;
                   A.uid = A.results_length results ;
                   A.abstraction_map = abs ;
-                  A.assumptions = ass
+                  A.assumptions = ass ;
+                  A.refinement_of = Some result ;
                 }
             )
         ) with Not_found ->

--- a/tests/lustre/contracts/refinement.lus
+++ b/tests/lustre/contracts/refinement.lus
@@ -1,0 +1,27 @@
+node count (in: bool) returns (cpt: int) ;
+let
+  cpt = (if in then 1 else 0) + (0 -> pre cpt) ;
+tel
+
+node sub (in: bool) returns (cpt: int) ;
+(*@contract
+  @mode begin (
+    @require count(true) <= 10 ;
+    @ensure  cpt >= 0 ;
+  ) ;
+  @mode and_then (
+    @require not begin ;
+    @ensure  true ;
+  ) ;
+*)
+let
+  cpt = count(in) ;
+tel
+
+node top (in: bool) returns (cpt: int) ;
+(*@contract
+  @guarantee cpt >= 0 ;
+*)
+let
+  cpt = sub(in) ;
+tel

--- a/tests/lustre/contracts/refinement.lus
+++ b/tests/lustre/contracts/refinement.lus
@@ -21,6 +21,7 @@ tel
 node top (in: bool) returns (cpt: int) ;
 (*@contract
   @guarantee cpt >= 0 ;
+  @guarantee (count(true) > 15) => false ;
 *)
 let
   cpt = sub(in) ;


### PR DESCRIPTION
Refinement is sound: we only refine `n` if `n` was proved to verify its contract.
So when refining, look at the status of the properties of the previous analysis:
* k-true is still k-true
* invariant is still invariant
* unknown is still unknown
* 0-false is now unknown
* **k-false** for k>0 is now **(k-1)-true**

So if `P` was previously falsified at 5, after refinement we know we only need to check it from 5.

Modified base to not check properties that are k'-true when it's checking k <= k'.
If there's nothing to check at k but there's still unknown properties, base will unroll the system and move on to k+1. See example below.

Also added actlit deactivation in base.

## Example

Example [`tests/lustre/contracts/refinement.lus`][example]:

```
node count (in: bool) returns (cpt: int) ;
let
  cpt = (if in then 1 else 0) + (0 -> pre cpt) ;
tel

node sub (in: bool) returns (cpt: int) ;
(*@contract
  @mode begin (
    @require count(true) <= 10 ;
    @ensure  cpt >= 0 ;
  ) ;
  @mode and_then (
    @require not begin ;
    @ensure  true ;
  ) ;
*)
let
  cpt = count(in) ;
tel

node top (in: bool) returns (cpt: int) ;
(*@contract
  @guarantee cpt >= 0 ;
  @guarantee (count(true) > 15) => false ;
*)
let
  cpt = sub(in) ;
tel
```

Running
```
kind2 --modular true --compositional true -v
```
proves `sub` correct.
Then Kind 2 analyzes `top` with `sub` abstracted and finds a cex at k=11 for the first guarantee and 15 for the second one.
`sub` is then refined, and in the new system `top`'s first guarantee has status 10-true.
There's nothing to check from 0 to 10 so BMC skips the checks:
```
 BMC at k = 0
    skipping

 BMC at k = 1
    skipping

 BMC at k = 2
    skipping

 BMC at k = 3
    skipping

 BMC at k = 4
    skipping

 BMC at k = 5
    skipping

<Success> Property guarantee[l23c2][1] is valid by inductive step after 1.053s.

 BMC at k = 6
    skipping

 BMC at k = 7
    skipping

 BMC at k = 8
    skipping

 BMC at k = 9
    skipping

 BMC at k = 10
    1 properties ( guarantee[l23c2][1] ). # BMC doesn't know it's an invariant yet.

 BMC at k = 11
    1 properties ( guarantee[l23c2][1] ). # BMC doesn't know it's an invariant yet.

 BMC at k = 12 # BMC just received guarantee[l23c2][1] as invariant.
    skipping   # The other one is 14-true from previous analysis so it skips the checks.

 BMC at k = 13
    skipping

 BMC at k = 14
    skipping

 BMC at k = 15
    1 properties ( guarantee[l24c2][2] ).

 Child process 13792 (bounded model checking) exited with return code 0

<Failure> Property guarantee[l24c2][2] is invalid by bounded model checking for k=15 after 1.085s.
```

[example]: https://github.com/AdrienChampion/kind2/blob/opt_refinement/tests/lustre/contracts/refinement.lus (Refinement example)