### PR TITLE
New contracts semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Log files.
+*.log
+
 # Generated bin directory.
 /bin
 

--- a/src/analysis.mli
+++ b/src/analysis.mli
@@ -39,8 +39,9 @@
     @author Christoph Sticksel *)
 
 
-(** Parameters for the creation of a transition system *)
-type param = {
+
+(** Information for the creation of a transition system *)
+type info = {
   (** The top system for the analysis run *)
   top : Scope.t ;
 
@@ -56,8 +57,17 @@ type param = {
 
   (** Result of the previous analysis of the top system if this analysis is a
       refinement. *)
-  refinement_of : result option
+  (* refinement_of : result option *)
 }
+
+(** Parameter of an analysis. *)
+type param =
+  (** Analysis of the contract of a system. *)
+  | ContractCheck of info
+  (** First analysis of a system. *)
+  | First of info
+  (** Refinement of a system. Store the result of the previous analysis. *)
+  | Refinement of info * result
 
 (** Result of analysing a transistion system *)
 and result = {
@@ -77,6 +87,11 @@ and result = {
       [Some false] if it does and some are unknown / falsified. *)
   requirements_valid : bool option ;
 }
+
+
+
+(** The info or a param. *)
+val info_of_param : param -> info
 
 (** Return [true] if a scope is flagged as abstract in the [abstraction_map] of
    a [param]. Default to [false] if the node is not in the map. *)

--- a/src/event.ml
+++ b/src/event.ml
@@ -1010,6 +1010,7 @@ let log_run_end results =
 
 (* Logs the start of an analysis. *)
 let log_analysis_start param =
+  let info = Analysis.info_of_param param in
   match !log_format with
   | F_pt ->
     if Flags.log_level () = L_off |> not then
@@ -1017,7 +1018,7 @@ let log_analysis_start param =
         @.%a@.@.Analyzing %a@   with %a\
       @.@."
       pp_print_hline ()
-      Scope.pp_print_scope param.Analysis.top
+      Scope.pp_print_scope info.Analysis.top
       Analysis.pp_print_param param
 
   | F_xml ->
@@ -1025,11 +1026,12 @@ let log_analysis_start param =
     let abstract, concrete =
       Scope.Map.fold (fun sys is_abstract (a,c) ->
         if is_abstract then sys :: a, c else a, sys :: c
-      ) param.Analysis.abstraction_map ([],[])
+      ) info.Analysis.abstraction_map ([],[])
     in
     (* Counting the number of assumption for each subsystem. *)
     let assumption_count =
-      param.Analysis.assumptions |> List.fold_left (fun map (key, _) ->
+      info.Analysis.assumptions
+      |> List.fold_left (fun map (key, _) ->
         let cpt = try (Scope.Map.find key map) + 1 with Not_found -> 1 in
         Scope.Map.add key cpt map
       ) Scope.Map.empty
@@ -1044,7 +1046,7 @@ let log_analysis_start param =
           assumptions=\"%a\"\
         />@.@.\
       "
-      Scope.pp_print_scope param.Analysis.top
+      Scope.pp_print_scope info.Analysis.top
       (pp_print_list Scope.pp_print_scope ",") concrete
       (pp_print_list Scope.pp_print_scope ",") abstract
       (pp_print_list (fun fmt (scope, cpt) ->

--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -100,13 +100,14 @@ let maximal_abstraction_for_testgen (type s)
     | None -> None
 
     (* All good. *)
-    | Some map -> Some {
-      Analysis.top = top ;
-      Analysis.uid = get_testgen_uid () ;
-      Analysis.abstraction_map = map ;
-      Analysis.assumptions = assumptions ;
-      Analysis.refinement_of = None ;
-    }
+    | Some map -> Some (
+      First {
+        Analysis.top = top ;
+        Analysis.uid = get_testgen_uid () ;
+        Analysis.abstraction_map = map ;
+        Analysis.assumptions = assumptions ;
+      }
+    )
 
   )
 
@@ -290,8 +291,10 @@ let slice_to_abstraction_and_property
 
   (* Replace top system with subsystem for slicing. *)
   let analysis' =
-    { analysis with Analysis.top =
-        TransSys.scope_of_trans_sys trans_sys' }
+    Analysis.First {
+      Analysis.info_of_param analysis
+      with Analysis.top = TransSys.scope_of_trans_sys trans_sys'
+    }
   in
 
   (* Return subsystem that contains the property *)

--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -101,7 +101,7 @@ let maximal_abstraction_for_testgen (type s)
 
     (* All good. *)
     | Some map -> Some (
-      First {
+      Analysis.First {
         Analysis.top = top ;
         Analysis.uid = get_testgen_uid () ;
         Analysis.abstraction_map = map ;
@@ -140,15 +140,18 @@ let next_analysis_of_strategy (type s)
         S.find_subsystem subsystem scope
       in
       subsystems |> List.map (
-        fun { S.scope ; S.has_contract } -> scope, has_contract
+        fun { S.scope ; S.has_contract ; S.has_modes } ->
+          scope, has_contract, has_modes
       )
     in
 
     S.all_subsystems subsystem
-    |> List.map (fun { S.scope ; S.has_contract } ->
-      scope, has_contract
+    |> List.map (fun { S.scope ; S.has_contract ; S.has_modes } ->
+      scope, has_contract, has_modes
     )
     |> Strategy.next_analysis results subs_of_scope
+    |> fun res ->
+      res
   )
 
   | Native subsystem -> (function _ -> assert false)

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -839,10 +839,11 @@ let rec ident_of_top = function
   | h :: tl -> ident_of_top tl
 
 
-(* Node has a contract if it has a global or at least one mode
-   contract *)
+(* Node has a contract if it has a global or at least one mode contract *)
 let has_contract { global_contracts; mode_contracts } = 
   not (global_contracts = [] && mode_contracts = [])
+
+let has_modes { mode_contracts } = mode_contracts <> []
 
 
 (* Node always has an implementation *)
@@ -978,6 +979,9 @@ let rec subsystem_of_nodes' nodes accum = function
         (* Does node have contracts? *)
         let has_contract = has_contract node in 
 
+        (* Does node have modes? *)
+        let has_modes = has_modes node in
+
         (* Does node have an implementation? *)
         let has_impl = has_impl node in
 
@@ -987,6 +991,7 @@ let rec subsystem_of_nodes' nodes accum = function
           { SubSystem.scope;
             SubSystem.source = node;
             SubSystem.has_contract;
+            SubSystem.has_modes;
             SubSystem.has_impl;
             SubSystem.subsystems  }
 

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -1287,9 +1287,9 @@ let root_and_leaves_of_abstraction_map
 
 (* Slice nodes to abstraction or implementation as indicated in
    [abstraction_map] *)
-let slice_to_abstraction'
-  ({ A.top } as analysis) roots subsystem { G.functions }
-=
+let slice_to_abstraction' analysis roots subsystem { G.functions } =
+
+  let { A.top } = A.info_of_param analysis in
 
   (* Get list of nodes from subsystem in toplogical order with the top
      node at the head of the list *)

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2306,7 +2306,7 @@ let rec trans_sys_of_node'
                  "%s_%a_%d"
                  I.init_uf_string
                  (LustreIdent.pp_print_ident false) node_name
-                 analysis_param.A.uid)
+                 (A.info_of_param analysis_param).A.uid)
               (List.map Var.type_of_var init_formals)
               Type.t_bool
           in
@@ -2340,7 +2340,7 @@ let rec trans_sys_of_node'
                  "%s_%a_%d"
                  I.trans_uf_string
                  (LustreIdent.pp_print_ident false) node_name
-                 analysis_param.A.uid)
+                 (A.info_of_param analysis_param).A.uid)
               (List.map Var.type_of_var trans_formals)
               Type.t_bool
           in
@@ -2410,11 +2410,10 @@ let rec trans_sys_of_node'
             tl
           
 
-let trans_sys_of_nodes subsystem globals (
-  { A.top; A.abstraction_map; A.assumptions; A.refinement_of }
-  as analysis_param
-) =
-  
+let trans_sys_of_nodes subsystem globals analysis_param =
+  let { A.top; A.abstraction_map; A.assumptions } =
+    A.info_of_param analysis_param
+  in
   (* Make sure top level system is not abstract
 
      Contracts would be trivially satisfied otherwise *)
@@ -2475,9 +2474,8 @@ let trans_sys_of_nodes subsystem globals (
 *)
 
   
-  ( match refinement_of with
-    | None -> ()
-    | Some result ->
+  ( match analysis_param with
+    | A.Refinement (_,result) ->
       (* The analysis that's going to run is a refinement. *)
       TransSys.get_prop_status_all result.sys
       |> List.iter (function
@@ -2502,6 +2500,7 @@ let trans_sys_of_nodes subsystem globals (
             ()
         )
       )
+    | _ -> ()
   ) ;
 
   trans_sys, subsystem', globals'

--- a/src/step2.ml
+++ b/src/step2.ml
@@ -188,7 +188,7 @@ let rec check_new_things ({ solver ; sys ; map } as ctx) =
       ()
 
 (* Returns the properties that cannot be falsified. *)
-let split ({ solver ; map } as ctx) =
+let split { solver ; map } =
 
   let rec loop falsifiable =
     if (List.length falsifiable) = (List.length map) then
@@ -290,7 +290,7 @@ let broadcast_if_safe ({ solver ; sys ; map } as ctx) unfalsifiable =
             (* Deactivating actlits. *)
             deactivate solver pos ;
             (* Adding invariant. *)
-            add_invariants solver [t] ;
+            add_invariants solver [t] |> ignore ;
             (* Don't keep. *)
             false
           ) else true

--- a/src/strategy.mli
+++ b/src/strategy.mli
@@ -26,7 +26,9 @@
 module A = Analysis
 
 val next_analysis:
-  A.results -> (Scope.t -> (Scope.t * bool) list) -> (Scope.t * bool) list ->
+  A.results ->
+  (Scope.t -> (Scope.t * bool * bool) list) ->
+  (Scope.t * bool * bool) list ->
   A.param option
 
 (* 

--- a/src/subSystem.ml
+++ b/src/subSystem.ml
@@ -28,6 +28,9 @@ type 'a t = {
   (* System can be abstracted to its contract. *)
   has_contract : bool ;
 
+  (* System has modes. *)
+  has_modes : bool ;
+
   (* System can be refined to its implementation. *)
   has_impl : bool ;
 

--- a/src/subSystem.mli
+++ b/src/subSystem.mli
@@ -40,6 +40,9 @@ type 'a t = {
   (** System can be abstracted to its contract *)
   has_contract : bool ;
 
+  (** System has modes. *)
+  has_modes : bool ;
+
   (** System can be refined to its implementation *)
   has_impl : bool ;
 

--- a/src/testgenDF.ml
+++ b/src/testgenDF.ml
@@ -252,7 +252,7 @@ let main (type s)
   let abstract, concrete =
     Scope.Map.fold (fun key value (a,c) ->
       if value then key :: a, c else a, key :: c
-    ) param.Analysis.abstraction_map ([],[])
+    ) (Analysis.info_of_param param).Analysis.abstraction_map ([],[])
   in
   Event.log L_info "%s@[<v>\
       Launching on %a.@ \

--- a/src/testgenDF.ml
+++ b/src/testgenDF.ml
@@ -245,8 +245,7 @@ and backward io solver tree modes contract_term =
 
 
 (* Entry point. *)
-let main (type s)
-: Analysis.param -> s InputSystem.t -> TSys.t -> unit
+let main (type s) : Analysis.param -> s InputSystem.t -> TSys.t -> unit
 = fun param input_sys sys ->
   (* Separating abstract and concrete systems. *)
   let abstract, concrete =

--- a/tests/lustre/contracts/refinement.lus
+++ b/tests/lustre/contracts/refinement.lus
@@ -5,6 +5,7 @@ tel
 
 node sub (in: bool) returns (cpt: int) ;
 (*@contract
+  @assume true -> in = not pre in ;
   @mode begin (
     @require count(true) <= 10 ;
     @ensure  cpt >= 0 ;
@@ -20,6 +21,7 @@ tel
 
 node top (in: bool) returns (cpt: int) ;
 (*@contract
+  @assume true -> in = not pre in ;
   @guarantee cpt >= 0 ;
   @guarantee (count(true) > 15) => false ;
 *)

--- a/tests/lustre/contracts/refinement_one_mode_active.lus
+++ b/tests/lustre/contracts/refinement_one_mode_active.lus
@@ -1,0 +1,30 @@
+node count (in: bool) returns (cpt: int) ;
+let
+  cpt = (if in then 1 else 0) + (0 -> pre cpt) ;
+tel
+
+node sub (in: bool) returns (cpt: int) ;
+(*@contract
+  @assume true -> in = not pre in ;
+  @mode begin (
+    @require count(true) <= 10 ;
+    @ensure  cpt >= 0 ;
+  ) ;
+  @mode and_then (
+    @require count(true) > 15 ;
+    @ensure  true ;
+  ) ;
+*)
+let
+  cpt = count(in) ;
+tel
+
+node top (in: bool) returns (cpt: int) ;
+(*@contract
+  @assume true -> in = not pre in ;
+  @guarantee cpt >= 0 ;
+  @guarantee (count(true) > 15) => false ;
+*)
+let
+  cpt = sub(in) ;
+tel


### PR DESCRIPTION
* mode completeness check
* cleaned `Analysis.param` a bit
* minor fixes in step2 that were triggering harmless warnings

Relevant testcases:

* [tests/lustre/contracts/refinement.lus][test 1]
* [tests/lustre/contracts/refinement_one_mode_active.lus][test 2]

When a system has a contract (`a`,`g`,`m`) where `m = { req_i, ens_i }` is not empty, run an analysis on the abstract system
```
a /\ { req_i => ens_i }
```
with property `\/ { req_i }`.

If it succeeds analyze the concrete system as usual.

If it fails stop. We stop because since the spec is not safe, it is meaningless to abstract that node above in the hierarchy.
The general argument is that there is a problem in the spec and it should be fixed before we do anything else.

[test 1]: https://github.com/AdrienChampion/kind2/blob/new_contracts_semantics/tests/lustre/contracts/refinement.lus (Test case for new contract semantics)
[test 2]: https://github.com/AdrienChampion/kind2/blob/new_contracts_semantics/tests/lustre/contracts/refinement_one_mode_active.lus (Test case for new contract semantics)