### PR TITLE
Contracts to props

### DIFF
--- a/src/flags.ml
+++ b/src/flags.ml
@@ -787,6 +787,26 @@ module Contracts = struct
     )
   let compositional () = !compositional
 
+  let translate_default = None
+  let translate = ref translate_default
+  let _ = add_spec
+    "--translate_contracts"
+    ( Arg.String (fun str -> translate := Some str) )
+    (fun fmt ->
+      Format.fprintf fmt
+        "@[<v>\
+          Translates a contracts in assertions / properties (experimental)@ \
+          Default: %t@]"
+        (fun fmt ->
+          Format.fprintf fmt "%s" (
+            match translate_default with
+            | None -> "off"
+            | Some f -> f
+          )
+        )
+    )
+  let translate_contracts () = !translate
+
   let check_modes_default = true
   let check_modes = ref check_modes_default
   let _ = add_spec

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -329,6 +329,9 @@ module Contracts : sig
   (** Compositional analysis. *)
   val compositional : unit -> bool
 
+  (** Translate contracts. *)
+  val translate_contracts : unit -> string option
+
   (** Check modes. *)
   val check_modes : unit -> bool
 

--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -30,6 +30,7 @@ type _ t =
 | Horn : unit S.t -> unit t
 
 let read_input_lustre input_file = Lustre (LustreInput.of_file input_file)
+let translate_contracts_lustre = ContractsToProps.translate_file
 
 let read_input_native input_file = assert false
 

--- a/src/inputSystem.mli
+++ b/src/inputSystem.mli
@@ -29,6 +29,8 @@ type _ t
 
 (** Read input from file *)
 val read_input_lustre : string -> LustreNode.t t
+(** Translate lustre contracts to properties. *)
+val translate_contracts_lustre : string -> string -> unit
 
 (** Returns the scopes of all the systems in an input systems, in topological
     order. *)

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -1244,6 +1244,7 @@ let main () =
 
   (* Set everything up and produce input system. *)
   let input_sys = setup () in
