### PR TITLE
Better flags

### DIFF
--- a/src/C2I.ml
+++ b/src/C2I.ml
@@ -192,21 +192,21 @@ let mk_solvers sys prop =
   let solver1 =
     SMTSolver.create_instance
       ~produce_assignments:true
-      (TransSys.get_logic sys) (Flags.smtsolver ())
+      (TransSys.get_logic sys) (Flags.Smt.solver ())
   in
   solver_ref_1 := Some solver1 ;
 
   let solver2 =
     SMTSolver.create_instance
       ~produce_assignments:true
-      (TransSys.get_logic sys) (Flags.smtsolver ())
+      (TransSys.get_logic sys) (Flags.Smt.solver ())
   in
   solver_ref_2 := Some solver2 ;
 
   let solver3 =
     SMTSolver.create_instance
       ~produce_assignments:true
-      (TransSys.get_logic sys) (Flags.smtsolver ())
+      (TransSys.get_logic sys) (Flags.Smt.solver ())
   in
   solver_ref_3 := Some solver3 ;
 

--- a/src/C2ICandidate.ml
+++ b/src/C2ICandidate.ml
@@ -739,14 +739,14 @@ let mk sys =
   (* Retrieving DNF and arithmetic sub-candidates sizes. *)
   let d_count, c_int_count, c_rat_count =
     (* DNF size. *)
-    ( if Flags.c2i_modes () then
+    ( if Flags.C2I.modes () then
         (* One disjunct per require + 1. *)
         (TransSys.get_mode_requires sys |> snd |> List.length) + 1
-      else Flags.c2i_dnf_size () ),
+      else Flags.C2I.dnf_size () ),
     (* Int cube size. *)
-    Flags.c2i_int_cube_size (),
+    Flags.C2I.int_cube_size (),
     (* rat cube size. *)
-    Flags.c2i_real_cube_size ()
+    Flags.C2I.real_cube_size ()
   in
 
   (* Retrieving relevant variables. *)
@@ -779,7 +779,7 @@ let mk sys =
   in
 
   let init_subs =
-    match Flags.c2i_modes (), TransSys.get_mode_requires sys with
+    match Flags.C2I.modes (), TransSys.get_mode_requires sys with
     | false, _ | true, (None, []) -> Nil
     | true, (Some ass, modes) ->
       (* Extract term for each requirement. *)

--- a/src/C2Icnf.ml
+++ b/src/C2Icnf.ml
@@ -119,7 +119,7 @@ let mk_solver sys init solver_ref =
   let solver = Solver.create_instance
     ~produce_assignments:true
     (Sys.get_logic sys)
-    (Flags.smtsolver ())
+    (Flags.Smt.solver ())
   in
 
   (** Sanity check that the solver referenced is not live. *)

--- a/src/CVC4Driver.ml
+++ b/src/CVC4Driver.ml
@@ -29,7 +29,7 @@ let cmd_line
     produce_interpolants =
   
   (* Path and name of CVC4 executable *)
-  let cvc4_bin = Flags.cvc4_bin () in
+  let cvc4_bin = Flags.Smt.cvc4_bin () in
 
   (* Use unsat cores *)
   if produce_cores then 

--- a/src/IC3.ml
+++ b/src/IC3.ml
@@ -48,7 +48,7 @@ let print_stats () =
 
   Event.stat
     ([Stat.misc_stats_title, Stat.misc_stats] @
-     (if Flags.ic3_abstr () = `IA then 
+     (if Flags.IC3.abstr () = `IA then 
         [Stat.ic3_stats_title, Stat.ic3_stats;
          Stat.ic3ia_stats_title, Stat.ic3ia_stats]
       else 
@@ -130,7 +130,7 @@ let handle_events
      instances *)
   let add_invariant inv = 
 
-    if Flags.ic3_use_invgen () then 
+    if Flags.IC3.use_invgen () then 
 
       match Term.var_offsets_of_term inv with
 
@@ -706,7 +706,7 @@ let ind_generalize solver prop_set frame clause literals =
 
      assert (not cons));
     
-    let k,d = match Flags.ic3_inductively_generalize() with
+    let k,d = match Flags.IC3.inductively_generalize() with
       | 1 -> linear_search clause [] (C.elements clause)
       | 2 -> linear_search clause [] (order_terms (C.elements clause) term_tbl)
       | 3 -> binary_search [] (Array.of_list (C.elements clause))
@@ -1013,7 +1013,7 @@ let rec block solver input_sys aparam trans_sys prop_set term_tbl predicates =
                 let cti_gen = 
 
                   (* Abstraction used? *)
-                  match Flags.ic3_abstr () with
+                  match Flags.IC3.abstr () with
 
                     (* No abstraction *)
                     | `None ->
@@ -1430,7 +1430,7 @@ let rec block solver input_sys aparam trans_sys prop_set term_tbl predicates =
                frames,
 
                (* Add cube to block to next higher frame if flag is set *)
-               if Flags.ic3_block_in_future () then
+               if Flags.IC3.block_in_future () then
 
                  add_to_block_tl
                    solver
@@ -1531,7 +1531,7 @@ let rec block solver input_sys aparam trans_sys prop_set term_tbl predicates =
                    raise (Counterexample (block_clause :: block_trace))
                  in
 
-                 (match Flags.ic3_abstr () with
+                 (match Flags.IC3.abstr () with
                    | `None ->
                      raise_cex ()
 
@@ -1589,7 +1589,7 @@ let rec block solver input_sys aparam trans_sys prop_set term_tbl predicates =
 
                     R_i-1[x] & C[x] & T[x,x'] & ~C[x'] is sat *)
                  let cti_gen =
-                   match Flags.ic3_abstr () with
+                   match Flags.IC3.abstr () with
                      | `None ->
 
                        extrapolate 
@@ -1877,7 +1877,7 @@ let fwd_propagate solver input_sys aparam trans_sys prop_set frames predicates =
       if 
 
         (* Inductive generalization after forward propagation? *)
-        Flags.ic3_fwd_prop_ind_gen () ||
+        Flags.IC3.fwd_prop_ind_gen () ||
 
         (* Inductively generalize forward propagated clause that was
            not generalized *)
@@ -1908,7 +1908,7 @@ let fwd_propagate solver input_sys aparam trans_sys prop_set frames predicates =
     let l = C.literals_of_clause c' in
 
     (* Subsumption after forward propagation? *)
-    if Flags.ic3_fwd_prop_subsume () then
+    if Flags.IC3.fwd_prop_subsume () then
 
       (* Is clause subsumed in frame? *)
       if F.is_subsumed a l then
@@ -1996,7 +1996,7 @@ let fwd_propagate solver input_sys aparam trans_sys prop_set frames predicates =
           (C.props_of_prop_set prop_set);
 
         (* Check inductiveness of blocking clauses? *)
-        if Flags.ic3_check_inductive () && prop <> [] then 
+        if Flags.IC3.check_inductive () && prop <> [] then 
 
           (
 
@@ -2233,7 +2233,7 @@ let fwd_propagate solver input_sys aparam trans_sys prop_set frames predicates =
             let fwd' = 
 
               (* Try propagating clauses before generalization? *)
-              if Flags.ic3_fwd_prop_non_gen () then
+              if Flags.IC3.fwd_prop_non_gen () then
 
                 (
                   
@@ -2847,7 +2847,7 @@ let rec restart_loop solver input_sys aparam trans_sys props predicates =
               "Problem contains real valued variables, \
                switching off approximate QE";
 
-            Flags.set_ic3_qe `Z3;
+            Flags.IC3.set_qe `Z3;
 
             props
 
@@ -3039,7 +3039,7 @@ let rec bmc_checks solver input_sys aparam trans_sys props =
 *)
 let main input_sys aparam trans_sys =
 
-  match Flags.smtsolver () with 
+  match Flags.Smt.solver () with 
 
     (* Yices with SMTLIB input does not work *)
     | `Yices_SMTLIB -> 
@@ -3062,12 +3062,12 @@ let main input_sys aparam trans_sys =
           ~produce_assignments:true
           ~produce_cores:true
           logic
-          (Flags.smtsolver ())
+          (Flags.Smt.solver ())
       in
 
 
       let bound =
-        match Flags.ic3_abstr () with
+        match Flags.IC3.abstr () with
           | `None -> 1
           | `IA -> 3
       in
@@ -3136,7 +3136,7 @@ let main input_sys aparam trans_sys =
         (TransSys.trans_of_bound trans_sys (Numeral.of_int bound));
 
       (* Print inductive assertions to file? *)
