### PR TITLE
Refinement flag, rust compile fix, feedback improvements

### DIFF
--- a/src/analysis.ml
+++ b/src/analysis.ml
@@ -38,6 +38,17 @@ type info = {
   (* refinement_of : result option *)
 }
 
+(** Shrinks an abstraction map to the subsystems of a system. *)
+let shrink_info_to_sys ({ abstraction_map } as info) sys =
+  let abstraction_map =
+    TransSys.fold_subsystems ?include_top:(Some false) (
+      fun map sys ->
+        let scope = TransSys.scope_of_trans_sys sys in
+        Scope.Map.add scope (Scope.Map.find scope abstraction_map) map
+    ) Scope.Map.empty sys
+  in
+  { info with abstraction_map }
+
 (** Parameter of an analysis. *)
 type param =
   (* Analysis of the contract of a system. *)
@@ -52,6 +63,9 @@ type param =
 and result = {
   (** Parameters of the analysis. *)
   param : param ;
+
+  (** Total time of the analysis. *)
+  time: float ;
 
   (** System analyzed, contains property statuses and invariants. *)
   sys : TransSys.t ;
@@ -74,6 +88,12 @@ let info_of_param = function
 | First info -> info
 | Refinement (info,_) -> info
 
+(** Shrinks a param to a system. *)
+let shrink_param_to_sys param sys = match param with
+| ContractCheck info -> ContractCheck (shrink_info_to_sys info sys)
+| First info -> First (shrink_info_to_sys info sys)
+| Refinement (info, res) -> Refinement ( (shrink_info_to_sys info sys), res )
+
 (* Retrieve the assumptions of a [scope] from a [param]. *)
 let param_assumptions_of_scope param scope =
   let { assumptions } = info_of_param param in
@@ -94,8 +114,8 @@ let param_scope_is_abstract param scope =
 (* Abstraction of a property source. *)
 type prop_kind = | Contract | Subreq | Prop
 
-(* Creates a [result] from a [param] and a [t]. *)
-let mk_result param sys =
+(* Creates a [result] from a [param], a [t] and an analysis time. *)
+let mk_result param sys time =
 
   let valid, invalid, unknown = TransSys.get_split_properties sys in
 
@@ -117,7 +137,7 @@ let mk_result param sys =
     find c_valid r_valid false unknown
   in
 
-  { param ; sys ; contract_valid ; requirements_valid }
+  { param ; time ; sys ; contract_valid ; requirements_valid }
 
 (** Returns true if all properties in the system in a [result] have been
     proved. *)
@@ -222,7 +242,7 @@ let pp_print_param fmt param =
 
     (fun fmt -> function
       | [], [] ->
-        Format.fprintf fmt " no subsystems"
+        Format.fprintf fmt " (no subsystems)"
       | concrete, abstract ->
         Format.fprintf fmt "@ subsystems@   @[<v>" ;
         ( match concrete with
@@ -259,32 +279,97 @@ let split_properties_nocands sys =
     |> List.rev in
   remove_cands valid, remove_cands invalid, remove_cands unknown
 
-let pp_print_result_quiet fmt { sys } =
+let pp_print_param_of_result fmt { param ; sys } =
+  let param = shrink_param_to_sys param sys in
+  match param with
+  | ContractCheck _ -> Format.fprintf fmt "checking mode exhaustiveness"
+  | First { abstraction_map } ->
+    let count =
+      Scope.Map.fold (
+        fun _ is_abs acc ->
+          if is_abs then acc + 1 else acc
+      ) abstraction_map 0
+    in
+    Format.fprintf
+      fmt "without refinement: %d abstract system%s" count (
+        if count = 1 then "" else "s"
+      )
+  | Refinement ( { abstraction_map }, { param = pre_param } ) ->
+    let { abstraction_map = pre_abs_map } = info_of_param pre_param in
+    let count =
+      Scope.Map.fold (
+        fun _ is_abs acc ->
+          if is_abs then acc + 1 else acc
+      ) abstraction_map 0
+    in
+    let refined =
+      Scope.Map.fold (
+        fun scope is_abs acc ->
+          if not is_abs then try (
+            if Scope.Map.find scope pre_abs_map then scope :: acc else acc
+          ) with Not_found -> (
+            Format.asprintf
+              "could not find system %a \
+              in abstraction map of previous result"
+              Scope.pp_print_scope scope ;
+            |> failwith
+          ) else acc
+      ) abstraction_map []
+    in
+    Format.fprintf
+      fmt
+      "with %d abstract system%s@ \
+      but after refining %d system%s:@   \
+      @[<hov>%a@]"
+      count
+      (if count = 1 then "" else "s")
+      (List.length refined)
+      (if (List.length refined) = 1 then "" else "s")
+      (pp_print_list
+        Scope.pp_print_scope
+        ",@ "
+      ) refined
+
+let pp_print_result_quiet fmt ({ time ; sys } as res) =
   match split_properties_nocands sys with
   | valid, [], [] ->
-    Format.fprintf fmt "%a | safe (%d properties)"
+    Format.fprintf fmt "%a:@   @[<v>\
+        @{<green>safe@} in %.3fs@ \
+        %a@ \
+        %d propert%s\
+      @]"
       Scope.pp_print_scope (TransSys.scope_of_trans_sys sys)
+      time
+      pp_print_param_of_result res
       (List.length valid)
+      ( match valid with
+        | [ _ ] -> "y"
+        | _ -> "ies" )
   | valid, [], unknown ->
-    Format.fprintf fmt "%a @[<v>\
-      | timeout@ \
-      | unknown: [ @[<hov>@{<yellow>%a@}@] ]@ \
-      | valid:   [ @[<hov>@{<green>%a@}@] ]\
-    @]"
-    Scope.pp_print_scope (TransSys.scope_of_trans_sys sys)
-    (pp_print_list Property.pp_print_prop_quiet ",@ ") unknown
-    (pp_print_list Property.pp_print_prop_quiet ",@ ") valid
+    Format.fprintf fmt "%a:@   @[<v>\
+        @{<red>timeout@}@ \
+        %a@ \
+        unknown: [ @[<hov>@{<yellow>%a@}@] ]@ \
+        valid:   [ @[<hov>@{<green>%a@}@] ]\
+      @]"
+      Scope.pp_print_scope (TransSys.scope_of_trans_sys sys)
+      pp_print_param_of_result res
+      (pp_print_list Property.pp_print_prop_quiet ",@ ") unknown
+      (pp_print_list Property.pp_print_prop_quiet ",@ ") valid
   | valid, invalid, unknown ->
-    Format.fprintf fmt "%a @[<v>\
-      | unsafe@ \
-      | invalid: [ @[<hov>@{<red>%a@}@] ]@ \
-      | unknown: [ @[<hov>@{<yellow>%a@}@] ]@ \
-      | valid:   [ @[<hov>@{<green>%a@}@] ]\
-    @]"
-    Scope.pp_print_scope (TransSys.scope_of_trans_sys sys)
-    (pp_print_list Property.pp_print_prop_quiet ",@ ") invalid
-    (pp_print_list Property.pp_print_prop_quiet ",@ ") unknown
-    (pp_print_list Property.pp_print_prop_quiet ",@ ") valid
+    Format.fprintf fmt "%a:@   @[<v>\
+        @{<red>unsafe@} in %.3fs@ \
+        %a@ \
+        invalid: [ @[<hov>@{<red>%a@}@] ]@ \
+        unknown: [ @[<hov>@{<yellow>%a@}@] ]@ \
+        valid:   [ @[<hov>@{<green>%a@}@] ]\
+      @]"
+      Scope.pp_print_scope (TransSys.scope_of_trans_sys sys)
+      time
+      pp_print_param_of_result res
+      (pp_print_list Property.pp_print_prop_quiet ",@ ") invalid
+      (pp_print_list Property.pp_print_prop_quiet ",@ ") unknown
+      (pp_print_list Property.pp_print_prop_quiet ",@ ") valid
 
 let pp_print_result fmt {
   param ; sys ; contract_valid ; requirements_valid

--- a/src/analysis.mli
+++ b/src/analysis.mli
@@ -60,6 +60,9 @@ type info = {
   (* refinement_of : result option *)
 }
 
+(** Shrinks an abstraction map to the subsystems of a system. *)
+val shrink_info_to_sys: info -> TransSys.t -> info
+
 (** Parameter of an analysis. *)
 type param =
   (** Analysis of the contract of a system. *)
@@ -73,6 +76,9 @@ type param =
 and result = {
   (** Parameters of the analysis. *)
   param : param ;
+
+  (** Runtime of the analysis. *)
+  time : float ;
 
   (** System analyzed, contains property statuses and invariants. *)
   sys : TransSys.t ;
@@ -93,6 +99,9 @@ and result = {
 (** The info or a param. *)
 val info_of_param : param -> info
 
+(** Shrinks a param to a system. *)
+val shrink_param_to_sys : param -> TransSys.t -> param
+
 (** Return [true] if a scope is flagged as abstract in the [abstraction_map] of
    a [param]. Default to [false] if the node is not in the map. *)
 val param_scope_is_abstract : param -> Scope.t -> bool
@@ -105,7 +114,7 @@ val param_assumptions_of_scope : param -> Scope.t -> Term.t list
 
 
 (** Returns a result from an analysis. *)
-val mk_result : param -> TransSys.t -> result
+val mk_result : param -> TransSys.t -> float -> result
 
 (** Returns true if all properties in the system in a [result] have been
     proved. *)

--- a/src/certifChecker.ml
+++ b/src/certifChecker.ml
@@ -21,6 +21,7 @@ open Lib
 open Actlit
 open Certificate
 
+module Ids = Lib.ReservedIds
 
 module TS = TransSys
 module TM = Term.TermMap
@@ -2150,7 +2151,7 @@ let merge_systems lustre_vars kind2_sys jkind_sys =
   (* Symbol for initial predicate of new system *)
   let init_uf =
     UfSymbol.mk_uf_symbol
-      (LustreIdent.init_uf_string ^"_"^ obs_name) 
+      (Ids.init_uf_string ^"_"^ obs_name) 
       vars_types
       Type.t_bool 
   in
@@ -2158,7 +2159,7 @@ let merge_systems lustre_vars kind2_sys jkind_sys =
   (* Symbol for transition relation of new system *)
   let trans_uf =
     UfSymbol.mk_uf_symbol
-      (LustreIdent.trans_uf_string ^"_"^ obs_name) 
+      (Ids.trans_uf_string ^"_"^ obs_name) 
       (vars_types @ vars_types)
       Type.t_bool 
   in

--- a/src/event.ml
+++ b/src/event.ml
@@ -393,7 +393,7 @@ let proved_pt mdl level trans_sys k prop =
          | None -> ()
          | Some k -> Format.fprintf ppf "for k=%d " k)
       pp_print_kind_module_pt mdl
-      (Stat.get_float Stat.total_time)
+      (Stat.get_float Stat.analysis_time)
 
 (* Pretty-print a counterexample *)
 let pp_print_counterexample_pt 
@@ -467,7 +467,7 @@ let cex_pt mdl level input_sys analysis trans_sys prop cex disproved =
           (function ppf -> match cex with
              | [] -> ()
              | ((_, c) :: _) -> Format.fprintf ppf "for k=%d " (List.length c))
-          (Stat.get_float Stat.total_time)
+          (Stat.get_float Stat.analysis_time)
           (* (pp_print_counterexample_pt *)
           (*    (log_level_of_int (int_of_log_level level + 2)) *)
           (*    input_sys analysis trans_sys prop disproved) *)
@@ -491,7 +491,7 @@ let cex_pt mdl level input_sys analysis trans_sys prop cex disproved =
            | [] -> ()
          | ((_, c) :: _) ->
            (List.length c) - 1 |> Format.fprintf ppf "for k=%d ")
-        (Stat.get_float Stat.total_time)
+        (Stat.get_float Stat.analysis_time)
         (pp_print_counterexample_pt
            level input_sys analysis trans_sys prop disproved)
         cex ;
@@ -660,7 +660,7 @@ let proved_xml mdl level trans_sys k prop =
         <Answer source=\"%a\">valid</Answer>@;<0 -2>\
         </Property>@]@.")
       prop
-      (Stat.get_float Stat.total_time)
+      (Stat.get_float Stat.analysis_time)
       (function ppf -> match k with 
          | None -> () 
          | Some k -> Format.fprintf ppf "<K>%d</K>@," k)
@@ -766,7 +766,7 @@ mdl level input_sys analysis trans_sys prop (
         %a@;<0 -2>\
         </Property>@]@.") 
       prop
-      (Stat.get_float Stat.total_time)
+      (Stat.get_float Stat.analysis_time)
       (function ppf -> match cex with 
          | [] -> () 
          | cex ->
@@ -1093,7 +1093,8 @@ let log_run_end results =
   | F_relay -> failwith "can only be called by supervisor"
 
 (* Logs the start of an analysis. *)
-let log_analysis_start param =
+let log_analysis_start sys param =
+  let param = Analysis.shrink_param_to_sys param sys in
   let info = Analysis.info_of_param param in
   match !log_format with
   | F_pt ->
@@ -1206,7 +1207,8 @@ let log_interruption signal =
 let invariant scope term cert = 
 
   (* Update time in case we are not running in parallel mode *)
-  Stat.update_time Stat.total_time;
+  Stat.update_time Stat.total_time ;
+  Stat.update_time Stat.analysis_time ;
   
   try
     
@@ -1222,7 +1224,8 @@ let invariant scope term cert =
 let prop_status status input_sys analysis trans_sys prop =
   
   (* Update time in case we are not running in parallel mode *)
-  Stat.update_time Stat.total_time;
+  Stat.update_time Stat.total_time ;
+  Stat.update_time Stat.analysis_time ;
   
   let mdl = get_module () in
 
@@ -1250,7 +1253,8 @@ let prop_status status input_sys analysis trans_sys prop =
 let step_cex input_sys analysis trans_sys prop cex =
   
   (* Update time in case we are not running in parallel mode *)
-  Stat.update_time Stat.total_time;
+  Stat.update_time Stat.total_time ;
+  Stat.update_time Stat.analysis_time ;
 
   log_cex true (get_module ()) L_warn input_sys analysis trans_sys prop cex ;
 
@@ -1267,7 +1271,8 @@ let step_cex input_sys analysis trans_sys prop cex =
 let execution_path trans_sys path = 
 
   (* Update time in case we are not running in parallel mode *)
-  Stat.update_time Stat.total_time;
+  Stat.update_time Stat.total_time ;
+  Stat.update_time Stat.analysis_time ;
   
   let mdl = get_module () in
 
@@ -1278,7 +1283,8 @@ let execution_path trans_sys path =
 let progress k =
 
   (* Update time in case we are not running in parallel mode *)
-  Stat.update_time Stat.total_time;
+  Stat.update_time Stat.total_time ;
+  Stat.update_time Stat.analysis_time ;
   
   let mdl = get_module () in
 
@@ -1297,7 +1303,8 @@ let progress k =
 (* Send statistics *)
 let stat stats = 
 
-  Stat.update_time Stat.total_time;
+  Stat.update_time Stat.total_time ;
+  Stat.update_time Stat.analysis_time ;
   
   let mdl = get_module () in
 
@@ -1336,7 +1343,8 @@ let terminate () =
 (* Receive all queued messages *)
 let recv () = 
 
-  Stat.update_time Stat.total_time;
+  Stat.update_time Stat.total_time ;
+  Stat.update_time Stat.analysis_time ;
   
   try
 

--- a/src/event.mli
+++ b/src/event.mli
@@ -93,7 +93,7 @@ val log_run_end : Analysis.result list -> unit
 (** Logs the start of an analysis.
     [log_analysis_start top abs] logs the start of an analysis for top
     system [top] with abstraction [abs]. *)
-val log_analysis_start : Analysis.param -> unit
+val log_analysis_start : TransSys.t -> Analysis.param -> unit
 
 (** Logs the end of an analysis.
     [log_analysis_start result] logs the end of an analysis. *)

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -71,7 +71,7 @@ let print_flags =
 module Make_Spec (Dummy:sig end) = struct
   (* All the flag specification of this module. *)
   let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
+  let add_specs specs = all_specs := List.rev_append specs !all_specs
   let add_spec flag parse desc = all_specs := (flag, parse, desc) :: !all_specs
 
   (* Returns all the flag specification of this module. *)
@@ -866,7 +866,7 @@ module Certif = struct
 
   (* All the flag specification of this module. *)
   let all_specs = ref []
-  let add_specs specs = all_specs := !all_specs @ specs
+  let add_specs specs = all_specs := List.rev_append specs !all_specs
   let add_spec flag parse desc = all_specs := (flag, parse, desc) :: !all_specs
 
   (* Returns all the flag specification of this module. *)
@@ -1469,7 +1469,7 @@ module Global = struct
   (* Prints help. *)
   let print_help () =
     Format.printf "%s@.  " usage_msg ;
-    all_specs () |> print_flags ;
+    all_specs () |> List.rev |> print_flags ;
     Format.printf "@."
 
 
@@ -1780,6 +1780,22 @@ module Global = struct
     )
   let modular () = !modular
 
+  let lus_compile_default = false
+  let lus_compile = ref lus_compile_default
+  let _ = add_spec
+    "--compile"
+    (bool_arg lus_compile)
+    (fun fmt ->
+      Format.fprintf fmt
+        "\
+          Nodes proved correct will be compiled to Rust@ \
+          Note that uninitialized pre's are not allowed in this mode@ \
+          Default: %a\
+        "
+        fmt_bool lus_compile_default
+    )
+  let lus_compile () = !lus_compile
+
 
   (* Reject unguarded pre's in Lustre file. *)
   let lus_strict_default = false
@@ -1796,22 +1812,7 @@ module Global = struct
         "
         fmt_bool lus_strict_default
     )
-  let lus_strict () = !lus_strict
-
-  let lus_compile_default = false
-  let lus_compile = ref lus_compile_default
-  let _ = add_spec
-    "--compile"
-    (bool_arg lus_compile)
-    (fun fmt ->
-      Format.fprintf fmt
-        "\
-          Nodes proved correct will be compiled to Rust@ \
-          Default: %a\
-        "
-        fmt_bool lus_compile_default
-    )
-  let lus_compile () = !lus_compile
+  let lus_strict () = !lus_strict || (lus_compile ())
 
   (* Active debug sections. *)
   let debug_default = []

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -845,6 +845,21 @@ module Contracts = struct
     )
   let check_implem () = !check_implem
 
+  let refinement_default = true
+  let refinement = ref refinement_default
+  let _ = add_spec
+    "--refinement"
+    (bool_arg refinement)
+    (fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        (De)activates refinement in compositional reasoning@ \
+        Default: %a\
+      @]"
+      fmt_bool refinement_default
+    )
+  let refinement () = !refinement
+
 end
 
 

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -347,6 +347,9 @@ module Contracts : sig
 
   (** Check modes. *)
   val check_implem : unit -> bool
+
+  (** Activate refinement. *)
+  val refinement : unit -> bool
 end
 
 

--- a/src/invarManager.ml
+++ b/src/invarManager.ml
@@ -183,7 +183,7 @@ let rec wait_for_children child_pids =
 
 
 (* Polling loop *)
-let rec loop done_at child_pids input_sys aparam trans_sys = 
+let rec loop done_at child_pids input_sys aparam trans_sys =
 
   handle_events input_sys aparam trans_sys;
 

--- a/src/jkindParser.ml
+++ b/src/jkindParser.ml
@@ -18,6 +18,8 @@
 
 open Lib
 
+module Ids = ReservedIds
+
 module HH = HString.HStringHashtbl
 module HS = HStringSExpr
 module D = GenericSMTLIBDriver
@@ -397,7 +399,7 @@ let of_channel in_ch =
   (* Predicate symbol for initial state predicate *)
   let init_uf_symbol = 
     UfSymbol.mk_uf_symbol
-      (LustreIdent.init_uf_string ^ "_JKind_0") 
+      (Ids.init_uf_string ^ "_JKind_0") 
       vars_types
       Type.t_bool 
   in
@@ -405,7 +407,7 @@ let of_channel in_ch =
   (* Predicate symbol for transition relation predicate *)
   let trans_uf_symbol = 
     UfSymbol.mk_uf_symbol
-      (LustreIdent.trans_uf_string ^ "_JKind_0") 
+      (Ids.trans_uf_string ^ "_JKind_0") 
       (vars_types @ vars_types)
       Type.t_bool 
   in

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -1073,7 +1073,7 @@ let post_verif input_sys result =
     let top_scope = TransSys.scope_of_trans_sys trans_sys in
     run_testgen input_sys top_scope ;
     compile_to_rust input_sys top_scope;
-    let uid = Analysis.(info_of_param result.param).uid in
+    let uid = Analysis.(info_of_param result.param).Analysis.uid in
     generate_certif_proofs uid input_sys trans_sys;
   )
 

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -1079,6 +1079,7 @@ let post_verif input_sys result =
 
 (* Launches analyses. *)
 let rec run_loop msg_setup modules results =
