### PR TITLE
Additional restrictions on constants and sub-ranges in Lustre

### DIFF
--- a/doc/usr/content/2_input/1_lustre.md
+++ b/doc/usr/content/2_input/1_lustre.md
@@ -357,3 +357,161 @@ guarantee true -> ( -- `m1`, `m2` and `m3` are exclusive.
 ) ;
 ```
 
+
+
+### Merge, When and Activate
+
+> **Disclaimer**: the first few examples of this section illustrating (unsafe)
+> uses of `when` and `activate` are **not legal** in Kind 2. They aim at
+> introducing the semantics of lustre clocks. As discussed below, they are only
+> legal when used inside a `merge`, hence making them safe clock-wise.
+>
+> Also, `activate` is actually not a legal Lustre v6 operator. It is however
+> legal in Scade 6.
+
+A `merge` is an operator combining several streams defined on **complementary**
+clocks. There is two ways to define a stream on a clock. First, by wrapping its
+definition inside a `when`.
+
+```
+node example (in: int) returns (out: int) ;
+var in_pos: bool ; x: int ;
+let
+  ...
+  in_pos = x >= 0 ;
+  x = in when in_pos ;
+  ...
+tel
+```
+
+Here, `x` is only defined when `in_pos`, its clock, is `true`. That is, with
+`nil` the undefined value, a trace of execution of `example` sliced to `x`
+could be
+
+| step |   | `in` | `in_pos` |  `x`  |
+|:----:|---|:----:|:--------:|:-----:|
+| 0    |   | `3`  |   `true` | `3`   |
+| 1    |   | `-2` |  `false` | `nil` |
+| 0    |   | `-1` |  `false` | `nil` |
+| 1    |   | `7`  |   `true` | `7`   |
+| 0    |   | `42` |   `true` | `42`  |
+
+The second way to define a stream on a clock is to wrap a node call with the
+`activate` keyword. The syntax for this is
+
+```
+(activate <node_name> every <clock>)(<input_1>, <input_2>, ...)
+```
+
+For example, consider the following node:
+
+```
+node sum_ge_10 (in: int) returns (out: bool) ;
+var sum: int ;
+let
+  sum = in + (0 -> pre sum) ;
+  out = sum >= 10 ;
+tel
+```
+
+Say now we call this node as follows:
+
+```
+node example (in: int) returns (...) ;
+var tmp, in_pos: bool ;
+let
+  ...
+  in_pos = in >= 0 ;
+  tmp = (activate sum_ge_10 every in_pos)(in) ;
+  ...
+tel
+```
+
+That is, we want `sum_ge_10(in)` to tick iff `in` is positive. Here is an
+example trace of `example` sliced to `tmp`; notice how the internal state of
+`sub` (*i.e.* `pre sub.sum`) is maintained so that it does refer to the value
+of `sub.sum` *at the last clock tick of the `activate`*:
+
+| step |   | `in` | `in_pos` |  `tmp`  |   | `sub.in` | `pre sub.sum` | `sub.sum` |
+|:----:|---|:----:|:--------:|:-------:|---|:--------:|:-------------:|:---------:|
+| 0    |   |  `3` |   `true` | `false` |   |      `3` |         `nil` |       `3` |
+| 1    |   |  `2` |   `true` | `false` |   |      `2` |           `3` |       `5` |
+| 2    |   | `-1` |  `false` |   `nil` |   |    `nil` |           `5` |     `nil` |
+| 3    |   |  `2` |   `true` | `false` |   |      `2` |           `5` |       `7` |
+| 4    |   | `-7` |  `false` |   `nil` |   |    `nil` |           `7` |     `nil` |
+| 5    |   | `35` |   `true` |  `true` |   |     `35` |           `7` |      `42` |
+| 6    |   | `-2` |  `false` |   `nil` |   |    `nil` |          `42` |     `nil` |
+
+
+Now, as mentioned above the `merge` operator combines two streams defined on
+**complimentary** clocks. The syntax of `merge` is:
+
+```
+merge( <clock> ; <e_1> ; <e_2> )
+```
+
+where `e_1` and `e_2` are streams defined on `<clock>` and `not <clock>`
+respectively, or on `not <clock>` and `<clock>` respectively.
+
+> Remark: Lustre v6 allows clocks of a user-defined, enumerated type: see
+> [the Lustre v6 manual](http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6/doc/lv6-ref-man.pdf),
+> page 41 for an example.
+>
+> **Kind 2 only supports boolean clocks.**
+
+
+Building on the previous example, say add two new streams `pre_tmp` and
+`safe_tmp`:
+
+```
+node example (in: int) returns (...) ;
+var tmp, in_pos, pre_tmp, safe_tmp: bool ;
+let
+  ...
+  in_pos = in >= 0 ;
+  tmp = (activate sum_ge_10 every in_pos)(in) ;
+  pre_tmp = false -> pre safe_tmp  ;
+  safe_tmp = merge( in_pos ; tmp ; pre_tmp when not in_pos ) ;
+  ...
+tel
+```
+That is, `safe_tmp` is the value of `tmp` whenever it is defined, otherwise it
+is the previous value of `safe_tmp` if any, and `false` otherwise.
+The execution trace given above becomes
+
+
+| step |   | `in` | `in_pos` |   `tmp` | `pre_tmp` | `safe_tmp` | 
+|:----:|---|:----:|:--------:|:-------:|:---------:|:----------:|
+| 0    |   |  `3` |   `true` | `false` |   `false` |    `false` |
+| 1    |   |  `2` |   `true` | `false` |   `false` |    `false` |
+| 2    |   | `-1` |  `false` |   `nil` |   `false` |    `false` |
+| 3    |   |  `2` |   `true` | `false` |   `false` |    `false` |
+| 4    |   | `-7` |  `false` |   `nil` |   `false` |    `false` |
+| 5    |   | `35` |   `true` |  `true` |   `false` |     `true` |
+| 6    |   | `-2` |  `false` |   `nil` |    `true` |     `true` |
+
+
+Just like with uninitialized `pre`s, if not careful one can easily end up
+manipulating undefined streams. Kind 2 forces good practice by allowing
+`when` and `activate ... every` expressions only inside a `merge`. All the
+examples of this section above this point are thus invalid from Kind 2's point
+of view.
+
+Rewriting them as valid Kind 2 input is not difficult however. Here is a legal
+version of the last example:
+
+```
+node example (in: int) returns (...) ;
+var in_pos, pre_tmp, safe_tmp: bool ;
+let
+  ...
+  in_pos = in >= 0 ;
+  pre_tmp = false -> pre safe_tmp  ;
+  safe_tmp = merge(
+    in_pos ;
+    (activate sum_ge_10 every in_pos)(in) ;
+    pre_tmp when not in_pos
+  ) ;
+  ...
+tel
+```

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -81,8 +81,8 @@ let eval_const_decl ?(ghost = false) ctx = function
         pos 
         (Format.asprintf 
            "Identifier %a is redeclared as constant" 
-           (I.pp_print_ident false) ident);
-
+           (I.pp_print_ident false) ident);      
+    
     (* Evaluate constant expression *)
     let res, _ = 
       S.eval_ast_expr
@@ -93,6 +93,16 @@ let eval_const_decl ?(ghost = false) ctx = function
         expr
     in
 
+    D.iter
+      (fun _ e ->
+         if not (E.is_const e) then
+           C.fail_at_position 
+             pos 
+             (Format.asprintf 
+                "Constant %a is defined with a non constant expression" 
+                (I.pp_print_ident false) ident);
+      ) res;
+    
     (* Distinguish typed and untyped constant here *)
     (match const_decl with 
 

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -92,16 +92,6 @@ let eval_const_decl ?(ghost = false) ctx = function
            "Invalid constant expression")
         expr
     in
-
-    D.iter
-      (fun _ e ->
-         if not (E.is_const e) then
-           C.fail_at_position 
-             pos 
-             (Format.asprintf 
-                "Constant %a is defined with a non constant expression" 
-                (I.pp_print_ident false) ident);
-      ) res;
     
     (* Distinguish typed and untyped constant here *)
     (match const_decl with 
@@ -139,14 +129,16 @@ let eval_const_decl ?(ghost = false) ctx = function
       (* No type check for untyped or free constant *)
       | _ -> ());
 
-    (* Ensure expression is constant *)
-    D.iter 
-      (fun _ e -> 
-         if not (E.is_const e) then 
-           (C.fail_at_position
-              pos
-              "Invalid constant expression"))
-      res;
+    
+    D.iter
+      (fun _ e ->
+         if not (E.is_const e) then
+           C.fail_at_position
+             pos
+             (Format.asprintf
+                "Invalid constant expression for %a"
+                (I.pp_print_ident false) ident);
+      ) res;
 
 
     (* Return context with new mapping of identifier to expression *)

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -716,7 +716,7 @@ let is_const_expr expr =
 (* Return true if the expression is constant *)
 let is_const { expr_init; expr_step } = 
   is_const_expr expr_init && is_const_expr expr_step &&
-    Term.equal expr_init expr_step
+    Term.equal expr_init (Term.bump_state Numeral.(~- one) expr_step)
     
 
 (* ********************************************************************** *)

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -710,20 +710,13 @@ let is_const_var { expr_init; expr_step } =
 let is_pre_var expr = is_var_at_offset expr (pre_base_offset, pre_offset)
 
 
+let is_const_expr expr = 
+  VS.for_all Var.is_const_state_var (Term.vars_of_term expr)
+  
 (* Return true if the expression is constant *)
 let is_const { expr_init; expr_step } = 
-
-  (* Are all variables in the expression constant? *)
-  VS.for_all
-    Var.is_const_state_var
-    (Term.vars_of_term expr_init)
-    
-  &&
-
-  (* Are all variables in the expression constant? *)
-  VS.for_all
-    Var.is_const_state_var
-    (Term.vars_of_term expr_step)
+  is_const_expr expr_init && is_const_expr expr_step &&
+    Term.equal expr_init expr_step
     
 
 (* ********************************************************************** *)

--- a/src/lustre/lustreSimplify.ml
+++ b/src/lustre/lustreSimplify.ml
@@ -1872,7 +1872,7 @@ let rec eval_ast_type ctx = function
      TODO: should allow constant node arguments as bounds, but then
      we'd have to check if in each node call the lower bound is less
      than or equal to the upper bound. *)
-  | A.IntRange (pos, lbound, ubound) -> 
+  | A.IntRange (pos, lbound, ubound) as t -> 
 
     (* Evaluate expressions for bounds to constants *)
     let const_lbound, const_ubound = 
@@ -1880,6 +1880,10 @@ let rec eval_ast_type ctx = function
        const_int_of_ast_expr ctx  pos ubound) 
     in
 
+    if Numeral.lt const_ubound const_lbound then
+      C.fail_at_position pos
+        (Format.asprintf "Invalid range %a" A.pp_print_lustre_type t);
+    
     (* Add to empty trie with empty index *)
     D.singleton D.empty_index (Type.mk_int_range const_lbound const_ubound)
 

--- a/tests/regression/error/const_not_const.lus
+++ b/tests/regression/error/const_not_const.lus
@@ -1,0 +1,6 @@
+const a = 0 -> 1;
+
+node n (x: int) returns (b: bool);
+let
+  b = true;
+tel

--- a/tests/regression/error/const_not_const.lus
+++ b/tests/regression/error/const_not_const.lus
@@ -3,4 +3,5 @@ const a = 0 -> 1;
 node n (x: int) returns (b: bool);
 let
   b = true;
+  --%PROPERTY true -> a = 1;
 tel

--- a/tests/regression/error/const_not_const.lus
+++ b/tests/regression/error/const_not_const.lus
@@ -1,4 +1,5 @@
-const a = 0 -> 1;
+const i = 1;
+const a = i -> 0;
 
 node n (x: int) returns (b: bool);
 let

--- a/tests/regression/error/empty_range.lus
+++ b/tests/regression/error/empty_range.lus
@@ -1,0 +1,4 @@
+node n (x: subrange [1, 0] of int) returns (b: bool);
+let
+  b = true;
+tel


### PR DESCRIPTION
Do not allow non constant expression in constant stream definitions. The following is now illegal:
```Lustre
const a : int = 1 -> 0;
```

Forbid empty sub-range types. The following declarations are now illegal:
```Lustre
type empty = subrange [1, 0] of int;
const a : subrange [1, 0] of int;
node n (x: subrange [-8, -100] of int) returns ...
```