-      (match Flags.ic3_print_to_file () with 
+      (match Flags.IC3.print_to_file () with
 
         (* Keep default formatter *)
         | None -> ()
@@ -3160,7 +3160,7 @@ let main input_sys aparam trans_sys =
       in
       let predicates =
 
-        match Flags.ic3_abstr () with
+        match Flags.IC3.abstr () with
 
           | `IA ->
 

--- a/src/MathSAT5Driver.ml
+++ b/src/MathSAT5Driver.ml
@@ -27,7 +27,7 @@ let cmd_line
     produce_interpolants = 
   
   (* Path and name of MathSAT5 executable *)
-  let mathsat5_bin = Flags.mathsat5_bin () in
+  let mathsat5_bin = Flags.Smt.mathsat5_bin () in
   [| mathsat5_bin; "-input=smt2" |]
 
 

--- a/src/QE.ml
+++ b/src/QE.ml
@@ -121,7 +121,7 @@ let get_checking_solver_instance trans_sys =
           ~produce_assignments:true
           (* add quantifiers to system logic *)
           (add_quantifiers (TransSys.get_logic trans_sys))
-          (Flags.smtsolver ())
+          (Flags.Smt.solver ())
       in
 (*
       (* Declare uninterpreted function symbols *)
@@ -656,7 +656,7 @@ let generalize trans_sys uf_defs model elim term =
      Term.pp_print_term 
      (Term.mk_and term'_bool) end);
 
-  let term' = let ic3_qe = Flags.ic3_qe () in match ic3_qe with 
+  let term' = let ic3_qe = Flags.IC3.qe () in match ic3_qe with 
     
     | `Z3
     | `Z3_impl

--- a/src/SMTLIBSolver.ml
+++ b/src/SMTLIBSolver.ml
@@ -644,12 +644,12 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
   let create_trace_ppf id = 
 
     (* Tracing of SMT commands enabled? *)
-    if Flags.smt_trace () then 
+    if Flags.Smt.trace () then 
 
       (* Name of SMT trace file *)
       let trace_filename = 
         Filename.concat
-          (Flags.smt_trace_dir ())
+          (Flags.Smt.trace_dir ())
           (Format.sprintf "%s.%s.%d.%s" 
              (Filename.basename (Flags.input_file ()))
              (suffix_of_kind_module (Event.get_module ()))

--- a/src/SMTSolver.ml
+++ b/src/SMTSolver.ml
@@ -44,7 +44,7 @@ type t =
   { 
     
     (* Type of SMT solver *)
-    solver_kind : Flags.smtsolver;
+    solver_kind : Flags.Smt.solver;
     
     (* Solver instance *)
     solver_inst : (module SolverSig.Inst);

--- a/src/SMTSolver.mli
+++ b/src/SMTSolver.mli
@@ -37,7 +37,7 @@ val create_instance :
   ?produce_cores:bool ->
   ?produce_interpolants:bool ->
   TermLib.logic ->
-  Flags.smtsolver ->
+  Flags.Smt.solver ->
   t
 
 (** Delete an instance of an SMT solver *)
@@ -170,7 +170,7 @@ val execute_custom_check_sat_command :
 
 val converter : t -> (module SMTExpr.Conv)
 
-val kind : t -> Flags.smtsolver
+val kind : t -> Flags.Smt.solver
 
 (** Output a comment into the trace *)
 val trace_comment : t -> string -> unit

--- a/src/Yices2SMT2Driver.ml
+++ b/src/Yices2SMT2Driver.ml
@@ -28,7 +28,7 @@ let cmd_line
     produce_interpolants = 
 
   (* Path and name of Yices executable *)
-  let yices2smt2_bin = Flags.yices2smt2_bin () in
+  let yices2smt2_bin = Flags.Smt.yices2smt2_bin () in
   [| yices2smt2_bin; "--incremental" |]
 
 

--- a/src/Z3Driver.ml
+++ b/src/Z3Driver.ml
@@ -27,7 +27,7 @@ let cmd_line
     produce_interpolants = 
 
   (* Path and name of Z3 executable *)
-  let z3_bin = Flags.z3_bin () in
+  let z3_bin = Flags.Smt.z3_bin () in
   [| z3_bin; "-smt2"; "-in" |]
 
 
@@ -37,7 +37,7 @@ let check_sat_limited_cmd ms =
   Format.sprintf "(check-sat-using (try-for smt %d))" ms
 
 
-let check_sat_assuming_supported () = Flags.smt_check_sat_assume ()
+let check_sat_assuming_supported () = Flags.Smt.check_sat_assume ()
 
 let check_sat_assuming_cmd () = "check-sat"
 

--- a/src/base.ml
+++ b/src/base.ml
@@ -98,7 +98,7 @@ let split trans solver k falsifiable to_split actlits =
     None
   in
 
-  if Flags.bmc_check_unroll () then ( 
+  if Flags.BmcKind.check_unroll () then ( 
     if SMTSolver.check_sat solver |> not then (
       Event.log
         L_warn
@@ -336,7 +336,7 @@ let rec next (input_sys, aparam, trans, solver, k, invariants, unknowns) =
     let k_p_1_int = Numeral.to_int k_p_1 in
 
     (* Checking if we have reached max k. *)
-    if Flags.bmc_max () > 0 && k_p_1_int > Flags.bmc_max () then
+    if Flags.BmcKind.max () > 0 && k_p_1_int > Flags.BmcKind.max () then
      Event.log
        L_info
        "BMC @[<v>reached maximal number of iterations.@]"
@@ -358,7 +358,7 @@ let init input_sys aparam trans =
   (* Creating solver. *)
   let solver =
     SMTSolver.create_instance ~produce_assignments:true
-      (TransSys.get_logic trans) (Flags.smtsolver ())
+      (TransSys.get_logic trans) (Flags.Smt.solver ())
   in
 
   (* Memorizing solver for clean on_exit. *)
@@ -385,7 +385,7 @@ let init input_sys aparam trans =
   |> SMTSolver.assert_term solver
   |> ignore ;
 
-  if Flags.bmc_check_unroll () then (
+  if Flags.BmcKind.check_unroll () then (
     if SMTSolver.check_sat solver |> not then (
       Event.log
         L_warn

--- a/src/compress.ml
+++ b/src/compress.ml
@@ -747,7 +747,7 @@ let check_and_block declare_fun trans_sys path =
   (* Generate blocking terms from equality relation *)
   let block_terms = 
 
-    if Flags.ind_compress_equal () then 
+    if Flags.BmcKind.compress_equal () then 
 
       fold_pairs equal_mod_input block_terms states
 
@@ -760,7 +760,7 @@ let check_and_block declare_fun trans_sys path =
   (* Generate blocking terms from same successor relation *)
   let block_terms = 
 
-    if Flags.ind_compress_same_succ () then 
+    if Flags.BmcKind.compress_same_succ () then 
 
       fold_pairs
         (same_successors
@@ -779,7 +779,7 @@ let check_and_block declare_fun trans_sys path =
   (* Generate blocking terms from same predecessor relation *)
   let block_terms = 
 
-    if Flags.ind_compress_same_pred () then 
+    if Flags.BmcKind.compress_same_pred () then 
 
       fold_pairs
         (same_predecessors

--- a/src/event.ml
+++ b/src/event.ml
@@ -573,8 +573,8 @@ let print_xml_header () =
       ",")
     (Flags.enable ())
     (Flags.timeout_wall ())
-    (Flags.bmc_max ())
-    (Flags.compositional ())
+    (Flags.BmcKind.max ())
+    (Flags.Contracts.compositional ())
     (Flags.modular ())
 
 
@@ -1020,7 +1020,7 @@ let log_run_end results =
   match !log_format with
   | F_pt ->
     (* Printing a short, human readable version of all the results. *)
-    if Flags.compositional () then
+    if Flags.Contracts.compositional () then
       Format.fprintf !log_ppf "%a@.@.Analysis breakdown:@   @[<v>%a@]@.@."
         pp_print_hline ()
         (pp_print_list Analysis.pp_print_result_quiet "@ ") (

--- a/src/extract.ml
+++ b/src/extract.ml
@@ -122,7 +122,7 @@ let choose_term (bool_terms, int_terms) =
     | h :: tl as terms -> 
 
       (* Heuristic to choose terms *)
-      match Flags.ic3_extract () with 
+      match Flags.IC3.extract () with 
 
         (* Always pick the first term *)
         | `First -> List.hd terms 

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -144,6 +144,26 @@ let enable_flag =
 (*   type smtsolver = Z3_SMTLIB | CVC4_SMTLIB arg smtsolver default CVC4_SMTLIB action smtsolver_action doc " choose SMT solver (available: %s, default: %s" *)
 
 
+(* Strings recognized as the bool value [true]. *)
+let true_strings = [ "true" ; "on" ; "t" ; "1" ]
+(* Strings recognized as the bool value [false]. *)
+let false_strings = [ "false" ; "off" ; "f" ; "0" ]
+(* String to bool. *)
+let bool_of_string s =
+  if List.mem s true_strings then true
+  else if List.mem s false_strings then false
+  else Arg.Bad (
+    Format.asprintf
+      "expected boolean (%a, %a), but got %s"
+      (pp_print_list Format.pp_print_string ", ") true_strings
+      (pp_print_list Format.pp_print_string ", ") false_strings
+      s
+  ) |> raise
+(* Parses a bool and sets a reference. *)
+let bool_arg reference = Arg.String (
+  fun s -> reference := bool_of_string s
+)
+
 
 (* Global flags. *)
 module Global = struct
@@ -406,7 +426,7 @@ module Global = struct
   let modular = ref modular_default
   let _ = add_spec (
     "--modular",
-    Arg.Bool (fun b -> modular := b),
+    bool_arg modular,
     Format.sprintf
       "bottom-up analysis of each node (default: %B)"
       modular_default
@@ -419,7 +439,7 @@ module Global = struct
   let lus_strict = ref lus_strict_default
   let _ = add_spec (
     "--lus_strict",
-    Arg.Bool (fun b -> lus_strict := b),
+    bool_arg lus_strict,
     Format.sprintf
       "Strict mode in Lustre: uninitialized pre and undefined \
       local variables are not allowed when this flag is present."
@@ -430,7 +450,7 @@ module Global = struct
   let lus_compile = ref lus_compile_default
   let _ = add_spec (
     "--lus_compile",
-    Arg.Bool (fun b -> lus_compile := b),
+    bool_arg lus_compile,
     Format.sprintf
       "@[<v 7>@,(default: %b)@ \
       Activates compiling to Rust, deactivates everything else.@]"
@@ -527,7 +547,7 @@ module Smt = struct
   let check_sat_assume = ref check_sat_assume_default
   let _ = add_spec (
     "--smt_check_sat_assume",
-    Arg.Bool (fun b -> check_sat_assume := b),
+    bool_arg check_sat_assume,
     Format.sprintf
       "Use check-sat with assumptions, or simulate with push/pop \
        when false (default: %B)"
@@ -542,7 +562,7 @@ module Smt = struct
   let short_names = ref short_names_default
   let _ = add_spec (
     "--smt_short_names",
-    Arg.Bool (fun b -> short_names := b),
+    bool_arg short_names,
     Format.sprintf
       "Send short variables names to SMT solver, send full names if false \
       (default: %B)"
@@ -674,7 +694,7 @@ module BmcKind = struct
   let check_unroll = ref check_unroll_default
   let _ = add_spec (
     "--bmc_check_unroll",
-    Arg.Bool (fun b -> check_unroll := b),
+    bool_arg check_unroll,
     Format.sprintf
       "(BMC) Check that the unrolling alone is satisfiable (default: %b)"
       check_unroll_default
@@ -685,7 +705,7 @@ module BmcKind = struct
   let print_cex = ref print_cex_default
   let _ = add_spec (
     "--ind_print_cex",
-    Arg.Bool (fun b -> print_cex := b),
+    bool_arg print_cex,
     Format.sprintf
       "(IND) Print counterexamples to induction (default: %b)"
       print_cex_default
@@ -696,7 +716,7 @@ module BmcKind = struct
   let compress = ref compress_default
   let _ = add_spec (
     "--ind_compress",
-    Arg.Bool (fun b -> compress := b),
+    bool_arg compress,
     Format.sprintf
       "(IND) Compress inductive counterexamples (default: %B)"
       compress_default
@@ -707,7 +727,7 @@ module BmcKind = struct
   let compress_equal = ref compress_equal_default
   let _ = add_spec (
     "--ind_compress_equal",
-    Arg.Bool (fun b -> compress_equal := b),
+    bool_arg compress_equal,
     Format.sprintf
       "(IND) Compress inductive counterexamples for states equal \
       modulo inputs (default: %B)"
@@ -719,7 +739,7 @@ module BmcKind = struct
   let compress_same_succ = ref compress_same_succ_default
   let _ = add_spec (
     "--ind_compress_same_succ",
-    Arg.Bool (fun b -> compress_same_succ := b),
+    bool_arg compress_same_succ,
     Format.sprintf
       "(IND) Compress inductive counterexamples for states \
       with same successors (default: %B)"
@@ -731,7 +751,7 @@ module BmcKind = struct
   let compress_same_pred = ref compress_same_pred_default
   let _ = add_spec (
   "--ind_compress_same_pred",
-    Arg.Bool (fun b -> compress_same_pred := b),
+    bool_arg compress_same_pred,
     Format.sprintf
       "(IND) Compress inductive counterexamples for states \
       with same predecessors (default: %B)"
@@ -743,7 +763,7 @@ module BmcKind = struct
   let lazy_invariants = ref lazy_invariants_default
   let _ = add_spec (
     "--ind_lazy_invariants",
-    Arg.Bool (fun b -> lazy_invariants := b),
+    bool_arg lazy_invariants,
     Format.sprintf
       "(IND) Asserts invariants lazily (default: %B)"
       lazy_invariants_default
@@ -771,7 +791,7 @@ module IC3 = struct
   let check_inductive = ref check_inductive_default
   let _ = add_spec (
     "--ic3_check_inductive",
-    Arg.Bool (fun b -> check_inductive := b),
+    bool_arg check_inductive,
     Format.sprintf
       "(IC3) Check inductiveness of blocking clauses (default: %s)"
       (string_of_check_inductive check_inductive_default)
@@ -807,7 +827,7 @@ module IC3 = struct
   let block_in_future = ref block_in_future_default
   let _ = add_spec (
     "--ic3_block_in_future",
-    Arg.Bool (fun b -> block_in_future := b),
+    bool_arg block_in_future,
     Format.sprintf
       "(IC3) Block counterexample in future frames (default: %s)"
       (string_of_block_in_future block_in_future_default)
@@ -819,7 +839,7 @@ module IC3 = struct
   let block_in_future_first = ref block_in_future_first_default
   let _ = add_spec (
     "--ic3_block_in_future_first",
-    Arg.Bool (fun b -> block_in_future_first := b),
+    bool_arg block_in_future_first,
     Format.sprintf
       "(IC3) Block counterexample in future frames first before returning to \
       frame (default: %s)"
@@ -832,7 +852,7 @@ module IC3 = struct
   let fwd_prop_non_gen = ref fwd_prop_non_gen_default
   let _ = add_spec (
     "--ic3_fwd_prop_non_gen",
-    Arg.Bool (fun b -> fwd_prop_non_gen := b),
+    bool_arg fwd_prop_non_gen,
     Format.sprintf
       "(IC3) Also propagate clauses before generalization (default: %s)"
       (string_of_fwd_prop_non_gen fwd_prop_non_gen_default)
@@ -844,7 +864,7 @@ module IC3 = struct
   let fwd_prop_ind_gen = ref fwd_prop_ind_gen_default
   let _ = add_spec (
     "--ic3_fwd_prop_ind_gen",
-    Arg.Bool (fun b -> fwd_prop_ind_gen := b),
+    bool_arg fwd_prop_ind_gen,
     Format.sprintf
       "(IC3) Inductively generalize all clauses after forward propagation \
       (default: %s)"
@@ -857,7 +877,7 @@ module IC3 = struct
   let fwd_prop_subsume = ref fwd_prop_subsume_default
   let _ = add_spec (
     "--ic3_fwd_prop_subsume",
-    Arg.Bool (fun b -> fwd_prop_subsume := b),
+    bool_arg fwd_prop_subsume,
     Format.sprintf
       "(IC3) Subsumption in forward propagation (default: %s)"
       (string_of_fwd_prop_subsume fwd_prop_subsume_default)
@@ -869,7 +889,7 @@ module IC3 = struct
   let use_invgen = ref use_invgen_default
   let _ = add_spec (
     "--ic3_use_invgen",
-    Arg.Bool (fun b -> use_invgen := b),
+    bool_arg use_invgen,
     Format.sprintf
       "(IC3) Use invariants from invariant generators (default: %s)"
       (string_of_use_invgen use_invgen_default)
@@ -970,7 +990,7 @@ module QE = struct
   let cooper_order_var_by_elim = ref cooper_order_var_by_elim_default
   let _ = add_spec (
     "--cooper_order_var_by_elim",
-    Arg.Bool (fun b -> cooper_order_var_by_elim := b),
+    bool_arg cooper_order_var_by_elim,
     Format.sprintf
       "(Cooper QE) Order variables in polynomials by order of \
       elimination (default: %B)"
@@ -982,7 +1002,7 @@ module QE = struct
   let cooper_general_lbound = ref cooper_general_lbound_default
   let _ = add_spec (
     "--cooper_general_lbound",
-    Arg.Bool (fun b -> cooper_general_lbound := b),
+    bool_arg cooper_general_lbound,
     Format.sprintf
       "(Cooper QE) Choose lower bounds containing variables \
       (default: %B)"
@@ -1010,7 +1030,7 @@ module Contracts = struct
   let compositional = ref compositional_default
   let _ = add_spec (
     "--compositional",
-    Arg.Bool (fun b -> compositional := b),
+    bool_arg compositional,
     Format.sprintf
       "abstract subnodes with a contract (default: %B)"
       compositional_default
@@ -1021,7 +1041,7 @@ module Contracts = struct
   let check_modes = ref check_modes_default
   let _ = add_spec (
     "--check_modes",
-    Arg.Bool (fun b -> check_modes := b),
+    bool_arg check_modes,
     Format.sprintf
       "checks the modes of a contracts are exhaustive \
       (default: %B, setting to `false` automatically activates `check_implem`)"
@@ -1033,7 +1053,7 @@ module Contracts = struct
   let check_implem = ref check_implem_default
   let _ = add_spec (
     "--check_implem",
-    Arg.Bool (fun b -> check_implem := b),
+    bool_arg check_implem,
     Format.sprintf
       "checks the implementation of nodes \
       (default: %B, setting to `false` automatically activates `check_modes`)"
@@ -1061,7 +1081,7 @@ module Testgen = struct
   let active = ref active_default
   let _ = add_spec (
     "--testgen",
-    Arg.Bool (fun b -> active := b),
+    bool_arg active,
     Format.sprintf
       "@[<v 7>@,(default: %b)@ \
       Activates test generation, deactivates everything else.@]"
@@ -1073,7 +1093,7 @@ module Testgen = struct
   let graph_only = ref graph_only_default
   let _ = add_spec (
     "--testgen_graph_only",
-    Arg.Bool (fun b -> graph_only := b),
+    bool_arg graph_only,
     Format.sprintf
      "@[<v 7>@,(default: %b)@ \
      Only draw the graph of reachable modes, do not log testcases.@ \
@@ -1113,7 +1133,7 @@ module Invgen = struct
   let prune_trivial = ref prune_trivial_default
   let _ = add_spec (
     "--invgen_prune_trivial",
-    Arg.Bool (fun b -> prune_trivial := b),
+    bool_arg prune_trivial,
     Format.sprintf
       "Invariant generation will communicate invariants not implied by the \
       transition relation (default: %B)."
@@ -1136,7 +1156,7 @@ module Invgen = struct
   let lift_candidates = ref lift_candidates_default
   let _ = add_spec (
     "--invgen_lift_candidates",
-    Arg.Bool (fun b -> lift_candidates := b),
+    bool_arg lift_candidates,
     Format.sprintf
       "Invariant generation will instantiate candidates from sub-nodes\
       (default: %B)."
@@ -1148,7 +1168,7 @@ module Invgen = struct
   let top_only = ref top_only_default
   let _ = add_spec (
     "--invgen_top_only",
-    Arg.Bool (fun b -> top_only := b),
+    bool_arg top_only,
     Format.sprintf
       "Only generate invariants for the top level\
       (default: %B)."
@@ -1160,7 +1180,7 @@ module Invgen = struct
   let mine_trans = ref mine_trans_default
   let _ = add_spec (
     "--invgen_mine_trans",
-    Arg.Bool (fun b -> mine_trans := b),
+    bool_arg mine_trans,
     Format.sprintf
       "Invariant generation will extract candidate terms from the transition \
       predicate (default: %B)."
@@ -1229,7 +1249,7 @@ module C2I = struct
   let modes = ref modes_default
   let _ = add_spec (
     "--c2i_modes",
-    Arg.Bool (fun b -> modes := b),
+    bool_arg modes,
     Format.sprintf
       "Activates mode subcandidates. Subsumes c2i_dnf_size (default %b)."
       modes_default

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -256,7 +256,7 @@ end = struct
     | "MathSat5" -> `MathSat5_SMTLIB
     | "Yices2" -> `Yices_SMTLIB
     | "Yices" -> `Yices_native
-    | _ -> Arg.Bad "Bad value for --smtsolver" |> raise
+    | _ -> Arg.Bad "Bad value for --smt_solver" |> raise
   let string_of_solver = function
     | `Z3_SMTLIB -> "Z3"
     | `CVC4_SMTLIB -> "CVC4"
@@ -268,7 +268,7 @@ end = struct
   let solver_default = `detect
   let solver = ref solver_default
   let _ = add_spec (
-    "--smtsolver",
+    "--smt_solver",
     Arg.String (fun str -> solver := solver_of_string str),
     fun fmt ->
       Format.fprintf fmt
@@ -297,7 +297,7 @@ end = struct
   let logic_default = `None
   let logic = ref logic_default
   let _ = add_spec (
-    "--smtlogic",
+    "--smt_logic",
     Arg.String (fun str -> logic := logic_of_string str),
     fun fmt ->
       Format.fprintf fmt
@@ -316,7 +316,7 @@ end = struct
   let check_sat_assume_default = true
   let check_sat_assume = ref check_sat_assume_default
   let _ = add_spec (
-    "--smt_check_sat_assume",
+    "--check_sat_assume",
     bool_arg check_sat_assume,
     fun fmt ->
       Format.fprintf fmt
@@ -500,6 +500,9 @@ end = struct
   let add_specs specs = all_specs := !all_specs @ specs
   let add_spec spec = add_specs [spec]
 
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
   let max_default = 0
   let max = ref max_default
   let _ = add_spec (
@@ -594,7 +597,7 @@ end = struct
         "@[<v>\
           Compress inductive counterexamples for states with same predecessors@ \
           Default: %B\
-        "
+        @]"
         compress_same_pred_default
   )
   let compress_same_pred () = !compress_same_pred
@@ -610,10 +613,6 @@ end = struct
         lazy_invariants_default
   )
   let lazy_invariants () = !lazy_invariants
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
 
 end
 
@@ -674,6 +673,9 @@ end = struct
   let all_specs = ref []
   let add_specs specs = all_specs := !all_specs @ specs
   let add_spec spec = add_specs [spec]
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
 
   let check_inductive_default = true
   let check_inductive = ref check_inductive_default
@@ -881,10 +883,6 @@ end = struct
   )
   let abstr () = !abstr
 
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-
 end
 
 
@@ -892,9 +890,9 @@ end
 module QE : sig
   include FlagModule
   (** Order variables in polynomials by order of elimination **)
-  val cooper_order_var_by_elim : unit -> bool
+  val order_var_by_elim : unit -> bool
   (** Choose lower bounds containing variables **)
-  val cooper_general_lbound : unit -> bool
+  val general_lbound : unit -> bool
 end = struct
 
   (* Short description of the module. *)
@@ -916,39 +914,38 @@ end = struct
   let add_specs specs = all_specs := !all_specs @ specs
   let add_spec spec = add_specs [spec]
 
-  let cooper_order_var_by_elim_default = false
-  let cooper_order_var_by_elim = ref cooper_order_var_by_elim_default
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+  let order_var_by_elim_default = false
+  let order_var_by_elim = ref order_var_by_elim_default
   let _ = add_spec (
-    "--cooper_order_var_by_elim",
-    bool_arg cooper_order_var_by_elim,
+    "--order_var_by_elim",
+    bool_arg order_var_by_elim,
     fun fmt ->
       Format.fprintf fmt
       "@[<v>\
         Order variables in polynomials by order of elimination@ \
         Default: %B\
       @]"
-      cooper_order_var_by_elim_default
+      order_var_by_elim_default
   )
-  let cooper_order_var_by_elim () = !cooper_order_var_by_elim
+  let order_var_by_elim () = !order_var_by_elim
 
-  let cooper_general_lbound_default = false
-  let cooper_general_lbound = ref cooper_general_lbound_default
+  let general_lbound_default = false
+  let general_lbound = ref general_lbound_default
   let _ = add_spec (
-    "--cooper_general_lbound",
-    bool_arg cooper_general_lbound,
+    "--general_lbound",
+    bool_arg general_lbound,
     fun fmt ->
       Format.fprintf fmt
       "@[<v>\
         Choose lower bounds containing variables@ \
         Default: %B\
       @]"
-      cooper_general_lbound_default
+      general_lbound_default
   )
-  let cooper_general_lbound () = !cooper_general_lbound
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
+  let general_lbound () = !general_lbound
 end
 
 
@@ -983,6 +980,9 @@ end = struct
   let all_specs = ref []
   let add_specs specs = all_specs := !all_specs @ specs
   let add_spec spec = add_specs [spec]
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
 
   let compositional_default = false
   let compositional = ref compositional_default
@@ -1026,10 +1026,6 @@ end = struct
   )
   let check_implem () = !check_implem
 
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-
 end
 
 
@@ -1060,6 +1056,9 @@ end = struct
   let all_specs = ref []
   let add_specs specs = all_specs := !all_specs @ specs
   let add_spec spec = add_specs [spec]
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
 
   let active_default = false
   let active = ref active_default
@@ -1106,10 +1105,6 @@ end = struct
   )
   let len () = !len
 
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-
 end
 
 
@@ -1148,6 +1143,9 @@ end = struct
   let all_specs = ref []
   let add_specs specs = all_specs := !all_specs @ specs
   let add_spec spec = add_specs [spec]
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
 
   let prune_trivial_default = true
   let prune_trivial = ref prune_trivial_default
@@ -1239,10 +1237,6 @@ end = struct
         @]"
   )
   let renice () = !renice
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
 end
 
 
@@ -1273,6 +1267,9 @@ end = struct
   let all_specs = ref []
   let add_specs specs = all_specs := !all_specs @ specs
   let add_spec spec = add_specs [spec]
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
 
   let dnf_size_default = 3
   let dnf_size = ref dnf_size_default
@@ -1333,10 +1330,6 @@ end = struct
         modes_default
   )
   let modes () = !modes
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
 end
 
 
@@ -1364,6 +1357,9 @@ end = struct
   let add_specs specs = all_specs := !all_specs @ specs
   let add_spec spec = add_specs [spec]
 
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
   let input_file_default = ""
   let input_file = ref input_file_default
   let _ = add_spec (
@@ -1390,9 +1386,6 @@ end = struct
   )
   let steps () = !steps
 
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
 end
 
 
@@ -1402,6 +1395,17 @@ end
 (* ********************************************************************** *)
 (* Maps identifiers to modules flag specifications and description        *)
 (* ********************************************************************** *)
+
+let usage_msg = Filename.basename Sys.executable_name |> Format.sprintf "\
+  Usage: %s [options] <lustre_file>@.\
+  Prove properties in Lustre program <lustre_file>.\
+"
+
+let global_usage_msg =
+  Format.sprintf "\
+    %s@.\
+    Global options follow, use \"--flags_of\" for module-specific information.\
+  " usage_msg
 
 let module_map = [
   ("smt",
@@ -1438,7 +1442,7 @@ let fmt_module_info fmt (id, m0d) =
   let module Flags = (val m0d: FlagModule) in
   Format.fprintf fmt
     "\
-      Module \"%s\":@.  \
+      |===| Module \"%s\":@.\
         @[<v>%t@]@.\
         @[<v>%a@]@.\
     "
@@ -1446,7 +1450,7 @@ let fmt_module_info fmt (id, m0d) =
     Flags.fmt_explain
     (pp_print_list
       (fun fmt (key, _, desc) ->
-        Format.fprintf fmt "%s:@     %t" key desc)
+        Format.fprintf fmt "  %s:@       %t" key desc)
       "@ "
     ) (Flags.all_specs ())
 
@@ -1457,17 +1461,33 @@ status [0]. If some operators are undefined, exits with [2]. Does nothing if
 the list is empty. *)
 let print_module_info = function
 | [] -> ()
-| ids -> (
+| (hd :: tl) as ids -> (
+  Format.printf "%s@.@." usage_msg ;
   if List.mem "all" ids then (
     Format.printf
-      "%a@."
+      "%a"
       (pp_print_list fmt_module_info "@.@.")
       module_map
   ) else (
-    ids |> List.iter ( fun id ->
+    (
+      try (
+        let m0d = module_map |> List.assoc hd in
+        Format.printf "%a" fmt_module_info (hd, m0d)
+      ) with Not_found -> (
+        Format.printf
+          "Unknown module \"%s\", legal values are@.  all, %a@."
+          hd
+          (pp_print_list
+            (fun fmt (key,_) -> Format.fprintf fmt "%s" key)
+            ", "
+          ) module_map ;
+        exit 2
+      )
+    ) ;
+    tl |> List.iter ( fun id ->
       try (
         let m0d = module_map |> List.assoc id in
-        Format.printf "%a@." fmt_module_info (id, m0d)
+        Format.printf "@.%a" fmt_module_info (id, m0d)
       ) with Not_found -> (
         Format.printf
           "Unknown module \"%s\", legal values are@.  all, %a@."
@@ -1500,23 +1520,15 @@ module Global = struct
   let add_specs specs = all_specs := !all_specs @ specs
   let add_spec spec = add_specs [spec]
 
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
 
   (* Input flag. *)
   let input_file_default = None
   let input_file = ref input_file_default
   let set_input_file f = input_file := Some f
   let input_file () = !input_file
-
-
-  (* Version flag. *)
-  let check_version_default = false
-  let check_version = ref check_version_default
-  let _ = add_spec (
-    "--version",
-    Arg.Set check_version,
-    Format.sprintf "@.     Output version information and exit"
-  )
-  let check_version () = !check_version
 
 
   (* Explain modules. *)
@@ -1532,16 +1544,16 @@ module Global = struct
       "@.    \
         explains and shows the flags for a Kind 2 module among\
         @.      %a\
-        @.      %-15s: explaination and flags for all Kind 2 modules\
+        @.      %-15s explaination and flags for all Kind 2 modules\
       "
       (pp_print_list
         ( fun fmt (key, m0d) ->
           let module Flags = (val m0d: FlagModule) in
           Format.fprintf fmt
-            "%-15s: %s" (Format.sprintf "%s" key) Flags.desc
+            "%-15s %s" (Format.sprintf "%s" key) Flags.desc
         ) "@.      "
       ) module_map
-      "\"all\""
+      "all"
   )
   let flags_of () = !flags_of
 
@@ -1607,85 +1619,13 @@ module Global = struct
     Arg.Set_string output_dir,
     Format.sprintf
       "@.     \
-        output directory for the files generated:@.     \
+        Output directory for the files generated:@.     \
         SMT traces, compilation, testgen, certification...@.     \
         Default: \"%s\"\
       "
       output_dir_default
   )
   let output_dir () = !output_dir
-
-  (* Active debug sections. *)
-  let debug_default = []
-  let debug_ref = ref debug_default
-  let _ = add_spec (
-    "--debug",
-    Arg.String (fun str -> debug_ref := str :: !debug_ref),
-    Format.sprintf
-      "@.     \
-        enable debug output for a section, give one --debug option\
-        @.     for each section to be enabled\
-      "
-  )
-  let debug () = !debug_ref
-
-
-  (* Debug messages to file. *)
-  let debug_log_default = None
-  let debug_log = ref debug_log_default
-  let _ = add_spec (
-    "--debug-log",
-    Arg.String (fun str -> debug_log := Some str),
-    Format.sprintf
-      "@.     \
-        output debug messages to file@.     \
-        Default: stdout\
-      "
-  )
-  let debug_log () = ! debug_log
-
-
-  (* Log level. *)
-  let log_level_default = L_warn
-  let log_level = ref log_level_default
-  let _ = add_specs ([
-    ( "-qq",
-      Arg.Unit (fun () -> log_level := L_off),
-      Format.sprintf "@.     Disable output completely"
-    ) ;
-    ( "-q",
-      Arg.Unit (fun () -> log_level := L_fatal),
-      Format.sprintf "@.     Disable output, fatal errors only"
-    ) ;
-    ( "-s",
-      Arg.Unit (fun () -> log_level := L_error),
-      Format.sprintf "@.     Silence output, errors only"
-    ) ;
-    ( "-v",
-      Arg.Unit (fun () -> log_level := L_info),
-      Format.sprintf "@.     Output informational messages"
-    ) ;
-    ( "-vv",
-      Arg.Unit (fun () -> log_level := L_debug),
-      Format.sprintf "@.     Output informational and debug messages"
-    ) ;
-    ( "-vvv",
-      Arg.Unit (fun () -> log_level := L_trace),
-      Format.sprintf "@.     Output informational, debug and trace messages"
-    )
-  ])
-  let log_level () = !log_level
-
-
-  (* XML log. *)
-  let log_format_xml_default = false
-  let log_format_xml = ref log_format_xml_default
-  let _ = add_spec (
-    "-xml",
-    Arg.Set log_format_xml,
-    Format.sprintf "@.     Output in XML format"
-  )
-  let log_format_xml () = !log_format_xml
 
 
   (* Timeout. *)
@@ -1696,14 +1636,14 @@ module Global = struct
       Arg.Set_float timeout_wall,
       Format.sprintf
         "@.     \
-          wallclock timeout in seconds@.     \
+          Wallclock timeout in seconds@.     \
           Default: %1.f\
         "
         timeout_wall_default
     ) ;
     ( "--timeout_wall",
       Arg.Set_float timeout_wall,
-      Format.sprintf "@.     for legacy, same as \"--timeout\""
+      Format.sprintf "@.     Same as \"--timeout\" (here for legacy)"
     )
   ])
   let timeout_wall () = !timeout_wall
@@ -1792,10 +1732,9 @@ module Global = struct
     Format.sprintf
       "@.     \
         Disable Kind module@.     \
-        Available: %s@.     \
-        Default enabled: %s\
+        Available: %s\
       "
-      enable_values (string_of_enable enable_default_after)
+      enable_values
   )
   let disabled () = !disabled
 
@@ -1838,15 +1777,95 @@ module Global = struct
     Format.sprintf
       "@.     \
         Nodes proved correct will be compiled to Rust@.     \
-        Default: %b@ \
+        Default: %b\
       "
       lus_compile_default
   )
   let lus_compile () = !lus_compile
 
+  (* Active debug sections. *)
+  let debug_default = []
+  let debug_ref = ref debug_default
+  let _ = add_spec (
+    "--debug",
+    Arg.String (fun str -> debug_ref := str :: !debug_ref),
+    Format.sprintf
+      "@.     \
+        Enable debug output for a section, give one --debug option\
+        @.     for each section to be enabled\
+      "
+  )
+  let debug () = !debug_ref
 
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
+
+  (* Debug messages to file. *)
+  let debug_log_default = None
+  let debug_log = ref debug_log_default
+  let _ = add_spec (
+    "--debug-log",
+    Arg.String (fun str -> debug_log := Some str),
+    Format.sprintf
+      "@.     \
+        Output debug messages to file@.     \
+        Default: stdout\
+      "
+  )
+  let debug_log () = ! debug_log
+
+
+  (* Log level. *)
+  let log_level_default = L_warn
+  let log_level = ref log_level_default
+  let _ = add_specs ([
+    ( "-qq",
+      Arg.Unit (fun () -> log_level := L_off),
+      Format.sprintf " Disable output completely"
+    ) ;
+    ( "-q",
+      Arg.Unit (fun () -> log_level := L_fatal),
+      Format.sprintf "  Disable output, fatal errors only"
+    ) ;
+    ( "-s",
+      Arg.Unit (fun () -> log_level := L_error),
+      Format.sprintf "  Silence output, errors only"
+    ) ;
+    ( "-v",
+      Arg.Unit (fun () -> log_level := L_info),
+      Format.sprintf "  Output informational messages"
+    ) ;
+    ( "-vv",
+      Arg.Unit (fun () -> log_level := L_debug),
+      Format.sprintf " Output informational and debug messages"
+    ) ;
+    ( "-vvv",
+      Arg.Unit (fun () -> log_level := L_trace),
+      Format.sprintf "Output informational, debug and trace messages"
+    )
+  ])
+  let log_level () = !log_level
+
+
+  (* XML log. *)
+  let log_format_xml_default = false
+  let log_format_xml = ref log_format_xml_default
+  let _ = add_spec (
+    "-xml",
+    Arg.Set log_format_xml,
+    Format.sprintf "Output in XML format"
+  )
+  let log_format_xml () = !log_format_xml
+
+
+  (* Version flag. *)
+  let check_version_default = false
+  let check_version = ref check_version_default
+  let _ = add_spec (
+    "--version",
+    Arg.Set check_version,
+    Format.sprintf "Print version information and exit"
+  )
+  let check_version () = !check_version
+
 end
 
 (* Re-exports. *)
@@ -1889,45 +1908,15 @@ let subdir_for scope =
 (* Parsing of command-line options into flags                             *)
 (* ********************************************************************** *)
 
-let usage_msg = Filename.basename Sys.executable_name |> Format.sprintf "\
-  Usage: %s [options] <lustre_file>@.\
-  Prove properties in Lustre program <lustre_file>\
-"
+let rec help_action () =
+  Arg.Help (Arg.usage_string speclist global_usage_msg) |> raise
 
-let global_msg = "\
-  Global options follow, use \"--flags_of\" for module-specific information\
-"
-
-let rec help_action () = raise (Arg.Help (Arg.usage_string speclist usage_msg))
-
-and speclist = Global.all_specs ()
-  (* [
-
-    (* Display help *)
-    ("-help",
-     Arg.Unit help_action,
-     " Display this list of options") ;
-    ("--help",
-     Arg.Unit help_action,
-     "Display this list of options") ;
-    ("-h",
-     Arg.Unit help_action,
-     "Display this list of options")
-
-  ] @ *)
-(*   [
-    Interpreter.all_specs ;
-    C2I.all_specs ;
-    Contracts.all_specs ;
-    IC3.all_specs ;
-    Invgen.all_specs ;
-    BmcKind.all_specs ;
-    Smt.all_specs ;
-    Global.all_specs ;
-  ] |> List.fold_left (
-    fun l specs -> (specs ()) @ l
-  ) []
- *)
+and speclist =
+  ("--help", Arg.Unit help_action, "\\") ::
+  ("-help", Arg.Unit help_action, " | Display this list of options") ::
+  ("-h", Arg.Unit help_action, "    /") :: (
+    Global.all_specs ()
+  )
 
 let anon_action s =
   match Global.input_file () with
@@ -1972,7 +1961,7 @@ let set_smtsolver = function
 let parse_argv () =
 
   (* Parse command-line arguments *)
-  Arg.parse speclist anon_action usage_msg;
+  Arg.parse speclist anon_action global_usage_msg ;
 
   (* Output version information only? *)
   if Global.check_version () then (
@@ -1981,7 +1970,7 @@ let parse_argv () =
   ) ;
 
   (* If any module info was requested, print it and exit. *)
-  Global.flags_of () |> print_module_info ;
+  Global.flags_of () |> List.rev |> print_module_info ;
 
   (* Finalize the list of enabled module. *)
   Global.finalize_enabled () ;
@@ -1990,8 +1979,8 @@ let parse_argv () =
   match Global.input_file () with
   | None ->
     Format.printf
-      "%s: No input file given.@\n" Sys.argv.(0);
-    Arg.usage speclist usage_msg;
+      "%s: No input file given.@\n" Sys.argv.(0) ;
+    Arg.usage speclist usage_msg ;
     exit 2
   | Some _ -> ()
   

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -1544,7 +1544,7 @@ module Global = struct
       "@.    \
         explains and shows the flags for a Kind 2 module among\
         @.      %a\
-        @.      %-15s explaination and flags for all Kind 2 modules\
+        @.      %-15s explanation and flags for all Kind 2 modules\
       "
       (pp_print_list
         ( fun fmt (key, m0d) ->

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -6,17 +6,17 @@
    may not use this file except in compliance with the License.  You
    may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0 
+   http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
    implied. See the License for the specific language governing
-   permissions and limitations under the License. 
+   permissions and limitations under the License.
 
 *)
 
-(* WARNING: DO NOT EDIT THE .ML FILE --- CHANGES WILL BE OVERWRITTEN 
+(* WARNING: DO NOT EDIT THE .ML FILE --- CHANGES WILL BE OVERWRITTEN
 
    Do not edit the .ml file but rather the .ml.in file, the .ml file
    is generated from the .ml.in file after each run of the configure
@@ -34,15 +34,15 @@ type ('a, 'b) flag =
     mutable value : 'a;
     of_arg : 'a -> 'b -> 'a;
     pp : Format.formatter -> 'a -> unit }
-    
 
-type int_flag = (int, int) flag 
 
-type float_flag = (float, float) flag 
+type int_flag = (int, int) flag
+
+type float_flag = (float, float) flag
 
 type bool_flag = (bool, bool) flag
 
-type unit_flag = (unit, bool) flag 
+type unit_flag = (unit, bool) flag
 
 type 'a string_flag = ('a, string) flag
 
@@ -60,16 +60,16 @@ let smtsolver_of_string = function
   | "Yices" -> `Yices
   | _ -> raise (Invalid_argument "smtsolver_of_string")
 
-let pp_print_smtsolver ppf = 
-  let p = Format.fprintf ppf in 
-  function 
+let pp_print_smtsolver ppf =
+  let p = Format.fprintf ppf in
+  function
     | `Z3_SMTLIB -> p "Z3_SMTLIB"
     | `Z3_API -> p "Z3_API"
     | `CVC4_SMTLIB -> p "CVC4_SMTLIB"
     | `CVC4_API -> p "CVC4_API"
     | `Yices -> p "Yices"
 
-let smtsolver_flag = 
+let smtsolver_flag =
   { longname = "smtsolver";
     shortname = None;
     value = `Z3_SMTLIB;
@@ -86,8 +86,8 @@ let kind_module_of_string = function
   | _ -> raise (Invalid_argument "smtsolver_of_string")
 
 
-let pp_print_kind_module ppf = 
-  let p = Format.fprintf ppf in 
+let pp_print_kind_module ppf =
+  let p = Format.fprintf ppf in
   function
     | `IC3 -> p "IC3"
     | `BMC -> p "BMC"
@@ -96,7 +96,7 @@ let pp_print_kind_module ppf =
     | `Interpreter -> p "interpreter"
 
 
-let enable_flag = 
+let enable_flag =
   { longname = "enable";
     shortname = Some "e";
     value = [];
@@ -110,12 +110,12 @@ let enable_flag =
 (* Types and defaults for flags                                            *)
 (* ********************************************************************** *)
 
-(* TODO: write camlp4 code for this 
-  
+(* TODO: write camlp4 code for this
+
    type <X> = <X1> | <X2> arg <O> default <X2> action <F> doc <D>
-      
-   becomes 
-   
+  
+   becomes
+
    type <X> = <X1> | <X2>
 
    let <X>_of_string = function
@@ -123,7 +123,7 @@ let enable_flag =
      | "<X2>" -> <X2>
      | _ raise (Arg.bad "Bad value for -<O>")
 
-   let string_of_<X> = function 
+   let string_of_<X> = function
      | <X1> -> "<X1>"
      | <X2> -> "<X2>"
 
@@ -131,1539 +131,1200 @@ let enable_flag =
 
    let <X>_default = <X2>
 
-   let <O>_spec = 
-     ("-<O>", 
-      String <F>, 
+   let <O>_spec =
+     ("-<O>",
+      String <F>,
       Format.sprintf <D> <X>_values <X>_default)
 
 *)
-      
+  
 
 (*   type <X> = <X1> | <X2> arg <O> default <X2> action <F> doc <D> *)
 
 (*   type smtsolver = Z3_SMTLIB | CVC4_SMTLIB arg smtsolver default CVC4_SMTLIB action smtsolver_action doc " choose SMT solver (available: %s, default: %s" *)
-  
-(* ********** *)
-
-let timeout_wall_default = 0. 
-
-(* ********** *) 
-
-let timeout_virtual_default = 0. 
-
-(* ********** *) 
-
-type smtsolver = [ `Z3_SMTLIB | `CVC4_SMTLIB | `MathSat5_SMTLIB | `Yices_SMTLIB | `Yices_native | `detect ]
-    
-let smtsolver_of_string = function
-  | "Z3" -> `Z3_SMTLIB
-  | "CVC4" -> `CVC4_SMTLIB
-  | "MathSat5" -> `MathSat5_SMTLIB
-  | "Yices2" -> `Yices_SMTLIB
-  | "Yices" -> `Yices_native
-  | _ -> raise (Arg.Bad "Bad value for --smtsolver")
-
-let string_of_smtsolver = function 
-  | `Z3_SMTLIB -> "Z3"
-  | `CVC4_SMTLIB -> "CVC4"
-  | `Yices_SMTLIB -> "Yices2"
-  | `Yices_native -> "Yices"
-  | `MathSat5_SMTLIB -> "MathSat5"
-  | `detect -> "detect"
-
-let smtsolver_values = "Z3, CVC4, MathSat5, Yices, Yices2"
-
-let smtsolver_default = `detect
-
-(* ********** *) 
-
-type smtlogic = [ `None | `detect | `Logic of string ]
-
-let smtlogic_values = [ `None ; `detect ; `Logic ("\"logic\"") ]
-
-let smtlogic_of_string = function
-  | "none" | "None" -> `None
-  | "detect" | "Detect" -> `detect
-  | s -> `Logic s
-
-let string_of_smtlogic = function
-  | `None -> "none"
-  | `detect -> "detect"
-  | `Logic s -> s
-
-let smtlogic_default = `None
-
-(* ********** *) 
-
-type z3_bin = string 
-
-let z3_bin_of_string s = s
-
-let string_of_z3_bin s = s 
-
-let z3_bin_default = "z3"
-
-(* ********** *) 
-
-type smt_check_sat_assume = bool
-
-let smt_check_sat_assume_of_string s = s
-
-let string_of_smt_check_sat_assume s = s 
-
-let smt_check_sat_assume_default = true
-
-(* ********** *) 
-
-type smt_short_names = bool
-
-let smt_short_names_of_string s = s
-
-let string_of_smt_short_names s = s 
-
-let smt_short_names_default = true
-
-(* ********** *) 
-
-type cvc4_bin = string 
-
-let cvc4_bin_of_string s = s
-
-let string_of_cvc4_bin s = s 
-
-let cvc4_bin_default = "cvc4"
-
-(* ********** *) 
-
-type mathsat5_bin = string 
-
-let mathsat5_bin_of_string s = s
-
-let string_of_mathsat5_bin s = s 
-
-let mathsat5_bin_default = "mathsat"
-
-(* ********** *) 
-
-type yices_bin = string 
-
-let yices_bin_of_string s = s
-
-let string_of_yices_bin s = s 
-
-let yices_bin_default = "yices"
 
 
-(* ********** *) 
 
-type yices2smt2_bin = string 
+(* Global flags. *)
+module Global = struct
 
-let yices2smt2_bin_of_string s = s
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
 
-let string_of_yices2smt2_bin s = s 
 
-let yices2smt2_bin_default = "yices-smt2"
+  (* Input flag. *)
+  let input_file_default = None
+  let input_file = ref input_file_default
+  let set_input_file f = input_file := Some f
+  let input_file () = !input_file
 
-(* ********** *) 
 
-type smt_trace = bool
+  (* Version flag. *)
+  let check_version_default = false
 
-let smt_trace_default = false
+  let check_version = ref check_version_default
+  let _ = add_spec (
+    "--version",
+    Arg.Set check_version,
+    Format.sprintf "Output version information and exit"
+  )
+  let check_version () = !check_version
 
-(* ********** *) 
 
-(* type kind_module = [ `IC3 | `BMC | `IND | `INVGEN ] *)
+  (* Main lustre node. *)
+  let lus_main_of_string s = Some s
+  let string_of_lus_main = function
+    | None -> "(none)"
+    | Some s -> s
+  let lus_main_default = None
 
-type enable = kind_module list 
+  let lus_main = ref lus_main_default
+  let _ = add_spec (
+    "--lus_main",
+    Arg.String (fun str -> lus_main := Some str),
+    Format.sprintf
+      "Use the given node as top node in Lustre input \
+      (default: \"--%%MAIN\" annotation in source if any, last node otherwise)"
+  )
+  let lus_main () = !lus_main
 
-let kind_module_of_string = function
-  | "IC3" -> `IC3
-  | "BMC" -> `BMC
-  | "IND" -> `IND
-  | "IND2" -> `IND2
-  | "INVGEN" -> `INVGEN
-  | "INVGENOS" -> `INVGENOS
-  | "C2I" -> `C2I
-  | "interpreter" -> `Interpreter
-  | unexpected -> Arg.Bad (
+
+  (* Input format. *)
+  type input_format = [
+    `Lustre | `Horn | `Native
+  ]
+  let input_format_of_string = function
+    | "lustre" -> `Lustre
+    | "horn" -> `Horn
+    | "native" -> `Native
+    | _ -> raise (Arg.Bad "Bad value for --input-format")
+  let string_of_input_format = function
+    | `Lustre -> "lustre"
+    | `Horn -> "horn"
+    | `Native -> "native"
+  let input_format_values = [
+    `Lustre ; `Native
+  ] |> List.map string_of_input_format |> String.concat ", "
+  let input_format_default = `Lustre
+
+  let input_format = ref input_format_default
+  let _ = add_spec (
+    "--input-format",
+    Arg.String (fun str -> input_format := input_format_of_string str),
+    Format.sprintf
+      "Format of input file (available: %s, default: %s)"
+      input_format_values
+      (string_of_input_format input_format_default)
+  )
+  let input_format () = !input_format
+
+
+  (* Output directory. *)
+  let output_dir_default = "kind2"
+  let output_dir = ref output_dir_default
+  let _ = add_spec (
+    "--output_dir",
+    Arg.Set_string output_dir,
+    Format.sprintf
+      "output directory for SMT traces, compilation, testgen and \
+      certification (default: %s)"
+      output_dir_default
+  )
+  let output_dir () = !output_dir
+
+  (* Active debug sections. *)
+  let debug_default = []
+  let debug_ref = ref debug_default
+  let _ = add_spec (
+    "--debug",
+    Arg.String (fun str -> debug_ref := str :: !debug_ref),
+    Format.sprintf
+      "enable debug output for a section, give one --debug option \
+      for each section to be enabled"
+  )
+  let debug () = !debug_ref
+
+
+  (* Debug messages to file. *)
+  let debug_log_default = None
+  let debug_log = ref debug_log_default
+  let _ = add_spec (
+    "--debug-log",
+    Arg.String (fun str -> debug_log := Some str),
+    Format.sprintf "output debug messages to file (default: stdout)"
+  )
+  let debug_log () = ! debug_log
+
+
+  (* Log level. *)
+  let log_level_default = L_warn
+  let log_level = ref log_level_default
+  let _ = add_specs ([
+    ( "-qq",
+      Arg.Unit (fun () -> log_level := L_off),
+      Format.sprintf "Disable output completely"
+    ) ;
+    ( "-q",
+      Arg.Unit (fun () -> log_level := L_fatal),
+      Format.sprintf "Disable output, fatal errors only"
+    ) ;
+    ( "-s",
+      Arg.Unit (fun () -> log_level := L_error),
+      Format.sprintf "Silence output, errors only"
+    ) ;
+    ( "-v",
+      Arg.Unit (fun () -> log_level := L_info),
+      Format.sprintf "Output informational messages"
+    ) ;
+    ( "-vv",
+      Arg.Unit (fun () -> log_level := L_debug),
+      Format.sprintf "Output informational and debug messages"
+    ) ;
+    ( "-vvv",
+      Arg.Unit (fun () -> log_level := L_trace),
+      Format.sprintf "Output informational, debug and trace messages"
+    )
+  ])
+  let log_level () = !log_level
+
+
+  (* XML log. *)
+  let log_format_xml_default = false
+  let log_format_xml = ref log_format_xml_default
+  let _ = add_spec (
+    "-xml",
+    Arg.Set log_format_xml,
+    Format.sprintf "Output in XML format"
+  )
+  let log_format_xml () = !log_format_xml
+
+
+  (* Timeout. *)
+  let timeout_wall_default = 0.
+  let timeout_wall = ref timeout_wall_default
+  let _ = add_specs ([
+    ( "--timeout",
+      Arg.Set_float timeout_wall,
+      Format.sprintf
+        "wallclock timeout in seconds (default: %1.f)"
+        timeout_wall_default
+    ) ;
+    ( "--timeout_wall",
+      Arg.Set_float timeout_wall,
+      Format.sprintf "for legacy, same as \"--timeout\""
+    )
+  ])
+  let timeout_wall () = !timeout_wall
+
+
+  (* Modules enabled. *)
+  type enable = kind_module list
+  let kind_module_of_string = function
+    | "IC3" -> `IC3
+    | "BMC" -> `BMC
+    | "IND" -> `IND
+    | "IND2" -> `IND2
+    | "INVGEN" -> `INVGEN
+    | "INVGENOS" -> `INVGENOS
+    | "C2I" -> `C2I
+    | "interpreter" -> `Interpreter
+    | unexpected -> Arg.Bad (
       Format.sprintf "Unexpected value \"%s\" for flag --enable" unexpected
     ) |> raise
-
-let string_of_kind_module = function
-  | `IC3 -> "IC3"
-  | `BMC -> "BMC"
-  | `IND -> "IND"
-  | `IND2 -> "IND2"
-  | `INVGEN -> "INVGEN"
-  | `INVGENOS -> "INVGENOS"
-  | `C2I -> "C2I"
-  | `Interpreter -> "interpreter"
-
-let string_of_enable = function
-  | head :: tail ->
-    ( List.fold_left
+  let string_of_kind_module = function
+    | `IC3 -> "IC3"
+    | `BMC -> "BMC"
+    | `IND -> "IND"
+    | `IND2 -> "IND2"
+    | `INVGEN -> "INVGEN"
+    | `INVGENOS -> "INVGENOS"
+    | `C2I -> "C2I"
+    | `Interpreter -> "interpreter"
+  let string_of_enable = function
+    | head :: tail -> (
+      List.fold_left
         ( fun s m -> s ^ ", " ^ (string_of_kind_module m) )
         ("[" ^ (string_of_kind_module head))
-        tail )
-    ^ "]"
-  | [] -> "[]"
+        tail
+      ) ^ "]"
+    | [] -> "[]"
+  let enable_values = [
+    `IC3 ; `BMC ; `IND ; `IND2 ; `INVGEN ; `INVGENOS ; `C2I ; `Interpreter
+  ] |> List.map string_of_kind_module |> String.concat ", "
 
-let enable_values = [
-  `IC3 ; `BMC ; `IND ; `IND2 ; `INVGEN ; `INVGENOS ; `C2I ; `Interpreter
-] |> List.map string_of_kind_module |> String.concat ", "
+  let enable_default_init = []
+  let disable_default_init = []
 
-let enable_default_init = []
-let disable_default_init = []
+  let enable_default_after = [
+    `BMC ; `IND ; `IND2 ; `IC3 ; `INVGEN ; `INVGENOS
+  ]
+  let enabled = ref enable_default_init
+  let disabled = ref disable_default_init
+  let finalize_enabled () =
+    (* If [enabled] is unchanged, set it do default after init. *)
+    if !enabled = enable_default_init then (
+      enabled := enable_default_after
+    ) ;
+    (* Remove disabled modules. *)
+    enabled := !enabled |> List.filter (
+      fun mdl -> List.mem mdl !disabled |> not
+    )
+  let _ = add_spec (
+    "--enable",
+    Arg.String (
+      fun str ->
+        let mdl = kind_module_of_string str in
+        if List.mem mdl !enabled |> not
+        then enabled := mdl :: !enabled
+    ),
+    Format.sprintf
+      "enable Kind module (available: %s, default: %s)"
+      enable_values
+      (string_of_enable enable_default_after)
+  )
+  let enabled () = !enabled
 
-let enable_default_after = [ `BMC; `IND; `IND2; `IC3; `INVGEN; `INVGENOS ]
+  (* Modules disabled. *)
+  let _ = add_spec (
+    "--disable",
+    Arg.String (
+      fun str ->
+        let mdl = kind_module_of_string str in
+        if List.mem mdl !disabled |> not
+        then disabled := mdl :: !disabled
+    ),
+    Format.sprintf "disable Kind module (available: %s, default enabled: %s)"
+      enable_values (string_of_enable enable_default_after)
+  )
+  let disabled () = !disabled
 
-(* ********** *) 
 
-type check_version = bool
+  (* Modular mode. *)
+  let modular_default = false
+  let modular = ref modular_default
+  let _ = add_spec (
+    "--modular",
+    Arg.Bool (fun b -> modular := b),
+    Format.sprintf
+      "bottom-up analysis of each node (default: %B)"
+      modular_default
+  )
+  let modular () = !modular
 
-let check_version_default = false
 
-(* ********** *) 
+  (* Reject unguarded pre's in Lustre file. *)
+  let lus_strict_default = false
+  let lus_strict = ref lus_strict_default
+  let _ = add_spec (
+    "--lus_strict",
+    Arg.Bool (fun b -> lus_strict := b),
+    Format.sprintf
+      "Strict mode in Lustre: uninitialized pre and undefined \
+      local variables are not allowed when this flag is present."
+  )
+  let lus_strict () = !lus_strict
 
-type bmc_max = int
-    
-let bmc_max_default = 0
+  let lus_compile_default = false
+  let lus_compile = ref lus_compile_default
+  let _ = add_spec (
+    "--lus_compile",
+    Arg.Bool (fun b -> lus_compile := b),
+    Format.sprintf
+      "@[<v 7>@,(default: %b)@ \
+      Activates compiling to Rust, deactivates everything else.@]"
+      lus_compile_default
+  )
+  let lus_compile () = !lus_compile
 
-(* ********** *) 
 
-type bmc_check_unroll = bool
-    
-let bmc_check_unroll_default = true
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+end
+
+(* Re-exports. *)
+type enable = Global.enable
+type input_format = Global.input_format
+
+
+
+(* Options related to the underlying SMT solver. *)
+module Smt = struct
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  (* Active SMT solver. *)
+  type solver = [
+    | `Z3_SMTLIB
+    | `CVC4_SMTLIB
+    | `MathSat5_SMTLIB
+    | `Yices_SMTLIB
+    | `Yices_native
+    | `detect
+  ]
+  let solver_of_string = function
+    | "Z3" -> `Z3_SMTLIB
+    | "CVC4" -> `CVC4_SMTLIB
+    | "MathSat5" -> `MathSat5_SMTLIB
+    | "Yices2" -> `Yices_SMTLIB
+    | "Yices" -> `Yices_native
+    | _ -> Arg.Bad "Bad value for --smtsolver" |> raise
+  let string_of_solver = function
+    | `Z3_SMTLIB -> "Z3"
+    | `CVC4_SMTLIB -> "CVC4"
+    | `Yices_SMTLIB -> "Yices2"
+    | `Yices_native -> "Yices"
+    | `MathSat5_SMTLIB -> "MathSat5"
+    | `detect -> "detect"
+  let solver_values = "Z3, CVC4, MathSat5, Yices, Yices2"
+  let solver_default = `detect
+  let solver = ref solver_default
+  let _ = add_spec (
+    "--smtsolver",
+    Arg.String (fun str -> solver := solver_of_string str),
+    Format.sprintf
+      "choose SMT solver (available: %s, default: %s)"
+      solver_values
+      (string_of_solver solver_default)
+  )
+  let set_solver s = solver := s
+  let solver () = !solver
+
+  (* Active SMT logic. *)
+  type logic = [
+    `None | `detect | `Logic of string
+  ]
+  let logic_values = [
+    `None ; `detect ; `Logic ("\"logic\"")
+  ]
+  let logic_of_string = function
+    | "none" | "None" -> `None
+    | "detect" | "Detect" -> `detect
+    | s -> `Logic s
+  let string_of_logic = function
+    | `None -> "none"
+    | `detect -> "detect"
+    | `Logic s -> s
+  let logic_default = `None
+  let logic = ref logic_default
+  let _ = add_spec (
+    "--smtlogic",
+    Arg.String (fun str -> logic := logic_of_string str),
+    "select logic for SMT solvers (\"none\" for no logic (default), and \
+     \"detect\" to detect with the input system, other SMTLIB logics will be \
+     passed to the solver)"
+  )
+  let logic () = !logic
+
+  (* Activates check-sat with assumptions when supported. *)
+  let check_sat_assume_of_string s = s
+  let string_of_check_sat_assume s = s
+  let check_sat_assume_default = true
+  let check_sat_assume = ref check_sat_assume_default
+  let _ = add_spec (
+    "--smt_check_sat_assume",
+    Arg.Bool (fun b -> check_sat_assume := b),
+    Format.sprintf
+      "Use check-sat with assumptions, or simulate with push/pop \
+       when false (default: %B)"
+      check_sat_assume_default
+  )
+  let check_sat_assume () = !check_sat_assume
+
+  (* Use short name for variables at SMT level. *)
+  let short_names_of_string s = s
+  let string_of_short_names s = s
+  let short_names_default = true
+  let short_names = ref short_names_default
+  let _ = add_spec (
+    "--smt_short_names",
+    Arg.Bool (fun b -> short_names := b),
+    Format.sprintf
+      "Send short variables names to SMT solver, send full names if false \
+      (default: %B)"
+      short_names_default
+  )
+  let short_names () = !short_names
+
+  (* Z3 binary. *)
+  let z3_bin_of_string s = s
+  let string_of_z3_bin s = s
+  let z3_bin_default = "z3"
+  let z3_bin = ref z3_bin_default
+  let _ = add_spec (
+    "--z3_bin",
+    Arg.Set_string z3_bin,
+    Format.sprintf
+      "executable of Z3 solver (default: %s)"
+      (string_of_z3_bin z3_bin_default)
+  )
+  let set_z3_bin str = z3_bin := str
+  let z3_bin () = ! z3_bin
+
+  (* CVC4 binary. *)
+  let cvc4_bin_of_string s = s
+  let string_of_cvc4_bin s = s
+  let cvc4_bin_default = "cvc4"
+  let cvc4_bin = ref cvc4_bin_default
+  let _ = add_spec (
+    "--cvc4_bin",
+    Arg.Set_string cvc4_bin,
+    Format.sprintf
+      "executable of CVC4 solver (default: %s)"
+      (string_of_cvc4_bin cvc4_bin_default)
+  )
+  let set_cvc4_bin str = cvc4_bin := str
+  let cvc4_bin () = !cvc4_bin
+
+  (* Mathsat 5 binary. *)
+  let mathsat5_bin_of_string s = s
+  let string_of_mathsat5_bin s = s
+  let mathsat5_bin_default = "mathsat"
+  let mathsat5_bin = ref mathsat5_bin_default
+  let _ = add_spec (
+    "--mathsat5_bin",
+    Arg.Set_string mathsat5_bin,
+    Format.sprintf
+      "executable of MathSAT5 solver (default: %s)"
+      (string_of_mathsat5_bin mathsat5_bin_default)
+  )
+  let set_mathsat5_bin str = mathsat5_bin := str
+  let mathsat5_bin () = !mathsat5_bin
+
+  (* Yices binary. *)
+  let yices_bin_of_string s = s
+  let string_of_yices_bin s = s
+  let yices_bin_default = "yices"
+  let yices_bin = ref yices_bin_default
+  let _ = add_spec (
+    "--yices_bin",
+    Arg.Set_string yices_bin,
+    Format.sprintf
+      "executable of Yices solver (default: %s)"
+      (string_of_yices_bin yices_bin_default)
+  )
+  let set_yices_bin str = yices_bin := str
+  let yices_bin () = !yices_bin
+
+  (* Yices 2 binary. *)
+  let yices2smt2_bin_of_string s = s
+  let string_of_yices2smt2_bin s = s
+  let yices2smt2_bin_default = "yices-smt2"
+  let yices2smt2_bin = ref yices2smt2_bin_default
+  let _ = add_spec (
+    "--yices2_bin",
+    Arg.Set_string yices2smt2_bin,
+    Format.sprintf
+      "executable of Yices2 SMT2 solver (default: %s)"
+      (string_of_yices2smt2_bin yices2smt2_bin_default)
+  )
+  let set_yices2smt2_bin str = yices2smt2_bin := str
+  let yices2smt2_bin () = !yices2smt2_bin
+
+  (* Activates logging of SMT interactions. *)
+  let trace_default = false
+  let trace = ref trace_default
+  let _ = add_spec (
+    "--smt_trace",
+    Arg.Set trace,
+    Format.sprintf "Write all SMT commands to files"
+  )
+  let trace () = !trace
+
+  (* Folder to log the SMT traces into. *)
+  let trace_dir () =
+    Global.output_dir () |> mk_dir ;
+    let dir = Global.output_dir () |> Format.sprintf "%s/smt_trace" in
+    mk_dir dir ;
+    dir
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+end
+
+
+
+
+(* BMC and k-induction flags. *)
+module BmcKind = struct
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let max_default = 0
+  let max = ref max_default
+  let _ = add_spec (
+    "--unroll_max",
+    Arg.Set_int max,
+    Format.sprintf
+      "(BMC, IND) Maximal number of iterations (default: %d, unlimited: 0)"
+      max_default
+  )
+  let max () = !max
+
+  let check_unroll_default = true
+  let check_unroll = ref check_unroll_default
+  let _ = add_spec (
+    "--bmc_check_unroll",
+    Arg.Bool (fun b -> check_unroll := b),
+    Format.sprintf
+      "(BMC) Check that the unrolling alone is satisfiable (default: %b)"
+      check_unroll_default
+  )
+  let check_unroll () = !check_unroll
+
+  let print_cex_default = false
+  let print_cex = ref print_cex_default
+  let _ = add_spec (
+    "--ind_print_cex",
+    Arg.Bool (fun b -> print_cex := b),
+    Format.sprintf
+      "(IND) Print counterexamples to induction (default: %b)"
+      print_cex_default
+  )
+  let print_cex () = !print_cex
+
+  let compress_default = true
+  let compress = ref compress_default
+  let _ = add_spec (
+    "--ind_compress",
+    Arg.Bool (fun b -> compress := b),
+    Format.sprintf
+      "(IND) Compress inductive counterexamples (default: %B)"
+      compress_default
+  )
+  let compress () = !compress
+
+  let compress_equal_default = true
+  let compress_equal = ref compress_equal_default
+  let _ = add_spec (
+    "--ind_compress_equal",
+    Arg.Bool (fun b -> compress_equal := b),
+    Format.sprintf
+      "(IND) Compress inductive counterexamples for states equal \
+      modulo inputs (default: %B)"
+      compress_equal_default
+  )
+  let compress_equal () = !compress_equal
+
+  let compress_same_succ_default = false
+  let compress_same_succ = ref compress_same_succ_default
+  let _ = add_spec (
+    "--ind_compress_same_succ",
+    Arg.Bool (fun b -> compress_same_succ := b),
+    Format.sprintf
+      "(IND) Compress inductive counterexamples for states \
+      with same successors (default: %B)"
+      compress_same_succ_default
+  )
+  let compress_same_succ () = !compress_same_succ
+
+  let compress_same_pred_default = false
+  let compress_same_pred = ref compress_same_pred_default
+  let _ = add_spec (
+  "--ind_compress_same_pred",
+    Arg.Bool (fun b -> compress_same_pred := b),
+    Format.sprintf
+      "(IND) Compress inductive counterexamples for states \
+      with same predecessors (default: %B)"
+      compress_same_pred_default
+  )
+  let compress_same_pred () = !compress_same_pred
+
+  let lazy_invariants_default = false
+  let lazy_invariants = ref lazy_invariants_default
+  let _ = add_spec (
+    "--ind_lazy_invariants",
+    Arg.Bool (fun b -> lazy_invariants := b),
+    Format.sprintf
+      "(IND) Asserts invariants lazily (default: %B)"
+      lazy_invariants_default
+  )
+  let lazy_invariants () = !lazy_invariants
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+end
+
+
+
+(* IC3 flags. *)
+module IC3 = struct
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let string_of_check_inductive = string_of_bool
+  let check_inductive_default = true
+  let check_inductive = ref check_inductive_default
+  let _ = add_spec (
+    "--ic3_check_inductive",
+    Arg.Bool (fun b -> check_inductive := b),
+    Format.sprintf
+      "(IC3) Check inductiveness of blocking clauses (default: %s)"
+      (string_of_check_inductive check_inductive_default)
+  )
+  let check_inductive () = !check_inductive
+
+  let print_to_file_default = None
+  let print_to_file = ref print_to_file_default
+  let _ = add_spec (
+    "--ic3_print_to_file",
+    Arg.String (fun str -> print_to_file := Some str),
+    Format.sprintf
+      "(IC3) Output file for blocking clauses (default: stdout)"
+  )
+  let print_to_file () = !print_to_file
+
+  let string_of_inductively_generalize = string_of_int
+  let inductively_generalize_default = 1
+  let inductively_generalize = ref inductively_generalize_default
+  let _ = add_spec (
+    "--ic3_inductively_generalize",
+    Arg.Set_int inductively_generalize,
+    Format.sprintf
+      "(IC3) Inductively generalize blocking clauses before forward \
+      propagation (0 = none, 1 = normal IG, 2 = IG with ordering) \
+      (default: %s)"
+      (string_of_inductively_generalize inductively_generalize_default)
+  )
+  let inductively_generalize () = !inductively_generalize
+
+  let string_of_block_in_future = string_of_bool
+  let block_in_future_default = true
+  let block_in_future = ref block_in_future_default
+  let _ = add_spec (
+    "--ic3_block_in_future",
+    Arg.Bool (fun b -> block_in_future := b),
+    Format.sprintf
+      "(IC3) Block counterexample in future frames (default: %s)"
+      (string_of_block_in_future block_in_future_default)
+  )
+  let block_in_future () = !block_in_future
+
+  let string_of_block_in_future_first = string_of_bool
+  let block_in_future_first_default = true
+  let block_in_future_first = ref block_in_future_first_default
+  let _ = add_spec (
+    "--ic3_block_in_future_first",
+    Arg.Bool (fun b -> block_in_future_first := b),
+    Format.sprintf
+      "(IC3) Block counterexample in future frames first before returning to \
+      frame (default: %s)"
+      (string_of_block_in_future_first block_in_future_first_default)
+  )
+  let block_in_future_first () = !block_in_future_first
+
+  let string_of_fwd_prop_non_gen = string_of_bool
+  let fwd_prop_non_gen_default = true
+  let fwd_prop_non_gen = ref fwd_prop_non_gen_default
+  let _ = add_spec (
+    "--ic3_fwd_prop_non_gen",
+    Arg.Bool (fun b -> fwd_prop_non_gen := b),
+    Format.sprintf
+      "(IC3) Also propagate clauses before generalization (default: %s)"
+      (string_of_fwd_prop_non_gen fwd_prop_non_gen_default)
+  )
+  let fwd_prop_non_gen () = !fwd_prop_non_gen
+
+  let string_of_fwd_prop_ind_gen = string_of_bool
+  let fwd_prop_ind_gen_default = true
+  let fwd_prop_ind_gen = ref fwd_prop_ind_gen_default
+  let _ = add_spec (
+    "--ic3_fwd_prop_ind_gen",
+    Arg.Bool (fun b -> fwd_prop_ind_gen := b),
+    Format.sprintf
+      "(IC3) Inductively generalize all clauses after forward propagation \
+      (default: %s)"
+      (string_of_fwd_prop_ind_gen fwd_prop_ind_gen_default)
+  )
+  let fwd_prop_ind_gen () = !fwd_prop_ind_gen
+
+  let string_of_fwd_prop_subsume = string_of_bool
+  let fwd_prop_subsume_default = true
+  let fwd_prop_subsume = ref fwd_prop_subsume_default
+  let _ = add_spec (
+    "--ic3_fwd_prop_subsume",
+    Arg.Bool (fun b -> fwd_prop_subsume := b),
+    Format.sprintf
+      "(IC3) Subsumption in forward propagation (default: %s)"
+      (string_of_fwd_prop_subsume fwd_prop_subsume_default)
+  )
+  let fwd_prop_subsume () = !fwd_prop_subsume
+
+  let string_of_use_invgen = string_of_bool
+  let use_invgen_default = true
+  let use_invgen = ref use_invgen_default
+  let _ = add_spec (
+    "--ic3_use_invgen",
+    Arg.Bool (fun b -> use_invgen := b),
+    Format.sprintf
+      "(IC3) Use invariants from invariant generators (default: %s)"
+      (string_of_use_invgen use_invgen_default)
+  )
+  let use_invgen () = !use_invgen
+
+  type qe = [
+    `Z3 | `Z3_impl | `Z3_impl2 | `Cooper
+  ]
+  let qe_of_string = function
+    | "Z3" -> `Z3
+    | "Z3-impl" -> `Z3_impl
+    | "Z3-impl2" -> `Z3_impl2
+    | "cooper" -> `Cooper
+    | _ -> raise (Arg.Bad "Bad value for --ic3_qe")
+  let string_of_qe = function
+    | `Z3 -> "Z3"
+    |  `Z3_impl -> "Z3-impl"
+    |  `Z3_impl2 -> "Z3-impl2"
+    | `Cooper -> "cooper"
+  let qe_values = [
+    `Z3 ; `Z3_impl ; `Z3_impl2 ; `Cooper
+  ] |> List.map string_of_qe |> String.concat ", "
+  let qe_default = `Cooper
+  let qe = ref qe_default
+  let _ = add_spec (
+    "--ic3_qe",
+    Arg.String (fun str -> qe := qe_of_string str),
+    Format.sprintf
+      "(IC3) choose quantifier elimination algorithm \
+      (available: %s, default: %s)"
+      qe_values (string_of_qe qe_default)
+  )
+  let set_qe q = qe := q
+  let qe () = !qe
+
+  type extract = [ `First | `Vars ]
+  let extract_of_string = function
+    | "first" -> `First
+    | "vars" -> `Vars
+    | _ -> raise (Arg.Bad "Bad value for --ic3_extract")
+  let string_of_extract = function
+    | `First -> "first"
+    | `Vars -> "vars"
+  let extract_values = [
+    `First ; `Vars
+  ] |> List.map string_of_extract |> String.concat ", "
+  let extract_default = `First
+  let extract = ref extract_default
+  let _ = add_spec (
+    "--ic3_extract",
+    Arg.String (fun str -> extract := extract_of_string str),
+    Format.sprintf
+      "(IC3) Heuristics for extraction of implicant \
+      (available: %s, default: %s)"
+      extract_values (string_of_extract extract_default)
+  )
+  let extract () = !extract
+
+  type abstr = [ `None | `IA ]
+  let abstr_of_string = function
+    | "None" -> `None
+    | "IA" -> `IA
+    | _ -> raise (Arg.Bad "Bad value for --ic3_abstr")
+  let string_of_abstr = function
+    | `IA -> "IA"
+    | `None -> "None"
+  let abstr_values = [
+    `None ; `IA
+  ] |> List.map string_of_abstr |> String.concat ", "
+  let abstr_default = `None
+  let abstr = ref abstr_default
+  let _ = add_spec (
+    "--ic3_abstr",
+    Arg.String (fun str -> abstr := abstr_of_string str),
+    Format.sprintf
+      "(IC3) choose method of abstraction in IC3 (available: %s, default: %s)"
+      abstr_values (string_of_abstr abstr_default)
+  )
+  let abstr () = !abstr
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+end
+
+
+(* Quantifier elimination module. *)
+module QE = struct
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let cooper_order_var_by_elim_default = false
+  let cooper_order_var_by_elim = ref cooper_order_var_by_elim_default
+  let _ = add_spec (
+    "--cooper_order_var_by_elim",
+    Arg.Bool (fun b -> cooper_order_var_by_elim := b),
+    Format.sprintf
+      "(Cooper QE) Order variables in polynomials by order of \
+      elimination (default: %B)"
+      cooper_order_var_by_elim_default
+  )
+  let cooper_order_var_by_elim () = !cooper_order_var_by_elim
+
+  let cooper_general_lbound_default = false
+  let cooper_general_lbound = ref cooper_general_lbound_default
+  let _ = add_spec (
+    "--cooper_general_lbound",
+    Arg.Bool (fun b -> cooper_general_lbound := b),
+    Format.sprintf
+      "(Cooper QE) Choose lower bounds containing variables \
+      (default: %B)"
+      cooper_general_lbound_default
+  )
+  let cooper_general_lbound () = !cooper_general_lbound
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+end
+
+
+
+
+(* Contracts flags. *)
+module Contracts = struct
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let compositional_default = false
+  let compositional = ref compositional_default
+  let _ = add_spec (
+    "--compositional",
+    Arg.Bool (fun b -> compositional := b),
+    Format.sprintf
+      "abstract subnodes with a contract (default: %B)"
+      compositional_default
+  )
+  let compositional () = !compositional
+
+  let check_modes_default = true
+  let check_modes = ref check_modes_default
+  let _ = add_spec (
+    "--check_modes",
+    Arg.Bool (fun b -> check_modes := b),
+    Format.sprintf
+      "checks the modes of a contracts are exhaustive \
+      (default: %B, setting to `false` automatically activates `check_implem`)"
+      check_modes_default
+  )
+  let check_modes () = !check_modes
+
+  let check_implem_default = true
+  let check_implem = ref check_implem_default
+  let _ = add_spec (
+    "--check_implem",
+    Arg.Bool (fun b -> check_implem := b),
+    Format.sprintf
+      "checks the implementation of nodes \
+      (default: %B, setting to `false` automatically activates `check_modes`)"
+      check_implem_default
+  )
+  let check_implem () = !check_implem
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+end
+
+
+
+(* Testgen flags. *)
+module Testgen = struct
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let active_default = false
+  let active = ref active_default
+  let _ = add_spec (
+    "--testgen",
+    Arg.Bool (fun b -> active := b),
+    Format.sprintf
+      "@[<v 7>@,(default: %b)@ \
+      Activates test generation, deactivates everything else.@]"
+      active_default
+  )
+  let active () = !active
+
+  let graph_only_default = false
+  let graph_only = ref graph_only_default
+  let _ = add_spec (
+    "--testgen_graph_only",
+    Arg.Bool (fun b -> graph_only := b),
+    Format.sprintf
+     "@[<v 7>@,(default: %b)@ \
+     Only draw the graph of reachable modes, do not log testcases.@ \
+     Does log errors.@]"
+     graph_only_default
+  )
+  let graph_only () = !graph_only
+
+  let len_default = 5
+  let len = ref len_default
+  let _ = add_spec (
+    "--testgen_len",
+    Arg.Set_int len,
+    Format.sprintf
+      "@[<v 7>@,(default: %d)@ \
+      Maximimum length for test generation.@]"
+      len_default
+  )
+  let len () = !len
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+end
+
+
+(* Invgen flags. *)
+module Invgen = struct
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let prune_trivial_default = true
+  let prune_trivial = ref prune_trivial_default
+  let _ = add_spec (
+    "--invgen_prune_trivial",
+    Arg.Bool (fun b -> prune_trivial := b),
+    Format.sprintf
+      "Invariant generation will communicate invariants not implied by the \
+      transition relation (default: %B)."
+      prune_trivial_default
+  )
+  let prune_trivial () = !prune_trivial
+
+  let max_succ_default = 1
+  let max_succ = ref max_succ_default
+  let _ = add_spec (
+    "--invgen_max_succ",
+    Arg.Int (fun b -> max_succ := b),
+    Format.sprintf
+      "Maximal number of successive iterations for subsystems (default: %d)."
+      max_succ_default
+  )
+  let max_succ () = !max_succ
+
+  let lift_candidates_default = false
+  let lift_candidates = ref lift_candidates_default
+  let _ = add_spec (
+    "--invgen_lift_candidates",
+    Arg.Bool (fun b -> lift_candidates := b),
+    Format.sprintf
+      "Invariant generation will instantiate candidates from sub-nodes\
+      (default: %B)."
+      lift_candidates_default
+  )
+  let lift_candidates () = !lift_candidates
+
+  let top_only_default = false
+  let top_only = ref top_only_default
+  let _ = add_spec (
+    "--invgen_top_only",
+    Arg.Bool (fun b -> top_only := b),
+    Format.sprintf
+      "Only generate invariants for the top level\
+      (default: %B)."
+      top_only_default
+  )
+  let top_only () = !top_only
+
+  let mine_trans_default = true
+  let mine_trans = ref mine_trans_default
+  let _ = add_spec (
+    "--invgen_mine_trans",
+    Arg.Bool (fun b -> mine_trans := b),
+    Format.sprintf
+      "Invariant generation will extract candidate terms from the transition \
+      predicate (default: %B)."
+      mine_trans_default
+  )
+  let mine_trans () = !mine_trans
+
+  let renice_default = 0
+  let renice = ref renice_default
+  let _ = add_spec (
+    "--invgen_renice",
+    Arg.Set_int renice,
+    "Renice invariant generation process. Give a positive argument to lower \
+    priority."
+  )
+  let renice () = !renice
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+end
+
+
+(* C2I flags. *)
+module C2I = struct
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let dnf_size_default = 3
+  let dnf_size = ref dnf_size_default
+  let _ = add_spec (
+    "--c2i_dnf",
+    Arg.Set_int dnf_size,
+    Format.sprintf
+      "Number of disjuncts in the DNF constructed by C2I (default %d)."
+      dnf_size_default
+  )
+  let dnf_size () = !dnf_size
+
+  let int_cube_size_default = 3
+  let int_cube_size = ref int_cube_size_default
+  let _ = add_spec (
+    "--c2i_int_cubes",
+    Arg.Set_int int_cube_size,
+    Format.sprintf
+      "Number of int cubes in the DNF constructed by C2I (default %d)."
+      int_cube_size_default
+  )
+  let int_cube_size () = !int_cube_size
+
+  let real_cube_size_default = 3
+  let real_cube_size = ref real_cube_size_default
+  let _ = add_spec (
+    "--c2i_real_cubes",
+    Arg.Set_int real_cube_size,
+    Format.sprintf
+      "Number of real cubes in the DNF constructed by C2I (default %d)."
+      real_cube_size_default
+  )
+  let real_cube_size () = !real_cube_size
+
+  let modes_default = true
+  let modes = ref modes_default
+  let _ = add_spec (
+    "--c2i_modes",
+    Arg.Bool (fun b -> modes := b),
+    Format.sprintf
+      "Activates mode subcandidates. Subsumes c2i_dnf_size (default %b)."
+      modes_default
+  )
+  let modes () = !modes
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+end
+
+
+(* Interpreter flags. *)
+module Interpreter = struct
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let input_file_default = ""
+  let input_file = ref input_file_default
+  let _ = add_spec (
+    "--interpreter_input_file",
+    Arg.Set_string input_file,
+    Format.sprintf "(Interpreter) Read input from file"
+  )
+  let input_file () = !input_file
+
+  let steps_default = 0
+  let steps = ref steps_default
+  let _ = add_spec (
+    "--interpreter_steps",
+    Arg.Set_int steps,
+    Format.sprintf
+      "(Interpreter) Run number of steps, override the number of \
+      steps given in the input file (default: %d)"
+      steps_default
+  )
+  let steps () = !steps
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+end
 
 (* ********** *)
-
-type ind_print_cex = bool
-let ind_print_cex_default = false
-
-(* ********** *)
-
-type ind_compress = bool
-    
-let ind_compress_default = true
-
-(* ********** *) 
-
-type ind_compress_equal = bool
-    
-let ind_compress_equal_default = true
-
-(* ********** *) 
-
-type ind_compress_same_succ = bool
-    
-let ind_compress_same_succ_default = false
-
-(* ********** *) 
-
-type ind_compress_same_pred = bool
-    
-let ind_compress_same_pred_default = false
-
-(* ********** *) 
-
-type ind_lazy_invariants = bool
-    
-let ind_lazy_invariants_default = false
-
-(* ********** *) 
-
-type strict = bool
-
-let strict_default = false
-
-(* ********** *) 
-
-type ic3_check_inductive = bool
-    
-let string_of_ic3_check_inductive = string_of_bool
-
-let ic3_check_inductive_default = true
-
-(* ********** *) 
-
-type ic3_print_to_file = string option
-    
-let ic3_print_to_file_default = None
-
-(* ********** *) 
-
-type ic3_inductively_generalize = int
-    
-let string_of_ic3_inductively_generalize = string_of_int
-
-let ic3_inductively_generalize_default = 1
-
-(* ********** *) 
-
-type ic3_block_in_future = bool
-    
-let string_of_ic3_block_in_future = string_of_bool
-
-let ic3_block_in_future_default = true
-
-(* ********** *) 
-
-type ic3_block_in_future_first = bool
-    
-let string_of_ic3_block_in_future_first = string_of_bool
-
-let ic3_block_in_future_first_default = true
-
-(* ********** *) 
-
-type ic3_fwd_prop_non_gen = bool
-    
-let string_of_ic3_fwd_prop_non_gen = string_of_bool
-
-let ic3_fwd_prop_non_gen_default = true
-
-(* ********** *) 
-
-type ic3_fwd_prop_ind_gen = bool
-    
-let string_of_ic3_fwd_prop_ind_gen = string_of_bool
-
-let ic3_fwd_prop_ind_gen_default = true
-
-(* ********** *) 
-
-type ic3_fwd_prop_subsume = bool
-    
-let string_of_ic3_fwd_prop_subsume = string_of_bool
-
-let ic3_fwd_prop_subsume_default = true
-
-(* ********** *) 
-
-type ic3_use_invgen = bool
-    
-let string_of_ic3_use_invgen = string_of_bool
-
-let ic3_use_invgen_default = true
-
-(* ********** *) 
-
-type ic3_qe = [ `Z3 | `Z3_impl | `Z3_impl2 | `Cooper ]
-    
-let ic3_qe_of_string = function
-  | "Z3" -> `Z3
-  | "Z3-impl" -> `Z3_impl
-  | "Z3-impl2" -> `Z3_impl2
-  | "cooper" -> `Cooper
-  | _ -> raise (Arg.Bad "Bad value for --ic3_qe")
-
-let string_of_ic3_qe = function 
-  | `Z3 -> "Z3"
-  |  `Z3_impl -> "Z3-impl"
-  |  `Z3_impl2 -> "Z3-impl2"
-  | `Cooper -> "cooper"
-
-let ic3_qe_values = "Z3, Z3-impl, Z3-impl-2, cooper"
-
-let ic3_qe_default = `Cooper
-
-(* ********** *) 
-
-type ic3_extract = [ `First | `Vars ]
-    
-let ic3_extract_of_string = function
-  | "first" -> `First
-  | "vars" -> `Vars
-  | _ -> raise (Arg.Bad "Bad value for --ic3_extract")
-
-let string_of_ic3_extract = function 
-  | `First -> "first"
-  | `Vars -> "vars"
-
-let ic3_extract_values = "first, vars"
-
-let ic3_extract_default = `First
-
-
-(* ********** *) 
-
-type ic3_abstr = [ `None | `IA ] 
-
-let ic3_abstr_of_string = function
-| "None" -> `None
-| "IA" -> `IA
-| _ -> raise (Arg.Bad "Bad value for --ic3_abstr")
-
-let string_of_ic3_abstr = function
-| `IA -> "IA"
-| `None -> "None"
-
-let ic3_abstr_values = "IA, None"
-
-let ic3_abstr_default = `None
-
-(* ********** *)
-
-type modular = bool
-let modular_values = "true, false"
-let modular_default = false
-
-type compositional = bool
-let compositional_values = "true, false"
-let compositional_default = false
-
-type output_dir = string
-let output_dir_default = "kind2"
-
-type skip_verif = bool
-let skip_verif_default = false
-
-type check_modes = bool
-let check_modes_values = "true, false"
-let check_modes_default = true
-
-type check_implem = bool
-let check_implem_values = "true, false"
-let check_implem_default = true
-
-(* ********** *) 
- 
-type cooper_order_var_by_elim = bool 
-     
-let cooper_order_var_by_elim_values = "true, false"
- 
-let cooper_order_var_by_elim_default = false
- 
-(* ********** *) 
- 
-type cooper_general_lbound = bool
-     
-let cooper_general_lbound_values = "true, false"
- 
-let cooper_general_lbound_default = false
-
-
-(* ********** *)
-
-(* Testgen things. *)
-
-type testgen_active = bool
-let testgen_active_default = false
-
-type testgen_graph_only = bool
-let testgen_graph_only_default = false
-
-type testgen_lustrec = string option
-let testgen_lustrec_default = None
-
-type testgen_len = int
-let testgen_len_default = 5
-
-
-(* ********** *)
-
-(* Compiling to Rust things. *)
-
-type compile = bool
-let compile_default = false
-
-
-(* ********** *)
-
-(* INVGEN things. *)
-
-type invgengraph_prune_trivial = bool
-
-let invgengraph_prune_trivial_default = true
-
-type invgengraph_max_succ = int
-
-let invgengraph_max_succ_default = 1
-
-type invgengraph_lift_candidates = bool
-
-let invgengraph_lift_candidates_default = false
-
-type invgengraph_top_only = bool
-
-let invgengraph_top_only_default = false
-
-type invgengraph_mine_trans = bool
-
-let invgengraph_mine_trans_default = true
-
-type invgengraph_renice = int
-
-let invgengraph_renice_default = 0
-
-
-(* ********** *)
-
-(* C2I things. *)
-
-type c2i_dnf_size = int
-let c2i_dnf_size_default = 3
-
-type c2i_int_cube_size = int
-let c2i_int_cube_size_default = 3
-
-type c2i_real_cube_size = int
-let c2i_real_cube_size_default = 3
-
-type c2i_modes = bool
-let c2i_modes_default = true
-
-(* ********** *) 
-
-type interpreter_input_file = string 
-
-let interpreter_input_file_of_string s = s
-
-let string_of_interpreter_input_file s = s 
-
-let interpreter_input_file_default = ""
-
-(* ********** *) 
-
-type interpreter_steps = int 
-
-let interpreter_steps_default = 0
-
-(* ********** *) 
-
-type input_format = [ `Lustre | `Horn | `Native ]
-    
-let input_format_of_string = function
-  | "lustre" -> `Lustre
-  | "horn" -> `Horn
-  | "native" -> `Native
-  | _ -> raise (Arg.Bad "Bad value for --input-format")
-
-let string_of_input_format = function 
-  | `Lustre -> "lustre"
-  | `Horn -> "horn"
-  | `Native -> "native"
-
-let input_format_values = "lustre, native"
-
-let input_format_default = `Lustre
-
-(* ********** *) 
-
-type lustre_main = string option
-
-let lustre_main_of_string s = Some s
-
-let string_of_lustre_main = function None -> "(none)" | Some s -> s
-
-let lustre_main_default = None
-
-(* ********** *) 
-
-type lustre_flatten_arrays = bool
-
-let string_of_lustre_flatten_arrays = string_of_bool
-
-let lustre_flatten_arrays_default = false
-
-(* ********** *) 
-
-let debug_default = []
-
-(* ********** *) 
-
-let debug_log_default = None
-
-(* ********** *) 
-
-let log_level_default = L_warn
-
-(* ********** *) 
-
-let log_format_xml_default = false
-
-(* ********** *) 
 
 (* All flags *)
-type flags = 
-  { mutable timeout_wall : float;
-    mutable timeout_virtual : float;
-    mutable smtsolver : smtsolver;
-    mutable smtlogic : smtlogic;
-    mutable z3_bin : z3_bin;
-    mutable smt_check_sat_assume : smt_check_sat_assume;
-    mutable smt_short_names : smt_short_names;
-    mutable cvc4_bin : cvc4_bin;
-    mutable mathsat5_bin : mathsat5_bin;
-    mutable yices_bin : yices_bin;
-    mutable yices2smt2_bin : yices2smt2_bin;
-    mutable smt_trace : smt_trace;
-    mutable enable : enable ;
-    mutable disable : enable ;
-    mutable check_version : check_version;
-    mutable bmc_max : bmc_max;
-    mutable bmc_check_unroll : bmc_check_unroll;
-    mutable ind_print_cex : ind_print_cex;
-    mutable ind_compress : ind_compress;
-    mutable ind_compress_equal : ind_compress_equal;
-    mutable ind_compress_same_succ : ind_compress_same_succ;
-    mutable ind_compress_same_pred : ind_compress_same_pred;
-    mutable ind_lazy_invariants : ind_lazy_invariants;
-    mutable ic3_qe : ic3_qe;
-    mutable ic3_extract : ic3_extract;
-    mutable ic3_check_inductive : ic3_check_inductive;
-    mutable ic3_print_to_file : ic3_print_to_file;
-    mutable ic3_inductively_generalize : ic3_inductively_generalize;
-    mutable ic3_block_in_future : ic3_block_in_future;
-    mutable ic3_block_in_future_first : ic3_block_in_future_first;
-    mutable ic3_fwd_prop_non_gen : ic3_fwd_prop_non_gen;
-    mutable ic3_fwd_prop_ind_gen : ic3_fwd_prop_ind_gen;
-    mutable ic3_fwd_prop_subsume : ic3_fwd_prop_subsume;
-    mutable ic3_use_invgen : ic3_use_invgen;
-    mutable ic3_abstr : ic3_abstr;
-    mutable modular : modular;
-    mutable compositional : compositional;
-    mutable output_dir : output_dir;
-    mutable skip_verif : skip_verif;
-    mutable check_modes : check_modes ;
-    mutable check_implem : check_implem ;
-    mutable cooper_order_var_by_elim : cooper_order_var_by_elim;
-    mutable cooper_general_lbound : cooper_general_lbound;
-    mutable testgen_active : testgen_active;
-    mutable testgen_graph_only : testgen_graph_only;
-    mutable testgen_lustrec : testgen_lustrec;
-    mutable testgen_len : testgen_len;
-    mutable compile : compile ;
-    mutable invgengraph_prune_trivial : invgengraph_prune_trivial;
-    mutable invgengraph_max_succ : invgengraph_max_succ;
-    mutable invgengraph_lift_candidates : invgengraph_lift_candidates;
-    mutable invgengraph_top_only : invgengraph_top_only;
-    mutable invgengraph_mine_trans : invgengraph_mine_trans;
-    mutable invgengraph_renice : invgengraph_renice;
-    mutable c2i_dnf_size : c2i_dnf_size;
-    mutable c2i_int_cube_size : c2i_int_cube_size;
-    mutable c2i_real_cube_size : c2i_real_cube_size;
-    mutable c2i_modes : c2i_modes;
-    mutable interpreter_input_file : interpreter_input_file;
-    mutable interpreter_steps : interpreter_steps;
-    mutable lustre_main : lustre_main;
-    mutable lustre_flatten_arrays : lustre_flatten_arrays;
-    mutable debug : string list;
-    mutable debug_log : string option;
-    mutable log_level : log_level;
-    mutable log_format_xml : bool;
-    mutable strict : strict;
-    mutable input_format : input_format;
-    mutable input_file : string option }
-    
+type flags = {
+  (* C2I flags. *)
+  mutable c2i_dnf_size : int ;
+  mutable c2i_int_cube_size : int ;
+  mutable c2i_real_cube_size : int ;
+  mutable c2i_modes : bool ;
+  (* Interpreter flags. *)
+  mutable interpreter_input_file : string ;
+  mutable interpreter_steps : int ;
+}
+
 (* Defaults for all flags *)
-let flags = 
-  { timeout_wall = timeout_wall_default;
-    timeout_virtual = timeout_virtual_default;
-    smtsolver = smtsolver_default;
-    smtlogic = smtlogic_default;
-    z3_bin = z3_bin_default;
-    smt_check_sat_assume = smt_check_sat_assume_default;
-    smt_short_names = smt_short_names_default;
-    cvc4_bin = cvc4_bin_default;
-    mathsat5_bin = mathsat5_bin_default;
-    yices_bin = yices_bin_default;
-    yices2smt2_bin = yices2smt2_bin_default;
-    smt_trace = smt_trace_default;
-    enable = enable_default_init;
-    disable = disable_default_init;
-    check_version = check_version_default;
-    bmc_max = bmc_max_default;
-    bmc_check_unroll = bmc_check_unroll_default;
-    ind_print_cex = ind_print_cex_default;
-    ind_compress = ind_compress_default;
-    ind_compress_equal = ind_compress_equal_default;
-    ind_compress_same_succ = ind_compress_same_succ_default;
-    ind_compress_same_pred = ind_compress_same_pred_default;
-    ind_lazy_invariants = ind_lazy_invariants_default;
-    ic3_qe = ic3_qe_default;
-    ic3_extract = ic3_extract_default;
-    ic3_check_inductive = ic3_check_inductive_default;
-    ic3_print_to_file = ic3_print_to_file_default;
-    ic3_inductively_generalize = ic3_inductively_generalize_default;
-    ic3_fwd_prop_non_gen = ic3_fwd_prop_non_gen_default;
-    ic3_fwd_prop_ind_gen = ic3_fwd_prop_ind_gen_default;
-    ic3_block_in_future = ic3_block_in_future_default;
-    ic3_block_in_future_first = ic3_block_in_future_first_default;
-    ic3_fwd_prop_subsume = ic3_fwd_prop_subsume_default;
-    ic3_use_invgen = ic3_use_invgen_default;
-    ic3_abstr = ic3_abstr_default;
-    compositional = compositional_default;
-    output_dir = output_dir_default;
-    skip_verif = skip_verif_default;
-    check_modes = check_modes_default;
-    check_implem = check_implem_default;
-    modular = modular_default;
-    cooper_order_var_by_elim = cooper_order_var_by_elim_default;
-    cooper_general_lbound = cooper_general_lbound_default;
-    testgen_active = testgen_active_default;
-    testgen_graph_only = testgen_graph_only_default;
-    testgen_lustrec = testgen_lustrec_default;
-    testgen_len = testgen_len_default;
-    compile = compile_default ;
-    invgengraph_prune_trivial = invgengraph_prune_trivial_default;
-    invgengraph_max_succ = invgengraph_max_succ_default;
-    invgengraph_lift_candidates = invgengraph_lift_candidates_default;
-    invgengraph_top_only = invgengraph_top_only_default;
-    invgengraph_mine_trans = invgengraph_mine_trans_default;
-    invgengraph_renice = invgengraph_renice_default;
-    c2i_dnf_size = c2i_dnf_size_default;
-    c2i_int_cube_size = c2i_int_cube_size_default;
-    c2i_real_cube_size = c2i_real_cube_size_default;
-    c2i_modes = c2i_modes_default;
-    interpreter_input_file = interpreter_input_file_default;
-    interpreter_steps = interpreter_steps_default;
-    lustre_main = lustre_main_default;
-    lustre_flatten_arrays = lustre_flatten_arrays_default;
-    debug = debug_default;
-    debug_log = debug_log_default;
-    log_level = log_level_default;
-    log_format_xml = log_format_xml_default;
-    strict = strict_default;
-    input_format = input_format_default;
-    input_file = None } 
-
-(* ********** *) 
-
-let timeout_wall_action o = flags.timeout_wall <- o  
-
-let timeout_wall_spec = 
-  ("--timeout", 
-   Arg.Float timeout_wall_action, 
-   Format.sprintf "wallclock timeout in seconds (default: %1.f)"
-    timeout_wall_default)
-
-let timeout_wall_legacy_spec = 
-  ("--timeout_wall", 
-   Arg.Float timeout_wall_action, 
-   Format.sprintf "for legacy, same as \"--timeout\"")
-
-(* ********** *) 
-
-let timeout_virtual_action o = flags.timeout_virtual <- o  
-
-let timeout_virtual_spec = 
-  ("--timeout_virtual", 
-   Arg.Float timeout_virtual_action, 
-   Format.sprintf "CPU timeout (default: %1.f)" timeout_virtual_default)
-
-(* ********** *) 
-
-let smtsolver_action o = flags.smtsolver <- (smtsolver_of_string o)
-  
-let smtsolver_spec = 
-  ("--smtsolver", 
-   Arg.String smtsolver_action, 
-   Format.sprintf "choose SMT solver (available: %s, default: %s)"
-                  smtsolver_values (string_of_smtsolver smtsolver_default))
-
-(* ********** *) 
-
-let smtlogic_action o = flags.smtlogic <- (smtlogic_of_string o)
-  
-let smtlogic_spec = 
-  ("--smtlogic", 
-   Arg.String smtlogic_action, 
-   "select logic for SMT solvers (\"none\" for no logic (default), and \
-    \"detect\" to detect with the input system, other SMTLIB logics will be \
-    passed to the solver)")
-
-(* ********** *) 
-
-let z3_bin_action o = flags.z3_bin <- (z3_bin_of_string o)
-  
-let z3_bin_spec = 
-  ("--z3_bin", 
-   Arg.String z3_bin_action, 
-   Format.sprintf "executable of Z3 solver (default: %s)"
-                  (string_of_z3_bin z3_bin_default))
-
-(* ********** *) 
-
-let smt_check_sat_assume_action o = flags.smt_check_sat_assume <- o
-  
-let smt_check_sat_assume_spec = 
-  ("--smt_check_sat_assume", 
-   Arg.Bool smt_check_sat_assume_action, 
-   Format.sprintf
-     "Use check-sat with assumptions, or simulate with push/pop \
-      when false (default: %B)"
-     smt_check_sat_assume_default)
-
-(* ********** *) 
-
-let smt_short_names_action o = flags.smt_short_names <- o
-  
-let smt_short_names_spec = 
-  ("--smt_short_names", 
-   Arg.Bool smt_short_names_action, 
-   Format.sprintf
-     "Send short variables names to SMT solver, send full names if false (default: %B)"
-     smt_short_names_default)
-
-(* ********** *) 
-
-let cvc4_bin_action o = flags.cvc4_bin <- (cvc4_bin_of_string o)
-  
-let cvc4_bin_spec = 
-  ("--cvc4_bin", 
-   Arg.String cvc4_bin_action, 
-   Format.sprintf "executable of CVC4 solver (default: %s)"
-                  (string_of_cvc4_bin cvc4_bin_default))
-
-(* ********** *) 
-
-let mathsat5_bin_action o = flags.mathsat5_bin <- (mathsat5_bin_of_string o)
-  
-let mathsat5_bin_spec = 
-  ("--mathsat5_bin", 
-   Arg.String mathsat5_bin_action, 
-   Format.sprintf "executable of MathSAT5 solver (default: %s)"
-                  (string_of_mathsat5_bin mathsat5_bin_default))
-
-(* ********** *) 
-
-let yices_bin_action o = flags.yices_bin <- (yices_bin_of_string o)
-  
-let yices_bin_spec = 
-  ("--yices_bin", 
-   Arg.String yices_bin_action, 
-   Format.sprintf "executable of Yices solver (default: %s)"
-                  (string_of_yices_bin yices_bin_default))
-
-(* ********** *) 
-
-let yices2smt2_bin_action o =
-  flags.yices2smt2_bin <- (yices2smt2_bin_of_string o)
-  
-let yices2smt2_bin_spec = 
-  ("--yices2_bin", 
-   Arg.String yices2smt2_bin_action, 
-   Format.sprintf "executable of Yices2 SMT2 solver (default: %s)"
-                  (string_of_yices2smt2_bin yices2smt2_bin_default))
-
-(* ********** *) 
-
-let smt_trace_action o = flags.smt_trace <- true
-  
-let smt_trace_spec = 
-  ("--smt_trace", 
-   Arg.Unit smt_trace_action, 
-   Format.sprintf "Write all SMT commands to files")
-
-(* ********** *) 
-
-let enable_action o = 
-
-  (* Ensure the each module is at most once in flags.enable *)
-  let mdl = kind_module_of_string o in
-  if not (List.mem mdl flags.enable) then flags.enable <- mdl :: flags.enable
-  
-let enable_spec = 
-  ("--enable", 
-   Arg.String enable_action, 
-   Format.sprintf "enable Kind module (available: %s, default: %s)"
-                  enable_values (string_of_enable enable_default_after))
-
-(* ********** *) 
-
-let disable_action o = 
-
-  (* Ensure the each module is at most once in flags.disable *)
-  let mdl = kind_module_of_string o in
-  if not (List.mem mdl flags.disable) then
-    flags.disable <- mdl :: flags.disable
-  
-let disable_spec = 
-  ("--disable", 
-   Arg.String disable_action,
-   Format.sprintf "disable Kind module (available: %s, default enabled: %s)"
-                  enable_values (string_of_enable enable_default_after))
-
-(* ********** *) 
-
-let check_version_action () = flags.check_version <- true
-  
-let check_version_spec = 
-  ("--version", 
-   Arg.Unit check_version_action, 
-   Format.sprintf "Output version information and exit")
-
-(* ********** *) 
-
-let bmc_max_action o = flags.bmc_max <- o
-  
-let bmc_max_spec = 
-  ("--bmc_max", 
-   Arg.Int bmc_max_action, 
-   Format.sprintf "(BMC, IND) Maximal number of iterations (default: %d, unlimited: 0)" bmc_max_default)
-
-(* ********** *) 
-
-let bmc_check_unroll_action o = flags.bmc_check_unroll <- o
-  
-let bmc_check_unroll_spec = 
-  ("--bmc_check_unroll", 
-   Arg.Bool bmc_check_unroll_action, 
-   Format.sprintf "(BMC) Check that the unrolling alone is satisfiable (default: %b)" bmc_check_unroll_default)
-
-(* ********** *) 
-
-let ind_print_cex_action o = flags.ind_print_cex <- o
-  
-let ind_print_cex_spec = 
-  ("--ind_print_cex", 
-   Arg.Bool ind_print_cex_action, 
-   Format.sprintf "(IND) Print counterexamples to induction (default: %b)" ind_print_cex_default)
-
-(* ********** *) 
-
-let ind_compress_action o = flags.ind_compress <- o
-  
-let ind_compress_spec = 
-  ("--ind_compress", 
-   Arg.Bool ind_compress_action, 
-   Format.sprintf "(IND) Compress inductive counterexamples (default: %B)"
-                  ind_compress_default)
-
-(* ********** *) 
-
-let ind_compress_equal_action o = flags.ind_compress_equal <- o
-  
-let ind_compress_equal_spec = 
-  ("--ind_compress_equal", 
-   Arg.Bool ind_compress_equal_action, 
-   Format.sprintf "(IND) Compress inductive counterexamples for states equal \
-                   modulo inputs (default: %B)" ind_compress_equal_default)
-
-(* ********** *) 
-
-let ind_compress_same_succ_action o = flags.ind_compress_same_succ <- o
-  
-let ind_compress_same_succ_spec = 
-  ("--ind_compress_same_succ", 
-   Arg.Bool ind_compress_same_succ_action, 
-   Format.sprintf "(IND) Compress inductive counterexamples for states \
-                   with same successors (default: %B)"
-                  ind_compress_same_succ_default)
-
-(* ********** *) 
-
-let ind_compress_same_pred_action o = flags.ind_compress_same_pred <- o
-  
-let ind_compress_same_pred_spec = 
-  ("--ind_compress_same_pred", 
-   Arg.Bool ind_compress_same_pred_action, 
-   Format.sprintf "(IND) Compress inductive counterexamples for states \
-                   with same predecessors (default: %B)"
-                  ind_compress_same_pred_default)
-
-(* ********** *) 
-
-let ind_lazy_invariants_action o = flags.ind_lazy_invariants <- o
-  
-let ind_lazy_invariants_spec = 
-  ("--ind_lazy_invariants", 
-   Arg.Bool ind_lazy_invariants_action, 
-   Format.sprintf "(IND) Asserts invariants lazily (default: %B)" ind_lazy_invariants_default)
-
-(* ********** *) 
-
-let strict_action o =
-  flags.strict <- true;
-  flags.smt_short_names <- false
-  
-let strict_spec = 
-  ("--strict", 
-   Arg.Unit strict_action, 
-   Format.sprintf "Strict mode in Lustre: uninitialized pre and undefined \
-                   local variables are not allowed when this flag is present. ")
-
-(* ********** *) 
-
-let ic3_qe_action o = flags.ic3_qe <- (ic3_qe_of_string o)
-  
-let ic3_qe_spec = 
-  ("--ic3_qe", 
-   Arg.String ic3_qe_action, 
-   Format.sprintf "(IC3) choose quantifier elimination algorithm \
-                   (available: %s, default: %s)"
-                  ic3_qe_values (string_of_ic3_qe ic3_qe_default))
-
-(* ********** *) 
-
-let ic3_extract_action o = flags.ic3_extract <- (ic3_extract_of_string o)
-  
-let ic3_extract_spec = 
-  ("--ic3_extract", 
-   Arg.String ic3_extract_action, 
-   Format.sprintf "(IC3) Heuristics for extraction of implicant \
-                   (available: %s, default: %s)"
-                  ic3_extract_values
-                  (string_of_ic3_extract ic3_extract_default))
-
-(* ********** *) 
-
-let ic3_check_inductive_action o = flags.ic3_check_inductive <- o
-  
-let ic3_check_inductive_spec = 
-  ("--ic3_check_inductive", 
-   Arg.Bool ic3_check_inductive_action, 
-   Format.sprintf "(IC3) Check inductiveness of blocking clauses (default: %s)"
-                  (string_of_ic3_check_inductive ic3_check_inductive_default))
-
-(* ********** *) 
-
-let ic3_print_to_file_action o = 
-  flags.ic3_print_to_file <- Some o
-  
-let ic3_print_to_file_spec = 
-  ("--ic3_print_to_file", 
-   Arg.String ic3_print_to_file_action, 
-   Format.sprintf "(IC3) Output file for blocking clauses (default: stdout)")
-
-(* ********** *) 
-
-let ic3_inductively_generalize_action o = flags.ic3_inductively_generalize <- o
-  
-let ic3_inductively_generalize_spec = 
-  ("--ic3_inductively_generalize", 
-   Arg.Int ic3_inductively_generalize_action, 
-   Format.sprintf "(IC3) Inductively generalize blocking clauses before forward propagation (0 = none, 1 = normal IG, 2 = IG with ordering) (default: %s)" (string_of_ic3_inductively_generalize ic3_inductively_generalize_default))
-
-(* ********** *) 
-
-let ic3_block_in_future_action o = flags.ic3_block_in_future <- o
-  
-let ic3_block_in_future_spec = 
-  ("--ic3_block_in_future", 
-   Arg.Bool ic3_block_in_future_action, 
-   Format.sprintf "(IC3) Block counterexample in future frames (default: %s)"
-                  (string_of_ic3_block_in_future ic3_block_in_future_default))
-
-(* ********** *) 
- 
-let ic3_block_in_future_first_action o = flags.ic3_block_in_future_first <- o
-  
-let ic3_block_in_future_first_spec = 
-  ("--ic3_block_in_future_first", 
-   Arg.Bool ic3_block_in_future_first_action, 
-   Format.sprintf "(IC3) Block counterexample in future frames first before returning to frame (default: %s)"
-                  (string_of_ic3_block_in_future_first ic3_block_in_future_first_default))
-
-(* ********** *) 
- 
-let ic3_fwd_prop_non_gen_action o = flags.ic3_fwd_prop_non_gen <- o
-  
-let ic3_fwd_prop_non_gen_spec = 
-  ("--ic3_fwd_prop_non_gen", 
-   Arg.Bool ic3_fwd_prop_non_gen_action, 
-   Format.sprintf "(IC3) Also propagate clauses before generalization (default: %s)"
-                  (string_of_ic3_fwd_prop_non_gen ic3_fwd_prop_non_gen_default))
-
-(* ********** *) 
- 
-let ic3_fwd_prop_ind_gen_action o = flags.ic3_fwd_prop_ind_gen <- o
-  
-let ic3_fwd_prop_ind_gen_spec = 
-  ("--ic3_fwd_prop_ind_gen", 
-   Arg.Bool ic3_fwd_prop_ind_gen_action, 
-   Format.sprintf "(IC3) Inductively generalize all clauses after forward propagation (default: %s)"
-                  (string_of_ic3_fwd_prop_ind_gen ic3_fwd_prop_ind_gen_default))
-
-(* ********** *) 
- 
-let ic3_fwd_prop_subsume_action o = flags.ic3_fwd_prop_subsume <- o
-  
-let ic3_fwd_prop_subsume_spec = 
-  ("--ic3_fwd_prop_subsume", 
-   Arg.Bool ic3_fwd_prop_subsume_action, 
-   Format.sprintf "(IC3) Subsumption in forward propagation (default: %s)"
-                  (string_of_ic3_fwd_prop_subsume ic3_fwd_prop_subsume_default))
-  
-(* ********** *) 
-
-let testgen_active_action o = flags.testgen_active <- o
-                                       
-let testgen_active_spec = 
-  ("--testgen", 
-   Arg.Bool testgen_active_action,
-   Format.sprintf
-     "@[<v 7>@,(default: %b)@ \
-      Activates test generation, deactivates everything else.@]"
-     testgen_active_default)
-(* ********** *) 
-
-let testgen_graph_only_action o = flags.testgen_graph_only <- o
-                                       
-let testgen_graph_only_spec = 
-  ("--testgen_graph_only", 
-   Arg.Bool testgen_graph_only_action,
-   Format.sprintf
-     "@[<v 7>@,(default: %b)@ \
-      Only draw the graph of reachable modes, do not log testcases.@ \
-      Does log errors.@]"
-     testgen_graph_only_default)
-  
-(* ********** *) 
-
-let testgen_lustrec_action o = flags.testgen_lustrec <- Some o
-                                       
-let testgen_lustrec_spec = 
-  ("--testgen_lustrec", 
-   Arg.String testgen_lustrec_action,
-   Format.sprintf
-     "@[<v 7>@,(default: %s)@ \
-      Sets the command for the lustreC compiler and activates@ \
-      oracle compilation.@]"
-     (match testgen_lustrec_default with | Some def -> def | _ -> "inactive"))
-  
-(* ********** *) 
-  
-let testgen_len_action o = flags.testgen_len <- o
-                                       
-let testgen_len_spec = 
-  ("--testgen_len", 
-   Arg.Int testgen_len_action,
-   Format.sprintf
-     "@[<v 7>@,(default: %d)@ \
-      Maximimum length for test generation.@]"
-     testgen_len_default)
-  
-(* ********** *) 
-
-let compile_action o = flags.compile <- o
-                                       
-let compile_spec = 
-  ("--compile",
-   Arg.Bool compile_action,
-   Format.sprintf
-     "@[<v 7>@,(default: %b)@ \
-      Activates compiling to Rust, deactivates everything else.@]"
-      compile_default)
-
-(* ********** *) 
- 
-let ic3_use_invgen_action o = flags.ic3_use_invgen <- o
-  
-let ic3_use_invgen_spec = 
-  ("--ic3_use_invgen", 
-   Arg.Bool ic3_use_invgen_action, 
-   Format.sprintf "(IC3) Use invariants from invariant generators (default: %s)"
-                  (string_of_ic3_use_invgen ic3_use_invgen_default))
-
-(* ********** *) 
-
-let ic3_abstr_action o = flags.ic3_abstr <- (ic3_abstr_of_string o)
-  
-let ic3_abstr_spec = 
-  ("--ic3_abstr", 
-   Arg.String ic3_abstr_action, 
-   Format.sprintf "(IC3) choose method of abstraction in IC3 \"
-                   (available: %s, default: %s)"
-                  ic3_abstr_values (string_of_ic3_abstr ic3_abstr_default))
-(* ********** *) 
- 
-let modular_action o = flags.modular <- o
-                                          
-let modular_spec = 
-  ("--modular", 
-   Arg.Bool modular_action, 
-   Format.sprintf
-    "bottom-up analysis of each node (available: %s, default: %B)"
-    modular_values
-    modular_default)
-
-(* ********** *) 
- 
-let compositional_action o = flags.compositional <- o
-                                          
-let compositional_spec = 
-  ("--compositional", 
-   Arg.Bool compositional_action, 
-   Format.sprintf
-    "abstract subnodes with a contract (available: %s, default: %B)"
-    compositional_values
-    compositional_default)
-
-(* ********** *) 
- 
-let skip_verif_action o = flags.skip_verif <- o
-                                          
-let skip_verif_spec = 
-  ("--skip_verif", 
-   Arg.Bool skip_verif_action, 
-   Format.sprintf
-    "output directory for smt traces, compilation, testgen and certification@ \
-    default: %b"
-    skip_verif_default)
-
-(* ********** *) 
- 
-let output_dir_action o = flags.output_dir <- o
-                                          
-let output_dir_spec = 
-  ("--output_dir", 
-   Arg.String output_dir_action, 
-   Format.sprintf
-    "output directory for smt traces, compilation, testgen and certification@ \
-    default: %s"
-    output_dir_default)
-
-(* ********** *) 
- 
-let check_modes_action o =
-  flags.check_modes <- o ;
-  if not o then flags.check_implem <- true
-                                          
-let check_modes_spec = 
-  ("--check_modes", 
-   Arg.Bool check_modes_action, 
-   Format.sprintf
-    "checks the modes of a contracts are exhaustive (available: %s, default: %B, setting to `false` automatically activates `check_implem`)"
-    check_modes_values
-    check_modes_default)
-
-(* ********** *) 
- 
-let check_implem_action o =
-  flags.check_implem <- o ;
-  if not o then flags.check_modes <- true
-                                          
-let check_implem_spec = 
-  ("--check_implem", 
-   Arg.Bool check_implem_action, 
-   Format.sprintf
-    "checks the implementation of nodes (available: %s, default: %B, setting to `false` automatically activates `check_modes`)"
-    check_implem_values
-    check_implem_default)
-
-(* ********** *)
- 
-let cooper_order_var_by_elim_action o = flags.cooper_order_var_by_elim <- o
-                                          
-let cooper_order_var_by_elim_spec = 
-  ("--cooper_order_var_by_elim", 
-   Arg.Bool cooper_order_var_by_elim_action, 
-   Format.sprintf "(Cooper QE) Order variables in polynomials by order of \
-                   elimination (available: %s, default: %B)"
-                  cooper_order_var_by_elim_values
-                  cooper_order_var_by_elim_default)
-  
-(* ********** *) 
-  
-let cooper_general_lbound_action o = flags.cooper_general_lbound <- o
-                                       
-let cooper_general_lbound_spec = 
-  ("--cooper_general_lbound", 
-   Arg.Bool cooper_general_lbound_action, 
-   Format.sprintf "(Cooper QE) Choose lower bounds containing variables (available: %s, default: %B)" cooper_general_lbound_values cooper_general_lbound_default)
-  
-(* ********** *) 
-  
-let invgengraph_prune_trivial_action o = flags.invgengraph_prune_trivial <- o
-                                       
-let invgengraph_prune_trivial_spec = 
-  ("--invgen_prune_trivial", 
-   Arg.Bool invgengraph_prune_trivial_action,
-   Format.sprintf
-     "Invariant generation will communicate invariants not implied by the\
-     transition relation (default: %B)."
-     invgengraph_prune_trivial_default)
-  
-let invgengraph_max_succ_action o = flags.invgengraph_max_succ <- o
-                                       
-let invgengraph_max_succ_spec = 
-  ("--invgen_max_succ", 
-   Arg.Int invgengraph_max_succ_action,
-   Format.sprintf
-     "Maximal number of successive iterations for subsystems (default: %d)."
-     invgengraph_max_succ_default)
-  
-let invgengraph_lift_candidates_action o = flags.invgengraph_lift_candidates <- o
-                                       
-let invgengraph_lift_candidates_spec = 
-  ("--invgen_lift_candidates", 
-   Arg.Bool invgengraph_lift_candidates_action,
-   Format.sprintf
-     "Invariant generation will instantiate candidates from sub-nodes\
-     (default: %B)."
-     invgengraph_lift_candidates_default)
-  
-let invgengraph_top_only_action o = flags.invgengraph_top_only <- o
-                                       
-let invgengraph_top_only_spec = 
-  ("--invgen_top_only", 
-   Arg.Bool invgengraph_top_only_action,
-   Format.sprintf
-     "Only generate invariants for the top level\
-     (default: %B)."
-     invgengraph_top_only_default)
-  
-let invgengraph_mine_trans_action o = flags.invgengraph_mine_trans <- o
-                                       
-let invgengraph_mine_trans_spec = 
-  ("--invgen_mine_trans", 
-   Arg.Bool invgengraph_mine_trans_action,
-   Format.sprintf
-     "Invariant generation will extract candidate terms from the transition predicate (default: %B)."
-     invgengraph_mine_trans_default)
-
-let invgengraph_renice_action o = flags.invgengraph_renice <- o
-                                       
-let invgengraph_renice_spec = 
-  ("--invgen_renice", 
-   Arg.Int invgengraph_renice_action,
-   "Renice invariant generation process. Give a positive argument to lower priority.")
-  
-(* ********** *) 
-
-let c2i_dnf_size_action o = flags.c2i_dnf_size <- o
-                                       
-let c2i_dnf_size_spec = 
-  ("--c2i_dnf", 
-   Arg.Int c2i_dnf_size_action,
-   Format.sprintf
-    "Number of disjuncts in the DNF constructed by C2I (default %d)."
-    c2i_dnf_size_default)
-
-let c2i_int_cube_size_action o = flags.c2i_int_cube_size <- o
-                                       
-let c2i_int_cube_size_spec = 
-  ("--c2i_int_cubes", 
-   Arg.Int c2i_int_cube_size_action,
-   Format.sprintf
-    "Number of int cubes in the DNF constructed by C2I (default %d)."
-    c2i_int_cube_size_default)
-
-let c2i_real_cube_size_action o = flags.c2i_real_cube_size <- o
-                                       
-let c2i_real_cube_size_spec = 
-  ("--c2i_real_cubes", 
-   Arg.Int c2i_real_cube_size_action,
-   Format.sprintf
-    "Number of real cubes in the DNF constructed by C2I (default %d)."
-    c2i_real_cube_size_default)
-
-let c2i_modes_action o = flags.c2i_modes <- o
-                                       
-let c2i_modes_spec = 
-  ("--c2i_modes", 
-   Arg.Bool c2i_modes_action,
-   Format.sprintf
-    "Activates mode subcandidates. Subsumes c2i_dnf_size (default %b)."
-    c2i_modes_default)
-  
-(* ********** *) 
-
-let interpreter_input_file_action o = flags.interpreter_input_file <- o
-                                       
-let interpreter_input_file_spec = 
-  ("--interpreter_input_file", 
-   Arg.String interpreter_input_file_action, 
-   Format.sprintf "(Interpreter) Read input from file")
-
-(* ********** *) 
-
-let interpreter_steps_action o = flags.interpreter_steps <- o
-                                       
-let interpreter_steps_spec = 
-  ("--interpreter_steps", 
-   Arg.Int interpreter_steps_action, 
-   Format.sprintf "(Interpreter) Run number of steps, override the number of \
-                   steps given in the input file")
-
-(* ********** *) 
-
-let lustre_main_action o = flags.lustre_main <- Some o
-                                       
-let lustre_main_spec = 
-  ("--lustre_main", 
-   Arg.String lustre_main_action, 
-   Format.sprintf "Use the given node as top node in Lustre input \
-                   (default: --%%MAIN annotation)")
-
-(* ********** *) 
-
-let lustre_flatten_arrays_action o = flags.lustre_flatten_arrays <- o
-                                       
-let lustre_flatten_arrays_spec = 
-  ("--lustre_flatten_arrays", 
-   Arg.Bool lustre_flatten_arrays_action, 
-   Format.sprintf
-     "Flatten arrays to one stream per element. If false, use quantified definitions. \
-      (default: %B)"
-     lustre_flatten_arrays_default)
-
-(* ********** *) 
-
-let debug_action o = flags.debug <- o :: flags.debug 
-  
-let debug_spec = 
-  ("--debug", 
-   Arg.String debug_action, 
-   Format.sprintf "enable debug output for a section, give one --debug option \
-                   for each section to be enabled")
-
-(* ********** *) 
-
-let debug_log_action o = flags.debug_log <- Some o
-  
-let debug_log_spec = 
-  ("--debug-log", 
-   Arg.String debug_log_action, 
-   Format.sprintf "output debug messages to file (default: stdout)")
-
-(* ********** *) 
-
-let log_level_action o () = flags.log_level <- o
-  
-let log_level_off_spec = 
-  ("-qq", 
-   Arg.Unit (log_level_action L_off), 
-   Format.sprintf "Disable output completely")
-
-let log_level_fatal_spec = 
-  ("-q", 
-   Arg.Unit (log_level_action L_fatal), 
-   Format.sprintf "Disable output, fatal errors only")
-
-let log_level_error_spec = 
-  ("-s", 
-   Arg.Unit (log_level_action L_error), 
-   Format.sprintf "Silence output, errors only")
-
-let log_level_info_spec = 
-  ("-v", 
-   Arg.Unit (log_level_action L_info), 
-   Format.sprintf "Output informational messages")
-
-let log_level_debug_spec = 
-  ("-vv", 
-   Arg.Unit (log_level_action L_debug), 
-   Format.sprintf "Output informational and debug messages")
-
-let log_level_trace_spec = 
-  ("-vvv", 
-   Arg.Unit (log_level_action L_trace), 
-   Format.sprintf "Output informational, debug and trace messages")
-
-(* ********** *) 
-
-let log_format_xml_action o () = flags.log_format_xml <- o
-
-let log_format_xml_spec = 
-  ("-xml", 
-   Arg.Unit (log_format_xml_action true), 
-   Format.sprintf "Output in XML format")
-
-(* ********** *) 
-
-let input_format_action o = flags.input_format <- (input_format_of_string o)
-  
-let input_format_spec = 
-  ("--input-format", 
-   Arg.String input_format_action, 
-   Format.sprintf "Format of input file (available: %s, default: %s)"
-                  input_format_values
-                  (string_of_input_format input_format_default))
-
-
-(* ********************************************************************** *)
-(* Pretty-printing of flags                                               *)
-(* ********************************************************************** *)
+let flags = {
+  (* C2I flags. *)
+  c2i_dnf_size = C2I.dnf_size_default ;
+  c2i_int_cube_size = C2I.int_cube_size_default ;
+  c2i_real_cube_size = C2I.real_cube_size_default ;
+  c2i_modes = C2I.modes_default ;
+  (* Interpreter flags. *)
+  interpreter_input_file = Interpreter.input_file_default;
+  interpreter_steps = Interpreter.steps_default;
+}
 
 
 (* ********************************************************************** *)
 (* Accessor functions for flags                                           *)
 (* ********************************************************************** *)
 
-let timeout_wall () = flags.timeout_wall
+(* |===| The following functions allow to access global flags directly. *)
 
-let timeout_virtual () = flags.timeout_virtual
-
-let smtsolver () = flags.smtsolver 
-
-let smtlogic () = flags.smtlogic 
-
-let z3_bin () = flags.z3_bin
-
-let smt_check_sat_assume () = flags.smt_check_sat_assume
-
-let smt_short_names () = flags.smt_short_names
-
-let cvc4_bin () = flags.cvc4_bin
-
-let mathsat5_bin () = flags.mathsat5_bin
-
-let yices_bin () = flags.yices_bin
-
-let yices2smt2_bin () = flags.yices_bin
-
-let smt_trace () = flags.smt_trace
-
-let enable () = flags.enable 
-
-let check_version () = flags.check_version 
-
-let bmc_max () = flags.bmc_max 
-
-let bmc_check_unroll () = flags.bmc_check_unroll 
-
-let ind_print_cex () = flags.ind_print_cex 
-
-let ind_compress () = flags.ind_compress 
-
-let ind_compress_equal () = flags.ind_compress_equal 
-
-let ind_compress_same_succ () = flags.ind_compress_same_succ 
-
-let ind_compress_same_pred () = flags.ind_compress_same_pred 
-
-let ind_lazy_invariants () = flags.ind_lazy_invariants
-
-let strict () = flags.strict
-
-let ic3_qe () = flags.ic3_qe 
-
-let set_ic3_qe f = flags.ic3_qe <- f
-
-let ic3_extract () = flags.ic3_extract 
-
-let ic3_check_inductive () = flags.ic3_check_inductive 
-
-let ic3_inductively_generalize () = true
-
-let ic3_print_to_file () = flags.ic3_print_to_file
-
-let ic3_inductively_generalize () = flags.ic3_inductively_generalize
-
-let ic3_block_in_future () = flags.ic3_block_in_future 
-
-let ic3_block_in_future_first () = flags.ic3_block_in_future_first 
-
-let ic3_fwd_prop_non_gen () = flags.ic3_fwd_prop_non_gen 
-
-let ic3_fwd_prop_ind_gen () = flags.ic3_fwd_prop_ind_gen 
-
-let ic3_fwd_prop_subsume () = flags.ic3_fwd_prop_subsume 
-
-let ic3_use_invgen () = flags.ic3_use_invgen 
-
-let ic3_abstr () = flags.ic3_abstr
-
-let set_ic3_abstr f = flags.ic3_abstr <- f
-
-let modular () = flags.modular
-
-let compositional () = flags.compositional
-
-let output_dir () = flags.output_dir
+let output_dir = Global.output_dir
+let enable = Global.enabled
+let check_version = Global.check_version
+let lus_strict = Global.lus_strict
+let modular = Global.modular
+let lus_main = Global.lus_main
+let debug = Global.debug
+let debug_log = Global.debug_log
+let log_level = Global.log_level
+let log_format_xml = Global.log_format_xml
+let input_format = Global.input_format
+let timeout_wall = Global.timeout_wall
+let input_file () = match Global.input_file () with
+  | Some f -> f
+  | None -> failwith "No input file given"
+let lus_compile = Global.lus_compile
 
 (* Path to subdirectory for a system (in the output directory). *)
 let subdir_for scope =
@@ -1672,350 +1333,113 @@ let subdir_for scope =
     (output_dir ())
     (pp_print_list Format.pp_print_string "_") scope
 
-let smt_trace_dir () =
-  mk_dir flags.output_dir ;
-  let dir = Format.sprintf "%s/smt_trace" flags.output_dir in
-  mk_dir dir ;
-  dir
-
-let check_modes () = flags.check_modes
-
-let check_implem () = flags.check_implem
-
-let cooper_order_var_by_elim () = flags.cooper_order_var_by_elim
-
-let cooper_general_lbound () = flags.cooper_general_lbound
-
-let testgen_active () = flags.testgen_active
-
-let testgen_graph_only () = flags.testgen_graph_only
-
-let testgen_lustrec () = flags.testgen_lustrec
-
-let testgen_len () = flags.testgen_len
-
-let compile () = flags.compile
-
-let invgengraph_prune_trivial () = flags.invgengraph_prune_trivial
-
-let invgengraph_max_succ () = flags.invgengraph_max_succ
-
-let invgengraph_lift_candidates () = flags.invgengraph_lift_candidates
-
-let invgengraph_top_only () = flags.invgengraph_top_only
-
-let invgengraph_mine_trans () = flags.invgengraph_mine_trans
-
-let invgengraph_renice () = flags.invgengraph_renice
-
-let c2i_dnf_size () = flags.c2i_dnf_size
-
-let c2i_int_cube_size () = flags.c2i_int_cube_size
-
-let c2i_real_cube_size () = flags.c2i_real_cube_size
-
-let c2i_modes () = flags.c2i_modes
-
-let interpreter_input_file () = flags.interpreter_input_file
-
-let interpreter_steps () = flags.interpreter_steps
-
-let lustre_main () = flags.lustre_main
-
-let lustre_flatten_arrays () = flags.lustre_flatten_arrays
-
-let debug () = flags.debug
-
-let debug_log () = flags.debug_log
-
-let log_level () = flags.log_level
-
-let log_format_xml () = flags.log_format_xml
-
-let input_format () = flags.input_format 
-
-let input_file () = match flags.input_file with 
-  | Some f -> f 
-  | None -> failwith "No input file given"
-
 
 (* ********************************************************************** *)
 (* Parsing of command-line options into flags                             *)
 (* ********************************************************************** *)
 
-let usage_msg = 
-  Format.sprintf 
-    "Usage: %s [options] FILE@\nProve properties in Lustre program FILE@\n" 
+let usage_msg =
+  Format.sprintf
+    "Usage: %s [options] FILE@\nProve properties in Lustre program FILE@\n"
     (Filename.basename Sys.executable_name)
 
 let rec help_action () = raise (Arg.Help (Arg.usage_string speclist usage_msg))
 
-and speclist = 
-  [
-
-    (* Wallclock timeout *)
-    timeout_wall_spec;
-    timeout_wall_legacy_spec;
-
-    (* CPU timeout *)
-    (* timeout_virtual_spec; *)
-
-    (* Set SMT solver *)
-    smtsolver_spec;
-
-    (* Set SMT logic *)
-    smtlogic_spec;
-
-    (* Set executable for Z3 solver *)
-    z3_bin_spec;
-
-    (* Use check-sat with assumptions or simulate with push/pop *)
-    smt_check_sat_assume_spec;
-
-    (* Send short names to SMT solver *)
-    smt_short_names_spec;
-
-    (* Set executable for CVC4 solver *)
-    cvc4_bin_spec;
-
-    (* Set executable for MathSAT5 solver *)
-    mathsat5_bin_spec;
-
-    (* Set executable for Yices solver *)
-    yices_bin_spec;
-
-    (* Set executable for Yices2 SMT2 solver *)
-    yices2smt2_bin_spec;
-
-    (* Write all SMT commands to files *)
-    smt_trace_spec;
-
-    (* Set enabled modules *)
-    enable_spec;
-    disable_spec;
-
-    (* Output version information and exit *)
-    check_version_spec;
-
-    (* Maximal number of iterations in BMC *)
-    bmc_max_spec;
-
-    (* Check that the unrolling alone is satisfiable in BMC *)
-    bmc_check_unroll_spec;
-
-    (* Print step cex *)
-    ind_print_cex_spec;
-
-    (* Compress inductive counterexamples *)
-    ind_compress_spec;
-
-    (* Compress inductive counterexamples when states are equal modulo
-       input *)
-    ind_compress_equal_spec;
-
-    (* Compress inductive counterexamples when states have same successors *)
-    ind_compress_same_succ_spec;
-
-    (* Compress inductive counterexamples when states have same predecessors *)
-    ind_compress_same_pred_spec;
-
-    (* Compress inductive counterexamples when states have same predecessors *)
-    ind_lazy_invariants_spec;
-
-    (* strict Lustre mode *)
-    strict_spec;
-    
-    (* Set QE in IC3 *)
-    ic3_qe_spec;
-
-    (* Heuristic for extraction of implicant *)
-    ic3_extract_spec;
-
-    (* Check inductiveness of blocking clauses *)
-    ic3_check_inductive_spec;
-
-    (* File for inductive of blocking clauses *)
-    ic3_print_to_file_spec;
-
-    (* Inductively generalize the blocking clause before forward propagating *)
-    ic3_inductively_generalize_spec;
-
-    (* Block counterexample in future frames *)
-    ic3_block_in_future_spec;
-
-    (* Block counterexample in future frames first before returning to frame *)
-    ic3_block_in_future_first_spec;
-
-    (* Also propagate clauses before generalization *)
-    ic3_fwd_prop_non_gen_spec;
-
-    (* Inductively generalize all clauses after forward propagation *)
-    ic3_fwd_prop_ind_gen_spec;
-
-    (* Subsumption in forward propagation *)
-    ic3_fwd_prop_subsume_spec;
-
-    (* Use invariants from invariant generators *)
-    ic3_use_invgen_spec;
-
-    (* Abstraction in IC3 *)
-    ic3_abstr_spec;
-
-    (* Modular. *)
-    modular_spec ;
-    (* Compositional. *)
-    compositional_spec ;
-    (* Output directory. *)
-    output_dir_spec ;
-    (* Check modes. *)
-    check_modes_spec ;
-    (* Check implementation. *)
-    check_implem_spec ;
-
-    (* Set option in Cooper QE*)
-    cooper_order_var_by_elim_spec;
-    cooper_general_lbound_spec;
-
-    (* Set testgen options. *)
-    testgen_active_spec;
-    testgen_graph_only_spec;
-    testgen_lustrec_spec;
-    testgen_len_spec;
-
-    (* Set compiling options. *)
-    compile_spec ;
-
-    (* Set invgen options. *)
-    invgengraph_prune_trivial_spec;
-    invgengraph_max_succ_spec;
-    invgengraph_lift_candidates_spec;
-    invgengraph_top_only_spec;
-    invgengraph_mine_trans_spec;
-    invgengraph_renice_spec;
-
-    (* Set C2I options. *)
-    c2i_dnf_size_spec ;
-    c2i_int_cube_size_spec ;
-    c2i_real_cube_size_spec ;
-    c2i_modes_spec ;
-
-    (* Read input from file *)
-    interpreter_input_file_spec;
-
-    (* Run number of steps, override the number of steps given in the
-       input file *)
-    interpreter_steps_spec;
-
-    (* Main node in Lustre input *)
-    lustre_main_spec;
-
-    (* Flatten arrays to one stream per element *)
-    lustre_flatten_arrays_spec;
-
-    (* Enable debug output *)
-    debug_spec;
-
-    (* Enable debug output *)
-    debug_log_spec;
-
-    (* Set verbosity of output *)
-    log_level_error_spec;
-    log_level_fatal_spec;
-    log_level_off_spec;
-    log_level_info_spec;
-    log_level_debug_spec;
-    log_level_trace_spec;
-
-    (* Set output format to XML *)
-    log_format_xml_spec;
-
-    (* Set input format *)
-    input_format_spec;
+and speclist =
+  (* [
 
     (* Display help *)
-    ("-help", 
-     Arg.Unit help_action, 
-     " Display this list of options");
-    ("--help", 
-     Arg.Unit help_action, 
-     "Display this list of options");
-    ("-h", 
-     Arg.Unit help_action, 
-     "    Display this list of options")
-  ]
-    
+    ("-help",
+     Arg.Unit help_action,
+     " Display this list of options") ;
+    ("--help",
+     Arg.Unit help_action,
+     "Display this list of options") ;
+    ("-h",
+     Arg.Unit help_action,
+     "Display this list of options")
 
-let anon_action s = 
-  match flags.input_file with 
-    | None -> flags.input_file <- Some s
+  ] @ *)
+  [
+    Interpreter.all_specs ;
+    C2I.all_specs ;
+    Contracts.all_specs ;
+    IC3.all_specs ;
+    Invgen.all_specs ;
+    BmcKind.all_specs ;
+    Smt.all_specs ;
+    Global.all_specs ;
+  ] |> List.fold_left (
+    fun l specs -> (specs ()) @ l
+  ) []
+
+
+let anon_action s =
+  match Global.input_file () with
+    | None -> Global.set_input_file s
     | Some _ -> raise (Arg.Bad "More than one input file given")
 
-let set_smtsolver = function 
+let set_smtsolver = function
 
-  | `Z3_SMTLIB as smtsolver -> 
+  | `Z3_SMTLIB as smtsolver ->
 
-    (function z3_bin -> 
-      flags.smtsolver <- smtsolver; 
-      flags.z3_bin <- z3_bin)
+    (function z3_bin ->
+      Smt.set_solver smtsolver ;
+      Smt.set_z3_bin z3_bin )
 
-  | `CVC4_SMTLIB as smtsolver -> 
+  | `CVC4_SMTLIB as smtsolver ->
 
-    (function cvc4_bin -> 
-      flags.smtsolver <- smtsolver; 
-      flags.cvc4_bin <- cvc4_bin)
+    (function cvc4_bin ->
+      Smt.set_solver smtsolver ;
+      Smt.set_cvc4_bin cvc4_bin )
 
-  | `MathSat5_SMTLIB as smtsolver -> 
+  | `MathSat5_SMTLIB as smtsolver ->
 
-    (function mathsat5_bin -> 
-      flags.smtsolver <- smtsolver; 
-      flags.mathsat5_bin <- mathsat5_bin)
+    (function mathsat5_bin ->
+      Smt.set_solver smtsolver ;
+      Smt.set_mathsat5_bin mathsat5_bin )
 
-  | `Yices_native as smtsolver -> 
+  | `Yices_native as smtsolver ->
 
-    (function yices_bin -> 
-      flags.smtsolver <- smtsolver; 
-      flags.yices_bin <- yices_bin)
+    (function yices_bin ->
+      Smt.set_solver smtsolver ;
+      Smt.set_yices_bin yices_bin )
 
-  | `Yices_SMTLIB as smtsolver -> 
+  | `Yices_SMTLIB as smtsolver ->
 
-    (function yices2smt2_bin -> 
-      flags.smtsolver <- smtsolver; 
-      flags.yices2smt2_bin <- yices2smt2_bin)
+    (function yices2smt2_bin ->
+      Smt.set_solver smtsolver ;
+      Smt.set_yices2smt2_bin yices2smt2_bin )
 
   | `detect -> (function _ -> ())
 
-       
-let parse_argv () = 
-  
+   
+let parse_argv () =
+
   (* Parse command-line arguments *)
   Arg.parse speclist anon_action usage_msg;
-  
-  (* Output version information only? *)
-  if check_version () then 
-    (Format.printf "%t@." pp_print_version; exit 0);
-    
-  (* Set default value if unchanged *)
-  if flags.enable = enable_default_init then
-    flags.enable <- enable_default_after;
 
-  (* Remove disabled modules. *)
-  flags.enable <- flags.enable |> List.filter (fun mdl ->
-    List.mem mdl flags.disable |> not
+  (* Output version information only? *)
+  if Global.check_version () then (
+    Format.printf "%t@." pp_print_version; exit 0
   ) ;
 
+  (* Finalize the list of enabled module. *)
+  Global.finalize_enabled () ;
+
   (* Fail if input file not set *)
-  match flags.input_file with 
-    | None -> 
-      Format.printf 
-        "%s: No input file given@\n" Sys.argv.(0);
-      Arg.usage speclist usage_msg;
-      exit 2
-    | Some _ -> ()
-      
-(* 
+  match Global.input_file () with
+  | None ->
+    Format.printf
+      "%s: No input file given.@\n" Sys.argv.(0);
+    Arg.usage speclist usage_msg;
+    exit 2
+  | Some _ -> ()
+  
+(*
    Local Variables:
    compile-command: "make -C .. -k"
    tuareg-interactive-program: "./kind2.top -I ./_build -I ./_build/SExpr"
    indent-tabs-mode: nil
-   End: 
+   End:
 *)

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -26,122 +26,126 @@
 
 open Lib
 
-(*
+(* 
 
-type ('a, 'b) flag =
-  { longname : string;
-    shortname : string option;
-    mutable value : 'a;
-    of_arg : 'a -> 'b -> 'a;
-    pp : Format.formatter -> 'a -> unit }
+# WORKFLOW.
 
+Flags are separated based on the technique(s) they impact. *Global flags* are
+the ones that don't impact any technique, or impact all of them. Log flags,
+help flags, timeout flags... are global flags.
 
-type int_flag = (int, int) flag
+**NB:** when adding a boolean flag, make sure to parse its value with the
+`bool_of_string` function.
 
-type float_flag = (float, float) flag
+## Adding a new (non-global) flag to an existing module
 
-type bool_flag = (bool, bool) flag
+Adding a new flag impacts three pieces of code. The first is the body of the
+module you're adding the flag to. Generally speaking, adding a flag looks like
 
-type unit_flag = (unit, bool) flag
+```ocaml
+(* Default value of the flag. *)
+let my_flag_default = ...
+(* Reference storing the value of the flag. *)
+let my_flag = ref my_flag_default
+(* Add flag specification to module specs. *)
+let _ = add_spec (
+  (* The actual flag. *)
+  "--my_flag",
+  (* What to do with the value given to the flag, see other flags. *)
+  ...,
+  (* Flag description. *)
+  fun fmt ->
+    Format.fprintf fmt
+      "@[<v>Description of my flag.@ Default: %a@]"
+      pp_print_default_value_of_my_flag my_flag_default
+)
+(* Flag value accessor. *)
+let my_flag () = !my_flag
+```
 
-type 'a string_flag = ('a, string) flag
+At this point your flag is integrated in the Kind 2 flags.
 
+To make it available to the rest of Kind 2, you need to modify the signature of
+the module you added the flag to
 
+* in this file, where the module is declared, and
+* in `flags.mli`.
 
-type smtsolver = [ `Z3_SMTLIB | `Z3_API | `CVC4_SMTLIB | `CVC4_API | `Yices ]
+The update to the signature is typically
 
-let smtsolver_of_string = function
-  | "Z3" -> `Z3_SMTLIB
-  | "Z3_SMTLIB" -> `Z3_SMTLIB
-  | "Z3_API" -> `Z3_API
-  | "CVC4" -> `CVC4_SMTLIB
-  | "CVC4_SMTLIB" -> `CVC4_SMTLIB
-  | "CVC4_API" -> `CVC4_API
-  | "Yices" -> `Yices
-  | _ -> raise (Invalid_argument "smtsolver_of_string")
-
-let pp_print_smtsolver ppf =
-  let p = Format.fprintf ppf in
-  function
-    | `Z3_SMTLIB -> p "Z3_SMTLIB"
-    | `Z3_API -> p "Z3_API"
-    | `CVC4_SMTLIB -> p "CVC4_SMTLIB"
-    | `CVC4_API -> p "CVC4_API"
-    | `Yices -> p "Yices"
-
-let smtsolver_flag =
-  { longname = "smtsolver";
-    shortname = None;
-    value = `Z3_SMTLIB;
-    of_arg = (function _ -> smtsolver_of_string);
-    pp = pp_print_smtsolver }
-
-
-let kind_module_of_string = function
-  | "IC3" -> `IC3
-  | "BMC" -> `BMC
-  | "IND" -> `IND
-  | "INVGEN" -> `INVGEN
-  | "interpreter" -> `Interpreter
-  | _ -> raise (Invalid_argument "smtsolver_of_string")
+```ocaml
+  val my_flag : unit -> type_of_my_flag
+```
 
 
-let pp_print_kind_module ppf =
-  let p = Format.fprintf ppf in
-  function
-    | `IC3 -> p "IC3"
-    | `BMC -> p "BMC"
-    | `IND -> p "IND"
-    | `INVGEN -> p "INVGEN"
-    | `Interpreter -> p "interpreter"
+## Adding a new global flag
+
+Global flags are given in the `Global` module. They are specified almost the
+same way as discussed in the previous section for non-global flags. The
+difference is in the spec definition, more precisely the flag description:
+
+```ocaml
+let _ = add_spec (
+  (* The actual flag. *)
+  "--my_flag",
+  (* What to do with the value given to the flag, see other flags. *)
+  ...,
+  (* Flag description IS DIFFERENT. *)
+  Format.sprintf "..."
+)
+```
+
+Unfortunately global flags rely on the ocaml `Arg` module which for some
+reason was written by someone oblivious to the format module. As a result
+the description has to be a string and it's rather tricky to have it look
+nice. See existing global flags for more info.
 
 
-let enable_flag =
-  { longname = "enable";
-    shortname = Some "e";
-    value = [];
-    of_arg = (function curval -> (function arg -> kind_module_of_string arg :: curval));
-    pp = (pp_print_list pp_print_kind_module ",@ ") }
+## Adding a new flag module
+
+The template to add a new module is
+
+```ocaml
+module MyModule : sig
+  include FlagModule
+end = struct
+
+  (* Identifier of the module. No space or special characters. *)
+  let id = "..."
+  (* Short description of the module. *)
+  let desc = "..."
+  (* Explanation of the module. *)
+  let fmt_explain fmt =
+    Format.fprintf fmt "@[<v>\
+      ...\
+    @]"
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+end
+```
+
+Don't forget to update `flags.mli`:
+
+```ocaml
+module MyModule : sig
+  include FlagModule
+end
+```
+
+You then need to add your module to the `module_map`, the association map
+between module identifiers and modules. Make sure the identifier for your
+module is not used yet.
+
+You can now add modules following the instructions in the previous section.
 
 *)
-
-
-(* ********************************************************************** *)
-(* Types and defaults for flags                                            *)
-(* ********************************************************************** *)
-
-(* TODO: write camlp4 code for this
-
-   type <X> = <X1> | <X2> arg <O> default <X2> action <F> doc <D>
-  
-   becomes
-
-   type <X> = <X1> | <X2>
-
-   let <X>_of_string = function
-     | "<X1>" -> <X1>
-     | "<X2>" -> <X2>
-     | _ raise (Arg.bad "Bad value for -<O>")
-
-   let string_of_<X> = function
-     | <X1> -> "<X1>"
-     | <X2> -> "<X2>"
-
-   let <X>_values = "<X1>, <X2>"
-
-   let <X>_default = <X2>
-
-   let <O>_spec =
-     ("-<O>",
-      String <F>,
-      Format.sprintf <D> <X>_values <X>_default)
-
-*)
-  
-
-(*   type <X> = <X1> | <X2> arg <O> default <X2> action <F> doc <D> *)
-
-(*   type smtsolver = Z3_SMTLIB | CVC4_SMTLIB arg smtsolver default CVC4_SMTLIB action smtsolver_action doc " choose SMT solver (available: %s, default: %s" *)
 
 
 (* Strings recognized as the bool value [true]. *)
@@ -166,6 +170,8 @@ let bool_arg reference = Arg.String (
 
 (* Signature of modules for flags. *)
 module type FlagModule = sig
+  (* Identifier of the module. *)
+  val id: string
   (* Short description of the module. *)
   val desc: string
   (* Explanation of the module. *)
@@ -223,6 +229,8 @@ module Smt: sig
   val set_yices2smt2_bin: string -> unit
 end = struct
 
+  (* Identifier of the module. *)
+  let id = "smt"
   (* Short description of the module. *)
   let desc = "SMT solver flags"
   (* Explanation of the module. *)
@@ -476,6 +484,8 @@ module BmcKind : sig
   val lazy_invariants : unit -> bool
 end = struct
 
+  (* Identifier of the module. *)
+  let id = "ind"
   (* Short description of the module. *)
   let desc = "BMC / K-induction flags"
   (* Explanation of the module. *)
@@ -657,6 +667,8 @@ module IC3 : sig
   val extract : unit -> extract
 end = struct
 
+  (* Identifier of the module. *)
+  let id = "ic3"
   (* Short description of the module. *)
   let desc = "IC3 flags"
   (* Explanation of the module. *)
@@ -895,6 +907,8 @@ module QE : sig
   val general_lbound : unit -> bool
 end = struct
 
+  (* Identifier of the module. *)
+  let id = "qe"
   (* Short description of the module. *)
   let desc = "quantifier elimination flags"
   (* Explanation of the module. *)
@@ -962,6 +976,8 @@ module Contracts : sig
   val check_implem : unit -> bool
 end = struct
 
+  (* Identifier of the module. *)
+  let id = "contract"
   (* Short description of the module. *)
   let desc = "contract and compositional verification flags"
   (* Explanation of the module. *)
@@ -1041,6 +1057,8 @@ module Testgen : sig
   val len : unit -> int
 end = struct
 
+  (* Identifier of the module. *)
+  let id = "test"
   (* Short description of the module. *)
   let desc = "test generation flags"
   (* Explanation of the module. *)
@@ -1127,6 +1145,8 @@ module Invgen : sig
   val renice : unit -> int
 end = struct
 
+  (* Identifier of the module. *)
+  let id = "invgen"
   (* Short description of the module. *)
   let desc = "invariant generation flags"
   (* Explanation of the module. *)
@@ -1253,6 +1273,8 @@ module C2I : sig
   val modes : unit -> bool
 end = struct
 
+  (* Identifier of the module. *)
+  let id = "c2i"
   (* Short description of the module. *)
   let desc = "C2I flags"
   (* Explanation of the module. *)
@@ -1343,6 +1365,8 @@ module Interpreter : sig
   val steps : unit -> int
 end = struct
 
+  (* Identifier of the module. *)
+  let id = "interpreter"
   (* Short description of the module. *)
   let desc = "interpreter flags"
   (* Explanation of the module. *)
@@ -1408,31 +1432,31 @@ let global_usage_msg =
   " usage_msg
 
 let module_map = [
-  ("smt",
+  (Smt.id,
     (module Smt: FlagModule)
   ) ;
-  ("ind",
+  (BmcKind.id,
     (module BmcKind: FlagModule)
   ) ;
-  ("ic3",
+  (IC3.id,
     (module IC3: FlagModule)
   ) ;
-  ("invgen",
+  (Invgen.id,
     (module Invgen: FlagModule)
   ) ;
-  ("c2i",
+  (C2I.id,
     (module C2I: FlagModule)
   ) ;
-  ("test",
+  (Testgen.id,
     (module Testgen: FlagModule)
   ) ;
-  ("interpreter",
+  (Interpreter.id,
     (module Interpreter: FlagModule)
   ) ;
-  ("qe",
+  (QE.id,
     (module QE: FlagModule)
   ) ;
-  ("contract",
+  (Contracts.id,
     (module Contracts: FlagModule)
   ) ;
 ]

--- a/src/flags.ml.in
+++ b/src/flags.ml.in
@@ -145,9 +145,9 @@ let enable_flag =
 
 
 (* Strings recognized as the bool value [true]. *)
-let true_strings = [ "true" ; "on" ; "t" ; "1" ]
+let true_strings = [ "true" ; "on" ; "t" ]
 (* Strings recognized as the bool value [false]. *)
-let false_strings = [ "false" ; "off" ; "f" ; "0" ]
+let false_strings = [ "false" ; "off" ; "f" ]
 (* String to bool. *)
 let bool_of_string s =
   if List.mem s true_strings then true
@@ -163,6 +163,1333 @@ let bool_of_string s =
 let bool_arg reference = Arg.String (
   fun s -> reference := bool_of_string s
 )
+
+(* Signature of modules for flags. *)
+module type FlagModule = sig
+  (* Short description of the module. *)
+  val desc: string
+  (* Explanation of the module. *)
+  val fmt_explain: Format.formatter -> unit
+  (* Specifications of all the flags in the module. *)
+  val all_specs: unit -> (
+    string * Arg.spec * (Format.formatter -> unit)
+  ) list
+end
+
+(* Options related to the underlying SMT solver. *)
+module Smt: sig
+  include FlagModule
+  (** Logic sendable to the SMT solver. *)
+  type logic = [
+    `None | `detect | `Logic of string
+  ]
+  (** Logic to send to the SMT solver *)
+  val logic : unit -> logic
+  (** Legal SMT solvers. *)
+  type solver = [
+    | `Z3_SMTLIB
+    | `CVC4_SMTLIB
+    | `MathSat5_SMTLIB
+    | `Yices_SMTLIB
+    | `Yices_native
+    | `detect
+  ]
+  (** Set SMT solver and executable *)
+  val set_solver : solver -> unit
+  (** Which SMT solver to use. *)
+  val solver : unit -> solver
+  (** Use check-sat with assumptions, or simulate with push/pop *)
+  val check_sat_assume : unit -> bool
+  (** Send short names to SMT solver *)
+  val short_names : unit -> bool
+  (** Executable of Z3 solver *)
+  val z3_bin : unit -> string
+  (** Executable of CVC4 solver *)
+  val cvc4_bin : unit -> string
+  (** Executable of MathSAT5 solver *)
+  val mathsat5_bin : unit -> string
+  (** Executable of Yices solver *)
+  val yices_bin : unit -> string
+  (** Executable of Yices2 SMT2 solver *)
+  val yices2smt2_bin : unit -> string
+  (** Write all SMT commands to files *)
+  val trace : unit -> bool
+  (** Path to the smt trace directory. *)
+  val trace_dir : unit -> string
+  val set_z3_bin: string -> unit
+  val set_cvc4_bin: string -> unit
+  val set_mathsat5_bin: string -> unit
+  val set_yices_bin: string -> unit
+  val set_yices2smt2_bin: string -> unit
+end = struct
+
+  (* Short description of the module. *)
+  let desc = "SMT solver flags"
+  (* Explanation of the module. *)
+  let fmt_explain fmt =
+    Format.fprintf fmt "@[<v>\
+      SMT solvers are the tools Kind 2 relies on to verify systems. Flags@ \
+      in this module control which solver Kind 2 uses, the path to the@ \
+      binary, and tweak how Kind 2 interacts with the solver at runtime.\
+    @]"
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+  (* Active SMT solver. *)
+  type solver = [
+    | `Z3_SMTLIB
+    | `CVC4_SMTLIB
+    | `MathSat5_SMTLIB
+    | `Yices_SMTLIB
+    | `Yices_native
+    | `detect
+  ]
+  let solver_of_string = function
+    | "Z3" -> `Z3_SMTLIB
+    | "CVC4" -> `CVC4_SMTLIB
+    | "MathSat5" -> `MathSat5_SMTLIB
+    | "Yices2" -> `Yices_SMTLIB
+    | "Yices" -> `Yices_native
+    | _ -> Arg.Bad "Bad value for --smtsolver" |> raise
+  let string_of_solver = function
+    | `Z3_SMTLIB -> "Z3"
+    | `CVC4_SMTLIB -> "CVC4"
+    | `Yices_SMTLIB -> "Yices2"
+    | `Yices_native -> "Yices"
+    | `MathSat5_SMTLIB -> "MathSat5"
+    | `detect -> "detect"
+  let solver_values = "Z3, CVC4, MathSat5, Yices, Yices2"
+  let solver_default = `detect
+  let solver = ref solver_default
+  let _ = add_spec (
+    "--smtsolver",
+    Arg.String (fun str -> solver := solver_of_string str),
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>choose SMT solver@ Available: %s@ Default: %s@]"
+        solver_values
+        (string_of_solver solver_default)
+  )
+  let set_solver s = solver := s
+  let solver () = !solver
+
+  (* Active SMT logic. *)
+  type logic = [
+    `None | `detect | `Logic of string
+  ]
+  let logic_values = [
+    `None ; `detect ; `Logic ("\"logic\"")
+  ]
+  let logic_of_string = function
+    | "none" | "None" -> `None
+    | "detect" | "Detect" -> `detect
+    | s -> `Logic s
+  let string_of_logic = function
+    | `None -> "none"
+    | `detect -> "detect"
+    | `Logic s -> s
+  let logic_default = `None
+  let logic = ref logic_default
+  let _ = add_spec (
+    "--smtlogic",
+    Arg.String (fun str -> logic := logic_of_string str),
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Select logic for SMT solvers@ \
+          \"none\" for no logic (default)@ \
+          \"detect\" to detect with the input system@ \
+          Other SMTLIB logics will be passed to the solver\
+        @]"
+  )
+  let logic () = !logic
+
+  (* Activates check-sat with assumptions when supported. *)
+  let check_sat_assume_of_string s = s
+  let string_of_check_sat_assume s = s
+  let check_sat_assume_default = true
+  let check_sat_assume = ref check_sat_assume_default
+  let _ = add_spec (
+    "--smt_check_sat_assume",
+    bool_arg check_sat_assume,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Use check-sat with assumptions, or simulate with push/pop@ \
+          when false@ \
+          Default: %B\
+        @]"
+      check_sat_assume_default
+  )
+  let check_sat_assume () = !check_sat_assume
+
+  (* Use short name for variables at SMT level. *)
+  let short_names_of_string s = s
+  let string_of_short_names s = s
+  let short_names_default = true
+  let short_names = ref short_names_default
+  let _ = add_spec (
+    "--smt_short_names",
+    bool_arg short_names,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Send short variables names to SMT solver, send full names if false@ \
+          Default: %B\
+        @]"
+      short_names_default
+  )
+  let short_names () = !short_names
+
+  (* Z3 binary. *)
+  let z3_bin_of_string s = s
+  let string_of_z3_bin s = s
+  let z3_bin_default = "z3"
+  let z3_bin = ref z3_bin_default
+  let _ = add_spec (
+    "--z3_bin",
+    Arg.Set_string z3_bin,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Executable of Z3 solver@ Default: \"%s\"@]"
+        (string_of_z3_bin z3_bin_default)
+  )
+  let set_z3_bin str = z3_bin := str
+  let z3_bin () = ! z3_bin
+
+  (* CVC4 binary. *)
+  let cvc4_bin_of_string s = s
+  let string_of_cvc4_bin s = s
+  let cvc4_bin_default = "cvc4"
+  let cvc4_bin = ref cvc4_bin_default
+  let _ = add_spec (
+    "--cvc4_bin",
+    Arg.Set_string cvc4_bin,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Executable of CVC4 solver@ Default: \"%s\"@]"
+        (string_of_cvc4_bin cvc4_bin_default)
+  )
+  let set_cvc4_bin str = cvc4_bin := str
+  let cvc4_bin () = !cvc4_bin
+
+  (* Mathsat 5 binary. *)
+  let mathsat5_bin_of_string s = s
+  let string_of_mathsat5_bin s = s
+  let mathsat5_bin_default = "mathsat"
+  let mathsat5_bin = ref mathsat5_bin_default
+  let _ = add_spec (
+    "--mathsat5_bin",
+    Arg.Set_string mathsat5_bin,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Executable of MathSAT5 solver@ Default: \"%s\"@]"
+        (string_of_mathsat5_bin mathsat5_bin_default)
+  )
+  let set_mathsat5_bin str = mathsat5_bin := str
+  let mathsat5_bin () = !mathsat5_bin
+
+  (* Yices binary. *)
+  let yices_bin_of_string s = s
+  let string_of_yices_bin s = s
+  let yices_bin_default = "yices"
+  let yices_bin = ref yices_bin_default
+  let _ = add_spec (
+    "--yices_bin",
+    Arg.Set_string yices_bin,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Executable of Yices solver@ Default: \"%s\"@]"
+        (string_of_yices_bin yices_bin_default)
+  )
+  let set_yices_bin str = yices_bin := str
+  let yices_bin () = !yices_bin
+
+  (* Yices 2 binary. *)
+  let yices2smt2_bin_of_string s = s
+  let string_of_yices2smt2_bin s = s
+  let yices2smt2_bin_default = "yices-smt2"
+  let yices2smt2_bin = ref yices2smt2_bin_default
+  let _ = add_spec (
+    "--yices2_bin",
+    Arg.Set_string yices2smt2_bin,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Executable of Yices2 SMT2 solver@ Default: \"%s\"@]"
+        (string_of_yices2smt2_bin yices2smt2_bin_default)
+  )
+  let set_yices2smt2_bin str = yices2smt2_bin := str
+  let yices2smt2_bin () = !yices2smt2_bin
+
+  (* Activates logging of SMT interactions. *)
+  let trace_default = false
+  let trace = ref trace_default
+  let _ = add_spec (
+    "--smt_trace",
+    Arg.Set trace,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Write all SMT commands to files@]"
+  )
+  let trace () = !trace
+
+  (* Folder to log the SMT traces into. *)
+  let trace_dir = ref None
+  let set_trace_dir s = trace_dir := Some s
+  let trace_dir () = match !trace_dir with
+    | None -> "."
+    | Some dir ->
+      mk_dir dir ;
+      let dir = Format.sprintf "%s/smt_trace" dir in
+      mk_dir dir ;
+      dir
+
+end
+
+
+
+
+(* BMC and k-induction flags. *)
+module BmcKind : sig
+  include FlagModule
+  (** Maximal number of iterations in BMC. *)
+  val max : unit -> int
+  (** Check that the unrolling of the system alone is satisfiable. *)
+  val check_unroll : unit -> bool
+  (** Print counterexamples to induction. *)
+  val print_cex : unit -> bool
+  (** Compress inductive counterexample. *)
+  val compress : unit -> bool
+  (** Compress inductive counterexample when states are equal modulo inputs. *)
+  val compress_equal : unit -> bool
+  (** Compress inductive counterexample when states have same successors. *)
+  val compress_same_succ : unit -> bool
+  (** Compress inductive counterexample when states have same predecessors. *)
+  val compress_same_pred : unit -> bool
+  (** Lazy assertion of invariants. *)
+  val lazy_invariants : unit -> bool
+end = struct
+
+  (* Short description of the module. *)
+  let desc = "BMC / K-induction flags"
+  (* Explanation of the module. *)
+  let fmt_explain fmt =
+    Format.fprintf fmt "@[<v>\
+      K-induction is the primary verification technique in Kind 2. It@ \
+      consists of two processes:@ \
+      > bounded model checking (BMC) explores the reachable states of the\
+      @   system looking for a falsification of one of the properties.@ \
+      > the (k-inductive) step tries to prove that from `k` succeeding states\
+      @   verifying the properties, it not possible to reach a state violating\
+      @   any of them. If this holds, then if BMC proved these properties to\
+      @   hold in the `k` first states, then by (k-)induction the properties\
+      @   hold.@ \
+      Internally many techniques such as path compression, multi-property,@ \
+      etc. are used to improve the basic scheme described above.@ \
+      Flags in this module deal with the behavior of BMC and step.\
+    @]"
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let max_default = 0
+  let max = ref max_default
+  let _ = add_spec (
+    "--unroll_max",
+    Arg.Set_int max,
+    fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        Maximal number of iterations for BMC and k-induction@ \
+        Default: %d, unlimited: 0\
+      @]"
+      max_default
+  )
+  let max () = !max
+
+  let check_unroll_default = true
+  let check_unroll = ref check_unroll_default
+  let _ = add_spec (
+    "--bmc_check_unroll",
+    bool_arg check_unroll,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Check that the unrolling alone is satisfiable@ \
+          Default: %b\
+        @]"
+        check_unroll_default
+  )
+  let check_unroll () = !check_unroll
+
+  let print_cex_default = false
+  let print_cex = ref print_cex_default
+  let _ = add_spec (
+    "--ind_print_cex",
+    bool_arg print_cex,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Print counterexamples to induction@ Default: %b@]"
+        print_cex_default
+  )
+  let print_cex () = !print_cex
+
+  let compress_default = true
+  let compress = ref compress_default
+  let _ = add_spec (
+    "--ind_compress",
+    bool_arg compress,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Compress inductive counterexamples@ Default: %B@]"
+        compress_default
+  )
+  let compress () = !compress
+
+  let compress_equal_default = true
+  let compress_equal = ref compress_equal_default
+  let _ = add_spec (
+    "--ind_compress_equal",
+    bool_arg compress_equal,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Compress inductive counterexamples for states equal modulo inputs@ \
+          Default: %B\
+        @]"
+        compress_equal_default
+  )
+  let compress_equal () = !compress_equal
+
+  let compress_same_succ_default = false
+  let compress_same_succ = ref compress_same_succ_default
+  let _ = add_spec (
+    "--ind_compress_same_succ",
+    bool_arg compress_same_succ,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Compress inductive counterexamples for states with same successors@ \
+          Default: %B\
+        @]"
+        compress_same_succ_default
+  )
+  let compress_same_succ () = !compress_same_succ
+
+  let compress_same_pred_default = false
+  let compress_same_pred = ref compress_same_pred_default
+  let _ = add_spec (
+  "--ind_compress_same_pred",
+    bool_arg compress_same_pred,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Compress inductive counterexamples for states with same predecessors@ \
+          Default: %B\
+        "
+        compress_same_pred_default
+  )
+  let compress_same_pred () = !compress_same_pred
+
+  let lazy_invariants_default = false
+  let lazy_invariants = ref lazy_invariants_default
+  let _ = add_spec (
+    "--ind_lazy_invariants",
+    bool_arg lazy_invariants,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Asserts invariants lazily@ Default: %B@]"
+        lazy_invariants_default
+  )
+  let lazy_invariants () = !lazy_invariants
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+end
+
+
+
+(* IC3 flags. *)
+module IC3 : sig
+  include FlagModule
+  (** Algorithm usable for quantifier elimination in IC3. *)
+  type qe = [
+    `Z3 | `Z3_impl | `Z3_impl2 | `Cooper
+  ]
+  (** The QE algorithm IC3 should use. *)
+  val qe : unit -> qe
+  (** Sets [qe]. *)
+  val set_qe : qe -> unit
+  (** Check inductiveness of blocking clauses. *)
+  val check_inductive : unit -> bool
+  (** File for inductive blocking clauses. *)
+  val print_to_file : unit -> string option
+  (** Tighten blocking clauses to an unsatisfiable core. *)
+  val inductively_generalize : unit -> int
+  (** Block counterexample in future frames. *)
+  val block_in_future : unit -> bool
+  (** Block counterexample in future frames first before returning to frame. *)
+  val block_in_future_first : unit -> bool
+  (** Also propagate clauses before generalization. *)
+  val fwd_prop_non_gen : unit -> bool
+  (** Inductively generalize all clauses after forward propagation. *)
+  val fwd_prop_ind_gen : unit -> bool
+  (** Subsumption in forward propagation. *)
+  val fwd_prop_subsume : unit -> bool
+  (** Use invariants from invariant generators. *)
+  val use_invgen : unit -> bool
+  (** Legal abstraction mechanisms for in IC3. *)
+  type abstr = [ `None | `IA ]
+  (** Abstraction mechanism IC3 should use. *)
+  val abstr : unit -> abstr
+  (** Legal heuristics for extraction of implicants in IC3. *)
+  type extract = [ `First | `Vars ]
+  (** Heuristic for extraction of implicants in IC3. *)
+  val extract : unit -> extract
+end = struct
+
+  (* Short description of the module. *)
+  let desc = "IC3 flags"
+  (* Explanation of the module. *)
+  let fmt_explain fmt =
+    Format.fprintf fmt "@[<v>\
+      IC3 (a.k.a. PDR) is a relatively recent technique that tries to prove@ \
+      a property by contructing an inductive invariant that implies it.@ \
+      The IC3 engine in Kind 2 performs quantifier elimination (see module@ \
+      \"qe\"), and because of how it is implemented it is known to be rather@ \
+      slow on systems using real variables.\
+    @]"
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let check_inductive_default = true
+  let check_inductive = ref check_inductive_default
+  let _ = add_spec (
+    "--ic3_check_inductive",
+    bool_arg check_inductive,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Check inductiveness of blocking clauses@ Default: %s@]"
+        (string_of_bool check_inductive_default)
+  )
+  let check_inductive () = !check_inductive
+
+  let print_to_file_default = None
+  let print_to_file = ref print_to_file_default
+  let _ = add_spec (
+    "--ic3_print_to_file",
+    Arg.String (fun str -> print_to_file := Some str),
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Output file for blocking clauses@ Default: stdout@]"
+  )
+  let print_to_file () = !print_to_file
+
+  let inductively_generalize_default = 1
+  let inductively_generalize = ref inductively_generalize_default
+  let _ = add_spec (
+    "--ic3_inductively_generalize",
+    Arg.Set_int inductively_generalize,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Inductively generalize blocking clauses before forward propagation@ \
+          0 = none@ \
+          1 = normal IG@ \
+          2 = IG with ordering@ \
+          Default: %s\
+        @]"
+        (string_of_int inductively_generalize_default)
+  )
+  let inductively_generalize () = !inductively_generalize
+
+  let block_in_future_default = true
+  let block_in_future = ref block_in_future_default
+  let _ = add_spec (
+    "--ic3_block_in_future",
+    bool_arg block_in_future,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Block counterexample in future frames@ Default: %s@]"
+        (string_of_bool block_in_future_default)
+  )
+  let block_in_future () = !block_in_future
+
+  let block_in_future_first_default = true
+  let block_in_future_first = ref block_in_future_first_default
+  let _ = add_spec (
+    "--ic3_block_in_future_first",
+    bool_arg block_in_future_first,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Block counterexample in future frames first before returning to@ \
+          frame@ \
+          Default: %s\
+        @]"
+        (string_of_bool block_in_future_first_default)
+  )
+  let block_in_future_first () = !block_in_future_first
+
+  let fwd_prop_non_gen_default = true
+  let fwd_prop_non_gen = ref fwd_prop_non_gen_default
+  let _ = add_spec (
+    "--ic3_fwd_prop_non_gen",
+    bool_arg fwd_prop_non_gen,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Also propagate clauses before generalization@ Default: %s@]"
+        (string_of_bool fwd_prop_non_gen_default)
+  )
+  let fwd_prop_non_gen () = !fwd_prop_non_gen
+
+  let fwd_prop_ind_gen_default = true
+  let fwd_prop_ind_gen = ref fwd_prop_ind_gen_default
+  let _ = add_spec (
+    "--ic3_fwd_prop_ind_gen",
+    bool_arg fwd_prop_ind_gen,
+    fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        Inductively generalize all clauses after forward propagation@ \
+        Default: %s\
+      @]"
+      (string_of_bool fwd_prop_ind_gen_default)
+  )
+  let fwd_prop_ind_gen () = !fwd_prop_ind_gen
+
+  let fwd_prop_subsume_default = true
+  let fwd_prop_subsume = ref fwd_prop_subsume_default
+  let _ = add_spec (
+    "--ic3_fwd_prop_subsume",
+    bool_arg fwd_prop_subsume,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Subsumption in forward propagation@ Default: %s@]"
+        (string_of_bool fwd_prop_subsume_default)
+  )
+  let fwd_prop_subsume () = !fwd_prop_subsume
+
+  let use_invgen_default = true
+  let use_invgen = ref use_invgen_default
+  let _ = add_spec (
+    "--ic3_use_invgen",
+    bool_arg use_invgen,
+    fun fmt  ->
+      Format.fprintf fmt
+        "@[<v>Use invariants from invariant generators@ Default: %s@]"
+        (string_of_bool use_invgen_default)
+  )
+  let use_invgen () = !use_invgen
+
+  type qe = [
+    `Z3 | `Z3_impl | `Z3_impl2 | `Cooper
+  ]
+  let qe_of_string = function
+    | "Z3" -> `Z3
+    | "Z3-impl" -> `Z3_impl
+    | "Z3-impl2" -> `Z3_impl2
+    | "cooper" -> `Cooper
+    | _ -> raise (Arg.Bad "Bad value for --ic3_qe")
+  let string_of_qe = function
+    | `Z3 -> "Z3"
+    |  `Z3_impl -> "Z3-impl"
+    |  `Z3_impl2 -> "Z3-impl2"
+    | `Cooper -> "cooper"
+  let qe_values = [
+    `Z3 ; `Z3_impl ; `Z3_impl2 ; `Cooper
+  ] |> List.map string_of_qe |> String.concat ", "
+  let qe_default = `Cooper
+  let qe = ref qe_default
+  let _ = add_spec (
+    "--ic3_qe",
+    Arg.String (fun str -> qe := qe_of_string str),
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Choose quantifier elimination algorithm@ \
+          Available: %s@ \
+          Default: %s\
+        @]"
+        qe_values (string_of_qe qe_default)
+  )
+  let set_qe q = qe := q
+  let qe () = !qe
+
+  type extract = [ `First | `Vars ]
+  let extract_of_string = function
+    | "first" -> `First
+    | "vars" -> `Vars
+    | _ -> raise (Arg.Bad "Bad value for --ic3_extract")
+  let string_of_extract = function
+    | `First -> "first"
+    | `Vars -> "vars"
+  let extract_values = [
+    `First ; `Vars
+  ] |> List.map string_of_extract |> String.concat ", "
+  let extract_default = `First
+  let extract = ref extract_default
+  let _ = add_spec (
+    "--ic3_extract",
+    Arg.String (fun str -> extract := extract_of_string str),
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Heuristics for extraction of implicant@ \
+          Available: %s@ \
+          Default: %s\
+        @]"
+        extract_values (string_of_extract extract_default)
+  )
+  let extract () = !extract
+
+  type abstr = [ `None | `IA ]
+  let abstr_of_string = function
+    | "None" -> `None
+    | "IA" -> `IA
+    | _ -> raise (Arg.Bad "Bad value for --ic3_abstr")
+  let string_of_abstr = function
+    | `IA -> "IA"
+    | `None -> "None"
+  let abstr_values = [
+    `None ; `IA
+  ] |> List.map string_of_abstr |> String.concat ", "
+  let abstr_default = `None
+  let abstr = ref abstr_default
+  let _ = add_spec (
+    "--ic3_abstr",
+    Arg.String (fun str -> abstr := abstr_of_string str),
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Choose method of abstraction in IC3@ Available: %s@ Default: %s\
+        @]"
+        abstr_values (string_of_abstr abstr_default)
+  )
+  let abstr () = !abstr
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+end
+
+
+(* Quantifier elimination module. *)
+module QE : sig
+  include FlagModule
+  (** Order variables in polynomials by order of elimination **)
+  val cooper_order_var_by_elim : unit -> bool
+  (** Choose lower bounds containing variables **)
+  val cooper_general_lbound : unit -> bool
+end = struct
+
+  (* Short description of the module. *)
+  let desc = "quantifier elimination flags"
+  (* Explanation of the module. *)
+  let fmt_explain fmt =
+    Format.fprintf fmt "@[<v>\
+      Quantifier elimination (QE) is a technique that, given some variables@ \
+      `v_1`, ..., `v_n` and a quantifier-free formula `f`, returns a@ \
+      quantifier-free formula equivalent to `(exists (v_1, ..., v_n) f)`.@ \
+      The QE implemented in Kind 2 does not support real arithmetic. If the@ \
+      solver used is z3, then z3's QE will be used instead of the internal@ \
+      one for systems with real variables.@ \
+      IC3 (module \"ic3\") is the only Kind 2 technique that uses QE.\
+    @]"
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let cooper_order_var_by_elim_default = false
+  let cooper_order_var_by_elim = ref cooper_order_var_by_elim_default
+  let _ = add_spec (
+    "--cooper_order_var_by_elim",
+    bool_arg cooper_order_var_by_elim,
+    fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        Order variables in polynomials by order of elimination@ \
+        Default: %B\
+      @]"
+      cooper_order_var_by_elim_default
+  )
+  let cooper_order_var_by_elim () = !cooper_order_var_by_elim
+
+  let cooper_general_lbound_default = false
+  let cooper_general_lbound = ref cooper_general_lbound_default
+  let _ = add_spec (
+    "--cooper_general_lbound",
+    bool_arg cooper_general_lbound,
+    fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        Choose lower bounds containing variables@ \
+        Default: %B\
+      @]"
+      cooper_general_lbound_default
+  )
+  let cooper_general_lbound () = !cooper_general_lbound
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+end
+
+
+
+
+(* Contracts flags. *)
+module Contracts : sig
+  include FlagModule
+  (** Compositional analysis. *)
+  val compositional : unit -> bool
+  (** Check modes. *)
+  val check_modes : unit -> bool
+  (** Check modes. *)
+  val check_implem : unit -> bool
+end = struct
+
+  (* Short description of the module. *)
+  let desc = "contract and compositional verification flags"
+  (* Explanation of the module. *)
+  let fmt_explain fmt =
+    Format.fprintf fmt "@[<v>\
+      Kind 2 extends Lustre with a syntax for assume-guarantee-like@ \
+      contracts. The syntax and semantics of contracts are described in@ \
+      Kind 2 documentation.@ \
+      Contracts allow to perform compositional verification, where sub-nodes@ \
+      with a contract are abstracted away by their specification. Also, the@ \
+      test generation technique (see module \"testgen\") relies on contracts@ \
+      to generate the testcases.\
+    @]"
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let compositional_default = false
+  let compositional = ref compositional_default
+  let _ = add_spec (
+    "--compositional",
+    bool_arg compositional,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Abstract subnodes with a contract@ Default: %B@]"
+        compositional_default
+  )
+  let compositional () = !compositional
+
+  let check_modes_default = true
+  let check_modes = ref check_modes_default
+  let _ = add_spec (
+    "--check_modes",
+    bool_arg check_modes,
+    fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        Checks the modes of a contracts are exhaustive@ \
+        Default: %B\
+      @]"
+      check_modes_default
+  )
+  let check_modes () = !check_modes
+
+  let check_implem_default = true
+  let check_implem = ref check_implem_default
+  let _ = add_spec (
+    "--check_implem",
+    bool_arg check_implem,
+    fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        Checks the implementation of nodes@ \
+        Default: %B\
+      @]"
+      check_implem_default
+  )
+  let check_implem () = !check_implem
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+end
+
+
+
+(* Testgen flags. *)
+module Testgen : sig
+  include FlagModule
+  (** Activates test generation. *)
+  val active : unit -> bool
+  (** Only generate graph of reachable modes, do not log testcases. *)
+  val graph_only : unit -> bool
+  (** Length of the test case generated. *)
+  val len : unit -> int
+end = struct
+
+  (* Short description of the module. *)
+  let desc = "test generation flags"
+  (* Explanation of the module. *)
+  let fmt_explain fmt =
+    Format.fprintf fmt "@[<v>\
+      Test generation uses the contract (see module \"contract\") attached@ \
+      to a node to explore the behavior of a node. For each behavior, a@ \
+      trace of inputs triggering it is generated and logged as a testcase in@ \
+      CSV.\
+    @]"
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let active_default = false
+  let active = ref active_default
+  let _ = add_spec (
+    "--testgen",
+    bool_arg active,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Activates test generation for systems proved correct@ \
+          Default: %b\
+        @]"
+        active_default
+  )
+  let active () = !active
+
+  let graph_only_default = false
+  let graph_only = ref graph_only_default
+  let _ = add_spec (
+    "--testgen_graph_only",
+    bool_arg graph_only,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Only draw the graph of reachable modes, do not log testcases.@ \
+          Default: %b\
+        @]"
+        graph_only_default
+  )
+  let graph_only () = !graph_only
+
+  let len_default = 5
+  let len = ref len_default
+  let _ = add_spec (
+    "--testgen_len",
+    Arg.Set_int len,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Maximimum length for test generation@ \
+          Default: %d\
+        @]"
+        len_default
+  )
+  let len () = !len
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+
+end
+
+
+(* Invgen flags. *)
+module Invgen : sig
+  include FlagModule
+  (** InvGen will remove trivial invariants, i.e. invariants implied by the
+      transition relation. *)
+  val prune_trivial : unit -> bool
+  (** Number of unrollings invariant generation should perform between
+    switching to a different systems. *)
+  val max_succ : unit -> int
+  (** InvGen will lift candidate terms from subsystems. **)
+  val lift_candidates : unit -> bool
+  (** InvGen will generate invariants only for top level. **)
+  val top_only : unit -> bool
+  (** InvGen will look for candidate terms in the transition predicate. *)
+  val mine_trans : unit -> bool
+  (** Renice invariant generation process. *)
+  val renice : unit -> int
+end = struct
+
+  (* Short description of the module. *)
+  let desc = "invariant generation flags"
+  (* Explanation of the module. *)
+  let fmt_explain fmt =
+    Format.fprintf fmt "@[<v>\
+      Invariant generation attempts to discover invariants of the form@ \
+      `<expr> => <expr>` using expressions mined from the initial and@ \
+      transition predicates of the system. The candidates invariants@ \
+      considered are selected by an incremental exploration of the reachable@ \
+      states.\
+    @]"
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let prune_trivial_default = true
+  let prune_trivial = ref prune_trivial_default
+  let _ = add_spec (
+    "--invgen_prune_trivial",
+    bool_arg prune_trivial,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Invariant generation will only communicate invariants not implied@ \
+          by the transition relation@ \
+          Default: %B\
+        @]"
+        prune_trivial_default
+  )
+  let prune_trivial () = !prune_trivial
+
+  let max_succ_default = 1
+  let max_succ = ref max_succ_default
+  let _ = add_spec (
+    "--invgen_max_succ",
+    Arg.Int (fun b -> max_succ := b),
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Maximal number of successive iterations for subsystems@ \
+          Default: %d\
+        @]"
+        max_succ_default
+  )
+  let max_succ () = !max_succ
+
+  let lift_candidates_default = false
+  let lift_candidates = ref lift_candidates_default
+  let _ = add_spec (
+    "--invgen_lift_candidates",
+    bool_arg lift_candidates,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Invariant generation will instantiate candidates from sub-nodes@ \
+          Default: %B\
+        @]"
+        lift_candidates_default
+  )
+  let lift_candidates () = !lift_candidates
+
+  let top_only_default = false
+  let top_only = ref top_only_default
+  let _ = add_spec (
+    "--invgen_top_only",
+    bool_arg top_only,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Only generate invariants for the top level@ \
+          Default: %B\
+        @]"
+        top_only_default
+  )
+  let top_only () = !top_only
+
+  let mine_trans_default = true
+  let mine_trans = ref mine_trans_default
+  let _ = add_spec (
+    "--invgen_mine_trans",
+    bool_arg mine_trans,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Invariant generation will extract candidate terms from the@ \
+          transition predicate@ \
+          Default: %B\
+        @]"
+        mine_trans_default
+  )
+  let mine_trans () = !mine_trans
+
+  let renice_default = 0
+  let renice = ref renice_default
+  let _ = add_spec (
+    "--invgen_renice",
+    Arg.Set_int renice,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Renice invariant generation process. Give a positive argument to@ \
+          lower priority\
+        @]"
+  )
+  let renice () = !renice
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+end
+
+
+(* C2I flags. *)
+module C2I : sig
+  include FlagModule
+  (** Number of disjuncts in the DNF constructed by C2I. *)
+  val dnf_size : unit -> int
+  (** Number of int cubes in the DNF constructed by C2I. *)
+  val int_cube_size : unit -> int
+  (** Number of real cubes in the DNF constructed by C2I. *)
+  val real_cube_size : unit -> int
+  (** Whether mode sub candidate is activated in c2i. *)
+  val modes : unit -> bool
+end = struct
+
+  (* Short description of the module. *)
+  let desc = "C2I flags"
+  (* Explanation of the module. *)
+  let fmt_explain fmt =
+    Format.fprintf fmt "@[<v>\
+      C2I is an invariant generation technique based on machine-learning.@ \
+      The Kind 2 implementation is still experimental and is inactive by@ \
+      default.\
+    @]"
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let dnf_size_default = 3
+  let dnf_size = ref dnf_size_default
+  let _ = add_spec (
+    "--c2i_dnf",
+    Arg.Set_int dnf_size,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Number of disjuncts in the DNF constructed by C2I@ \
+          Default %d\
+        @]"
+        dnf_size_default
+  )
+  let dnf_size () = !dnf_size
+
+  let int_cube_size_default = 3
+  let int_cube_size = ref int_cube_size_default
+  let _ = add_spec (
+    "--c2i_int_cubes",
+    Arg.Set_int int_cube_size,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Number of int cubes in the DNF constructed by C2I@ \
+          Default %d\
+        @]"
+        int_cube_size_default
+  )
+  let int_cube_size () = !int_cube_size
+
+  let real_cube_size_default = 3
+  let real_cube_size = ref real_cube_size_default
+  let _ = add_spec (
+    "--c2i_real_cubes",
+    Arg.Set_int real_cube_size,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Number of real cubes in the DNF constructed by C2I@ \
+          Default %d\
+        @]"
+        real_cube_size_default
+  )
+  let real_cube_size () = !real_cube_size
+
+  let modes_default = true
+  let modes = ref modes_default
+  let _ = add_spec (
+    "--c2i_modes",
+    bool_arg modes,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Activates mode subcandidates. Subsumes \"c2i_dnf_size\"@ \
+          Default %b\
+        @]"
+        modes_default
+  )
+  let modes () = !modes
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+end
+
+
+(* Interpreter flags. *)
+module Interpreter : sig
+  include FlagModule
+  (** Read input from file. *)
+  val input_file : unit -> string
+  (** Run number of steps, override the number of steps given in the input
+    file. *)
+  val steps : unit -> int
+end = struct
+
+  (* Short description of the module. *)
+  let desc = "interpreter flags"
+  (* Explanation of the module. *)
+  let fmt_explain fmt =
+    Format.fprintf fmt "@[<v>\
+      The interpreter is a special mode where Kind 2 reads inputs from a@ \
+      file and prints the outputs of the system at each step.\
+    @]"
+
+  (* All the flag specification of this module. *)
+  let all_specs = ref []
+  let add_specs specs = all_specs := !all_specs @ specs
+  let add_spec spec = add_specs [spec]
+
+  let input_file_default = ""
+  let input_file = ref input_file_default
+  let _ = add_spec (
+    "--interpreter_input_file",
+    Arg.Set_string input_file,
+    fun fmt ->
+      Format.fprintf fmt "@[<v>Read input from file@]"
+  )
+  let input_file () = !input_file
+
+  let steps_default = 0
+  let steps = ref steps_default
+  let _ = add_spec (
+    "--interpreter_steps",
+    Arg.Set_int steps,
+    fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Run number of steps, override the number of steps given in the@ \
+          input file@ \
+          Default: %d\
+        @]"
+        steps_default
+  )
+  let steps () = !steps
+
+
+  (* Returns all the flag specification of this module. *)
+  let all_specs () = !all_specs
+end
+
+
+
+
+
+(* ********************************************************************** *)
+(* Maps identifiers to modules flag specifications and description        *)
+(* ********************************************************************** *)
+
+let module_map = [
+  ("smt",
+    (module Smt: FlagModule)
+  ) ;
+  ("ind",
+    (module BmcKind: FlagModule)
+  ) ;
+  ("ic3",
+    (module IC3: FlagModule)
+  ) ;
+  ("invgen",
+    (module Invgen: FlagModule)
+  ) ;
+  ("c2i",
+    (module C2I: FlagModule)
+  ) ;
+  ("test",
+    (module Testgen: FlagModule)
+  ) ;
+  ("interpreter",
+    (module Interpreter: FlagModule)
+  ) ;
+  ("qe",
+    (module QE: FlagModule)
+  ) ;
+  ("contract",
+    (module Contracts: FlagModule)
+  ) ;
+]
+
+(* Formats an element of [module_map]. *)
+let fmt_module_info fmt (id, m0d) =
+  let module Flags = (val m0d: FlagModule) in
+  Format.fprintf fmt
+    "\
+      Module \"%s\":@.  \
+        @[<v>%t@]@.\
+        @[<v>%a@]@.\
+    "
+    id
+    Flags.fmt_explain
+    (pp_print_list
+      (fun fmt (key, _, desc) ->
+        Format.fprintf fmt "%s:@     %t" key desc)
+      "@ "
+    ) (Flags.all_specs ())
+
+(* Prints module info for a list of identifiers. If ["all"] is in the list,
+prints info for all modules.
+If the input list is not empty and all identifiers are defined, exits with
+status [0]. If some operators are undefined, exits with [2]. Does nothing if
+the list is empty. *)
+let print_module_info = function
+| [] -> ()
+| ids -> (
+  if List.mem "all" ids then (
+    Format.printf
+      "%a@."
+      (pp_print_list fmt_module_info "@.@.")
+      module_map
+  ) else (
+    ids |> List.iter ( fun id ->
+      try (
+        let m0d = module_map |> List.assoc id in
+        Format.printf "%a@." fmt_module_info (id, m0d)
+      ) with Not_found -> (
+        Format.printf
+          "Unknown module \"%s\", legal values are@.  all, %a@."
+          id
+          (pp_print_list
+            (fun fmt (key,_) -> Format.fprintf fmt "%s" key)
+            ", "
+          ) module_map ;
+        exit 2
+      )
+    )
+  ) ;
+  exit 0
+)
+
+
+
+
+(* ********************************************************************** *)
+(* Global flags                                                           *)
+(* ********************************************************************** *)
+
 
 
 (* Global flags. *)
@@ -183,14 +1510,40 @@ module Global = struct
 
   (* Version flag. *)
   let check_version_default = false
-
   let check_version = ref check_version_default
   let _ = add_spec (
     "--version",
     Arg.Set check_version,
-    Format.sprintf "Output version information and exit"
+    Format.sprintf "@.     Output version information and exit"
   )
   let check_version () = !check_version
+
+
+  (* Explain modules. *)
+  let flags_of_default = []
+  let flags_of = ref flags_of_default
+  let _ = add_spec (
+    "--flags_of",
+    Arg.String (
+      fun str -> if List.mem str !flags_of |> not then
+        flags_of := str :: !flags_of
+    ),
+    Format.asprintf
+      "@.    \
+        explains and shows the flags for a Kind 2 module among\
+        @.      %a\
+        @.      %-15s: explaination and flags for all Kind 2 modules\
+      "
+      (pp_print_list
+        ( fun fmt (key, m0d) ->
+          let module Flags = (val m0d: FlagModule) in
+          Format.fprintf fmt
+            "%-15s: %s" (Format.sprintf "%s" key) Flags.desc
+        ) "@.      "
+      ) module_map
+      "\"all\""
+  )
+  let flags_of () = !flags_of
 
 
   (* Main lustre node. *)
@@ -205,8 +1558,10 @@ module Global = struct
     "--lus_main",
     Arg.String (fun str -> lus_main := Some str),
     Format.sprintf
-      "Use the given node as top node in Lustre input \
-      (default: \"--%%MAIN\" annotation in source if any, last node otherwise)"
+      "@.     \
+        Use the given node as top node in Lustre input@.     \
+        Default: \"--%%MAIN\" annotation in source if any, last node otherwise\
+      "
   )
   let lus_main () = !lus_main
 
@@ -234,7 +1589,10 @@ module Global = struct
     "--input-format",
     Arg.String (fun str -> input_format := input_format_of_string str),
     Format.sprintf
-      "Format of input file (available: %s, default: %s)"
+      "@.     \
+        Format of input file@.     \
+        Available: %s, Default: %s\
+      "
       input_format_values
       (string_of_input_format input_format_default)
   )
@@ -248,8 +1606,11 @@ module Global = struct
     "--output_dir",
     Arg.Set_string output_dir,
     Format.sprintf
-      "output directory for SMT traces, compilation, testgen and \
-      certification (default: %s)"
+      "@.     \
+        output directory for the files generated:@.     \
+        SMT traces, compilation, testgen, certification...@.     \
+        Default: \"%s\"\
+      "
       output_dir_default
   )
   let output_dir () = !output_dir
@@ -261,8 +1622,10 @@ module Global = struct
     "--debug",
     Arg.String (fun str -> debug_ref := str :: !debug_ref),
     Format.sprintf
-      "enable debug output for a section, give one --debug option \
-      for each section to be enabled"
+      "@.     \
+        enable debug output for a section, give one --debug option\
+        @.     for each section to be enabled\
+      "
   )
   let debug () = !debug_ref
 
@@ -273,7 +1636,11 @@ module Global = struct
   let _ = add_spec (
     "--debug-log",
     Arg.String (fun str -> debug_log := Some str),
-    Format.sprintf "output debug messages to file (default: stdout)"
+    Format.sprintf
+      "@.     \
+        output debug messages to file@.     \
+        Default: stdout\
+      "
   )
   let debug_log () = ! debug_log
 
@@ -284,27 +1651,27 @@ module Global = struct
   let _ = add_specs ([
     ( "-qq",
       Arg.Unit (fun () -> log_level := L_off),
-      Format.sprintf "Disable output completely"
+      Format.sprintf "@.     Disable output completely"
     ) ;
     ( "-q",
       Arg.Unit (fun () -> log_level := L_fatal),
-      Format.sprintf "Disable output, fatal errors only"
+      Format.sprintf "@.     Disable output, fatal errors only"
     ) ;
     ( "-s",
       Arg.Unit (fun () -> log_level := L_error),
-      Format.sprintf "Silence output, errors only"
+      Format.sprintf "@.     Silence output, errors only"
     ) ;
     ( "-v",
       Arg.Unit (fun () -> log_level := L_info),
-      Format.sprintf "Output informational messages"
+      Format.sprintf "@.     Output informational messages"
     ) ;
     ( "-vv",
       Arg.Unit (fun () -> log_level := L_debug),
-      Format.sprintf "Output informational and debug messages"
+      Format.sprintf "@.     Output informational and debug messages"
     ) ;
     ( "-vvv",
       Arg.Unit (fun () -> log_level := L_trace),
-      Format.sprintf "Output informational, debug and trace messages"
+      Format.sprintf "@.     Output informational, debug and trace messages"
     )
   ])
   let log_level () = !log_level
@@ -316,7 +1683,7 @@ module Global = struct
   let _ = add_spec (
     "-xml",
     Arg.Set log_format_xml,
-    Format.sprintf "Output in XML format"
+    Format.sprintf "@.     Output in XML format"
   )
   let log_format_xml () = !log_format_xml
 
@@ -328,12 +1695,15 @@ module Global = struct
     ( "--timeout",
       Arg.Set_float timeout_wall,
       Format.sprintf
-        "wallclock timeout in seconds (default: %1.f)"
+        "@.     \
+          wallclock timeout in seconds@.     \
+          Default: %1.f\
+        "
         timeout_wall_default
     ) ;
     ( "--timeout_wall",
       Arg.Set_float timeout_wall,
-      Format.sprintf "for legacy, same as \"--timeout\""
+      Format.sprintf "@.     for legacy, same as \"--timeout\""
     )
   ])
   let timeout_wall () = !timeout_wall
@@ -400,7 +1770,11 @@ module Global = struct
         then enabled := mdl :: !enabled
     ),
     Format.sprintf
-      "enable Kind module (available: %s, default: %s)"
+      "@.     \
+        Enable Kind module@.     \
+        Available: %s@.     \
+        Default: %s\
+      "
       enable_values
       (string_of_enable enable_default_after)
   )
@@ -415,7 +1789,12 @@ module Global = struct
         if List.mem mdl !disabled |> not
         then disabled := mdl :: !disabled
     ),
-    Format.sprintf "disable Kind module (available: %s, default enabled: %s)"
+    Format.sprintf
+      "@.     \
+        Disable Kind module@.     \
+        Available: %s@.     \
+        Default enabled: %s\
+      "
       enable_values (string_of_enable enable_default_after)
   )
   let disabled () = !disabled
@@ -428,7 +1807,10 @@ module Global = struct
     "--modular",
     bool_arg modular,
     Format.sprintf
-      "bottom-up analysis of each node (default: %B)"
+      "@.     \
+        bottom-up analysis of each node@.     \
+        Default: %B\
+      "
       modular_default
   )
   let modular () = !modular
@@ -441,8 +1823,10 @@ module Global = struct
     "--lus_strict",
     bool_arg lus_strict,
     Format.sprintf
-      "Strict mode in Lustre: uninitialized pre and undefined \
-      local variables are not allowed when this flag is present."
+      "@.     \
+        Strict mode in Lustre: uninitialized pre and undefined@.     \
+        Local variables are not allowed when this flag is present\
+      "
   )
   let lus_strict () = !lus_strict
 
@@ -452,8 +1836,10 @@ module Global = struct
     "--lus_compile",
     bool_arg lus_compile,
     Format.sprintf
-      "@[<v 7>@,(default: %b)@ \
-      Activates compiling to Rust, deactivates everything else.@]"
+      "@.     \
+        Nodes proved correct will be compiled to Rust@.     \
+        Default: %b@ \
+      "
       lus_compile_default
   )
   let lus_compile () = !lus_compile
@@ -466,861 +1852,6 @@ end
 (* Re-exports. *)
 type enable = Global.enable
 type input_format = Global.input_format
-
-
-
-(* Options related to the underlying SMT solver. *)
-module Smt = struct
-
-  (* All the flag specification of this module. *)
-  let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
-  let add_spec spec = add_specs [spec]
-
-  (* Active SMT solver. *)
-  type solver = [
-    | `Z3_SMTLIB
-    | `CVC4_SMTLIB
-    | `MathSat5_SMTLIB
-    | `Yices_SMTLIB
-    | `Yices_native
-    | `detect
-  ]
-  let solver_of_string = function
-    | "Z3" -> `Z3_SMTLIB
-    | "CVC4" -> `CVC4_SMTLIB
-    | "MathSat5" -> `MathSat5_SMTLIB
-    | "Yices2" -> `Yices_SMTLIB
-    | "Yices" -> `Yices_native
-    | _ -> Arg.Bad "Bad value for --smtsolver" |> raise
-  let string_of_solver = function
-    | `Z3_SMTLIB -> "Z3"
-    | `CVC4_SMTLIB -> "CVC4"
-    | `Yices_SMTLIB -> "Yices2"
-    | `Yices_native -> "Yices"
-    | `MathSat5_SMTLIB -> "MathSat5"
-    | `detect -> "detect"
-  let solver_values = "Z3, CVC4, MathSat5, Yices, Yices2"
-  let solver_default = `detect
-  let solver = ref solver_default
-  let _ = add_spec (
-    "--smtsolver",
-    Arg.String (fun str -> solver := solver_of_string str),
-    Format.sprintf
-      "choose SMT solver (available: %s, default: %s)"
-      solver_values
-      (string_of_solver solver_default)
-  )
-  let set_solver s = solver := s
-  let solver () = !solver
-
-  (* Active SMT logic. *)
-  type logic = [
-    `None | `detect | `Logic of string
-  ]
-  let logic_values = [
-    `None ; `detect ; `Logic ("\"logic\"")
-  ]
-  let logic_of_string = function
-    | "none" | "None" -> `None
-    | "detect" | "Detect" -> `detect
-    | s -> `Logic s
-  let string_of_logic = function
-    | `None -> "none"
-    | `detect -> "detect"
-    | `Logic s -> s
-  let logic_default = `None
-  let logic = ref logic_default
-  let _ = add_spec (
-    "--smtlogic",
-    Arg.String (fun str -> logic := logic_of_string str),
-    "select logic for SMT solvers (\"none\" for no logic (default), and \
-     \"detect\" to detect with the input system, other SMTLIB logics will be \
-     passed to the solver)"
-  )
-  let logic () = !logic
-
-  (* Activates check-sat with assumptions when supported. *)
-  let check_sat_assume_of_string s = s
-  let string_of_check_sat_assume s = s
-  let check_sat_assume_default = true
-  let check_sat_assume = ref check_sat_assume_default
-  let _ = add_spec (
-    "--smt_check_sat_assume",
-    bool_arg check_sat_assume,
-    Format.sprintf
-      "Use check-sat with assumptions, or simulate with push/pop \
-       when false (default: %B)"
-      check_sat_assume_default
-  )
-  let check_sat_assume () = !check_sat_assume
-
-  (* Use short name for variables at SMT level. *)
-  let short_names_of_string s = s
-  let string_of_short_names s = s
-  let short_names_default = true
-  let short_names = ref short_names_default
-  let _ = add_spec (
-    "--smt_short_names",
-    bool_arg short_names,
-    Format.sprintf
-      "Send short variables names to SMT solver, send full names if false \
-      (default: %B)"
-      short_names_default
-  )
-  let short_names () = !short_names
-
-  (* Z3 binary. *)
-  let z3_bin_of_string s = s
-  let string_of_z3_bin s = s
-  let z3_bin_default = "z3"
-  let z3_bin = ref z3_bin_default
-  let _ = add_spec (
-    "--z3_bin",
-    Arg.Set_string z3_bin,
-    Format.sprintf
-      "executable of Z3 solver (default: %s)"
-      (string_of_z3_bin z3_bin_default)
-  )
-  let set_z3_bin str = z3_bin := str
-  let z3_bin () = ! z3_bin
-
-  (* CVC4 binary. *)
-  let cvc4_bin_of_string s = s
-  let string_of_cvc4_bin s = s
-  let cvc4_bin_default = "cvc4"
-  let cvc4_bin = ref cvc4_bin_default
-  let _ = add_spec (
-    "--cvc4_bin",
-    Arg.Set_string cvc4_bin,
-    Format.sprintf
-      "executable of CVC4 solver (default: %s)"
-      (string_of_cvc4_bin cvc4_bin_default)
-  )
-  let set_cvc4_bin str = cvc4_bin := str
-  let cvc4_bin () = !cvc4_bin
-
-  (* Mathsat 5 binary. *)
-  let mathsat5_bin_of_string s = s
-  let string_of_mathsat5_bin s = s
-  let mathsat5_bin_default = "mathsat"
-  let mathsat5_bin = ref mathsat5_bin_default
-  let _ = add_spec (
-    "--mathsat5_bin",
-    Arg.Set_string mathsat5_bin,
-    Format.sprintf
-      "executable of MathSAT5 solver (default: %s)"
-      (string_of_mathsat5_bin mathsat5_bin_default)
-  )
-  let set_mathsat5_bin str = mathsat5_bin := str
-  let mathsat5_bin () = !mathsat5_bin
-
-  (* Yices binary. *)
-  let yices_bin_of_string s = s
-  let string_of_yices_bin s = s
-  let yices_bin_default = "yices"
-  let yices_bin = ref yices_bin_default
-  let _ = add_spec (
-    "--yices_bin",
-    Arg.Set_string yices_bin,
-    Format.sprintf
-      "executable of Yices solver (default: %s)"
-      (string_of_yices_bin yices_bin_default)
-  )
-  let set_yices_bin str = yices_bin := str
-  let yices_bin () = !yices_bin
-
-  (* Yices 2 binary. *)
-  let yices2smt2_bin_of_string s = s
-  let string_of_yices2smt2_bin s = s
-  let yices2smt2_bin_default = "yices-smt2"
-  let yices2smt2_bin = ref yices2smt2_bin_default
-  let _ = add_spec (
-    "--yices2_bin",
-    Arg.Set_string yices2smt2_bin,
-    Format.sprintf
-      "executable of Yices2 SMT2 solver (default: %s)"
-      (string_of_yices2smt2_bin yices2smt2_bin_default)
-  )
-  let set_yices2smt2_bin str = yices2smt2_bin := str
-  let yices2smt2_bin () = !yices2smt2_bin
-
-  (* Activates logging of SMT interactions. *)
-  let trace_default = false
-  let trace = ref trace_default
-  let _ = add_spec (
-    "--smt_trace",
-    Arg.Set trace,
-    Format.sprintf "Write all SMT commands to files"
-  )
-  let trace () = !trace
-
-  (* Folder to log the SMT traces into. *)
-  let trace_dir () =
-    Global.output_dir () |> mk_dir ;
-    let dir = Global.output_dir () |> Format.sprintf "%s/smt_trace" in
-    mk_dir dir ;
-    dir
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-
-end
-
-
-
-
-(* BMC and k-induction flags. *)
-module BmcKind = struct
-
-  (* All the flag specification of this module. *)
-  let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
-  let add_spec spec = add_specs [spec]
-
-  let max_default = 0
-  let max = ref max_default
-  let _ = add_spec (
-    "--unroll_max",
-    Arg.Set_int max,
-    Format.sprintf
-      "(BMC, IND) Maximal number of iterations (default: %d, unlimited: 0)"
-      max_default
-  )
-  let max () = !max
-
-  let check_unroll_default = true
-  let check_unroll = ref check_unroll_default
-  let _ = add_spec (
-    "--bmc_check_unroll",
-    bool_arg check_unroll,
-    Format.sprintf
-      "(BMC) Check that the unrolling alone is satisfiable (default: %b)"
-      check_unroll_default
-  )
-  let check_unroll () = !check_unroll
-
-  let print_cex_default = false
-  let print_cex = ref print_cex_default
-  let _ = add_spec (
-    "--ind_print_cex",
-    bool_arg print_cex,
-    Format.sprintf
-      "(IND) Print counterexamples to induction (default: %b)"
-      print_cex_default
-  )
-  let print_cex () = !print_cex
-
-  let compress_default = true
-  let compress = ref compress_default
-  let _ = add_spec (
-    "--ind_compress",
-    bool_arg compress,
-    Format.sprintf
-      "(IND) Compress inductive counterexamples (default: %B)"
-      compress_default
-  )
-  let compress () = !compress
-
-  let compress_equal_default = true
-  let compress_equal = ref compress_equal_default
-  let _ = add_spec (
-    "--ind_compress_equal",
-    bool_arg compress_equal,
-    Format.sprintf
-      "(IND) Compress inductive counterexamples for states equal \
-      modulo inputs (default: %B)"
-      compress_equal_default
-  )
-  let compress_equal () = !compress_equal
-
-  let compress_same_succ_default = false
-  let compress_same_succ = ref compress_same_succ_default
-  let _ = add_spec (
-    "--ind_compress_same_succ",
-    bool_arg compress_same_succ,
-    Format.sprintf
-      "(IND) Compress inductive counterexamples for states \
-      with same successors (default: %B)"
-      compress_same_succ_default
-  )
-  let compress_same_succ () = !compress_same_succ
-
-  let compress_same_pred_default = false
-  let compress_same_pred = ref compress_same_pred_default
-  let _ = add_spec (
-  "--ind_compress_same_pred",
-    bool_arg compress_same_pred,
-    Format.sprintf
-      "(IND) Compress inductive counterexamples for states \
-      with same predecessors (default: %B)"
-      compress_same_pred_default
-  )
-  let compress_same_pred () = !compress_same_pred
-
-  let lazy_invariants_default = false
-  let lazy_invariants = ref lazy_invariants_default
-  let _ = add_spec (
-    "--ind_lazy_invariants",
-    bool_arg lazy_invariants,
-    Format.sprintf
-      "(IND) Asserts invariants lazily (default: %B)"
-      lazy_invariants_default
-  )
-  let lazy_invariants () = !lazy_invariants
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-
-end
-
-
-
-(* IC3 flags. *)
-module IC3 = struct
-
-  (* All the flag specification of this module. *)
-  let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
-  let add_spec spec = add_specs [spec]
-
-  let string_of_check_inductive = string_of_bool
-  let check_inductive_default = true
-  let check_inductive = ref check_inductive_default
-  let _ = add_spec (
-    "--ic3_check_inductive",
-    bool_arg check_inductive,
-    Format.sprintf
-      "(IC3) Check inductiveness of blocking clauses (default: %s)"
-      (string_of_check_inductive check_inductive_default)
-  )
-  let check_inductive () = !check_inductive
-
-  let print_to_file_default = None
-  let print_to_file = ref print_to_file_default
-  let _ = add_spec (
-    "--ic3_print_to_file",
-    Arg.String (fun str -> print_to_file := Some str),
-    Format.sprintf
-      "(IC3) Output file for blocking clauses (default: stdout)"
-  )
-  let print_to_file () = !print_to_file
-
-  let string_of_inductively_generalize = string_of_int
-  let inductively_generalize_default = 1
-  let inductively_generalize = ref inductively_generalize_default
-  let _ = add_spec (
-    "--ic3_inductively_generalize",
-    Arg.Set_int inductively_generalize,
-    Format.sprintf
-      "(IC3) Inductively generalize blocking clauses before forward \
-      propagation (0 = none, 1 = normal IG, 2 = IG with ordering) \
-      (default: %s)"
-      (string_of_inductively_generalize inductively_generalize_default)
-  )
-  let inductively_generalize () = !inductively_generalize
-
-  let string_of_block_in_future = string_of_bool
-  let block_in_future_default = true
-  let block_in_future = ref block_in_future_default
-  let _ = add_spec (
-    "--ic3_block_in_future",
-    bool_arg block_in_future,
-    Format.sprintf
-      "(IC3) Block counterexample in future frames (default: %s)"
-      (string_of_block_in_future block_in_future_default)
-  )
-  let block_in_future () = !block_in_future
-
-  let string_of_block_in_future_first = string_of_bool
-  let block_in_future_first_default = true
-  let block_in_future_first = ref block_in_future_first_default
-  let _ = add_spec (
-    "--ic3_block_in_future_first",
-    bool_arg block_in_future_first,
-    Format.sprintf
-      "(IC3) Block counterexample in future frames first before returning to \
-      frame (default: %s)"
-      (string_of_block_in_future_first block_in_future_first_default)
-  )
-  let block_in_future_first () = !block_in_future_first
-
-  let string_of_fwd_prop_non_gen = string_of_bool
-  let fwd_prop_non_gen_default = true
-  let fwd_prop_non_gen = ref fwd_prop_non_gen_default
-  let _ = add_spec (
-    "--ic3_fwd_prop_non_gen",
-    bool_arg fwd_prop_non_gen,
-    Format.sprintf
-      "(IC3) Also propagate clauses before generalization (default: %s)"
-      (string_of_fwd_prop_non_gen fwd_prop_non_gen_default)
-  )
-  let fwd_prop_non_gen () = !fwd_prop_non_gen
-
-  let string_of_fwd_prop_ind_gen = string_of_bool
-  let fwd_prop_ind_gen_default = true
-  let fwd_prop_ind_gen = ref fwd_prop_ind_gen_default
-  let _ = add_spec (
-    "--ic3_fwd_prop_ind_gen",
-    bool_arg fwd_prop_ind_gen,
-    Format.sprintf
-      "(IC3) Inductively generalize all clauses after forward propagation \
-      (default: %s)"
-      (string_of_fwd_prop_ind_gen fwd_prop_ind_gen_default)
-  )
-  let fwd_prop_ind_gen () = !fwd_prop_ind_gen
-
-  let string_of_fwd_prop_subsume = string_of_bool
-  let fwd_prop_subsume_default = true
-  let fwd_prop_subsume = ref fwd_prop_subsume_default
-  let _ = add_spec (
-    "--ic3_fwd_prop_subsume",
-    bool_arg fwd_prop_subsume,
-    Format.sprintf
-      "(IC3) Subsumption in forward propagation (default: %s)"
-      (string_of_fwd_prop_subsume fwd_prop_subsume_default)
-  )
-  let fwd_prop_subsume () = !fwd_prop_subsume
-
-  let string_of_use_invgen = string_of_bool
-  let use_invgen_default = true
-  let use_invgen = ref use_invgen_default
-  let _ = add_spec (
-    "--ic3_use_invgen",
-    bool_arg use_invgen,
-    Format.sprintf
-      "(IC3) Use invariants from invariant generators (default: %s)"
-      (string_of_use_invgen use_invgen_default)
-  )
-  let use_invgen () = !use_invgen
-
-  type qe = [
-    `Z3 | `Z3_impl | `Z3_impl2 | `Cooper
-  ]
-  let qe_of_string = function
-    | "Z3" -> `Z3
-    | "Z3-impl" -> `Z3_impl
-    | "Z3-impl2" -> `Z3_impl2
-    | "cooper" -> `Cooper
-    | _ -> raise (Arg.Bad "Bad value for --ic3_qe")
-  let string_of_qe = function
-    | `Z3 -> "Z3"
-    |  `Z3_impl -> "Z3-impl"
-    |  `Z3_impl2 -> "Z3-impl2"
-    | `Cooper -> "cooper"
-  let qe_values = [
-    `Z3 ; `Z3_impl ; `Z3_impl2 ; `Cooper
-  ] |> List.map string_of_qe |> String.concat ", "
-  let qe_default = `Cooper
-  let qe = ref qe_default
-  let _ = add_spec (
-    "--ic3_qe",
-    Arg.String (fun str -> qe := qe_of_string str),
-    Format.sprintf
-      "(IC3) choose quantifier elimination algorithm \
-      (available: %s, default: %s)"
-      qe_values (string_of_qe qe_default)
-  )
-  let set_qe q = qe := q
-  let qe () = !qe
-
-  type extract = [ `First | `Vars ]
-  let extract_of_string = function
-    | "first" -> `First
-    | "vars" -> `Vars
-    | _ -> raise (Arg.Bad "Bad value for --ic3_extract")
-  let string_of_extract = function
-    | `First -> "first"
-    | `Vars -> "vars"
-  let extract_values = [
-    `First ; `Vars
-  ] |> List.map string_of_extract |> String.concat ", "
-  let extract_default = `First
-  let extract = ref extract_default
-  let _ = add_spec (
-    "--ic3_extract",
-    Arg.String (fun str -> extract := extract_of_string str),
-    Format.sprintf
-      "(IC3) Heuristics for extraction of implicant \
-      (available: %s, default: %s)"
-      extract_values (string_of_extract extract_default)
-  )
-  let extract () = !extract
-
-  type abstr = [ `None | `IA ]
-  let abstr_of_string = function
-    | "None" -> `None
-    | "IA" -> `IA
-    | _ -> raise (Arg.Bad "Bad value for --ic3_abstr")
-  let string_of_abstr = function
-    | `IA -> "IA"
-    | `None -> "None"
-  let abstr_values = [
-    `None ; `IA
-  ] |> List.map string_of_abstr |> String.concat ", "
-  let abstr_default = `None
-  let abstr = ref abstr_default
-  let _ = add_spec (
-    "--ic3_abstr",
-    Arg.String (fun str -> abstr := abstr_of_string str),
-    Format.sprintf
-      "(IC3) choose method of abstraction in IC3 (available: %s, default: %s)"
-      abstr_values (string_of_abstr abstr_default)
-  )
-  let abstr () = !abstr
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-
-end
-
-
-(* Quantifier elimination module. *)
-module QE = struct
-
-  (* All the flag specification of this module. *)
-  let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
-  let add_spec spec = add_specs [spec]
-
-  let cooper_order_var_by_elim_default = false
-  let cooper_order_var_by_elim = ref cooper_order_var_by_elim_default
-  let _ = add_spec (
-    "--cooper_order_var_by_elim",
-    bool_arg cooper_order_var_by_elim,
-    Format.sprintf
-      "(Cooper QE) Order variables in polynomials by order of \
-      elimination (default: %B)"
-      cooper_order_var_by_elim_default
-  )
-  let cooper_order_var_by_elim () = !cooper_order_var_by_elim
-
-  let cooper_general_lbound_default = false
-  let cooper_general_lbound = ref cooper_general_lbound_default
-  let _ = add_spec (
-    "--cooper_general_lbound",
-    bool_arg cooper_general_lbound,
-    Format.sprintf
-      "(Cooper QE) Choose lower bounds containing variables \
-      (default: %B)"
-      cooper_general_lbound_default
-  )
-  let cooper_general_lbound () = !cooper_general_lbound
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-end
-
-
-
-
-(* Contracts flags. *)
-module Contracts = struct
-
-  (* All the flag specification of this module. *)
-  let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
-  let add_spec spec = add_specs [spec]
-
-  let compositional_default = false
-  let compositional = ref compositional_default
-  let _ = add_spec (
-    "--compositional",
-    bool_arg compositional,
-    Format.sprintf
-      "abstract subnodes with a contract (default: %B)"
-      compositional_default
-  )
-  let compositional () = !compositional
-
-  let check_modes_default = true
-  let check_modes = ref check_modes_default
-  let _ = add_spec (
-    "--check_modes",
-    bool_arg check_modes,
-    Format.sprintf
-      "checks the modes of a contracts are exhaustive \
-      (default: %B, setting to `false` automatically activates `check_implem`)"
-      check_modes_default
-  )
-  let check_modes () = !check_modes
-
-  let check_implem_default = true
-  let check_implem = ref check_implem_default
-  let _ = add_spec (
-    "--check_implem",
-    bool_arg check_implem,
-    Format.sprintf
-      "checks the implementation of nodes \
-      (default: %B, setting to `false` automatically activates `check_modes`)"
-      check_implem_default
-  )
-  let check_implem () = !check_implem
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-
-end
-
-
-
-(* Testgen flags. *)
-module Testgen = struct
-
-  (* All the flag specification of this module. *)
-  let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
-  let add_spec spec = add_specs [spec]
-
-  let active_default = false
-  let active = ref active_default
-  let _ = add_spec (
-    "--testgen",
-    bool_arg active,
-    Format.sprintf
-      "@[<v 7>@,(default: %b)@ \
-      Activates test generation, deactivates everything else.@]"
-      active_default
-  )
-  let active () = !active
-
-  let graph_only_default = false
-  let graph_only = ref graph_only_default
-  let _ = add_spec (
-    "--testgen_graph_only",
-    bool_arg graph_only,
-    Format.sprintf
-     "@[<v 7>@,(default: %b)@ \
-     Only draw the graph of reachable modes, do not log testcases.@ \
-     Does log errors.@]"
-     graph_only_default
-  )
-  let graph_only () = !graph_only
-
-  let len_default = 5
-  let len = ref len_default
-  let _ = add_spec (
-    "--testgen_len",
-    Arg.Set_int len,
-    Format.sprintf
-      "@[<v 7>@,(default: %d)@ \
-      Maximimum length for test generation.@]"
-      len_default
-  )
-  let len () = !len
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-
-end
-
-
-(* Invgen flags. *)
-module Invgen = struct
-
-  (* All the flag specification of this module. *)
-  let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
-  let add_spec spec = add_specs [spec]
-
-  let prune_trivial_default = true
-  let prune_trivial = ref prune_trivial_default
-  let _ = add_spec (
-    "--invgen_prune_trivial",
-    bool_arg prune_trivial,
-    Format.sprintf
-      "Invariant generation will communicate invariants not implied by the \
-      transition relation (default: %B)."
-      prune_trivial_default
-  )
-  let prune_trivial () = !prune_trivial
-
-  let max_succ_default = 1
-  let max_succ = ref max_succ_default
-  let _ = add_spec (
-    "--invgen_max_succ",
-    Arg.Int (fun b -> max_succ := b),
-    Format.sprintf
-      "Maximal number of successive iterations for subsystems (default: %d)."
-      max_succ_default
-  )
-  let max_succ () = !max_succ
-
-  let lift_candidates_default = false
-  let lift_candidates = ref lift_candidates_default
-  let _ = add_spec (
-    "--invgen_lift_candidates",
-    bool_arg lift_candidates,
-    Format.sprintf
-      "Invariant generation will instantiate candidates from sub-nodes\
-      (default: %B)."
-      lift_candidates_default
-  )
-  let lift_candidates () = !lift_candidates
-
-  let top_only_default = false
-  let top_only = ref top_only_default
-  let _ = add_spec (
-    "--invgen_top_only",
-    bool_arg top_only,
-    Format.sprintf
-      "Only generate invariants for the top level\
-      (default: %B)."
-      top_only_default
-  )
-  let top_only () = !top_only
-
-  let mine_trans_default = true
-  let mine_trans = ref mine_trans_default
-  let _ = add_spec (
-    "--invgen_mine_trans",
-    bool_arg mine_trans,
-    Format.sprintf
-      "Invariant generation will extract candidate terms from the transition \
-      predicate (default: %B)."
-      mine_trans_default
-  )
-  let mine_trans () = !mine_trans
-
-  let renice_default = 0
-  let renice = ref renice_default
-  let _ = add_spec (
-    "--invgen_renice",
-    Arg.Set_int renice,
-    "Renice invariant generation process. Give a positive argument to lower \
-    priority."
-  )
-  let renice () = !renice
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-end
-
-
-(* C2I flags. *)
-module C2I = struct
-
-  (* All the flag specification of this module. *)
-  let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
-  let add_spec spec = add_specs [spec]
-
-  let dnf_size_default = 3
-  let dnf_size = ref dnf_size_default
-  let _ = add_spec (
-    "--c2i_dnf",
-    Arg.Set_int dnf_size,
-    Format.sprintf
-      "Number of disjuncts in the DNF constructed by C2I (default %d)."
-      dnf_size_default
-  )
-  let dnf_size () = !dnf_size
-
-  let int_cube_size_default = 3
-  let int_cube_size = ref int_cube_size_default
-  let _ = add_spec (
-    "--c2i_int_cubes",
-    Arg.Set_int int_cube_size,
-    Format.sprintf
-      "Number of int cubes in the DNF constructed by C2I (default %d)."
-      int_cube_size_default
-  )
-  let int_cube_size () = !int_cube_size
-
-  let real_cube_size_default = 3
-  let real_cube_size = ref real_cube_size_default
-  let _ = add_spec (
-    "--c2i_real_cubes",
-    Arg.Set_int real_cube_size,
-    Format.sprintf
-      "Number of real cubes in the DNF constructed by C2I (default %d)."
-      real_cube_size_default
-  )
-  let real_cube_size () = !real_cube_size
-
-  let modes_default = true
-  let modes = ref modes_default
-  let _ = add_spec (
-    "--c2i_modes",
-    bool_arg modes,
-    Format.sprintf
-      "Activates mode subcandidates. Subsumes c2i_dnf_size (default %b)."
-      modes_default
-  )
-  let modes () = !modes
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-end
-
-
-(* Interpreter flags. *)
-module Interpreter = struct
-
-  (* All the flag specification of this module. *)
-  let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
-  let add_spec spec = add_specs [spec]
-
-  let input_file_default = ""
-  let input_file = ref input_file_default
-  let _ = add_spec (
-    "--interpreter_input_file",
-    Arg.Set_string input_file,
-    Format.sprintf "(Interpreter) Read input from file"
-  )
-  let input_file () = !input_file
-
-  let steps_default = 0
-  let steps = ref steps_default
-  let _ = add_spec (
-    "--interpreter_steps",
-    Arg.Set_int steps,
-    Format.sprintf
-      "(Interpreter) Run number of steps, override the number of \
-      steps given in the input file (default: %d)"
-      steps_default
-  )
-  let steps () = !steps
-
-
-  (* Returns all the flag specification of this module. *)
-  let all_specs () = !all_specs
-end
-
-(* ********** *)
-
-(* All flags *)
-type flags = {
-  (* C2I flags. *)
-  mutable c2i_dnf_size : int ;
-  mutable c2i_int_cube_size : int ;
-  mutable c2i_real_cube_size : int ;
-  mutable c2i_modes : bool ;
-  (* Interpreter flags. *)
-  mutable interpreter_input_file : string ;
-  mutable interpreter_steps : int ;
-}
-
-(* Defaults for all flags *)
-let flags = {
-  (* C2I flags. *)
-  c2i_dnf_size = C2I.dnf_size_default ;
-  c2i_int_cube_size = C2I.int_cube_size_default ;
-  c2i_real_cube_size = C2I.real_cube_size_default ;
-  c2i_modes = C2I.modes_default ;
-  (* Interpreter flags. *)
-  interpreter_input_file = Interpreter.input_file_default;
-  interpreter_steps = Interpreter.steps_default;
-}
 
 
 (* ********************************************************************** *)
@@ -1358,14 +1889,18 @@ let subdir_for scope =
 (* Parsing of command-line options into flags                             *)
 (* ********************************************************************** *)
 
-let usage_msg =
-  Format.sprintf
-    "Usage: %s [options] FILE@\nProve properties in Lustre program FILE@\n"
-    (Filename.basename Sys.executable_name)
+let usage_msg = Filename.basename Sys.executable_name |> Format.sprintf "\
+  Usage: %s [options] <lustre_file>@.\
+  Prove properties in Lustre program <lustre_file>\
+"
+
+let global_msg = "\
+  Global options follow, use \"--flags_of\" for module-specific information\
+"
 
 let rec help_action () = raise (Arg.Help (Arg.usage_string speclist usage_msg))
 
-and speclist =
+and speclist = Global.all_specs ()
   (* [
 
     (* Display help *)
@@ -1380,7 +1915,7 @@ and speclist =
      "Display this list of options")
 
   ] @ *)
-  [
+(*   [
     Interpreter.all_specs ;
     C2I.all_specs ;
     Contracts.all_specs ;
@@ -1392,7 +1927,7 @@ and speclist =
   ] |> List.fold_left (
     fun l specs -> (specs ()) @ l
   ) []
-
+ *)
 
 let anon_action s =
   match Global.input_file () with
@@ -1441,8 +1976,12 @@ let parse_argv () =
 
   (* Output version information only? *)
   if Global.check_version () then (
-    Format.printf "%t@." pp_print_version; exit 0
+    Format.printf "%t@." pp_print_version ;
+    exit 0
   ) ;
+
+  (* If any module info was requested, print it and exit. *)
+  Global.flags_of () |> print_module_info ;
 
   (* Finalize the list of enabled module. *)
   Global.finalize_enabled () ;

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -170,9 +170,9 @@ end
 (** {2 QE flags} *)
 module QE : sig
   (** Order variables in polynomials by order of elimination **)
-  val cooper_order_var_by_elim : unit -> bool
+  val order_var_by_elim : unit -> bool
   (** Choose lower bounds containing variables **)
-  val cooper_general_lbound : unit -> bool
+  val general_lbound : unit -> bool
 end
 
 

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -18,10 +18,10 @@
 
 (** Command-line flags
 
-    Use the OCaml module [Arg] to parse the command-line and store the
-    value in a record type.
-   
-    @author Christoph Sticksel *)
+Use the OCaml module [Arg] to parse the command-line and store the
+value in a record type.
+
+@author Christoph Sticksel *)
 
 
 (** {1 Accessors for flags} *)

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -6,317 +6,260 @@
    may not use this file except in compliance with the License.  You
    may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0 
+   http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
    implied. See the License for the specific language governing
-   permissions and limitations under the License. 
+   permissions and limitations under the License.
 
 *)
 
-(** Command-line flags 
+(** Command-line flags
 
     Use the OCaml module [Arg] to parse the command-line and store the
     value in a record type.
-    
+   
     @author Christoph Sticksel *)
+
 
 (** {1 Accessors for flags} *)
 
-(** Wallclock timeout *)
-val timeout_wall : unit -> float
 
-(** CPU timeout *)
-val timeout_virtual : unit -> float
-
-(** SMT Solver to use *)
-type smtsolver = 
-  [ `Z3_SMTLIB
-  | `CVC4_SMTLIB
-  | `MathSat5_SMTLIB
-  | `Yices_SMTLIB
-  | `Yices_native
-  | `detect ]
-
-(** Return SMT solver *)
-val smtsolver : unit -> smtsolver 
-
-(** Set SMT solver and executable *)
-val set_smtsolver : smtsolver -> string -> unit
-
-(* (\** Return SMT solver to use with IC3 *\) *)
-(* val ic3_smtsolver : unit -> smtsolver  *)
-
-(* (\** Return SMT solver to use with Quantifier Elimination *\) *)
-(* val qe_smtsolver : unit -> smtsolver  *)
-
-(** detect logic to send SMT solver *)
-type smtlogic = [ `None | `detect | `Logic of string ]
-val smtlogic : unit -> smtlogic 
-
-(** Executable of Z3 solver *)
-type z3_bin = string
-val z3_bin : unit -> z3_bin
-
-(** Use check-sat with assumptions, or simulate with push/pop *)
-type smt_check_sat_assume = bool
-val smt_check_sat_assume : unit -> smt_check_sat_assume
-
-(** Send short names to SMT solver *)
-type smt_short_names = bool
-val smt_short_names : unit -> smt_short_names
-
-(** Executable of CVC4 solver *)
-type cvc4_bin = string
-val cvc4_bin : unit -> cvc4_bin
-
-(** Executable of MathSAT5 solver *)
-type mathsat5_bin = string
-val mathsat5_bin : unit -> mathsat5_bin
-
-(** Executable of Yices solver *)
-type yices_bin = string
-val yices_bin : unit -> yices_bin
-
-(** Executable of Yices2 SMT2 solver *)
-type yices2smt2_bin = string
-val yices2smt2_bin : unit -> yices2smt2_bin
-
-(** Write all SMT commands to files *)
-type smt_trace = bool
-val smt_trace : unit -> smt_trace
-
-(** Enabled Kind modules *)
-type enable = Lib.kind_module list
-val enable : unit -> enable
-
-(** Maximal number of iterations in BMC *)
-type bmc_max = int
-val bmc_max : unit -> bmc_max
-
-(** Check that the unrolling of the system alone is satisfiable. *)
-type bmc_check_unroll = bool
-val bmc_check_unroll : unit -> bmc_check_unroll
-
-(** Print counterexamples to induction. *)
-type ind_print_cex = bool
-val ind_print_cex : unit -> ind_print_cex
+(** {2 Meta flags} *)
 
 (** Output version information and exit *)
-type check_version = bool
-val check_version : unit -> check_version
+val check_version : unit -> bool
 
-(** Compress inductive counterexample *)
-type ind_compress = bool
-val ind_compress : unit -> ind_compress
 
-(** Compress inductive counterexample when states are equal modulo
-    inputs *)
-type ind_compress_equal = bool
-val ind_compress_equal : unit -> ind_compress_equal
+(** {2 Generic flags} *)
 
-(** Compress inductive counterexample when states have same successors *)
-type ind_compress_same_succ = bool
-val ind_compress_same_succ : unit -> ind_compress_same_succ
-
-(** Compress inductive counterexample when states have same predecessors *)
-type ind_compress_same_pred = bool
-val ind_compress_same_pred : unit -> ind_compress_same_pred
-
-(** Lazy assertion of invariants. *)
-type ind_lazy_invariants = bool
-val ind_lazy_invariants : unit -> ind_lazy_invariants
-
-(** Strict Lustre mode *)
-type strict = bool
-val strict : unit -> strict
-
-(** Algorithm for quantifier elimination in IC3 *)
-type ic3_qe = [ `Z3 | `Z3_impl | `Z3_impl2 | `Cooper ]
-val ic3_qe : unit -> ic3_qe
-val set_ic3_qe : ic3_qe -> unit
-
-(** Heuristics for extraction of implicant *)
-type ic3_extract = [ `First | `Vars ]
-val ic3_extract : unit -> ic3_extract
-
-(** Check inductiveness of blocking clauses *)
-type ic3_check_inductive = bool
-val ic3_check_inductive : unit -> ic3_check_inductive
-
-(** File for inductive blocking clauses *)
-type ic3_print_to_file = string option 
-val ic3_print_to_file : unit -> ic3_print_to_file
-
-(** Tighten blocking clauses to an unsatisfiable core *)
-type ic3_inductively_generalize = int
-val ic3_inductively_generalize : unit -> ic3_inductively_generalize
-
-(** Block counterexample in future frames *)
-type ic3_block_in_future = bool
-val ic3_block_in_future : unit -> ic3_block_in_future
-  
-(** Block counterexample in future frames first before returning to frame *)
-type ic3_block_in_future_first = bool
-val ic3_block_in_future_first : unit -> ic3_block_in_future_first  
-
-(** Also propagate clauses before generalization *)
-type ic3_fwd_prop_non_gen = bool
-val ic3_fwd_prop_non_gen : unit -> ic3_fwd_prop_non_gen
-
-(** Inductively generalize all clauses after forward propagation *)
-type ic3_fwd_prop_ind_gen = bool
-val ic3_fwd_prop_ind_gen : unit -> ic3_fwd_prop_ind_gen
-
-(** Subsumption in forward propagation *)
-type ic3_fwd_prop_subsume = bool
-val ic3_fwd_prop_subsume : unit -> ic3_fwd_prop_subsume
-
-(** Use invariants from invariant generators *)
-type ic3_use_invgen = bool
-val ic3_use_invgen : unit -> ic3_use_invgen
-
-(** Abstraction mechanism to use in IC3 *)
-type ic3_abstr = [ `None | `IA ]
-val ic3_abstr : unit -> ic3_abstr
-
+(** Input file *)
+val input_file : unit -> string
+(** Main node in Lustre file *)
+val lus_main : unit -> string option
+(** Format of input file *)
+type input_format = [ `Lustre | `Horn | `Native ]
+val input_format : unit -> input_format
+(** Output directory for the files Kind 2 generates. *)
+val output_dir : unit -> string
 (** Debug sections to enable *)
 val debug : unit -> string list
-
 (** Logfile for debug output  *)
 val debug_log : unit -> string option
-
 (** Verbosity level *)
 val log_level : unit -> Lib.log_level
-
 (** Output in XML format *)
 val log_format_xml : unit -> bool
-
+(** Wallclock timeout. *)
+val timeout_wall : unit -> float
+(** The Kind modules enabled is a list of [kind_module]s. *)
+type enable = Lib.kind_module list
+(** The modules enabled. *)
+val enable : unit -> enable
 (** Modular analysis. *)
-type modular = bool
-val modular : unit -> modular
+val modular : unit -> bool
+(** Strict Lustre mode. *)
+val lus_strict : unit -> bool
+(** Activates compilation to Rust. *)
+val lus_compile : unit -> bool
 
-(** Compositional analysis. *)
-type compositional = bool
-val compositional : unit -> compositional
 
-(** Compositional analysis. *)
-type output_dir = string
-val output_dir : unit -> output_dir
+(** {2 SMT solver flags} *)
+module Smt : sig
+  (** Logic sendable to the SMT solver. *)
+  type logic = [
+    `None | `detect | `Logic of string
+  ]
+  (** Logic to send to the SMT solver *)
+  val logic : unit -> logic
+  (** Legal SMT solvers. *)
+  type solver = [
+    | `Z3_SMTLIB
+    | `CVC4_SMTLIB
+    | `MathSat5_SMTLIB
+    | `Yices_SMTLIB
+    | `Yices_native
+    | `detect
+  ]
+  (** Set SMT solver and executable *)
+  val set_solver : solver -> unit
+  (** Which SMT solver to use. *)
+  val solver : unit -> solver
+  (** Use check-sat with assumptions, or simulate with push/pop *)
+  val check_sat_assume : unit -> bool
+  (** Send short names to SMT solver *)
+  val short_names : unit -> bool
+  (** Executable of Z3 solver *)
+  val z3_bin : unit -> string
+  (** Executable of CVC4 solver *)
+  val cvc4_bin : unit -> string
+  (** Executable of MathSAT5 solver *)
+  val mathsat5_bin : unit -> string
+  (** Executable of Yices solver *)
+  val yices_bin : unit -> string
+  (** Executable of Yices2 SMT2 solver *)
+  val yices2smt2_bin : unit -> string
+  (** Write all SMT commands to files *)
+  val trace : unit -> bool
+  (** Path to the smt trace directory. *)
+  val trace_dir : unit -> string
+end
+
+
+(** {2 BMC / k-induction flags} *)
+module BmcKind : sig
+  (** Maximal number of iterations in BMC. *)
+  val max : unit -> int
+  (** Check that the unrolling of the system alone is satisfiable. *)
+  val check_unroll : unit -> bool
+  (** Print counterexamples to induction. *)
+  val print_cex : unit -> bool
+  (** Compress inductive counterexample. *)
+  val compress : unit -> bool
+  (** Compress inductive counterexample when states are equal modulo inputs. *)
+  val compress_equal : unit -> bool
+  (** Compress inductive counterexample when states have same successors. *)
+  val compress_same_succ : unit -> bool
+  (** Compress inductive counterexample when states have same predecessors. *)
+  val compress_same_pred : unit -> bool
+  (** Lazy assertion of invariants. *)
+  val lazy_invariants : unit -> bool
+end
+
+
+(** {2 IC3 flags} *)
+module IC3 : sig
+  (** Algorithm usable for quantifier elimination in IC3. *)
+  type qe = [
+    `Z3 | `Z3_impl | `Z3_impl2 | `Cooper
+  ]
+  (** The QE algorithm IC3 should use. *)
+  val qe : unit -> qe
+  (** Sets [qe]. *)
+  val set_qe : qe -> unit
+  (** Check inductiveness of blocking clauses. *)
+  val check_inductive : unit -> bool
+  (** File for inductive blocking clauses. *)
+  val print_to_file : unit -> string option
+  (** Tighten blocking clauses to an unsatisfiable core. *)
+  val inductively_generalize : unit -> int
+  (** Block counterexample in future frames. *)
+  val block_in_future : unit -> bool
+  (** Block counterexample in future frames first before returning to frame. *)
+  val block_in_future_first : unit -> bool
+  (** Also propagate clauses before generalization. *)
+  val fwd_prop_non_gen : unit -> bool
+  (** Inductively generalize all clauses after forward propagation. *)
+  val fwd_prop_ind_gen : unit -> bool
+  (** Subsumption in forward propagation. *)
+  val fwd_prop_subsume : unit -> bool
+  (** Use invariants from invariant generators. *)
+  val use_invgen : unit -> bool
+  (** Legal abstraction mechanisms for in IC3. *)
+  type abstr = [ `None | `IA ]
+  (** Abstraction mechanism IC3 should use. *)
+  val abstr : unit -> abstr
+  (** Legal heuristics for extraction of implicants in IC3. *)
+  type extract = [ `First | `Vars ]
+  (** Heuristic for extraction of implicants in IC3. *)
+  val extract : unit -> extract
+end
+
+(** {2 QE flags} *)
+module QE : sig
+  (** Order variables in polynomials by order of elimination **)
+  val cooper_order_var_by_elim : unit -> bool
+  (** Choose lower bounds containing variables **)
+  val cooper_general_lbound : unit -> bool
+end
+
+
+(** {2 Contracts flags} *)
+module Contracts : sig
+  (** Compositional analysis. *)
+  val compositional : unit -> bool
+  (** Check modes. *)
+  val check_modes : unit -> bool
+  (** Check modes. *)
+  val check_implem : unit -> bool
+end
+
+
+(** {2 Testgen flags. *)
+
+module Testgen : sig
+  (** Activates test generation. *)
+  val active : unit -> bool
+  (** Only generate graph of reachable modes, do not log testcases. *)
+  val graph_only : unit -> bool
+  (** Length of the test case generated. *)
+  val len : unit -> int
+end
+
+
+(** {2 Invgen flags} *)
+module Invgen : sig
+  (** InvGen will remove trivial invariants, i.e. invariants implied by the
+      transition relation. *)
+  val prune_trivial : unit -> bool
+  (** Number of unrollings invariant generation should perform between
+    switching to a different systems. *)
+  val max_succ : unit -> int
+  (** InvGen will lift candidate terms from subsystems. **)
+  val lift_candidates : unit -> bool
+  (** InvGen will generate invariants only for top level. **)
+  val top_only : unit -> bool
+  (** InvGen will look for candidate terms in the transition predicate. *)
+  val mine_trans : unit -> bool
+  (** Renice invariant generation process. *)
+  val renice : unit -> int
+end
+
+
+(** {2 C2I flags} *)
+module C2I : sig
+  (** Number of disjuncts in the DNF constructed by C2I. *)
+  val dnf_size : unit -> int
+  (** Number of int cubes in the DNF constructed by C2I. *)
+  val int_cube_size : unit -> int
+  (** Number of real cubes in the DNF constructed by C2I. *)
+  val real_cube_size : unit -> int
+  (** Whether mode sub candidate is activated in c2i. *)
+  val modes : unit -> bool
+end
+
+
+(** {2 Interpreter flags} *)
+module Interpreter : sig
+  (** Read input from file. *)
+  val input_file : unit -> string
+  (** Run number of steps, override the number of steps given in the input
+    file. *)
+  val steps : unit -> int
+end
+
+
+(** {1 Convenience functions} *)
 
 (** Path to subdirectory for a system (in the output directory). *)
 val subdir_for : string list -> string
 
-(** Path to the smt trace directory. *)
-val smt_trace_dir : unit -> string
+(** Sets the solver kind (z3, CVC4, ...) and the actual command for that solver
+at the same time. *)
+val set_smtsolver : Smt.solver -> string -> unit
 
-(** Check modes. *)
-type check_modes = bool
-val check_modes : unit -> check_modes
-
-(** Check modes. *)
-type check_implem = bool
-val check_implem : unit -> check_implem
-
-(** Order variables in polynomials by order of elimination **)
-type cooper_order_var_by_elim = bool
-val cooper_order_var_by_elim : unit -> cooper_order_var_by_elim
-
-(** Choose lower bounds containing variables **)
-type cooper_general_lbound = bool
-val cooper_general_lbound : unit -> cooper_general_lbound
-
-(** Activates test generation. *)
-type testgen_active = bool
-val testgen_active : unit -> testgen_active
-
-(** Only generate graph of reachable modes, do not log testcases. *)
-type testgen_graph_only = bool
-val testgen_graph_only : unit -> testgen_graph_only
-
-(** Command for lustrec. *)
-type testgen_lustrec = string option
-val testgen_lustrec : unit -> testgen_lustrec
-
-(** Length of the test case generated. *)
-type testgen_len = int
-val testgen_len : unit -> testgen_len
-
-(** Activates compilation to Rust. *)
-type compile = bool
-val compile : unit -> compile
-
-(** InvGen will remove trivial invariants, i.e. invariants implied by
-    the transition relation.. **)
-type invgengraph_prune_trivial = bool
-val invgengraph_prune_trivial : unit -> invgengraph_prune_trivial
-type invgengraph_max_succ = int
-val invgengraph_max_succ : unit -> invgengraph_max_succ
-(** InvGen will lift candidate terms from subsystems.. **)
-type invgengraph_lift_candidates = bool
-val invgengraph_lift_candidates : unit -> invgengraph_lift_candidates
-(** InvGen will generate invariants only for top level. **)
-type invgengraph_top_only = bool
-val invgengraph_top_only : unit -> invgengraph_top_only
-(** InvGen will look for candidate terms in the transition
-    predicate. *)
-type invgengraph_mine_trans = bool
-val invgengraph_mine_trans : unit -> invgengraph_mine_trans
-
-(** Renice invariant generation process *)
-type invgengraph_renice = int
-val invgengraph_renice : unit -> invgengraph_renice
-
-(** Number of disjuncts in the DNF constructed by C2I. *)
-type c2i_dnf_size = int
-val c2i_dnf_size : unit -> c2i_dnf_size
-
-(** Number of int cubes in the DNF constructed by C2I. *)
-type c2i_int_cube_size = int
-val c2i_int_cube_size : unit -> c2i_int_cube_size
-
-(** Number of real cubes in the DNF constructed by C2I. *)
-type c2i_real_cube_size = int
-val c2i_real_cube_size : unit -> c2i_real_cube_size
-
-(** Whether mode sub candidate is activated in c2i. *)
-type c2i_modes = bool
-val c2i_modes : unit -> c2i_modes
-
-(** Read input from file **)
-type interpreter_input_file = string
-val interpreter_input_file : unit -> interpreter_input_file
-
-(** Run number of steps, override the number of steps given in the
-    input file **)
-type interpreter_steps = int
-val interpreter_steps : unit -> interpreter_steps
-
-(** Format of input file *)
-type input_format = [ `Lustre | `Horn | `Native ]
-val input_format : unit -> input_format 
-
-(** Input file *)
-val input_file : unit -> string 
-
-(** Main node in Lustre file *)
-val lustre_main : unit -> string option
-
-(** Flatten arrays to one stream per element *)
-type lustre_flatten_arrays = bool
-val lustre_flatten_arrays : unit -> lustre_flatten_arrays
 
 (** {1 Parsing of the command line} *)
 
 (** Parse the command line *)
 val parse_argv : unit -> unit
 
-(* 
+(*
    Local Variables:
    compile-command: "make -C .. -k"
    tuareg-interactive-program: "./kind2.top -I ./_build -I ./_build/SExpr"
    indent-tabs-mode: nil
-   End: 
+   End:
 *)

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -132,7 +132,7 @@ let main input_file input_sys aparam trans_sys =
     (* Number of steps to simulate *)
     let steps = 
 
-      match Flags.interpreter_steps () with 
+      match Flags.Interpreter.steps () with 
 
         (* Simulate length of smallest input if number of steps not given *)
         | s when s <= 0 -> input_length
@@ -164,7 +164,8 @@ let main input_file input_sys aparam trans_sys =
 
     (* Create solver instance *)
     let solver = 
-      SMTSolver.create_instance ~produce_assignments:true logic (Flags.smtsolver ())
+      Flags.Smt.solver ()
+      |> SMTSolver.create_instance ~produce_assignments:true logic
     in
 
     (* Create a reference for the solver. Only used in on_exit. *)

--- a/src/invGenCandTermGen.ml
+++ b/src/invGenCandTermGen.ml
@@ -471,7 +471,7 @@ module CandidateTermGen = struct
              |> set_of_term init
 
              (* Candidates from trans. *)
-             |> if Flags.invgengraph_mine_trans ()
+             |> if Flags.Invgen.mine_trans ()
                 then set_of_term trans else identity
            in
 
@@ -486,7 +486,7 @@ module CandidateTermGen = struct
 
            let sorted_result =
              result
-             |> ( if Flags.invgengraph_lift_candidates () then
+             |> ( if Flags.Invgen.lift_candidates () then
                     TSet.fold
                       ( fun term map ->
                         TransSys.instantiate_term_all_levels
@@ -511,7 +511,7 @@ module CandidateTermGen = struct
 
         let final =
           (* Only getting to system if required. *)
-          ( if Flags.invgengraph_top_only ()
+          ( if Flags.Invgen.top_only ()
             then get_last result else result )
           |> (
             (* One state-ing everything if required. *)

--- a/src/invGenGraph.ml
+++ b/src/invGenGraph.ml
@@ -803,7 +803,7 @@ module Make (InModule : In) : Out = struct
 
       if
         base_unsat_on_first_check
-        || Flags.invgengraph_max_succ () <= count
+        || Flags.Invgen.max_succ () <= count
       then
         (* Done, returning new binding. *)
         binding', cand_count
@@ -888,7 +888,7 @@ module Make (InModule : In) : Out = struct
     let lsd =
       LSD.create
         two_state
-        (Flags.invgengraph_top_only ())
+        (Flags.Invgen.top_only ())
         trans_sys
     in
 

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -99,7 +99,7 @@ let set_sigalrm_handler () =
 
 (* Renices the current process. Used for invariant generation. *)
 let renice () =
-  let nice =  (Flags.invgengraph_renice ()) in
+  let nice =  (Flags.Invgen.renice ()) in
 
   if nice < 0 then
     Event.log L_info
@@ -118,7 +118,7 @@ let main_of_process = function
   | `INVGEN -> renice () ; InvGenTS.main
   | `INVGENOS -> renice () ; InvGenOS.main
   | `C2I -> renice () ; C2I.main
-  | `Interpreter -> Interpreter.main (Flags.interpreter_input_file ())
+  | `Interpreter -> Interpreter.main (Flags.Interpreter.input_file ())
   | `Supervisor -> InvarManager.main child_pids
   | `Parser -> (fun _ _ _ -> ())
 
@@ -636,7 +636,7 @@ let run_process messaging_setup process =
 let check_smtsolver () =
 
   (* SMT solver from command-line *)
-  match Flags.smtsolver () with
+  match Flags.Smt.solver () with
 
     (* User chose Z3 *)
     | `Z3_SMTLIB ->
@@ -644,7 +644,7 @@ let check_smtsolver () =
       let z3_exec =
 
         (* Check if Z3 is on the path *)
-        try find_on_path (Flags.z3_bin ()) with
+        try find_on_path (Flags.Smt.z3_bin ()) with
 
           | Not_found ->
 
@@ -652,7 +652,7 @@ let check_smtsolver () =
             Event.log
               L_fatal
               "Z3 executable %s not found."
-              (Flags.z3_bin ()) ;
+              (Flags.Smt.z3_bin ()) ;
 
             exit 2
 
@@ -666,7 +666,7 @@ let check_smtsolver () =
       let cvc4_exec =
 
         (* Check if CVC4 is on the path *)
-        try find_on_path (Flags.cvc4_bin ()) with
+        try find_on_path (Flags.Smt.cvc4_bin ()) with
 
           | Not_found ->
 
@@ -674,7 +674,7 @@ let check_smtsolver () =
             Event.log
               L_fatal
               "CVC4 executable %s not found."
-              (Flags.cvc4_bin ()) ;
+              (Flags.Smt.cvc4_bin ()) ;
 
             exit 2
 
@@ -691,7 +691,7 @@ let check_smtsolver () =
       let mathsat5_exec =
 
         (* Check if MathSat5 is on the path *)
-        try find_on_path (Flags.mathsat5_bin ()) with
+        try find_on_path (Flags.Smt.mathsat5_bin ()) with
 
           | Not_found ->
 
@@ -699,7 +699,7 @@ let check_smtsolver () =
             Event.log
               L_fatal
               "MathSat5 executable %s not found."
-              (Flags.mathsat5_bin ()) ;
+              (Flags.Smt.mathsat5_bin ()) ;
 
             exit 2
 
@@ -717,7 +717,7 @@ let check_smtsolver () =
       let yices_exec =
 
         (* Check if MathSat5 is on the path *)
-        try find_on_path (Flags.yices_bin ()) with
+        try find_on_path (Flags.Smt.yices_bin ()) with
 
           | Not_found ->
 
@@ -725,7 +725,7 @@ let check_smtsolver () =
             Event.log
               L_fatal
               "Yices executable %s not found."
-              (Flags.yices_bin ()) ;
+              (Flags.Smt.yices_bin ()) ;
 
             exit 2
 
@@ -743,7 +743,7 @@ let check_smtsolver () =
       let yices_exec =
 
         (* Check if MathSat5 is on the path *)
-        try find_on_path (Flags.yices2smt2_bin ()) with
+        try find_on_path (Flags.Smt.yices2smt2_bin ()) with
 
           | Not_found ->
 
@@ -751,7 +751,7 @@ let check_smtsolver () =
             Event.log
               L_fatal
               "Yices2 SMT2 executable %s not found."
-              (Flags.yices2smt2_bin ()) ;
+              (Flags.Smt.yices2smt2_bin ()) ;
 
             exit 2
 
@@ -768,7 +768,7 @@ let check_smtsolver () =
 
       try
 
-        let z3_exec = find_on_path (Flags.z3_bin ()) in
+        let z3_exec = find_on_path (Flags.Smt.z3_bin ()) in
 
         Event.log L_info "Using Z3 executable %s." z3_exec ;
 
@@ -781,7 +781,7 @@ let check_smtsolver () =
 
         try
 
-          let cvc4_exec = find_on_path (Flags.cvc4_bin ()) in
+          let cvc4_exec = find_on_path (Flags.Smt.cvc4_bin ()) in
 
           Event.log
             L_info
@@ -797,7 +797,7 @@ let check_smtsolver () =
 
           try
 
-            let mathsat5_exec = find_on_path (Flags.mathsat5_bin ()) in
+            let mathsat5_exec = find_on_path (Flags.Smt.mathsat5_bin ()) in
 
             Event.log
               L_info
@@ -813,7 +813,7 @@ let check_smtsolver () =
 
             try
 
-              let yices_exec = find_on_path (Flags.yices_bin ()) in
+              let yices_exec = find_on_path (Flags.Smt.yices_bin ()) in
 
               Event.log
                 L_info
@@ -930,7 +930,7 @@ let setup () =
 (* Runs test generation on the system (scope) specified by abstracting
    everything. *)
 let run_testgen input_sys top =
-  if Flags.testgen_active () then (
+  if Flags.Testgen.active () then (
     match InputSystem.maximal_abstraction_for_testgen input_sys top [] with
     | None ->
       Event.log L_warn
@@ -974,7 +974,7 @@ let run_testgen input_sys top =
 
 (* Compiles a system (scope) to Rust. *)
 let compile_to_rust input_sys top =
-  if Flags.compile () then (
+  if Flags.lus_compile () then (
     (* Creating root dir if needed. *)
     Flags.output_dir () |> mk_dir ;
     let target = Flags.subdir_for top in
@@ -1112,7 +1112,7 @@ let launch () =
 
     (* Run interpreter. *)
     Interpreter.main
-      (Flags.interpreter_input_file ())
+      (Flags.Interpreter.input_file ())
       (get !cur_input_sys)
       (get !cur_aparam)
       (get !cur_trans_sys) ;

--- a/src/lockStepDriver.ml
+++ b/src/lockStepDriver.ml
@@ -327,7 +327,7 @@ let create two_state top_only top_sys =
 
   let new_inst_sys () =
     SMTSolver.create_instance ~produce_assignments: true
-      (TransSys.get_logic top_sys) (Flags.smtsolver ())
+      (TransSys.get_logic top_sys) (Flags.Smt.solver ())
   in
 
   (* Solvers. *)
@@ -735,7 +735,7 @@ let increment_and_query_step
   let not_trivial, trivial =
     (* Pruning direct consequences of the transition relation if
           the flag requests it. *)
-    if Flags.invgengraph_prune_trivial () then
+    if Flags.Invgen.prune_trivial () then
       prune_trivial
         pruning_solver [] actlit terms_to_check
     else terms_to_check, []

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -1169,7 +1169,7 @@ let rec has_unguarded_pre ung = function
     if ung then begin
       (* Fail only if in strict mode *)
       let err_or_warn =
-        if Flags.strict () then error_at_position else warn_at_position in
+        if Flags.lus_strict () then error_at_position else warn_at_position in
 
       err_or_warn pos
         (Format.asprintf "@[<hov 2>Unguarded pre in expression@ %a@]"
@@ -1186,7 +1186,7 @@ let rec has_unguarded_pre ung = function
 
 let has_unguarded_pre e =
   let u = has_unguarded_pre true e in
-  if u && Flags.strict () then raise Parser_error;
+  if u && Flags.lus_strict () then raise Parser_error;
   u
       
 

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -2010,7 +2010,7 @@ let function_of_context = function
       D.fold
         (fun i sv a -> 
            let u = 
-             (if Flags.smt_short_names () then 
+             (if Flags.Smt.short_names () then 
                 UfSymbol.mk_fresh_uf_symbol
               else
                 UfSymbol.mk_uf_symbol

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -74,7 +74,7 @@ let of_channel in_ch =
   let main_node = 
 
     (* Command-line flag for main node given? *)
-    match Flags.lustre_main () with 
+    match Flags.lus_main () with 
       
       (* Use given identifier to choose main node *)
       | Some s -> LustreIdent.mk_string_ident s

--- a/src/poly.ml
+++ b/src/poly.ml
@@ -223,7 +223,7 @@ let get_coe_in_poly_obv (v: Var.t) (pl: poly) : Numeral.t =
 
 let get_coe_in_poly v pl = 
 
-  match (Flags.cooper_order_var_by_elim ()) with
+  match (Flags.QE.cooper_order_var_by_elim ()) with
       
     | false -> get_coe_in_poly_anyorder v pl
 
@@ -391,7 +391,7 @@ let multiply_poly_list (ptl: poly list) : poly =
 let rec compare_variables (l: Var.t list) (v1: Var.t) (v2: Var.t) : int =
 
   (* Order variables by order of elimination? *)
-  match (Flags.cooper_order_var_by_elim ()) with
+  match (Flags.QE.cooper_order_var_by_elim ()) with
 
     (* Use ordering on Var *)
     | false -> Var.compare_vars v1 v2

--- a/src/poly.ml
+++ b/src/poly.ml
@@ -223,7 +223,7 @@ let get_coe_in_poly_obv (v: Var.t) (pl: poly) : Numeral.t =
 
 let get_coe_in_poly v pl = 
 
-  match (Flags.QE.cooper_order_var_by_elim ()) with
+  match (Flags.QE.order_var_by_elim ()) with
       
     | false -> get_coe_in_poly_anyorder v pl
 
@@ -391,7 +391,7 @@ let multiply_poly_list (ptl: poly list) : poly =
 let rec compare_variables (l: Var.t list) (v1: Var.t) (v2: Var.t) : int =
 
   (* Order variables by order of elimination? *)
-  match (Flags.QE.cooper_order_var_by_elim ()) with
+  match (Flags.QE.order_var_by_elim ()) with
 
     (* Use ordering on Var *)
     | false -> Var.compare_vars v1 v2

--- a/src/stateVar.ml
+++ b/src/stateVar.ml
@@ -285,7 +285,7 @@ let mk_state_var
     
     try 
       
-      if Flags.smt_short_names () then raise Not_found;
+      if Flags.Smt.short_names () then raise Not_found;
 
       let _ = 
         UfSymbol.uf_symbol_of_string 
@@ -305,7 +305,7 @@ let mk_state_var
        (* Create an uninterpreted function symbol for the state variable *)
        let state_var_uf_symbol = 
 
-         (if Flags.smt_short_names () then 
+         (if Flags.Smt.short_names () then 
             
             gen_uf
               

--- a/src/step2.ml
+++ b/src/step2.ml
@@ -96,7 +96,7 @@ let mk_ctx in_sys param sys =
     Smt.create_instance
       ~produce_assignments:true
       (Sys.get_logic sys)
-      (Flags.smtsolver())
+      (Flags.Smt.solver())
   in
   (* Memorizing solver for clean exit. *)
   solver_ref := Some solver ;

--- a/src/strategy.ml
+++ b/src/strategy.ml
@@ -110,9 +110,9 @@ let first_param_of results all_nodes scope =
       (* Can/should we abstract this system? *)
       let is_abstract =
         if sys = scope then 
-          has_modes && (Flags.check_modes ())
+          has_modes && (Flags.Contracts.check_modes ())
         else
-          abstractable && (Flags.compositional ())
+          abstractable && (Flags.Contracts.compositional ())
       in
       let abstraction = Scope.Map.add sys is_abstract abstraction in
       if is_abstract then
@@ -197,7 +197,7 @@ module MonolithicStrategy : Strategy = struct
       | [ {
         A.param = A.ContractCheck info ;
         A.contract_valid ;
-      } ] when Flags.check_implem () ->
+      } ] when Flags.Contracts.check_implem () ->
         first_analysis_of_contract_check top info contract_valid
       (* Not the first analysis, done. *)
       | _ -> None
@@ -245,7 +245,7 @@ module ModularStrategy : Strategy = struct
           (* Format.printf "| %a@." Scope.pp_print_scope sys ; *)
           match A.results_find sys results with
           | [] -> assert false
-          | _ when Flags.check_implem () |> not -> go_up prefix
+          | _ when Flags.Contracts.check_implem () |> not -> go_up prefix
           | [ {
             A.param = A.ContractCheck info ;
             A.contract_valid ;

--- a/src/termAttr.ml
+++ b/src/termAttr.ml
@@ -204,7 +204,7 @@ module YicesPrinter : Printer =
 
 (* Select apropriate printer based on solver *)
 let select_printer () =
-  match Flags.smtsolver () with
+  match Flags.Smt.solver () with
   | `Yices_native -> (module YicesPrinter : Printer)
   | _ -> (module SMTLIBPrinter : Printer)
 

--- a/src/testgen.ml
+++ b/src/testgen.ml
@@ -180,7 +180,7 @@ let run_strategy out_dir sys strategy =
       (TransSys.get_scope sys)
       (TransSys.get_logic sys)
       (TransSys.get_abstraction sys)
-      (Flags.smtsolver ())
+      (Flags.Smt.solver ())
   in
 
   (* Memorizing solver for clean exit. *)
@@ -485,8 +485,8 @@ let oracle_of_nodes out_dir nodes =
     sliced ;
 
   Unix.close file ;
-
-  ( match Flags.testgen_lustrec () with
+(* 
+  ( match Flags.Testgenlustrec () with
     | None -> Format.printf "Skipping oracle compilation.@."
     | Some lustrec ->
       Format.printf "Compiling oracle.@." ;
@@ -535,7 +535,7 @@ let oracle_of_nodes out_dir nodes =
         | Unix.WSIGNALED n ->
           Format.printf "> /!\\ killed by signal %d.@." n
         | Unix.WSTOPPED n ->
-          Format.printf "> /!\\ stopped by signal %d.@." n ) ) ;
+          Format.printf "> /!\\ stopped by signal %d.@." n ) ) ; *)
 
   Format.printf "@." ;
 

--- a/src/testgenDF.ml
+++ b/src/testgenDF.ml
@@ -160,7 +160,7 @@ and forward target io solver tree modes contract_term =
   let rec loop () =
     (* Format.printf "  tree: %a@." Tree.pp_print_tree tree ; *)
     let k = Tree.depth_of tree |> Num.succ in
-    if Flags.testgen_len () > Num.to_int k then (
+    if Flags.Testgen.len () > Num.to_int k then (
       (* We haven't reached the max depth yet, keep going forward. *)
       (* Format.printf "  at %a@." Num.pp_print_numeral k ; *)
       let modes = modes |> List.map (fun (n,t) -> n, Term.bump_state k t) in

--- a/src/testgenIO.ml
+++ b/src/testgenIO.ml
@@ -67,7 +67,7 @@ let mk input_sys sys root name title =
   let edir = Format.sprintf "%s/errors" dir in
   mk_dir dir ;
   let class_file =
-    if Flags.testgen_graph_only () |> not then (
+    if Flags.Testgen.graph_only () |> not then (
 
       (* |===| XML class file. *)
       let class_file =
@@ -124,7 +124,7 @@ let init_error (type s)
 (* Closes internal file descriptors. *)
 let rm (type s) : s t -> unit
 = fun { class_file ; graph_file ; error_file } ->
-  if Flags.testgen_graph_only () |> not then (
+  if Flags.Testgen.graph_only () |> not then (
     (* |===| Finishing class file. *)
     let class_fmt = fmt_of_file class_file in
     Format.fprintf class_fmt "@.</data>@.@?" ;
@@ -223,7 +223,7 @@ let log_testcase (type s)
   (* Format.printf "  log_testcase@." ; *)
   t.uid <- t.uid + 1 ;
 
-  if Flags.testgen_graph_only () |> not then (
+  if Flags.Testgen.graph_only () |> not then (
     (* |===| Logging testcase. *)
     (* Format.printf "    logging testcase@." ; *)
     let name, path, tc_file = testcase_csv t in

--- a/src/testgenSolver.ml
+++ b/src/testgenSolver.ml
@@ -63,7 +63,7 @@ let mk sys =
     S.create_instance
       ~produce_assignments:true
       (Sys.get_logic sys)
-      (Flags.smtsolver ())
+      (Flags.Smt.solver ())
   in
   (* println "declaring vars@0" ; *)
   (* Declaring variables at 0. *)

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -1373,7 +1373,7 @@ let mk_trans_sys
   in
 
   (* Logic fragment of transition system  *)
-  let logic = match Flags.smtlogic () with
+  let logic = match Flags.Smt.logic () with
 
     (* Logic fragment should not be declared *)
     | `None -> `None

--- a/src/yicesDriver.ml
+++ b/src/yicesDriver.ml
@@ -28,7 +28,7 @@ let cmd_line
     produce_interpolants = 
 
   (* Path and name of Yices executable *)
-  let yices_bin = Flags.yices_bin () in
+  let yices_bin = Flags.Smt.yices_bin () in
 
   [| yices_bin |]
 

--- a/src/yicesNative.ml
+++ b/src/yicesNative.ml
@@ -1023,12 +1023,12 @@ let execute_custom_check_sat_command cmd solver =
 let create_trace_ppf id = 
 
   (* Tracing of SMT commands enabled? *)
-  if Flags.smt_trace () then 
+  if Flags.Smt.trace () then 
     
     (* Name of SMT trace file *)
     let trace_filename = 
       Filename.concat
-        (Flags.smt_trace_dir ())
+        (Flags.Smt.trace_dir ())
         (Format.sprintf "%s.%s.%d.ys" 
                         (Filename.basename (Flags.input_file ()))
                         (suffix_of_kind_module (Event.get_module ()))


### PR DESCRIPTION
* workflow is documented in `flags.ml.in`
* removed obsolete flags
* renamed long flags
* compartmented flags into modules
* localized flag values, default, action and description as much as possible
* expose module-based, clean and safe interface internally
* huge improvements in help messages readability
* on-demand, module-specific information and flags
* added new ways to give values to boolean flags:
    * `true` can be passed as `on` or `t`
    * `false` can be passed as `off` or `f`

# Module separation of flags

Flags belonging together are now compartmented into modules. Besides the global flags in the `Global` module, Kind 2 has the following modules:

| Module | ID |
|:---:|:---:|
| Smt | `smt` |
| BmcKind | `ind` |
| IC3 | `ic3` |
| QE | `qe` |
| Contract | `contract` |
| Invgen | `invgen` |
| C2I | `c2i` |
| Testgen | `test` |
| Interpreter | `interpreter` |

# On-demand, module-specific explanations and flags

Running `kind2 -h` (or `--help` or `-help`) now only prints the *global flags*. These are the technique-agnostic flags such as `--lus_main`, `--timeout`, `--modular`, *etc.*. See below for a complete list.

One of the global flags is `--flags_of` which takes one of the module IDs given above and prints an explanation of the module along with the flags that control it. It also accepts `all` which prints the information for all modules.

A few examples follow.

# Global options

```
> kind2 -h
Usage: kind2-wip [options] <lustre_file>
Prove properties in Lustre program <lustre_file>.
Global options follow, use "--flags_of" for module-specific information.
  --help \
  -help  | Display this list of options
  -h     /
  --flags_of
    explains and shows the flags for a Kind 2 module among
      smt             SMT solver flags
      ind             BMC / K-induction flags
      ic3             IC3 flags
      invgen          invariant generation flags
      c2i             C2I flags
      test            test generation flags
      interpreter     interpreter flags
      qe              quantifier elimination flags
      contract        contract and compositional verification flags
      all             explaination and flags for all Kind 2 modules
  --lus_main
     Use the given node as top node in Lustre input
     Default: "--%MAIN" annotation in source if any, last node otherwise
  --input-format
     Format of input file
     Available: lustre, native, Default: lustre
  --output_dir
     Output directory for the files generated:
     SMT traces, compilation, testgen, certification...
     Default: "kind2"
  --timeout
     Wallclock timeout in seconds
     Default: 0
  --timeout_wall
     Same as "--timeout" (here for legacy)
  --enable
     Enable Kind module
     Available: IC3, BMC, IND, IND2, INVGEN, INVGENOS, C2I, interpreter
     Default: [BMC, IND, IND2, IC3, INVGEN, INVGENOS]
  --disable
     Disable Kind module
     Available: IC3, BMC, IND, IND2, INVGEN, INVGENOS, C2I, interpreter
  --modular
     bottom-up analysis of each node
     Default: false
  --lus_strict
     Strict mode in Lustre: uninitialized pre and undefined
     Local variables are not allowed when this flag is present
  --lus_compile
     Nodes proved correct will be compiled to Rust
     Default: false
  --debug
     Enable debug output for a section, give one --debug option
     for each section to be enabled
  --debug-log
     Output debug messages to file
     Default: stdout
  -qq  Disable output completely
  -q   Disable output, fatal errors only
  -s   Silence output, errors only
  -v   Output informational messages
  -vv  Output informational and debug messages
  -vvv Output informational, debug and trace messages
  -xml Output in XML format
  --version Print version information and exit
```

# Example of the `--flags_of` flag

```
> kind2 --flags_of ic3
Usage: kind2-wip [options] <lustre_file>
Prove properties in Lustre program <lustre_file>.

|===| Module "ic3":
IC3 (a.k.a. PDR) is a relatively recent technique that tries to prove
a property by contructing an inductive invariant that implies it.
The IC3 engine in Kind 2 performs quantifier elimination (see module
"qe"), and because of how it is implemented it is known to be rather
slow on systems using real variables.
  --ic3_check_inductive:
      Check inductiveness of blocking clauses
      Default: true
  --ic3_print_to_file:
      Output file for blocking clauses
      Default: stdout
  --ic3_inductively_generalize:
      Inductively generalize blocking clauses before forward propagation
      0 = none
      1 = normal IG
      2 = IG with ordering
      Default: 1
  --ic3_block_in_future:
      Block counterexample in future frames
      Default: true
  --ic3_block_in_future_first:
      Block counterexample in future frames first before returning to
      frame
      Default: true
  --ic3_fwd_prop_non_gen:
      Also propagate clauses before generalization
      Default: true
  --ic3_fwd_prop_ind_gen:
      Inductively generalize all clauses after forward propagation
      Default: true
  --ic3_fwd_prop_subsume:
      Subsumption in forward propagation
      Default: true
  --ic3_use_invgen:
      Use invariants from invariant generators
      Default: true
  --ic3_qe:
      Choose quantifier elimination algorithm
      Available: Z3, Z3-impl, Z3-impl2, cooper
      Default: cooper
  --ic3_extract:
      Heuristics for extraction of implicant
      Available: first, vars
      Default: first
  --ic3_abstr:
      Choose method of abstraction in IC3
      Available: None, IA
      Default: None
```

```
> kind2 --flags_of c2i --flags_of invgen
Usage: kind2-wip [options] <lustre_file>
Prove properties in Lustre program <lustre_file>.

|===| Module "c2i":
C2I is an invariant generation technique based on machine-learning.
The Kind 2 implementation is still experimental and is inactive by
default.
  --c2i_dnf:
      Number of disjuncts in the DNF constructed by C2I
      Default 3
  --c2i_int_cubes:
      Number of int cubes in the DNF constructed by C2I
      Default 3
  --c2i_real_cubes:
      Number of real cubes in the DNF constructed by C2I
      Default 3
  --c2i_modes:
      Activates mode subcandidates. Subsumes "c2i_dnf_size"
      Default true

|===| Module "invgen":
Invariant generation attempts to discover invariants of the form
`<expr> => <expr>` using expressions mined from the initial and
transition predicates of the system. The candidates invariants
considered are selected by an incremental exploration of the reachable
states.
  --invgen_prune_trivial:
      Invariant generation will only communicate invariants not implied
      by the transition relation
      Default: true
  --invgen_max_succ:
      Maximal number of successive iterations for subsystems
      Default: 1
  --invgen_lift_candidates:
      Invariant generation will instantiate candidates from sub-nodes
      Default: false
  --invgen_top_only:
      Only generate invariants for the top level
      Default: false
  --invgen_mine_trans:
      Invariant generation will extract candidate terms from the
      transition predicate
      Default: true
  --invgen_renice:
      Renice invariant generation process. Give a positive argument to
      lower priority
```

```
> kind2 --flags_of all
Usage: kind2-wip [options] <lustre_file>
Prove properties in Lustre program <lustre_file>.

|===| Module "smt":
SMT solvers are the tools Kind 2 relies on to verify systems. Flags
in this module control which solver Kind 2 uses, the path to the
binary, and tweak how Kind 2 interacts with the solver at runtime.
  --smt_solver:
      choose SMT solver
      Available: Z3, CVC4, MathSat5, Yices, Yices2
      Default: detect
  --smt_logic:
      Select logic for SMT solvers
      "none" for no logic (default)
      "detect" to detect with the input system
      Other SMTLIB logics will be passed to the solver
  --check_sat_assume:
      Use check-sat with assumptions, or simulate with push/pop
      when false
      Default: true
  --smt_short_names:
      Send short variables names to SMT solver, send full names if false
      Default: true
  --z3_bin:
      Executable of Z3 solver
      Default: "z3"
  --cvc4_bin:
      Executable of CVC4 solver
      Default: "cvc4"
  --mathsat5_bin:
      Executable of MathSAT5 solver
      Default: "mathsat"
  --yices_bin:
      Executable of Yices solver
      Default: "yices"
  --yices2_bin:
      Executable of Yices2 SMT2 solver
      Default: "yices-smt2"
  --smt_trace:
      Write all SMT commands to files


|===| Module "ind":
K-induction is the primary verification technique in Kind 2. It
consists of two processes:
> bounded model checking (BMC) explores the reachable states of the
  system looking for a falsification of one of the properties.
> the (k-inductive) step tries to prove that from `k` succeeding states
  verifying the properties, it not possible to reach a state violating
  any of them. If this holds, then if BMC proved these properties to
  hold in the `k` first states, then by (k-)induction the properties
  hold.
Internally many techniques such as path compression, multi-property,
etc. are used to improve the basic scheme described above.
Flags in this module deal with the behavior of BMC and step.
  --unroll_max:
      Maximal number of iterations for BMC and k-induction
      Default: 0, unlimited: 0
  --bmc_check_unroll:
      Check that the unrolling alone is satisfiable
      Default: true
  --ind_print_cex:
      Print counterexamples to induction
      Default: false
  --ind_compress:
      Compress inductive counterexamples
      Default: true
  --ind_compress_equal:
      Compress inductive counterexamples for states equal modulo inputs
      Default: true
  --ind_compress_same_succ:
      Compress inductive counterexamples for states with same successors
      Default: false
  --ind_compress_same_pred:
      Compress inductive counterexamples for states with same predecessors
      Default: false
  --ind_lazy_invariants:
      Asserts invariants lazily
      Default: false


|===| Module "ic3":
IC3 (a.k.a. PDR) is a relatively recent technique that tries to prove
a property by contructing an inductive invariant that implies it.
The IC3 engine in Kind 2 performs quantifier elimination (see module
"qe"), and because of how it is implemented it is known to be rather
slow on systems using real variables.
  --ic3_check_inductive:
      Check inductiveness of blocking clauses
      Default: true
  --ic3_print_to_file:
      Output file for blocking clauses
      Default: stdout
  --ic3_inductively_generalize:
      Inductively generalize blocking clauses before forward propagation
      0 = none
      1 = normal IG
      2 = IG with ordering
      Default: 1
  --ic3_block_in_future:
      Block counterexample in future frames
      Default: true
  --ic3_block_in_future_first:
      Block counterexample in future frames first before returning to
      frame
      Default: true
  --ic3_fwd_prop_non_gen:
      Also propagate clauses before generalization
      Default: true
  --ic3_fwd_prop_ind_gen:
      Inductively generalize all clauses after forward propagation
      Default: true
  --ic3_fwd_prop_subsume:
      Subsumption in forward propagation
      Default: true
  --ic3_use_invgen:
      Use invariants from invariant generators
      Default: true
  --ic3_qe:
      Choose quantifier elimination algorithm
      Available: Z3, Z3-impl, Z3-impl2, cooper
      Default: cooper
  --ic3_extract:
      Heuristics for extraction of implicant
      Available: first, vars
      Default: first
  --ic3_abstr:
      Choose method of abstraction in IC3
      Available: None, IA
      Default: None


|===| Module "invgen":
Invariant generation attempts to discover invariants of the form
`<expr> => <expr>` using expressions mined from the initial and
transition predicates of the system. The candidates invariants
considered are selected by an incremental exploration of the reachable
states.
  --invgen_prune_trivial:
      Invariant generation will only communicate invariants not implied
      by the transition relation
      Default: true
  --invgen_max_succ:
      Maximal number of successive iterations for subsystems
      Default: 1
  --invgen_lift_candidates:
      Invariant generation will instantiate candidates from sub-nodes
      Default: false
  --invgen_top_only:
      Only generate invariants for the top level
      Default: false
  --invgen_mine_trans:
      Invariant generation will extract candidate terms from the
      transition predicate
      Default: true
  --invgen_renice:
      Renice invariant generation process. Give a positive argument to
      lower priority


|===| Module "c2i":
C2I is an invariant generation technique based on machine-learning.
The Kind 2 implementation is still experimental and is inactive by
default.
  --c2i_dnf:
      Number of disjuncts in the DNF constructed by C2I
      Default 3
  --c2i_int_cubes:
      Number of int cubes in the DNF constructed by C2I
      Default 3
  --c2i_real_cubes:
      Number of real cubes in the DNF constructed by C2I
      Default 3
  --c2i_modes:
      Activates mode subcandidates. Subsumes "c2i_dnf_size"
      Default true


|===| Module "test":
Test generation uses the contract (see module "contract") attached
to a node to explore the behavior of a node. For each behavior, a
trace of inputs triggering it is generated and logged as a testcase in
CSV.
  --testgen:
      Activates test generation for systems proved correct
      Default: false
  --testgen_graph_only:
      Only draw the graph of reachable modes, do not log testcases.
      Default: false
  --testgen_len:
      Maximimum length for test generation
      Default: 5


|===| Module "interpreter":
The interpreter is a special mode where Kind 2 reads inputs from a
file and prints the outputs of the system at each step.
  --interpreter_input_file:
      Read input from file
  --interpreter_steps:
      Run number of steps, override the number of steps given in the
      input file
      Default: 0


|===| Module "qe":
Quantifier elimination (QE) is a technique that, given some variables
`v_1`, ..., `v_n` and a quantifier-free formula `f`, returns a
quantifier-free formula equivalent to `(exists (v_1, ..., v_n) f)`.
The QE implemented in Kind 2 does not support real arithmetic. If the
solver used is z3, then z3's QE will be used instead of the internal
one for systems with real variables.
IC3 (module "ic3") is the only Kind 2 technique that uses QE.
  --order_var_by_elim:
      Order variables in polynomials by order of elimination
      Default: false
  --general_lbound:
      Choose lower bounds containing variables
      Default: false


|===| Module "contract":
Kind 2 extends Lustre with a syntax for assume-guarantee-like
contracts. The syntax and semantics of contracts are described in
Kind 2 documentation.
Contracts allow to perform compositional verification, where sub-nodes
with a contract are abstracted away by their specification. Also, the
test generation technique (see module "testgen") relies on contracts
to generate the testcases.
  --compositional:
      Abstract subnodes with a contract
      Default: false
  --check_modes:
      Checks the modes of a contracts are exhaustive
      Default: true
  --check_implem:
      Checks the implementation of nodes
      Default: true
```
