### PR TITLE
Log trusted assumptions in proofs as additional goals and better step counterexamples

### DIFF
--- a/src/certif/jkindParser.ml
+++ b/src/certif/jkindParser.ml
@@ -490,13 +490,15 @@ let get_jkind_transsys file =
 
   Debug.certif "Parsing from JKind dump file: %s" dump_file;
 
-  let in_ch = open_in dump_file in
-  let sys = of_channel in_ch in
+  try
+    let in_ch = open_in dump_file in
+    let sys = of_channel in_ch in
 
-  (* Close file *)
-  close_in in_ch;
+    (* Close file *)
+    close_in in_ch;
 
-  sys
+    sys
+  with Sys_error _ -> failwith "JKind dump failed"
 
 
 (* 

--- a/src/certif/proof.ml
+++ b/src/certif/proof.ml
@@ -476,7 +476,7 @@ let rec apply_subst sigma sexp =
   with Not_found ->
     match sexp with
     | List l ->
-      let l' = List.map (apply_subst sigma) l in
+      let l' = List.rev_map (apply_subst sigma) l |> List.rev in
       if List.for_all2 (==) l l' then sexp
       else List l'
     | Atom _ -> sexp

--- a/src/certif/proof.mli
+++ b/src/certif/proof.mli
@@ -28,6 +28,9 @@ val proofname : string
 (** The file to store the LFSC proof the frontend *)
 val frontend_proofname : string
 
+(** The file to store the LFSC trusted formulas. *)
+val trustfname : string
+
 (** Generate the LFSC proof of invariance for the original properties and write
     it in the file [!proofname]. *)
 val generate_inv_proof : Certificate.invariant -> unit

--- a/src/event.ml
+++ b/src/event.ml
@@ -1336,6 +1336,12 @@ let update_trans_sys_sub input_sys analysis trans_sys events =
     (* Property found false *)
     | (m, StepCex (p, cex)) :: tl -> 
 
+      (* remove uninterresting first state for step counterexamples *)
+      let cex = List.map (function
+          | (sv, []) as c -> c
+          | (sv, _::vl) -> sv, vl) cex
+      in
+      
       (* Output disproved property *)
       log_cex false m L_warn input_sys analysis trans_sys p cex ;
 

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -2071,7 +2071,9 @@ let anon_action s =
     Global.set_input_file s;
     Global.set_input_format s;
     Global.set_output_dir s;
-  | _ -> raise (Arg.Bad "More than one input file given")
+  | _ ->
+    if s.[0] = '-' then raise (UnknownFlag s)
+    else raise (Arg.Bad ("More than one input file given: "^s))
 
 
 let bool_of_string ((flag, _, desc) as tuple) s =

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -953,6 +953,19 @@ module Certif = struct
     )
   let abstr () = !abstr
 
+  let log_trust_default = false
+  let log_trust = ref log_trust_default
+  let _ = add_spec
+    "--log_trust"
+    (bool_arg log_trust)
+    (fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Log trusted parts of the proof in a separate file \
+         for users to fill.@ Default: %a@]"
+        fmt_bool log_trust_default
+    )
+  let log_trust () = !log_trust
+
   type mink = [ `No | `Fwd | `Bwd | `Dicho | `FrontierDicho | `Auto]
   let mink_values = [ `No; `Fwd; `Bwd; `Dicho; `FrontierDicho; `Auto]
   let mink_of_string = function

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -370,6 +370,9 @@ module Certif : sig
   (** Use abstract type indexes in certificates/proofs. *)
   val abstr : unit -> bool
 
+  (** Log trusted parts of proofs. *)
+  val log_trust : unit -> bool
+
   (** Minimization stragegy for k *)
   val mink : unit -> mink
 


### PR DESCRIPTION
Trust statements are exported with a proof to be added manually, in an additional auxiliary LFSC file. This is activated with option `--log_trusted true`.

Don't show step first state of step counter examples to not confuse users.