+  Stat.start_timer Stat.analysis_time ;
 
   let aparam, Input input_sys, trans_sys =
     get !cur_aparam, get !cur_input_sys, get !cur_trans_sys
@@ -1095,7 +1096,7 @@ let rec run_loop msg_setup modules results =
 
       (* Event.log L_fatal "Launching analysis with param %a"
         Analysis.pp_print_param aparam ; *)
-      Event.log_analysis_start aparam ;
+      Event.log_analysis_start trans_sys aparam ;
 
       (* Output the transition system. *)
       (debug parse "%a" TransSys.pp_print_trans_sys trans_sys end) ;
@@ -1117,7 +1118,9 @@ let rec run_loop msg_setup modules results =
       Some trans_sys |> slaughter_kids `Supervisor
   ) ;
 
-  let result = Analysis.mk_result aparam trans_sys in
+  let result =
+    Stat.get_float Stat.analysis_time |> Analysis.mk_result aparam trans_sys
+  in
 
   Event.log_analysis_end result ;
 

--- a/src/lib.ml
+++ b/src/lib.ml
@@ -1426,6 +1426,49 @@ let syscall cmd =
   ignore(Unix.close_process (ic, oc));
   Buffer.contents buf
 
+(* ********************************************************************** *)
+(* Reserved identifiers                                                   *)
+(* ********************************************************************** *)
+
+module ReservedIds = struct
+
+  let abs_ident_string = "abs"
+  let oracle_ident_string = "nondet"
+  let instance_ident_string = "instance"
+  let init_flag_ident_string = "init_flag"
+  let all_req_ident_string = "all_req"
+  let all_ens_ident_string = "all_ens"
+  let inst_ident_string = "inst"
+  let init_uf_string = "__node_init"
+  let trans_uf_string = "__node_trans"
+  let index_ident_string = "__index"
+
+  (* Init flag string. *)
+  let init_flag_string = "__init_flag"
+  (* Abstraction depth input string. *)
+  let depth_input_string = "__depth_input"
+  (* Abstraction depth input string. *)
+  let max_depth_input_string = "__max_depth_input"
+
+  let reserved_strings = [
+    init_flag_string ;
+    depth_input_string ;
+    max_depth_input_string ;
+
+    abs_ident_string ;
+    oracle_ident_string ;
+    instance_ident_string ;
+    init_flag_ident_string ;
+    all_req_ident_string ;
+    all_ens_ident_string ;
+    inst_ident_string ;
+    init_uf_string ;
+    trans_uf_string ;
+    index_ident_string ;
+  ]
+
+end
+
 
 (* 
    Local Variables:

--- a/src/lib.mli
+++ b/src/lib.mli
@@ -412,6 +412,42 @@ val files_cat_open : ?add_prefix:(Format.formatter -> unit) ->
 (** Get standard output of command *)
 val syscall : string -> string
 
+(** Reserved identifiers. *)
+module ReservedIds : sig
+
+  (** New variables from abstraction. *)
+  val abs_ident_string: string
+  (** New oracle input. *)
+  val oracle_ident_string: string
+  (** Unique identifier for node instance. *)
+  val instance_ident_string: string
+  (** First instant flag. *)
+  val init_flag_ident_string: string
+  (** Observer for contract requirements. *)
+  val all_req_ident_string: string
+  (** Observer for contract ensures. *)
+  val all_ens_ident_string: string
+  (** New variables from node instance. *)
+  val inst_ident_string: string
+  (** Initial predicate. *)
+  val init_uf_string: string
+  (** Transition relation. *)
+  val trans_uf_string: string
+  (** New clock initialization flag. *)
+  val index_ident_string: string
+
+  (** Init flag string. *)
+  val init_flag_string: string
+  (** Abstraction depth input string. *)
+  val depth_input_string: string
+  (** Abstraction depth input string. *)
+  val max_depth_input_string: string
+
+  (** All reserved identifiers. *)
+  val reserved_strings: string list
+
+end
+
 (* 
    Local Variables:
    compile-command: "make -C .. -k"

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1066,7 +1066,8 @@ let mk_local_for_expr
             if is_ghost then (
               (* Don't change source of svar if already there. *)
               try
-                N.get_state_var_source node state_var ; ctx
+                N.get_state_var_source node state_var |> ignore ;
+                ctx
               with Not_found -> {
                 ctx with node = Some (
                   N.set_state_var_source node state_var N.Ghost

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1369,9 +1369,8 @@ let rec eval_node_contract_call ctx scope (
           ) ;
 
           C.add_expr_for_ident
-            ~shadow:true ctx (LustreIdent.mk_string_ident in_id) expr ;
+            ~shadow:true ctx (LustreIdent.mk_string_ident in_id) expr
 
-          ctx
       ) ctx in_params in_formals
     with
     | Invalid_argument _ ->  C.fail_at_position call_pos (

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1954,14 +1954,7 @@ let declarations_to_nodes decls =
   let ctx = declarations_to_context ctx decls in
 
   (* Return nodes in context *)
-  (
-    C.get_nodes ctx |> List.map (
-      fun node ->
-        Format.printf "node: @[<v>%a@]@.@."
-          (N.pp_print_node true) node ;
-        node
-    )
-  ), { G.functions = C.get_functions ctx }
+  C.get_nodes ctx, { G.functions = C.get_functions ctx }
 
 
 (*

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -2065,10 +2065,10 @@ let mk_pre
   in
 
   (* Return expression and new definitions *)
-  ({ expr with expr_init = expr_init';
-               expr_step = expr_step';
-               expr_type = expr_type' }, 
-   ctx'') 
+  { expr_init = expr_init' ;
+    expr_step = expr_step' ;
+    expr_type = expr_type' ;
+  }, ctx''
 
 
 (* ********************************************************************** *)

--- a/src/lustre/lustreIdent.ml
+++ b/src/lustre/lustreIdent.ml
@@ -17,6 +17,7 @@
 *)
 
 open Lib
+open Lib.ReservedIds
 
 (* ********************************************************************** *)
 (* Types and pretty-printers                                              *)
@@ -117,32 +118,6 @@ let push_index (base, index) int = (base, int :: index)
 (* ********************************************************************** *)
 (* Reserved identifiers                                                   *)
 (* ********************************************************************** *)
-
-
-(* Reserved identifiers *)
-let abs_ident_string =  "abs" 
-let oracle_ident_string =  "nondet" 
-let instance_ident_string =  "instance"
-let init_flag_ident_string =  "init_flag"
-let all_req_ident_string =  "all_req"
-let all_ens_ident_string =  "all_ens"
-let inst_ident_string =  "inst" 
-let init_uf_string = "__node_init"
-let trans_uf_string = "__node_trans"
-let index_ident_string =  "__index" 
-
-let reserved_strings =
-  [ abs_ident_string;
-    oracle_ident_string;
-    instance_ident_string;
-    init_flag_ident_string;
-    all_req_ident_string;
-    all_ens_ident_string;
-    inst_ident_string;
-    init_uf_string;
-    trans_uf_string;
-    index_ident_string ]
-  @ StateVar.reserved_strings
 
 (* Identifier for new variables from abstrations *)
 let abs_ident = mk_string_ident abs_ident_string

--- a/src/lustre/lustreIdent.mli
+++ b/src/lustre/lustreIdent.mli
@@ -105,12 +105,6 @@ val inst_ident : t
 (** Identifier for index variables in arrays *)
 val index_ident : t
 
-(** Identifier of uninterpreted symbol for initial state constraint *)
-val init_uf_string : string 
-
-(** Identifier of uninterpreted symbol for transition relation *)
-val trans_uf_string : string 
-
 
 (* 
    Local Variables:

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -18,6 +18,8 @@
 
 open Lib
 
+module Ids = Lib.ReservedIds
+
 module I = LustreIdent
 module D = LustreIndex
 module E = LustreExpr
@@ -2160,7 +2162,7 @@ let rec trans_sys_of_node'
             UfSymbol.mk_uf_symbol
               (Format.asprintf
                  "%s_%a_%d"
-                 I.init_uf_string
+                 Ids.init_uf_string
                  (LustreIdent.pp_print_ident false) node_name
                  (A.info_of_param analysis_param).A.uid)
               (List.map Var.type_of_var init_formals)
@@ -2194,7 +2196,7 @@ let rec trans_sys_of_node'
             UfSymbol.mk_uf_symbol
               (Format.asprintf
                  "%s_%a_%d"
-                 I.trans_uf_string
+                 Ids.trans_uf_string
                  (LustreIdent.pp_print_ident false) node_name
                  (A.info_of_param analysis_param).A.uid)
               (List.map Var.type_of_var trans_formals)

--- a/src/nativeInput.ml
+++ b/src/nativeInput.ml
@@ -18,6 +18,8 @@
 
 open Lib
 
+module Ids = Lib.ReservedIds
+
 module HH = HString.HStringHashtbl
 module HS = HStringSExpr
 module D = GenericSMTLIBDriver
@@ -64,12 +66,12 @@ let seen_systems = HH.create 17
 
 (* Return the name of the initial state constraint predicate *)
 let init_pred_hname pred =
-  Format.sprintf "%s_%s_0" LustreIdent.init_uf_string
+  Format.sprintf "%s_%s_0" Ids.init_uf_string
     (HString.string_of_hstring pred)
 
 (* Return the name of the transition relation predicate *)
 let trans_pred_hname pred =
-  Format.sprintf "%s_%s_0" LustreIdent.trans_uf_string
+  Format.sprintf "%s_%s_0" Ids.trans_uf_string
     (HString.string_of_hstring pred)
 
 

--- a/src/stat.ml
+++ b/src/stat.ml
@@ -110,7 +110,8 @@ let get_int_list item = get_value item
 (* Start the timer for the statistics item *)
 let start_timer item = 
 
-  item.temp <- (Unix.gettimeofday ())
+  item.temp <- (Unix.gettimeofday ()) ;
+  item.value <- 0.
 
 (* Record the time since the call to {!start_timer} of this item, stop
    the timer *)
@@ -694,6 +695,9 @@ let pp_print_certif_stats ppf =
 let total_time = 
   empty_item "Total time" 0.
 
+let analysis_time = 
+  empty_item "Analysis time" 0.
+
 let clause_of_term_time = 
   empty_item "clause_of_term time" 0.
 
@@ -707,6 +711,7 @@ let misc_stats_title = "General"
 
 let misc_stats = 
   [ F total_time;
+    F analysis_time;
     F clause_of_term_time;
     F smtexpr_of_term_time; 
     F term_of_smtexpr_time ]
@@ -728,3 +733,4 @@ let pp_print_misc_stats ppf =
    indent-tabs-mode: nil
    End: 
 *)
+  

--- a/src/stat.mli
+++ b/src/stat.mli
@@ -447,6 +447,8 @@ val pp_print_certif_stats : Format.formatter -> unit
 (** Total time *)
 val total_time : float_item
 
+val analysis_time : float_item
+
 val clause_of_term_time : float_item
 
 val smtexpr_of_term_time : float_item

--- a/src/stateVar.ml
+++ b/src/stateVar.ml
@@ -17,6 +17,7 @@
 *)
 
 open Lib
+open Lib.ReservedIds
 
 
 (* ********************************************************************* *)
@@ -343,21 +344,6 @@ let mk_state_var
 
        (* Return state variable *)
        state_var
-
-(* Init flag string. *)
-let init_flag_string = "__init_flag"
-
-(* Abstraction depth input string. *)
-let depth_input_string = "__depth_input"
-
-(* Abstraction depth input string. *)
-let max_depth_input_string = "__max_depth_input"
-
-(* Transition system reserved strings. *)
-let reserved_strings =
-  [ init_flag_string ;
-    depth_input_string ;
-    max_depth_input_string ]
 
 (* Returns a scoped init flag. *)
 let mk_init_flag scope =

--- a/src/stateVar.mli
+++ b/src/stateVar.mli
@@ -86,9 +86,6 @@ val mk_depth_input : string list -> t
 (** Creates a scoped depth input. *)
 val mk_max_depth_input : string list -> t
 
-(** State var reserved strings. *)
-val reserved_strings : string list
-
 (** Import a state variable from a different instance into this
    hashcons table *)
 val import : t -> t

--- a/src/strategy.ml
+++ b/src/strategy.ml
@@ -255,7 +255,7 @@ module ModularStrategy : Strategy = struct
               (* Format.printf "|> all proved, going up@." ; *)
               (* Going up. *)
               go_up prefix
-            ) else (
+            ) else if Flags.Contracts.refinement () then (
               match get_params results subs_of_scope result with
               | None -> (* Cannot refine, going up. *)
                 (* Format.printf "Cannot refine for %a@."
@@ -274,7 +274,7 @@ module ModularStrategy : Strategy = struct
                     result
                   )
                 )
-            )
+            ) else go_up prefix
         ) with Not_found ->
           (* Format.printf "|> not the last system, going down@." ; *)
           (* Not the last system analyzed, going down. *)

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -316,7 +316,7 @@ val get_subsystem_instances : t -> (t * instance list) list
     scope are identical. The transition system [t] itself is returned
     if [s] is its scope.
 
-    Raise [Not_found] if there is no transistion system of scope [s]
+    Raise [Not_found] if there is no transition system of scope [s]
     in the subsystems of [t]. *)
 val find_subsystem_of_scope : t -> Scope.t -> t
 


### PR DESCRIPTION
- `--compile` forces `--lus_strict`: no unguarded pre's when compiling (also updated [TCM repo](https://github.com/kind2-mc/cocospec_tcm_experiments))

- added global flag to completely disable refinement

- factored reserved ids in `Lib`

- feedback improvements:

    - total vs analysis time: analysis time is now used everywhere except in the final breakdown
    - added the time of the analysis in `Analysis.result`
    - when printing the abstraction map, slice it to the current system (*i.e.* don't report the status of the systems **above** the current system)
    - report refined node in final breakdown
    - other minor improvements to feedback (mostly in the final breakdown)