+  input_sys_ref := Some input_sys ;
 
   (* Not launching if we're just translating contracts. *)
   match Flags.Contracts.translate_contracts () with

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -1120,11 +1120,8 @@ let rec run_loop msg_setup modules results =
 
 
 (* Looks at the modules activated and decides what to do. *)
-let launch () =
+let launch input_sys =
 
-  TermLib.Signals.ignore_sigpipe () ;
-
-  let input_sys = setup () in
   let results = Analysis.mk_results () in
 
 
@@ -1243,7 +1240,25 @@ let launch () =
 
 
 (* Entry point *)
-let main () = launch ()
+let main () =
+
+  (* Set everything up and produce input system. *)
+  let input_sys = setup () in
+
+  (* Not launching if we're just translating contracts. *)
+  match Flags.Contracts.translate_contracts () with
+  | Some target -> (
+    let src = Flags.input_file () in
+    Event.log_uncond "Translating contracts to file \"%s\"" target ;
+    try (
+      InputSystem.translate_contracts_lustre src target ;
+      Event.log_uncond "Success"
+    ) with e ->
+      Event.log L_error
+        "Could not translate contracts from file \"%s\":@ %s"
+        src (Printexc.to_string e)
+  )
+  | None -> launch input_sys
 
 ;;
 

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -1125,7 +1125,6 @@ let launch () =
   TermLib.Signals.ignore_sigpipe () ;
 
   let input_sys = setup () in
-  input_sys_ref := Some input_sys ;
   let results = Analysis.mk_results () in
 
 

--- a/src/lustre/contractsToProps.ml
+++ b/src/lustre/contractsToProps.ml
@@ -1,0 +1,223 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+open Lib
+
+module Ast = LustreAst
+module Expr = LustreExpr
+
+let blah txt pos = Format.asprintf "%s at %a" txt pp_print_pos pos
+let blah_opt txt name pos =
+  Format.asprintf "%s%t at %a"
+    txt
+    (fun fmt -> match name with
+      | None -> ()
+      | Some name -> Format.fprintf fmt " (%s)" name
+    )
+    pp_print_pos pos
+
+let rec collect_contracts (locals, asserts, props) = function
+| head :: tail -> (
+  let triple = match head with
+
+    | Ast.GhostConst dec ->
+      let pos, info = match dec with
+        | Ast.FreeConst (pos,_,_)
+        | Ast.UntypedConst (pos,_,_) ->
+          Format.asprintf "\
+            [contracts translator] %a: untyped ghost consts are unsupported\
+          " pp_print_pos pos
+          |> failwith
+        | Ast.TypedConst (pos,id,expr,typ) -> pos, (id, expr, typ)
+      in
+      (
+        blah "Contract constant declaration" pos, info
+      ) :: locals, asserts, props
+
+    | Ast.GhostVar dec ->
+      let pos, info = match dec with
+        | Ast.FreeConst (pos,_,_)
+        | Ast.UntypedConst (pos,_,_) ->
+          Format.asprintf "\
+            [contracts translator] %a: untyped ghost vars are unsupported\
+          " pp_print_pos pos
+          |> failwith
+        | Ast.TypedConst (pos,id,expr,typ) -> pos, (id, expr, typ)
+      in
+      (
+        blah "Contract variable declaration" pos, info
+      ) :: locals, asserts, props
+
+    | Ast.Assume (pos, name, expr) ->
+      locals, (
+        blah_opt "Assumption" name pos, Ast.Assert (dummy_pos, expr)
+      ) :: asserts, props
+
+    | Ast.Guarantee (pos, name, expr) ->
+      locals, asserts, (blah_opt "Guarantee" name pos, [], expr) :: props
+
+    | Ast.Mode (pos, name, reqs, enss) ->
+      let reqs = List.map (fun (_, _, e) -> e) reqs in
+      let props =
+        enss |> List.fold_left (
+          fun acc (e_pos, e_name, e_expr) ->
+            (
+              blah
+                (Format.sprintf "%s from mode %s"
+                  (blah_opt "Ensure" e_name e_pos)
+                  name
+                )
+                pos,
+              reqs,
+              e_expr
+            ) :: acc
+        ) props
+      in
+      locals, asserts, props
+
+    | Ast.ContractCall (pos,_,_,_) ->
+      Format.asprintf "\
+        [contracts translator] %a: contract calls are unsupported\
+      " pp_print_pos pos
+      |> failwith
+  in
+
+  collect_contracts triple tail
+)
+
+| [] -> List.rev locals, List.rev asserts, List.rev props
+
+
+let fmt_node_decl fmt (
+  ident, params, ins, outs, locals, eqs
+) (c_locals, c_asserts, c_properties) =
+
+  (* Header. *)
+  Format.fprintf fmt "\
+    node %a%a (@.  \
+      @[<hov>%a@]@.\
+    ) returns (@.  \
+      @[<hov>%a@]@.\
+    ) ;@.@?\
+  " Ast.pp_print_ident ident
+    Ast.pp_print_node_param_list params
+    (pp_print_list Ast.pp_print_const_clocked_typed_ident " ;@ ") ins
+    (pp_print_list Ast.pp_print_clocked_typed_ident " ;@ ") outs ;
+
+  (* Locals. *)
+  let locals_empty, c_locals_empty = locals = [], c_locals = [] in
+  if not locals_empty || not c_locals_empty then (
+
+    (
+      if locals_empty then
+        Format.fprintf fmt "var@."
+      else
+        Format.fprintf fmt "  @[<v>%a@]@." Ast.pp_print_node_local_decl locals
+    ) ;
+
+    if not c_locals_empty then
+      c_locals |> List.iter (
+        fun (blah, (id,_,typ)) ->
+          Format.fprintf fmt "  -- %s@.  %a: %a ;@."
+            blah
+            Ast.pp_print_ident id
+            Ast.pp_print_lustre_type typ
+      )
+  ) ;
+
+  (* Equations. *)
+  Format.fprintf fmt "let@." ;
+  Format.fprintf fmt "  @[<v>%a@]@.@?"
+    (pp_print_list Ast.pp_print_node_equation "@ ") eqs ;
+
+  if eqs <> [] then Format.fprintf fmt "@." ;
+
+  c_locals |> List.iter (
+    fun (blah, (id,expr,_)) ->
+      Format.fprintf fmt "  -- %s@.  %a = %a ;@."
+        blah
+        Ast.pp_print_ident id
+        Ast.pp_print_expr expr
+  ) ;
+  if c_locals <> [] then Format.fprintf fmt "@." ;
+  
+  c_asserts |> List.iter (
+    fun (blah, ass) ->
+      Format.fprintf fmt "  -- %s@.  %a@."
+        blah Ast.pp_print_node_equation ass
+  ) ;
+  if c_asserts <> [] then Format.fprintf fmt "@." ;
+
+  c_properties |> List.iter (
+    fun (blah, lhs, rhs) ->
+      Format.fprintf fmt "  -- %s@.  --%%PROPERTY " blah ;
+      ( match lhs with
+        | [] -> ()
+        | _ ->
+          Format.fprintf fmt "(not (%a)) or "
+            (pp_print_list Ast.pp_print_expr " and ") lhs
+      ) ;
+      Format.fprintf fmt "(%a) ;@." Ast.pp_print_expr rhs
+  ) ;
+  if c_properties <> [] then Format.fprintf fmt "@." ;
+
+  Format.fprintf fmt "tel@."
+
+
+
+let rec fmt_declarations fmt = function
+| dec :: tail -> (
+  ( match dec with
+
+    | Ast.ContractNodeDecl (pos,_) ->
+      Format.asprintf "\
+        [contracts translator] %a: contract node declarations are unsupported\
+      " pp_print_pos pos
+      |> failwith
+
+    | Ast.NodeDecl (pos, (wan,two,tri,far,fiv,six,contract)) -> (
+      let contract_info = match contract with
+        | None -> ([],[],[])
+        | Some c -> collect_contracts ([],[],[]) c
+      in
+      fmt_node_decl fmt (wan,two,tri,far,fiv,six) contract_info
+    )
+
+    | dec -> Ast.pp_print_declaration fmt dec
+  ) ;
+  Format.fprintf fmt "@.@.@?" ;
+  fmt_declarations fmt tail
+)
+| [] -> ()
+
+let translate program target =
+  let tgt = open_out target in
+  let fmt = Format.formatter_of_out_channel tgt in
+
+  fmt_declarations fmt program ;
+
+  exit 2
+
+(* 
+   Local Variables:
+   compile-command: "make -C .. -k"
+   tuareg-interactive-program: "./kind2.top -I ./_build -I ./_build/SExpr"
+   indent-tabs-mode: nil
+   End: 
+*)
+  

--- a/src/lustre/contractsToProps.ml
+++ b/src/lustre/contractsToProps.ml
@@ -205,13 +205,14 @@ let rec fmt_declarations fmt = function
 )
 | [] -> ()
 
-let translate program target =
+let translate ast target =
   let tgt = open_out target in
   let fmt = Format.formatter_of_out_channel tgt in
+  fmt_declarations fmt ast
 
-  fmt_declarations fmt program ;
-
-  exit 2
+let translate_file file target =
+  let ast = LustreInput.ast_of_file file in
+  translate ast target
 
 (* 
    Local Variables:

--- a/src/lustre/contractsToProps.mli
+++ b/src/lustre/contractsToProps.mli
@@ -1,0 +1,30 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+(** Translates the contract from the first file into properties and writes
+the result in the second file. *)
+val translate_file : string -> string -> unit
+
+(* 
+   Local Variables:
+   compile-command: "make -C .. -k"
+   tuareg-interactive-program: "./kind2.top -I ./_build -I ./_build/SExpr"
+   indent-tabs-mode: nil
+   End: 
+*)
+  

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -801,12 +801,14 @@ let pp_print_array_def_index ppf ident =
 
 let pp_print_eq_lhs ppf = function
 
-  | StructDef (pos, [l]) -> pp_print_struct_item ppf l
+  | StructDef (pos, [l]) ->
+    pp_print_struct_item ppf l
       
-  | StructDef (pos, l) -> (pp_print_list pp_print_struct_item "@,") ppf l
+  | StructDef (pos, l) ->
+    Format.fprintf ppf "(%a)"
+      (pp_print_list pp_print_struct_item ",") l
                             
   | ArrayDef (pos, i, l) ->
-
     Format.fprintf ppf
       "%a%a"
       pp_print_ident i
@@ -959,7 +961,7 @@ let pp_print_contract_spec ppf = function
 | Some contract ->
   Format.fprintf 
     ppf
-    "@[<v 2>(*@contract@ %a@]@ *)"
+    "@[<v 2>(*@contract@ %a@]@ *)@ "
     pp_print_contract contract
 
 
@@ -1002,7 +1004,7 @@ let pp_print_declaration ppf = function
        returns@ @[<hv 1>(%a)@];@]@ \
        %a\
        %a\
-       @[<hv 2>let@ \
+       @[<v 2>let@ \
        %a@;<1 -2>\
        tel;@]@]"
       pp_print_ident n 

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -278,6 +278,7 @@ type declaration =
 type t = declaration list
 
 (** {1 Pretty-printers} *)
+val pp_print_node_param_list : Format.formatter -> node_param list -> unit
 val pp_print_ident : Format.formatter -> ident -> unit
 val pp_print_expr : Format.formatter -> expr -> unit
 val pp_print_array_slice : Format.formatter -> expr * expr -> unit

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -26,9 +26,8 @@ module D = LustreDeclarations
 module S = SubSystem
 
 
-
-(* Parse from input channel *)
-let of_channel in_ch = 
+(* Constructs an AST from an input channel. *)
+let ast_of_channel in_ch =
 
   (* Create lexing buffer *)
   let lexbuf = Lexing.from_function LustreLexer.read_from_lexbuf_stack in
@@ -39,29 +38,20 @@ let of_channel in_ch =
     (try Filename.dirname (Flags.input_file ())
      with Failure _ -> Sys.getcwd ());
 
-  (* Lustre file is a list of declarations *)
-  let declarations = 
+  try
+    (* Parse file to list of declarations *)
+    LustreParser.main LustreLexer.token lexbuf 
+  with
+  | LustreParser.Error ->
+    let lexer_pos = Lexing.lexeme_start_p lexbuf in
+    C.fail_at_position (position_of_lexing lexer_pos) "Syntax error"
 
-    try 
 
-      (* Parse file to list of declarations *)
-      LustreParser.main LustreLexer.token lexbuf 
+(* Parse from input channel *)
+let of_channel in_ch =
 
-    with 
-
-      | LustreParser.Error ->
-
-        let lexer_pos = 
-          Lexing.lexeme_start_p lexbuf 
-        in
-
-        C.fail_at_position
-          (position_of_lexing lexer_pos)
-          "Syntax error"
-
-  in
-
-  ContractsToProps.translate declarations "blah.lus" ;
+  (* Get declarations from channel. *)
+  let declarations = ast_of_channel in_ch in
 
   (* Format.printf "declarations:@   @[<v>%a@]@.@."
     (pp_print_list LustreAst.pp_print_declaration "@ ") declarations ; *)
@@ -121,16 +111,28 @@ let of_channel in_ch =
   (* Return a subsystem tree from the list of nodes *)
   N.subsystem_of_nodes nodes', globals
   
-
-(* Open and parse from file *)
-let of_file filename = 
+(* Returns the AST from a file. *)
+let ast_of_file filename =
 
   (* Open the given file for reading *)
   let in_ch = match filename with
     | "" -> stdin
-    | _ -> open_in filename in
+    | _ -> open_in filename
+  in
 
-    of_channel in_ch
+  ast_of_channel in_ch
+
+
+(* Open and parse from file *)
+let of_file filename =
+
+  (* Open the given file for reading *)
+  let in_ch = match filename with
+    | "" -> stdin
+    | _ -> open_in filename
+  in
+
+  of_channel in_ch
 
 
 (* 

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -61,6 +61,8 @@ let of_channel in_ch =
 
   in
 
+  ContractsToProps.translate declarations "blah.lus" ;
+
   (* Format.printf "declarations:@   @[<v>%a@]@.@."
     (pp_print_list LustreAst.pp_print_declaration "@ ") declarations ; *)
 

--- a/src/lustre/lustreInput.mli
+++ b/src/lustre/lustreInput.mli
@@ -119,6 +119,9 @@
     and refinement from analysis strategies. *)
 val of_file : string -> LustreNode.t SubSystem.t * LustreGlobals.t
 
+(** Parse from the file, returns the AST. *)
+val ast_of_file : string -> LustreAst.declaration list
+
 (* 
    Local Variables:
    compile-command: "make -C .. -k"

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -454,7 +454,7 @@ let pp_print_node safe ppf {
      %a%t\
      %t\
      %a@;<1 -2>\
-     tel;@]@]"  
+     tel;@]@]@?"  
 
     (* %a *)
     (I.pp_print_ident safe) name


### PR DESCRIPTION
Translation of Kind 2 contracts in terms of assertions and properties

Limitations (justified below):
- does not generate properties corresponding to calls being safe
- untyped ghost variables are unsupported
- contract node declarations and contract imports are not supported

These limitations come from the primary goal of the translator, which is to stay as close as possible to the original file. That is, no intermediary variables, no oracles for unguarded `pre`'s...

To achieve this, the translator works on the AST before all the contextual checks (typing, contract sanity checking, *etc.*). Still, we will not compile a system that does not pass these checks: Kind 2 will parse and construct the input system as usual before it retrieves the AST and translates the contracts.