### PR TITLE
Transitivity in dependency analysis of forward references

### DIFF
--- a/src/lustre/lustreDependencies.ml
+++ b/src/lustre/lustreDependencies.ml
@@ -97,6 +97,13 @@ let add deps (key_type, key_ident) (val_type, val_ident) =
       dep
     )
   in
+  
+  (* Transitivity *)
+  (try DeclMap.iter
+         (fun t -> ISet.iter (dep_add dep t))
+         (IMap.find deps val_ident)
+   with Not_found -> ());
+  
   dep_add dep val_type val_ident
 
 (** Checks if an identifier depends on a declaration. *)


### PR DESCRIPTION
Otherwise Kind 2 loop on things like:
```
type t0 = t1;
type t1 = t2;
type t2 = t0;
```