### PR TITLE
Improvements in parsing and flags

### DIFF
--- a/src/SMTLIBSolver.ml
+++ b/src/SMTLIBSolver.ml
@@ -646,10 +646,16 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
     (* Tracing of SMT commands enabled? *)
     if Flags.Smt.trace () then 
 
+      let tdir = Flags.Smt.trace_dir () in
+      (* Create root dir if needed. *)
+      Flags.output_dir () |> mk_dir ;
+      (* Create smt_trace dir if needed. *)
+      mk_dir tdir ;
+
       (* Name of SMT trace file *)
       let trace_filename = 
         Filename.concat
-          (Flags.Smt.trace_dir ())
+          tdir
           (Format.sprintf "%s.%s.%d.%s" 
              (Filename.basename (Flags.input_file ()))
              (suffix_of_kind_module (Event.get_module ()))

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -175,12 +175,15 @@ val color : unit -> bool
 
 (** {2 SMT solver flags} *)
 module Smt : sig
+
   (** Logic sendable to the SMT solver. *)
   type logic = [
     `None | `detect | `Logic of string
   ]
+
   (** Logic to send to the SMT solver *)
   val logic : unit -> logic
+
   (** Legal SMT solvers. *)
   type solver = [
     | `Z3_SMTLIB
@@ -190,26 +193,37 @@ module Smt : sig
     | `Yices_native
     | `detect
   ]
+
   (** Set SMT solver and executable *)
   val set_solver : solver -> unit
+
   (** Which SMT solver to use. *)
   val solver : unit -> solver
+
   (** Use check-sat with assumptions, or simulate with push/pop *)
   val check_sat_assume : unit -> bool
+
   (** Send short names to SMT solver *)
   val short_names : unit -> bool
+
   (** Executable of Z3 solver *)
   val z3_bin : unit -> string
+
   (** Executable of CVC4 solver *)
   val cvc4_bin : unit -> string
+
   (** Executable of MathSAT5 solver *)
   val mathsat5_bin : unit -> string
+
   (** Executable of Yices solver *)
   val yices_bin : unit -> string
+
   (** Executable of Yices2 SMT2 solver *)
   val yices2smt2_bin : unit -> string
+
   (** Write all SMT commands to files *)
   val trace : unit -> bool
+
   (** Path to the smt trace directory. *)
   val trace_dir : unit -> string
 end

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -248,16 +248,16 @@ type contract_ghost_const = const_decl
 type contract_ghost_var = const_decl
 
 (* A contract assume. *)
-type contract_assume = position * expr
+type contract_assume = position * string option * expr
 
 (* A contract guarantee. *)
-type contract_guarantee = position * expr
+type contract_guarantee = position * string option * expr
 
 (* A contract requirement. *)
-type contract_require = position * expr
+type contract_require = position * string option * expr
 
 (* A contract ensure. *)
-type contract_ensure = position * expr
+type contract_ensure = position * string option * expr
 
 (* A contract mode. *)
 type contract_mode =
@@ -888,29 +888,33 @@ let pp_print_contract_ghost_var ppf = function
       pp_print_expr e
 
     
-let pp_print_contract_assume ppf (_,e) =
+let pp_print_contract_assume ppf (_, n, e) =
   Format.fprintf
     ppf
-    "@[<hv 3>assume@ %a;@]"
+    "@[<hv 3>assume%s@ %a;@]"
+    (match n with None -> "" | Some s -> " \""^s^"\"")
     pp_print_expr e
 
-let pp_print_contract_guarantee ppf (_,e) =
+let pp_print_contract_guarantee ppf (_, n, e) =
   Format.fprintf
     ppf
-    "@[<hv 3>guarantee@ %a;@]"
+    "@[<hv 3>guarantee%s@ %a;@]"
+    (match n with None -> "" | Some s -> " \""^s^"\"")
     pp_print_expr e
 
     
-let pp_print_contract_require ppf (_,e) =
+let pp_print_contract_require ppf (_, n, e) =
   Format.fprintf
     ppf
-    "@[<hv 3>require@ %a;@]"
+    "@[<hv 3>require%s@ %a;@]"
+    (match n with None -> "" | Some s -> " \""^s^"\"")
     pp_print_expr e
 
-let pp_print_contract_ensure ppf (_,e) =
+let pp_print_contract_ensure ppf (_, n, e) =
   Format.fprintf
     ppf
-    "@[<hv 3>ensure@ %a;@]"
+    "@[<hv 3>ensure%s@ %a;@]"
+    (match n with None -> "" | Some s -> " \""^s^"\"")
     pp_print_expr e
 
 let cond_new_line b fmt () =

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -263,23 +263,21 @@ type contract_ensure = position * expr
 type contract_mode =
   position * ident * (contract_require list) * (contract_ensure list)
 
-(* Equations that can appear in a contract node. *)
-type contract_node_equation =
-  | GhostEquation of position * ident * expr
-  | Assume of contract_assume
-  | Guarantee of contract_guarantee
-  | Require of contract_require
-  | Ensure of contract_ensure
-
 (* A contract call. *)
 type contract_call = position * ident * expr list * expr list
 
+(* Equations that can appear in a contract node. *)
+type contract_node_equation =
+  | GhostConst of contract_ghost_const
+  | GhostVar of contract_ghost_var
+  | Assume of contract_assume
+  | Guarantee of contract_guarantee
+  | Mode of contract_mode
+  | ContractCall of contract_call
+
 (* A contract is some ghost consts / var, and assumes guarantees and modes. *)
-type contract =
-  contract_ghost_const list * contract_ghost_var list * (
-    contract_assume list * contract_guarantee list *
-    contract_mode list * contract_call list
-  ) list
+type contract = contract_node_equation list
+
 
 (* A node declaration *)
 type node_decl =
@@ -938,24 +936,19 @@ let pp_print_contract_call fmt (_, id, in_params, out_params) =
 
 let all_empty = List.for_all (fun l -> l = [])
 
-let pp_print_contract fmt (g_consts, g_vars, lst) =
-  Format.fprintf
-    fmt "@[<v>%a@ %a%a@]"
-    (pp_print_list pp_print_contract_ghost_const "@ ") g_consts
-    (pp_print_list pp_print_contract_ghost_var "@ ") g_vars
-    (
-      pp_print_list (
-        fun fmt (ass, gua, modes, calls) ->
-          Format.fprintf fmt
-            "%a@ %a@ %a@ %a"
-            (pp_print_list pp_print_contract_assume "@ ") ass
-            (pp_print_list pp_print_contract_guarantee "@ ") gua
-            (pp_print_list pp_print_contract_mode "@ ") modes
-            (pp_print_list pp_print_contract_call "@ ") calls
-      ) "@ "
-    ) lst
+let pp_print_contract_item fmt = function
+  | GhostConst c -> pp_print_contract_ghost_const fmt c
+  | GhostVar v -> pp_print_contract_ghost_var fmt v
+  | Assume a -> pp_print_contract_assume fmt a
+  | Guarantee g -> pp_print_contract_guarantee fmt g
+  | Mode m -> pp_print_contract_mode fmt m
+  | ContractCall call -> pp_print_contract_call fmt call
 
-let is_contract_empty = function | [],[],[],[],[] -> true | _ -> false
+
+let pp_print_contract fmt contract =
+  Format.fprintf fmt "@[<v>%a@]"
+    (pp_print_list pp_print_contract_item "@ ") contract
+
 
 let pp_print_contract_spec ppf = function
 | None -> ()
@@ -965,23 +958,6 @@ let pp_print_contract_spec ppf = function
     "@[<v 2>(*@contract@ %a@]@ *)"
     pp_print_contract contract
 
-(* Pretty-prints a contract node equation. *)
-let pp_print_contract_node_equation ppf = function
-
-  | GhostEquation (pos, l, e) ->
-     Format.fprintf
-       ppf
-       "@[<hv 2>@[<hv 1>(%a)@] =@ %a;@]"
-       pp_print_ident l
-       pp_print_expr e
-
-  | Assume req -> pp_print_contract_assume ppf req
-
-  | Guarantee ens -> pp_print_contract_guarantee ppf ens
-
-  | Require req -> pp_print_contract_require ppf req
-
-  | Ensure ens -> pp_print_contract_ensure ppf ens
 
 (* Pretty-prints a contract node. *)
 let pp_print_contract_node ppf (

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -197,23 +197,25 @@ type contract_ensure = position * expr
 type contract_mode =
   position * ident * (contract_require list) * (contract_ensure list)
 
-(* Equations that can appear in a contract node. *)
-type contract_node_equation =
-  | GhostEquation of position * ident * expr
-  | Assume of contract_assume
-  | Guarantee of contract_guarantee
-  | Require of contract_require
-  | Ensure of contract_ensure
-
 (* A contract call. *)
 type contract_call = position * ident * expr list * expr list
 
+(* Equations that can appear in a contract node. *)
+type contract_node_equation =
+  | GhostConst of contract_ghost_const
+  | GhostVar of contract_ghost_var
+  | Assume of contract_assume
+  | Guarantee of contract_guarantee
+  | Mode of contract_mode
+  | ContractCall of contract_call
+
 (* A contract is some ghost consts / var, and assumes guarantees and modes. *)
-type contract =
-  contract_ghost_const list * contract_ghost_var list * (
-    contract_assume list * contract_guarantee list *
-    contract_mode list * contract_call list
-  ) list
+type contract = contract_node_equation list
+
+  (*   contract_ghost_const list * contract_ghost_var list * ( *)
+  (*   contract_assume list * contract_guarantee list * *)
+  (*   contract_mode list * contract_call list *)
+  (* ) list *)
 
 (** Declaration of a node as a tuple of
 

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -182,16 +182,16 @@ type contract_ghost_const = const_decl
 type contract_ghost_var = const_decl
 
 (* A contract assume. *)
-type contract_assume = position * expr
+type contract_assume = position * string option * expr
 
 (* A contract guarantee. *)
-type contract_guarantee = position * expr
+type contract_guarantee = position * string option * expr
 
 (* A contract requirement. *)
-type contract_require = position * expr
+type contract_require = position * string option * expr
 
 (* A contract ensure. *)
-type contract_ensure = position * expr
+type contract_ensure = position * string option * expr
 
 (* A contract mode. *)
 type contract_mode =

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -765,6 +765,8 @@ let mk_fresh_oracle
     ({ node; definitions_allowed; fresh_oracle_index } as ctx) 
     state_var_type =
 
+  let state_var_type = Type.generalize state_var_type in
+  
   match definitions_allowed with 
 
     (* Fail with error if no new definitions allowed *)

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1304,8 +1304,8 @@ let add_node_local ?(ghost = false) ctx ident pos index_types =
           { ctx with node = Some { node with N.locals = local :: locals } }
 
 
-(* Add node assume/guarantees to context *)
-let add_node_ass_gua ctx assumes guarantees = 
+(* Add node assumes to context *)
+let add_node_ass ctx assumes = 
 
   match ctx with
 
@@ -1313,8 +1313,23 @@ let add_node_ass_gua ctx assumes guarantees =
 
     | { node = Some ({ N.contract } as node) } ->
       let contract = match contract with
-        | None -> C.mk assumes guarantees []
-        | Some contract -> C.add_ass_gua contract assumes guarantees
+        | None -> C.mk assumes [] []
+        | Some contract -> C.add_ass contract assumes
+      in
+      (* Return node with contract added *)
+      { ctx with node = Some { node with N.contract = Some contract } }
+
+(* Add guarantees to context *)
+let add_node_gua ctx guarantees = 
+
+  match ctx with
+
+    | { node = None } -> raise (Invalid_argument "add_node_global_contract")
+
+    | { node = Some ({ N.contract } as node) } ->
+      let contract = match contract with
+        | None -> C.mk [] guarantees []
+        | Some contract -> C.add_gua contract guarantees
       in
       (* Return node with contract added *)
       { ctx with node = Some { node with N.contract = Some contract } }

--- a/src/lustre/lustreContext.mli
+++ b/src/lustre/lustreContext.mli
@@ -237,9 +237,11 @@ val outputs_of_current_node : t -> StateVar.t LustreIndex.t
 val add_node_local :
   ?ghost:bool -> t -> LustreIdent.t -> Lib.position -> Type.t LustreIndex.t -> t
 
-(** Adds assumptions and guarantees to a node. *)
-val add_node_ass_gua :
-  t -> LustreContract.svar list -> LustreContract.svar list -> t
+(** Adds assumptions to a node. *)
+val add_node_ass : t -> LustreContract.svar list -> t
+
+(** Adds guarantees to a node. *)
+val add_node_gua : t -> LustreContract.svar list -> t
 
 (** Add modes to node *)
 val add_node_mode : t -> LustreContract.mode -> t

--- a/src/lustre/lustreContract.ml
+++ b/src/lustre/lustreContract.ml
@@ -44,12 +44,12 @@ let pprint_pos fmt pos =
 let prop_name_of_svar { pos ; num ; name = s; scope } kind name =
   match s with
   | Some n ->
-    Format.asprintf "%a%s" (
+    Format.asprintf "%a%s[%d]" (
       pp_print_list (
         fun fmt (pos, call) ->
           Format.fprintf fmt "%s[%a]." call pprint_pos pos
       ) ""
-    ) scope n
+    ) scope n num
     
   | None ->
     Format.asprintf "%a%s%s[%a][%d]" (

--- a/src/lustre/lustreContract.ml
+++ b/src/lustre/lustreContract.ml
@@ -74,17 +74,26 @@ let mk assumes guarantees modes = {
   assumes ; guarantees ; modes
 }
 
-let add_ass_gua t assumes guarantees = {
+
+let add_ass t assumes = {
   t with
-    assumes = assumes @ t.assumes ;
-    guarantees = guarantees @ t.guarantees ;
+    assumes = List.rev_append (List.rev assumes) t.assumes ;
 }
 
+
+let add_gua t guarantees = {
+  t with
+    guarantees = List.rev_append (List.rev guarantees) t.guarantees ;
+}
+
+
 let add_modes t modes = { t with modes = modes @ t.modes }
+
 
 let svars_of_list l set = l |> List.fold_left (
   fun set { svar } -> SVarSet.add svar set
 ) set
+
 
 let svars_of_modes modes set = modes |> List.fold_left (
   fun set { requires ; ensures } ->
@@ -92,10 +101,12 @@ let svars_of_modes modes set = modes |> List.fold_left (
     |> svars_of_list ensures
 ) set
 
+
 let svars_of { assumes ; guarantees ; modes } =
   svars_of_list assumes SVarSet.empty
   |> svars_of_list guarantees
   |> svars_of_modes modes
+
 
 (* Output a space if list is not empty *)
 let space_if_nonempty = function

--- a/src/lustre/lustreContract.ml
+++ b/src/lustre/lustreContract.ml
@@ -26,12 +26,13 @@ module SVarSet = SVar.StateVarSet
 type svar = {
   pos: position ;
   num: int ;
+  name: string option;
   svar: SVar.t ;
   scope: (position * string) list ;
 }
 
-let mk_svar pos num svar scope = {
-  pos ; num ; svar ; scope
+let mk_svar pos num name svar scope = {
+  pos ; num ; name; svar ; scope
 }
 
 (* Quiet pretty printer for non dummy positions. *)
@@ -40,13 +41,24 @@ let pprint_pos fmt pos =
   let f = if f = "" then "" else f ^ "|" in
   Format.fprintf fmt "%sl%dc%d" f l c
 
-let prop_name_of_svar { pos ; num ; scope } kind name =
-  Format.asprintf "%a%s%s[%a][%d]" (
-    pp_print_list (
-      fun fmt (pos, call) ->
-        Format.fprintf fmt "%s[%a]." call pprint_pos pos
-    ) ""
-  ) scope kind name pprint_pos pos num
+let prop_name_of_svar { pos ; num ; name = s; scope } kind name =
+  match s with
+  | Some n ->
+    Format.asprintf "%a%s" (
+      pp_print_list (
+        fun fmt (pos, call) ->
+          Format.fprintf fmt "%s[%a]." call pprint_pos pos
+      ) ""
+    ) scope n
+    
+  | None ->
+    Format.asprintf "%a%s%s[%a][%d]" (
+      pp_print_list (
+        fun fmt (pos, call) ->
+          Format.fprintf fmt "%s[%a]." call pprint_pos pos
+      ) ""
+    ) scope kind name pprint_pos pos num
+
 
 type mode = {
   name: I.t ;

--- a/src/lustre/lustreContract.mli
+++ b/src/lustre/lustreContract.mli
@@ -81,8 +81,11 @@ val empty: unit -> t
 list of modes. *)
 val mk: svar list -> svar list -> mode list -> t
 
-(** Adds assumes and guarantees to a contract. *)
-val add_ass_gua: t -> svar list -> svar list -> t
+(** Adds assumes to a contract. *)
+val add_ass: t -> svar list -> t
+
+(** Adds guarantees to a contract. *)
+val add_gua: t -> svar list -> t
 
 (** Adds modes to a contract. *)
 val add_modes: t -> mode list -> t

--- a/src/lustre/lustreContract.mli
+++ b/src/lustre/lustreContract.mli
@@ -21,6 +21,7 @@
 type svar = {
   (** Position of the original expression. *)
   pos: Lib.position ;
+
   (** Number given to it at parse time.
 
   If this svar is an assumption / a guarantee, it means it's the [num]
@@ -29,15 +30,21 @@ type svar = {
   If this svar is a require / an ensure, it means it's the [num] require
   / ensure of the mode it's from. *)
   num: int ;
+
+  (** optional name for an assume or a guarantee *)
+  name: string option;
+  
   (** Actual state variable. *)
   svar: StateVar.t ;
+
   (** Succession of imports leading to this precise state variable. *)
   scope: (Lib.position * string) list ;
 }
 
 (** Creates a [svar]. *)
 val mk_svar :
-  Lib.position -> int -> StateVar.t -> (Lib.position * string) list -> svar
+  Lib.position -> int -> string option ->
+  StateVar.t -> (Lib.position * string) list -> svar
 
 (** Generates a property name.
 

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -983,7 +983,7 @@ let contract_check_no_output ctx expr =
     else None
 
 (* Evaluates a generic contract item: assume, guarantee, require or ensure. *)
-let eval_contract_item check scope (ctx, accum, count) (pos, expr) =
+let eval_contract_item check scope (ctx, accum, count) (pos, iname, expr) =
   (* Scope is created backwards. *)
   let scope = List.rev scope in
   (* Evaluate exrpession to a Boolean expression, may change context. *)
@@ -1033,7 +1033,7 @@ let eval_contract_item check scope (ctx, accum, count) (pos, expr) =
   let svar, ctx = C.mk_local_for_expr ~is_ghost:true pos ctx expr in
   (* Add state variable to accumulator, continue with possibly modified
   context. *)
-  ctx, (Contract.mk_svar pos count svar scope) :: accum, count + 1
+  ctx, (Contract.mk_svar pos count iname svar scope) :: accum, count + 1
 
 (* Introduce fresh state variable for an assume expression *)
 let eval_ass = eval_contract_item (Some "assume")

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -967,7 +967,7 @@ let mk_int d =
 
   { expr_init = expr; 
     expr_step = expr; 
-    expr_type = Type.t_int } 
+    expr_type = Type.mk_int_range d d } 
 
 
 (* Real constant *)
@@ -1985,7 +1985,7 @@ let mk_pre
     ({ expr_init; expr_step; expr_type } as expr) = 
 
   (* Apply pre to initial state expression *)
-  let expr_init', ctx' = match expr_init with
+  let expr_init', expr_type', ctx' = match expr_init with
 
     (* Expression is a constant not part of an unguarded pre expression *)
     | t when
@@ -1998,7 +1998,7 @@ let mk_pre
               | Term.T.Const c1 when 
                      Symbol.is_numeral c1 || Symbol.is_decimal c1 -> true
               | _ -> false)) ->
-       (expr_init, ctx)
+       (expr_init, expr_type, ctx)
           
     (* Expression is a variable at the current instant not part of an unguarded
        pre expression *)
@@ -2008,9 +2008,13 @@ let mk_pre
         Numeral.(Var.offset_of_state_var_instance (Term.free_var_of_term t) =
                  base_offset) ->
       
-      (Term.bump_state Numeral.(- one) t, ctx) 
+      (Term.bump_state Numeral.(- one) t, expr_type, ctx)
+      
     (* Expression is not a variable at the current instant *)
     | _ ->
+
+      let expr_type = Type.generalize expr_type in
+      let expr = { expr with expr_type } in
        
       (* Fresh state variable for identifier *)
       let state_var, ctx' = mk_state_var_for_expr ctx expr in 
@@ -2019,19 +2023,19 @@ let mk_pre
       let var = Var.mk_state_var_instance state_var pre_base_offset in
 
       (* Return term and new definitions *)
-      (Term.mk_var var, ctx')
+      (Term.mk_var var, expr_type, ctx')
       
   in
 
   (* Apply pre to step state expression *)
-  let expr_step', ctx'' = match expr_step with 
+  let expr_step', expr_type', ctx'' = match expr_step with 
 
     (* Expression is identical to initial state *)
     | _ when not unguarded &&
              Term.equal expr_step expr_init -> 
 
       (* Re-use abstraction for initial state *)
-      (expr_init', ctx')
+      (expr_init', expr_type', ctx')
 
     (* Expression is a variable at the current instant *)
     | t when
@@ -2039,11 +2043,14 @@ let mk_pre
         Numeral.(Var.offset_of_state_var_instance (Term.free_var_of_term t) =
                  cur_offset) ->
 
-      (Term.bump_state Numeral.(- one) t, ctx')
+      (Term.bump_state Numeral.(- one) t, expr_type', ctx')
 
     (* Expression is not a variable *)
     | _ -> 
-      
+
+      let expr_type = Type.generalize expr_type' in
+      let expr = { expr with expr_type } in
+       
       (* Fresh state variable for expression *)
       let state_var, ctx' = mk_state_var_for_expr ctx' expr in
 
@@ -2051,12 +2058,14 @@ let mk_pre
       let var = Var.mk_state_var_instance state_var Numeral.(- one) in
 
       (* Return term and new definitions *)
-      (Term.mk_var var, ctx')
+      (Term.mk_var var, expr_type, ctx')
       
   in
 
   (* Return expression and new definitions *)
-  ({ expr with expr_init = expr_init'; expr_step = expr_step' }, 
+  ({ expr with expr_init = expr_init';
+               expr_step = expr_step';
+               expr_type = expr_type' }, 
    ctx'') 
 
 

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -240,7 +240,8 @@ let keyword_table = mk_hashtbl [
   ("const", CONST) ;
   
   (* Node / function declaration *)
-  ("node", NODE) ; ("function", FUNCTION) ;
+  ("node", NODE) ;
+  (* ("function", FUNCTION) ; *)
   ("returns", RETURNS) ;
   ("var", VAR) ;
   ("let", LET) ;
@@ -277,8 +278,16 @@ let keyword_table = mk_hashtbl [
   
   (* Temporal operators *)
   ("pre", PRE) ; ("fby", FBY) ;
+
+  (* |===| Block annotation contract stuff. *)
+  ("mode", MODE);
+  ("assume", ASSUME);
+  ("guarantee", GUARANTEE);
+  ("require", REQUIRE);
+  ("ensure", ENSURE);
       
-]
+  ]
+
     
 }
 
@@ -313,45 +322,25 @@ let newline = '\r'* '\n'
 (* Toplevel function *)
 rule token = parse
 
-
   (* |===| Annotations. *)
 
   (* Inline. *)
-  | "--%" { PERCENTANNOT }
-  | "--!" { BANGANNOT }
-  | "--@import" { INLINEIMPORTCONTRACT }
-  | "--@mode" { INLINEMODE }
-  | "--@assume" { INLINEASSUME }
-  | "--@guarantee" { INLINEGUARANTEE }
-  | "--@require" { INLINEREQUIRE }
-  | "--@ensure" { INLINEENSURE }
-  | "--@const" { INLINECONST }
-  | "--@var" { INLINEVAR }
+  |"--%" { PERCENTANNOT }
+  |"--!" { BANGANNOT }
 
   (* Parenthesis star (PS) block annotations. *)
-  | "(*%" { PSPERCENTBLOCK }
-  | "(*!" { PSBANGBLOCK }
+  | "(*" ('%'|'!') { PSBLOCKSTART }
   | "(*@" { PSATBLOCK }
 
   (* End of parenthesis star (PS). *)
   | "*)" { PSBLOCKEND }
 
   (* Slash star (SS) block annotations. *)
-  | "/*%" { SSPERCENTBLOCK }
-  | "/*!" { SSBANGBLOCK }
+  | "/*" ('%'|'!') { SSBLOCKSTART }
   | "/*@" { SSATBLOCK }
 
   (* End of slash star (SS). *)
   | "*/" { SSBLOCKEND }
-
-
-  (* |===| Block annotation contract stuff. *)
-
-  | "mode" { MODE }
-  | "assume" { ASSUME }
-  | "guarantee" { GUARANTEE }
-  | "require" { REQUIRE }
-  | "ensure" { ENSURE }
 
 
   (* |===| Actual comments. *)

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -378,16 +378,20 @@ contract_ghost_const:
     { A.GhostConst (A.UntypedConst (mk_pos $startpos, i, e)) }
 
 contract_assume:
-  ASSUME; e = expr; SEMICOLON { A.Assume (mk_pos $startpos, e) }
+  ASSUME; name = option(STRING); e = expr; SEMICOLON
+  { A.Assume (mk_pos $startpos, name, e) }
 
 contract_guarantee:
-  GUARANTEE; e = expr; SEMICOLON { A.Guarantee (mk_pos $startpos, e) }
+  GUARANTEE; name = option(STRING); e = expr; SEMICOLON
+  { A.Guarantee (mk_pos $startpos, name, e) }
 
 contract_require:
-  REQUIRE; e = expr; SEMICOLON { mk_pos $startpos, e }
+  REQUIRE; name = option(STRING); e = expr; SEMICOLON
+  { mk_pos $startpos, name, e }
 
 contract_ensure:
-  ENSURE; e = expr; SEMICOLON { mk_pos $startpos, e }
+  ENSURE; name = option(STRING); e = expr; SEMICOLON
+  { mk_pos $startpos, name, e }
 
 mode_equation:
   MODE; n = ident; LPAREN;

--- a/src/testgenTree.ml
+++ b/src/testgenTree.ml
@@ -194,7 +194,7 @@ let update ({ tree } as t) mode_conj = match tree with
 
 
 (* |===| Pretty printers. *)
-let pp_print_tree fmt ({ tree } as t) =
+let pp_print_tree fmt { tree } =
   Format.fprintf fmt "@[<v>at %a (%a)@]"
     Num.pp_print_numeral (match tree with
       | Top -> Num.(~- one) | Node (k,_,_,_) -> k

--- a/src/type.ml
+++ b/src/type.ml
@@ -406,6 +406,12 @@ let rec check_type  { Hashcons.node = t1 }  { Hashcons.node = t2 } =
     | _ -> false
 
 
+let generalize t = match node_of_type t with
+  | IntRange _ -> t_int
+  | _ -> t
+
+
+
 
 (* 
    Local Variables:

--- a/src/type.mli
+++ b/src/type.mli
@@ -145,6 +145,9 @@ val all_index_types_of_array : t -> t list
 (** Return type of array elements *)
 val elem_type_of_array : t -> t
 
+(** Generalize a type (remoe intranges) *)
+val generalize : t -> t
+
 
 (** {1 Pretty-printing} *)
 

--- a/src/yicesNative.ml
+++ b/src/yicesNative.ml
@@ -1024,11 +1024,17 @@ let create_trace_ppf id =
 
   (* Tracing of SMT commands enabled? *)
   if Flags.Smt.trace () then 
-    
+
+    let tdir = Flags.Smt.trace_dir () in
+    (* Create root dir if needed. *)
+    Flags.output_dir () |> mk_dir ;
+    (* Create smt_trace dir if needed. *)
+    mk_dir tdir ;
+
     (* Name of SMT trace file *)
     let trace_filename = 
       Filename.concat
-        (Flags.Smt.trace_dir ())
+        tdir
         (Format.sprintf "%s.%s.%d.ys" 
                         (Filename.basename (Flags.input_file ()))
                         (suffix_of_kind_module (Event.get_module ()))

--- a/tests/regression/error/check_type.lus
+++ b/tests/regression/error/check_type.lus
@@ -44,8 +44,10 @@ tel
 type pair = { one, two: int };
 
 node X (a1: real; a2: int) returns (b0: [real, int]; c0: [int,  bool]);
-  --@ensures a1 > 0.0;
-  --@requires a2 > 0;
+  (*@contract 
+     guarantee a1 > 0.0;
+     assume a2 > 0;
+   *)
 var
   a3: int;
   b1: pair;
@@ -116,8 +118,10 @@ node X
   (a: int; const b: int) 
 returns 
   (d: [bool, int, real]; f: subrange [-1, 1] of int);
-  --@requires pre (pre a > 2);
-  --@ensures pre (d[0] => false);
+  (*@contract
+    assume pre (pre a > 2);
+    guarantee pre (d[0] => false);
+  *)
 var
   e: enum { one, two };
   a1, a2, a3, a4: int;

--- a/tests/regression/error/test-func-sliced.lus
+++ b/tests/regression/error/test-func-sliced.lus
@@ -1,19 +1,22 @@
 function sincos(in: real) returns (sin: real; cos: real);
---@const max = 1.0;
---@const pi = 3.14;
---@const tau = 2.0 * pi;
---@var min = - max;
---@require in <= 0.0 or in >= 0.0;
---@ensure min <= sin and sin <= max;
+(*@contract
+  const max = 1.0;
+  const pi = 3.14;
+  const tau = 2.0 * pi;
+  var min = - max;
+  assume in <= 0.0 or in >= 0.0;
+  guarantee min <= sin and sin <= max;
 
---@mode pos;
---@require 0.0 <= in and in <= tau;
---@ensure sin >= 0.0;
+  mode pos (
+    require 0.0 <= in and in <= tau;
+    ensure sin >= 0.0;
+  );
 
---@mode neg;
---@require - tau <= in and in <= 0.0;
---@ensure sin <= 0.0;
-
+  mode neg (
+    require - tau <= in and in <= 0.0;
+    ensure sin <= 0.0;
+  );
+*)
 node X (in: real) returns (OK: bool);
 var inn: real ;
 let
@@ -24,11 +27,13 @@ let
 tel;
 
 node id (in: real) returns (out: int);
---@const max = 1.0;
---@const pi = 3.14;
---@const tau = 2.0 * pi;
---@var min = - max;
---@require - tau <= in ;
+(*@contract
+  const max = 1.0;
+  const pi = 3.14;
+  const tau = 2.0 * pi;
+  var min = - max;
+  assume - tau <= in ;
+*)
 var inn: real ; ok: bool ;
 let
   out = (int in);
@@ -39,7 +44,8 @@ let
 tel;
 
 function exp (x, y: real) returns (out: real);
--- --@ensure out >= id(out);
--- --@ensure out <= sin(out);
-
+(* -- contract
+   guarantee out >= id(out);
+   guarantee out <= sin(out);
+*)
 function sin(in: real) returns (out: int);

--- a/tests/regression/falsifiable/test-oracles.lus
+++ b/tests/regression/falsifiable/test-oracles.lus
@@ -1,11 +1,11 @@
 node X(x: int) returns (y: int);
 (*@contract  
-   assume pre(x) > 2;
-   guarantee pre(x > 3);
+   assume "pre is gt 2" pre(x) > 2;
+   guarantee "then after, pre is gt 3" pre(x > 3);
 *)
 let
   assert (pre pre (x + 1) > 0);
-  --%PROPERTY 1 > x;
+  --%PROPERTY "less1" 1 > x;
 tel;
 
 
@@ -14,6 +14,6 @@ var d: int;
 let
   c = condact(clk, X(0), 0);
   d = X(0);
-  --%PROPERTY c > 0 or c <= 0;
+  --%PROPERTY "trivial" c > 0 or c <= 0;
   --%MAIN ;
 tel;

--- a/tests/regression/falsifiable/test-oracles.lus
+++ b/tests/regression/falsifiable/test-oracles.lus
@@ -1,6 +1,8 @@
 node X(x: int) returns (y: int);
-  --@assume pre(x) > 2;
-  --@guarantee pre(x > 3);
+(*@contract  
+   assume pre(x) > 2;
+   guarantee pre(x > 3);
+*)
 let
   assert (pre pre (x + 1) > 0);
   --%PROPERTY 1 > x;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -37,7 +37,7 @@ contract_dir="${test_dir}/contracts"
 shift
 k2_args="$@"
 
-basic_k2_cmd="$k2_args"
+basic_k2_cmd="$k2_args --color false"
 contract_k2_cmd="$basic_k2_cmd --modular true --compositional true"
 
 success_code="20"


### PR DESCRIPTION
## Flags

- More concise module (use `include Make_Spec (struct end)`)
- Default output directory for an input `file.lus` is `./file.out/`
- SMT traces are produced in `./file.out/smt_trace`

## Parsing

- Fix shift/reduce conflicts
- Removed inline contracts  (**Beware:** _e.g_, `--@assume ...` is now a comment and ignored)
- Allow contracts items in any order
- Guarantees / assumptions / ensures ... can now be named, _e.g._, `guarantee "my guarantee" x > 1;`

## Other

Revert to typing integer constants like `1` as `[1;1]`, but now the type is generalized when we want to introduce abstractions as state variables.