### PR TITLE
Contract var stream fix

### DIFF
--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -368,8 +368,8 @@ contract_ghost_var:
     i = ident ; COLON ; t = lustre_type; EQUALS ; e = expr ;
     SEMICOLON 
     { A.GhostVar (A.TypedConst (mk_pos $startpos, i, e, t)) }
-  | VAR ; i = ident ; EQUALS ; e = expr ; SEMICOLON 
-    { A.GhostVar (A.UntypedConst (mk_pos $startpos, i, e)) }
+(*  | VAR ; i = ident ; EQUALS ; e = expr ; SEMICOLON 
+    { A.GhostVar (A.UntypedConst (mk_pos $startpos, i, e)) } *)
 
 contract_ghost_const:
   | CONST; i = ident; COLON; t = lustre_type; EQUALS; e = expr; SEMICOLON 

--- a/tests/regression/success/block_annot_syntax.lus
+++ b/tests/regression/success/block_annot_syntax.lus
@@ -34,7 +34,7 @@ node my_node (in: int) returns (out: int) ;
 (*@contract
 
   const bound = 10 ;
-  var in_bounded = abs(in) < bound ;
+  var in_bounded: bool = abs(in) < bound ;
 
   assume in_bounded ;
   guarantee out >= - bound ;

--- a/tests/regression/success/contract_ordering.lus
+++ b/tests/regression/success/contract_ordering.lus
@@ -42,7 +42,7 @@ node my_node (in: int) returns (out: int) ;
 (*@contract
 
   const bound = 10 ;
-  var in_bounded = abs(in) < bound ;
+  var in_bounded: bool = abs(in) < bound ;
 
   assume in_bounded ;
   guarantee out >= - bound ;

--- a/tests/regression/success/mode_reqs_by_idents.lus
+++ b/tests/regression/success/mode_reqs_by_idents.lus
@@ -35,7 +35,7 @@ node my_node (in: int) returns (out: int) ;
 (*@contract
 
   const bound = 10 ;
-  var in_bounded = abs(in) < bound ;
+  var in_bounded: bool = abs(in) < bound ;
 
   assume in_bounded ;
   guarantee out >= - bound ;

--- a/tests/regression/success/mode_reqs_by_idents_shadowing.lus
+++ b/tests/regression/success/mode_reqs_by_idents_shadowing.lus
@@ -35,7 +35,7 @@ node my_node (in: int ; in_pos: int) returns (out: int) ;
 (*@contract
 
   const bound = 10 ;
-  var in_bounded = abs(in) < bound ;
+  var in_bounded: bool = abs(in) < bound ;
 
   assume in_bounded ;
   guarantee out >= - bound ;


### PR DESCRIPTION
Ghost variables were actually treated as constants. That is, they could not mention `pre` of themselves. This is fixed now.

**NB:** the type annotation for ghost variables is **no longer optional**. The syntax is

```
var blah: bool = ... ;
```

The type annotation for constants however is still optional.