### PR TITLE
Bugfix no outputs in assumptions/requires check

### DIFF
--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -926,7 +926,12 @@ let setup () =
       | `Lustre -> InputSystem.read_input_lustre
       | `Native -> (* InputSystem.read_input_native *) assert false
       | `Horn   -> (* InputSystem.read_input_horn *)   assert false
-  with e -> (* Could not create input system. *)
+  with (* Could not create input system. *)
+  | LustreAst.Parser_error ->
+    (* Don't do anything for parser error, they should already have printed
+    some stuff. *)
+    exit status_error
+  | e ->
     
     let backtrace = Printexc.get_raw_backtrace () in
 

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -54,6 +54,7 @@ module N = LustreNode
 module F = LustreFunction
 
 module SVT = StateVar.StateVarHashtbl
+module SVS = StateVar.StateVarSet
 
 module VS = Var.VarSet
 
@@ -466,8 +467,10 @@ let add_type_for_ident ({ ident_type_map } as ctx) ident l_type =
 
 
 (* Return nodes defined in context *)
-let get_nodes { nodes } = nodes 
+let get_nodes { nodes } = nodes
 
+(* Return the current node in context. *)
+let get_node { node } = node
 
 (* Return functions defined in context *)
 let get_functions { funcs } = funcs 
@@ -636,6 +639,22 @@ let mk_state_var
   state_var, ctx
 
 
+(* Exception because can't iterate manually over bindings in fucking hash
+tables. *)
+exception FoundIt of E.t
+
+(* Resolve an svar to an expression *)
+let expr_of_svar { expr_state_var_map } svar =
+  try
+    expr_state_var_map |> ET.iter (
+      fun expr svar' ->
+        Format.printf "  - %a@." StateVar.pp_print_state_var svar ;
+        if svar == svar' then raise (FoundIt expr) else ()
+    ) ;
+    None
+  with FoundIt expr -> Some expr
+
+
 
 (* Resolve an indentifier to an expression in all scopes *)
 let rec expr_of_ident' ident = function 
@@ -643,12 +662,11 @@ let rec expr_of_ident' ident = function
   | [] -> raise Not_found
 
   | m :: tl ->
-
     try IT.find m ident with Not_found -> expr_of_ident' ident tl
 
 
 (* Resolve an indentifier to an expression *)
-let expr_of_ident { ident_expr_map } ident = 
+let expr_of_ident { ident_expr_map } ident =
   expr_of_ident' ident ident_expr_map
 
 
@@ -991,7 +1009,7 @@ let mk_local_for_expr
     ({ node; 
        definitions_allowed;
        fresh_local_index } as ctx)
-    ({ E.expr_type } as expr) = 
+    ({ E.expr_type } as expr) =
   
   match definitions_allowed with 
 
@@ -1022,11 +1040,16 @@ let mk_local_for_expr
           in
 
           let ctx =
-            if is_ghost then { ctx with
-              node = Some (
-                N.set_state_var_source node state_var N.Ghost
-              )
-            } else ctx
+            if is_ghost then (
+              (* Don't change source of svar if already there. *)
+              try
+                N.get_state_var_source node state_var ; ctx
+              with Not_found -> {
+                ctx with node = Some (
+                  N.set_state_var_source node state_var N.Ghost
+                )
+              }
+            ) else ctx
           in
 
           (* Return variable and changed context *)
@@ -1163,9 +1186,10 @@ let call_outputs_of_node_call
       (* No node call found *)
       with Not_found -> None 
 
+module SVM = StateVar.StateVarMap
 
 (* Add node input to context *)
-let add_node_input ?is_const ctx ident index_types = 
+let add_node_input ?is_const ctx ident index_types =
 
   match ctx with 
 
@@ -1304,6 +1328,76 @@ let add_node_local ?(ghost = false) ctx ident pos index_types =
         | { node = None } -> assert false
         | { node = Some node } ->
           { ctx with node = Some { node with N.locals = local :: locals } }
+
+(** The svars in the COI of the input expression, in the current node.
+
+Returns [None] if there's no current node.
+Raises [Not_found] if some svars in the COI do not have an equation and are
+not outputs of node calls.
+
+Used to check that the assumes and requires of a contract do not mention
+the outputs. *)
+let trace_svars_of ctx expr = match ctx with
+| { node = None } -> None | { node = (Some node) } -> (
+
+  (* Svars of an expression. *)
+  let svars_of e =
+    E.base_state_vars_of_init_expr e
+    |> SVS.union (E.cur_state_vars_of_step_expr e)
+  in
+  (* Set of an index. *)
+  let to_set idx = D.fold ( fun _ elm set -> SVS.add elm set ) idx SVS.empty in
+  (* $(a \setminus b) \cup c$ *)
+  let diff_union a b c = SVS.diff a b |> SVS.union c in
+
+  let rec loop (mem, to_do) =
+    if SVS.is_empty to_do then mem else (
+      (mem, SVS.empty) |> SVS.fold (
+        fun svar (mem, to_do) ->
+          let mem = SVS.add svar mem in
+          match (
+            (* Fresh vars do not have a source, catching that here. *)
+            try N.get_state_var_source node svar with Not_found -> N.Local
+          ) with
+          | N.Oracle
+          | N.Input
+          | N.Output -> mem, to_do
+          | N.Local
+          | N.Ghost -> (
+            let svars =
+              (* Do we have an equation for svar? *)
+              match N.equation_of_svar node svar with
+              | Some (_, _, expr) -> svars_of expr
+              | None -> (
+                (* Is it the output of a node call? *)
+                match N.node_call_of_svar node svar with
+                | Some { N.call_inputs } -> to_set call_inputs
+                | None -> (
+                  (* Is it the output of a function call? *)
+                  match N.function_call_of_svar node svar with
+                  | Some { N.call_inputs } ->
+                    D.fold (
+                      fun _ expr set -> svars_of expr |> SVS.union set
+                    ) call_inputs SVS.empty
+                  | None -> (
+                    (* Is it purely contextual?. *)
+                    match expr_of_svar ctx svar with
+                    | Some expr -> svars_of expr
+                    | None -> raise Not_found
+                  )
+                )
+              )
+            in
+            mem, diff_union svars mem to_do
+          )
+      ) to_do
+      |> loop
+    )
+  in
+  Some (
+    (SVS.empty, svars_of expr) |> loop
+  )
+)
 
 
 (* Add node assumes to context *)

--- a/src/lustre/lustreContext.mli
+++ b/src/lustre/lustreContext.mli
@@ -121,11 +121,24 @@ val add_type_for_ident : t -> LustreIdent.t -> Type.t LustreIndex.t -> t
 (** Return the nodes in the context *)
 val get_nodes : t -> LustreNode.t list
 
+(** Return the current node in context. *)
+val get_node : t -> LustreNode.t option
+
 (** Return the functions in the context *)
 val get_functions : t -> LustreFunction.t list
 
 (** The contract nodes in the context. *)
 val contract_nodes : t -> LustreAst.contract_node_decl list
+
+(** The svars in the COI of the input expression, in the current node.
+
+Returns [None] if there's no current node.
+Raises [Not_found] if some svars in the COI do not have an equation and are
+not outputs of node calls.
+
+Used to check that the assumes and requires of a contract do not mention
+the outputs in [LustreDeclarations]. *)
+val trace_svars_of : t -> LustreExpr.t -> StateVar.StateVarSet.t option
 
 (** Add a contract node to the context for inlining later *)
 val add_contract_node_decl_to_context :

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -443,7 +443,7 @@ let pp_print_node safe ppf {
   in
 
   Format.fprintf ppf 
-    "@[<hv>@[<hv 2>node %a@ @[<hv 1>(%a)@]@;<1 -2>\
+    "@[<v>@[<hv 2>node %a@ @[<hv 1>(%a)@]@;<1 -2>\
      returns@ @[<hv 1>(%a)@];@]@ \
      %a\
      @[<v>%t@]\
@@ -685,7 +685,33 @@ let ordered_equations_of_node { equations } stateful init =
 
   loop [] [] equations
 
+(** Returns the equation for a state variable if any. *)
+let equation_of_svar { equations } svar =
+  try Some (
+    equations |> List.find (fun (svar',_,_) -> svar == svar')
+  ) with Not_found -> None
 
+(** Returns the node call the svar is the output of, if any. *)
+let node_call_of_svar { calls } svar =
+  let rec loop: node_call list -> node_call option = function
+    | ({ call_outputs } as call) :: _ when D.exists (
+      fun _ svar' -> svar == svar'
+    ) call_outputs -> Some call
+    | _ :: tail -> loop tail
+    | [] -> None
+  in
+  loop calls
+
+(** Returns the function call the svar is the output of, if any. *)
+let function_call_of_svar { function_calls } svar =
+  let rec loop = function
+    | ({ call_outputs } as call) :: _ when D.exists (
+      fun _ svar' -> svar == svar'
+    ) call_outputs -> Some call
+    | _ :: tail -> loop tail
+    | [] -> None
+  in
+  loop function_calls
 
 (* Return the scope of the name of the node *)
 let scope_of_node { name } = name |> I.to_scope

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -307,6 +307,15 @@ val name_of_node : t -> LustreIdent.t
 val ordered_equations_of_node :
   t -> StateVar.t list -> bool -> equation list
 
+(** Returns the equation for a state variable if any. *)
+val equation_of_svar : t -> StateVar.t -> equation option
+
+(** Returns the node call the svar is (one of) the output(s) of, if any. *)
+val node_call_of_svar : t -> StateVar.t -> node_call option
+
+(** Returns the function call the svar is (one of) the output(s) of, if any. *)
+val function_call_of_svar : t -> StateVar.t -> function_call option
+
 (** Return the scope of the node *)
 val scope_of_node : t -> Scope.t
 

--- a/src/lustre/lustreSimplify.ml
+++ b/src/lustre/lustreSimplify.ml
@@ -99,7 +99,8 @@ let rec eval_ast_expr ctx = function
   (* ****************************************************************** *)
 
   (* Identifier *)
-  | A.Ident (pos, ident) -> eval_ident ctx pos ident
+  | A.Ident (pos, ident) ->
+    eval_ident ctx pos ident
 
   (* Mode ref *)
   | A.ModeRef (pos, p4th) -> (
@@ -898,7 +899,7 @@ let rec eval_ast_expr ctx = function
       (Some defaults)
 
   (* Node call without activation condition *)
-  | A.Call (pos, ident, args) -> 
+  | A.Call (pos, ident, args) ->
 
     eval_node_or_function_call 
       ctx

--- a/tests/regression/error/cocospec_node_call_check.lus
+++ b/tests/regression/error/cocospec_node_call_check.lus
@@ -1,0 +1,18 @@
+(*
+  Tests that the restrictions on the variables usable in an assume apply also
+  to node calls in assumes.
+*)
+
+node pass_through(x : int) returns (y : int) ;
+let
+  y = x ;
+tel
+
+node top(input : int) returns (output : int) ;
+(*@contract
+  assume input < pass_through(output) ;
+  guarantee true ;
+*)
+let
+  output = input ;
+tel


### PR DESCRIPTION
Discovered by John Backes (thanks!)

Mentioning the outputs of the node in the assumptions / requirements of the contract of a node is illegal. Inputs of node calls where not checked, it was thus easy to bypass the check by calling, say, a pass-through node.

See regression test added in this PR for more details.