### PR TITLE
Extern nodes and functions

### DIFF
--- a/doc/usr/content/2_input/1_lustre.md
+++ b/doc/usr/content/2_input/1_lustre.md
@@ -562,3 +562,114 @@ A trace of execution for the node top could be:
 > Boolean input for the reset stream for each node. However providing a
 > built-in  way to do it facilitates the modeling of complex control systems.
 
+
+## Partially undefined nodes
+
+Kind 2 allows nodes to only partially define their outputs. For instance, the
+node
+
+```
+node count (trigger: bool) returns (count: int ; error: bool) ;
+(*@contract
+  var once: bool = trigger or (false -> pre once) ;
+  guarantee count >= 0 ;
+  mode still_zero (
+    require not once ;
+    ensure count = 0 ;
+  ) ;
+  mode gt (
+    require not ::still_zero ;
+    ensure count > 0 ;
+  ) ;
+*)
+let
+  count = (if trigger then 1 else 0) + (0 -> pre count) ;
+tel
+```
+can be analyzed: first for mode exhaustiveness, and the body is checked against
+its contract, although it is only *partially* defined.
+Here, both will succeed.
+
+
+## The `extern` keyword
+
+Nodes (and functions, see below) can be declared `extern`. This means that the
+node does not have a body (`let ... tel`). In a Lustre compiler, this is
+usually used to encode a C function or more generally a call to an external
+library.
+
+In Kind 2, this means that the node is always abstract in the contract-sense.
+It can never be refined, and is always abstracted by its contract. If none is
+given, then the implicit (rather weak) contract
+
+```
+(*@contract
+  assume true ;
+  guarantee true ;
+*)
+```
+is used.
+
+In a modular analysis, `extern` nodes will not be analyzed, although if their
+contract has modes they will be checked for exhaustiveness, consistently with
+the usual Kind 2 contract workflow.
+
+
+### Partially-defined nodes VS `extern`
+
+Kind 2 allows (partially) undefined nodes, that is nodes in which some streams
+do not have a definition. At first glance, it might seem like a node with no
+definitions at all (with an empty body) is the same as an `extern` node.
+
+It is not the case. A (partially) undefined node *still has a (potentially
+empty) body* which can be analyzed. The fact that it is not completely defined
+does not change this fact.
+If a (partially) undefined node is at the top level, or is in the cone of
+influence of the top node in a modular analysis, then it **will** be analyzed.
+
+An `extern` node on the other hand *explicitely does not have a body*. Its
+non-existent body will thus never be analyzed.
+
+
+## Functions
+
+Kind 2 supports the `function` keyword which is used just like the `node` one
+but has slightly different semantics. Like the name suggests, the output(s) of
+a `function` should be a *non-temporal* combination of its inputs. That is, a
+function cannot the `->`, `pre`, `merge`, `when`, `condact`, or `activate`
+operators. A function is also not allowed to call a node, only other functions.
+In Lustre terms, functions are stateless.
+
+In Kind 2, these retrictions extend to the contract attached to the function,
+if any. Note that besides the ones mentioned here, no additional restrictions
+are enforced on functions compared to nodes.
+
+### Benefits
+
+Functions are interesting in the model-checking context of Kind 2 mainly as
+a mean to make an abstraction more precise. A realistic use-case is when one
+wants to abstract non-linear expressions. While the simple expression `x*y`
+seems harmless, at SMT-level it means bringing in the theory of non-linear
+arithmetic.
+
+Non-linear arithmetic has a huge impact not only on the performances of the
+underlying SMT solvers, but also on the SMT-level features Kind 2 can use (not
+to mention undecidability). Typically, non-lineary arithmetic tends to prevent
+Kind 2 from performing satisfiability checks with assumptions, a feature it
+heavily relies on.
+
+The bottom line is that as soon as some non-linear expression appear, Kind 2
+will most likely fail to analyze most non-trivial systems because the
+underlying solver will simply give up.
+
+Hence, it is usually [extremely rewarding](https://www.researchgate.net/publication/304360220_CoCoSpec_A_Mode-Aware_Contract_Language_for_Reactive_Systems)
+to abstract non-linear expressions away in a separate *function* equipped with
+a contract. The contract would be a linear abstraction of the non-linear
+expression that is precise enough to prove the system using correct. That way,
+a compositional analysis would *i)* verify the abstraction is correct and *ii)*
+analyze the rest of the system using this abstraction, thus making the analysis
+a linear one.
+
+Using a function instead of a node simply results in a better abstraction. Kind
+2 will encode, at SMT-level, that the outputs of this component depend on the
+*current* version of its inputs only, not on its previous values.

--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -125,50 +125,41 @@ let maximal_abstraction_for_testgen (type s)
 let next_analysis_of_strategy (type s)
 : s t -> 'a -> Analysis.param option = function
 
-  | Lustre subsystem -> (fun results -> 
-      (* let nodes = 
-         N.nodes_of_subsystem subsystem
-         in
-
-         assert (nodes <> []) ;
-
-         Some {
-         Analysis.top = List.hd nodes |> N.scope_of_node ;
-
-         Analysis.abstraction_map =
-          nodes |> List.fold_left (fun m n ->
-            Scope.Map.add (N.scope_of_node n) false m
-          ) Scope.Map.empty ;
-
-         Analysis.assumptions = []
-         } *)
-
+  | Lustre subsystem -> (
+    fun results ->
       let subs_of_scope scope =
         let { S.subsystems } = S.find_subsystem subsystem scope in
         subsystems
-        |> List.map (fun { S.scope ; S.has_contract; S.has_modes } ->
-            scope, has_contract, has_modes)
+        |> List.map (
+          fun ({ S.scope } as sub) ->
+            scope, S.strategy_info_of sub
+        )
       in
-
-
       S.all_subsystems subsystem
-      |> List.map (fun { S.scope ; S.has_contract ; S.has_modes } ->
-          scope, has_contract, has_modes)
+      |> List.map (
+        fun ({ S.scope } as sub) ->
+          scope, S.strategy_info_of sub
+      )
       |> Strategy.next_analysis results subs_of_scope
-    )
+  )
 
-  | Native subsystem -> (fun results ->
+  | Native subsystem -> (
+    fun results ->
       let subs_of_scope scope =
         let { S.subsystems } = S.find_subsystem subsystem scope in
         subsystems
-        |> List.map (fun { S.scope ; S.has_contract; S.has_modes } ->
-            scope, has_contract, has_modes)
+        |> List.map (
+          fun ({ S.scope } as sub) ->
+            scope, S.strategy_info_of sub
+        )
       in
-      
       S.all_subsystems subsystem
-      |> List.map (fun { S.scope ; S.has_contract ; S.has_modes } ->
-          scope, has_contract, has_modes)
-      |> Strategy.next_analysis results subs_of_scope)
+      |> List.map (
+        fun ({ S.scope } as sub) ->
+          scope, S.strategy_info_of sub
+      )
+      |> Strategy.next_analysis results subs_of_scope
+  )
          
   | Horn subsystem -> (function _ -> assert false)
 
@@ -407,8 +398,8 @@ fun sys ->
   | Lustre sub -> (
     match
       S.all_subsystems sub
-      |> List.map (fun { S.scope ; S.has_contract ; S.has_modes } ->
-        scope, has_contract, has_modes
+      |> List.map (fun ({ S.scope } as sub) ->
+        scope, S.strategy_info_of sub
       )
       |> Strategy.monolithic
     with

--- a/src/lustre/contractsToProps.ml
+++ b/src/lustre/contractsToProps.ml
@@ -190,7 +190,7 @@ let rec fmt_declarations fmt = function
       " pp_print_pos pos
       |> failwith
 
-    | Ast.NodeDecl (pos, (wan,two,tri,far,fiv,six,contract)) -> (
+    | Ast.NodeDecl (pos, (wan, _, two,tri,far,fiv,six,contract)) -> (
       let contract_info = match contract with
         | None -> ([],[],[])
         | Some c -> collect_contracts ([],[],[]) c

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -264,9 +264,12 @@ type contract_node_equation =
 type contract = contract_node_equation list
 
 
-(* A node or function declaration *)
+(* A node or function declaration
+
+Boolean flag indicates whether node / function is extern. *)
 type node_decl =
   ident
+  * bool
   * node_param list
   * const_clocked_typed_decl list
   * clocked_typed_decl list
@@ -975,11 +978,11 @@ let pp_print_contract_node ppf (
 
 
 let pp_print_node_or_fun_decl is_fun ppf (
-  pos, (n, p, i, o, l, e, r)
+  pos, (n, ext, p, i, o, l, e, r)
 ) =
 
     Format.fprintf ppf
-      "@[<hv>@[<hv 2>%s %a%t@ \
+      "@[<hv>@[<hv 2>%s%s %a%t@ \
        @[<hv 1>(%a)@]@;<1 -2>\
        returns@ @[<hv 1>(%a)@];@]@ \
        %a\
@@ -987,6 +990,7 @@ let pp_print_node_or_fun_decl is_fun ppf (
        @[<v 2>let@ \
        %a@;<1 -2>\
        tel;@]@]"
+      (if ext then "extern " else "")
       (if is_fun then "function" else "node")
       pp_print_ident n 
       (function ppf -> pp_print_node_param_list ppf p)
@@ -1007,11 +1011,11 @@ let pp_print_declaration ppf = function
 
   | ConstDecl (pos, c) -> pp_print_const_decl ppf c
 
-  | NodeDecl (pos, (n, p, i, o, l, e, r)) ->
-    pp_print_node_or_fun_decl false ppf (pos, (n, p, i, o, l, e, r))
+  | NodeDecl (pos, decl) ->
+    pp_print_node_or_fun_decl false ppf (pos, decl)
 
-  | FuncDecl (pos, (n, p, i, o, l, e, r)) ->
-    pp_print_node_or_fun_decl true ppf (pos, (n, p, i, o, l, e, r))
+  | FuncDecl (pos, decl) ->
+    pp_print_node_or_fun_decl true ppf (pos, decl)
 
   | ContractNodeDecl (pos, (n,p,i,o,e)) ->
 

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -221,6 +221,7 @@ type contract = contract_node_equation list
 (** Declaration of a node or function as a tuple of
 
     - its identifier,
+    - a flag, true if the node / function is extern
     - its type parameters,
     - the list of its inputs,
     - the list of its outputs,
@@ -229,6 +230,7 @@ type contract = contract_node_equation list
     - its optional contract specification *)
 type node_decl =
   ident
+  * bool
   * node_param list
   * const_clocked_typed_decl list
   * clocked_typed_decl list

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -276,7 +276,7 @@ let create_node = function
   (* Not in a node or function *)
   | { ident_type_map; ident_expr_map; expr_state_var_map } as ctx -> 
 
-    (function ident -> 
+    (fun ident is_extern ->
 
       (* Add empty node to context *)
       { ctx with 
@@ -285,7 +285,7 @@ let create_node = function
           ident_type_map = IT.copy ident_type_map;
           ident_expr_map = List.map IT.copy ident_expr_map;
           expr_state_var_map = ET.copy expr_state_var_map;
-          node = Some (N.empty_node ident) } )
+          node = Some (N.empty_node ident is_extern) } )
 
 (** Returns the modes of the current node. *)
 let current_node_modes = function

--- a/src/lustre/lustreContext.mli
+++ b/src/lustre/lustreContext.mli
@@ -73,8 +73,8 @@ val pop_contract_scope : t -> t
 val contract_scope_of : t -> string list
 
 (** Return a copy of the context with an empty node of the given name
-    in the context *)
-val create_node : t -> LustreIdent.t -> t 
+    and is extern flag in the context *)
+val create_node : t -> LustreIdent.t -> bool -> t
 
 (** Returns the name of the current node, if any. *)
 val current_node_name : t -> LustreIdent.t option

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1656,7 +1656,7 @@ let declaration_to_context ctx = function
 
 (* Function declaration without parameters *)
 | A.FuncDecl (
-  pos, (i, [], inputs, outputs, locals, equations, contracts)
+  pos, (i, ext, [], inputs, outputs, locals, equations, contracts)
 ) -> (
 
   (* Identifier of AST identifier *)
@@ -1704,7 +1704,7 @@ let declaration_to_context ctx = function
   ) ;
 
   (* Create separate context for function *)
-  let fun_ctx = C.create_node ctx ident in
+  let fun_ctx = C.create_node ctx ident ext in
   (* Mark node as function. *)
   let fun_ctx = C.set_node_function fun_ctx in
 
@@ -1736,7 +1736,7 @@ let declaration_to_context ctx = function
 
 (* Node declaration without parameters *)
 | A.NodeDecl (
-  pos, (i, [], inputs, outputs, locals, equations, contracts)
+  pos, (i, ext, [], inputs, outputs, locals, equations, contracts)
 ) -> (
 
   (* Identifier of AST identifier *)
@@ -1750,7 +1750,7 @@ let declaration_to_context ctx = function
   ) ;
 
   (* Create separate context for node *)
-  let node_ctx = C.create_node ctx ident in
+  let node_ctx = C.create_node ctx ident ext in
 
   (* Evaluate node declaration in separate context *)
   let node_ctx = 

--- a/src/lustre/lustreDependencies.ml
+++ b/src/lustre/lustreDependencies.ml
@@ -129,9 +129,9 @@ let info_of_decl = function
 | A.ConstDecl (pos, A.TypedConst(_, ident, _, _)) ->
   pos, ident |> I.mk_string_ident, Const
 
-| A.NodeDecl (pos, (ident, _, _, _, _, _, _)) ->
+| A.NodeDecl (pos, (ident, _, _, _, _, _, _, _)) ->
   pos, ident |> I.mk_string_ident, NodeOrFun
-| A.FuncDecl (pos, (ident, _, _, _, _, _, _)) ->
+| A.FuncDecl (pos, (ident, _, _, _, _, _, _, _)) ->
   pos, ident |> I.mk_string_ident, NodeOrFun
 
 | A.ContractNodeDecl (pos, (ident, _, _, _, _)) ->
@@ -150,8 +150,8 @@ let insert_decl decl (f_type, f_ident) decls =
   let has_ident = match f_type with
     | NodeOrFun -> (
       function
-      | A.NodeDecl (_, (i, _, _, _, _, _, _)) -> i = ident
-      | A.FuncDecl (_, (i, _, _, _, _, _, _)) -> i = ident
+      | A.NodeDecl (_, (i, _, _, _, _, _, _, _)) -> i = ident
+      | A.FuncDecl (_, (i, _, _, _, _, _, _, _)) -> i = ident
       | _ -> false
     )
     | Type -> (

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -243,6 +243,7 @@ let keyword_table = mk_hashtbl [
   ("const", CONST) ;
   
   (* Node / function declaration *)
+  ("extern", EXTERN) ;
   ("node", NODE) ;
   ("function", FUNCTION) ;
   ("returns", RETURNS) ;

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -150,6 +150,9 @@ type t = {
   name : LustreIdent.t;
   (** Name of the node *)
 
+  is_extern : bool;
+  (** Is the node extern? *)
+
   instance : StateVar.t;
   (** Distinguished constant state variable uniquely identifying the
       node instance *)
@@ -226,10 +229,10 @@ type t = {
 type state_var_instance = position * LustreIdent.t * StateVar.t
 
 
-(** Return a node of the given name without inputs, outputs, oracles,
-    equations, etc. Create a state variable for the {!t.instance} and
+(** Return a node of the given name and is extern flag without inputs, outputs,
+    oracles, equations, etc. Create a state variable for the {!t.instance} and
     {!t.init_flag} fields, and set {!t.is_main} to false. *)
-val empty_node : LustreIdent.t -> t
+val empty_node : LustreIdent.t -> bool -> t
 
 (** {1 Pretty-printers} *)
 
@@ -281,10 +284,6 @@ val ident_of_top : t list -> LustreIdent.t
 (** Return true if the node has a global or at least one mode
     contract *)
 val has_contract : t -> bool
-
-(** Return false if the body of the node is empty, that is, all
-    equations are ghost and there are no assertions *)
-val has_impl : t -> bool
 
 (** Return a tree-like subsystem hierarchy from a flat list of nodes,
     where the top node is at the head of the list. *)

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -73,6 +73,7 @@ let mk_pos = position_of_lexing
 %token CONST
     
 (* Tokens for node declarations *)
+%token EXTERN
 %token NODE
 %token LPARAMBRACKET
 %token RPARAMBRACKET
@@ -190,7 +191,6 @@ one_expr: e = expr EOF { e }
 (* A Lustre program is a list of declarations *)
 main: p = list(decl) EOF { List.flatten p }
 
-
 (* A declaration is a type, a constant, a node or a function declaration *)
 decl:
   | d = const_decl { List.map 
@@ -199,8 +199,24 @@ decl:
   | d = type_decl { List.map 
                       (function e -> A.TypeDecl (mk_pos $startpos, e)) 
                       d }
-  | NODE ; d = node_decl { [A.NodeDecl (mk_pos $startpos, d)] }
-  | FUNCTION ; d = node_decl { [A.FuncDecl (mk_pos $startpos, d)] }
+  | NODE ; decl = node_decl ; def = node_def {
+    let (n, p, i, o, r) = decl in
+    let (l, e) = def in
+    [A.NodeDecl ( mk_pos $startpos, (n, false, p, i, o, l, e, r) )]
+  }
+  | FUNCTION ; decl = node_decl ; def = node_def {
+    let (n, p, i, o, r) = decl in
+    let (l, e) = def in
+    [A.FuncDecl (mk_pos $startpos, (n, false, p, i, o, l, e, r))]
+  }
+  | EXTERN ; NODE ; decl = node_decl {
+    let (n, p, i, o, r) = decl in
+    [A.NodeDecl ( mk_pos $startpos, (n, true, p, i, o, [], [], r) )]
+  }
+  | EXTERN ; FUNCTION ; decl = node_decl {
+    let (n, p, i, o, r) = decl in
+    [A.FuncDecl (mk_pos $startpos, (n, true, p, i, o, [], [], r))]
+  }
   | d = contract_decl { [A.ContractNodeDecl (mk_pos $startpos, d)] }
   | d = node_param_inst { [A.NodeParamInst (mk_pos $startpos, d)] }
 
@@ -326,7 +342,7 @@ enum_type: ENUM LCURLYBRACKET; l = ident_list; RCURLYBRACKET { l }
 (* ********************************************************************** *)
 
 
-(* A node declaration *)
+(* A node declaration and contract. *)
 node_decl:
 | n = ident;
   p = loption(static_params);
@@ -334,20 +350,20 @@ node_decl:
   RETURNS;
   o = tlist(LPAREN, SEMICOLON, RPAREN, clocked_typed_idents);
   SEMICOLON;
-  r = option(contract_spec);
+  r = option(contract_spec)
+  {
+    (n, p, List.flatten i, List.flatten o, r)
+  }
+
+(* A node definition (locals + body). *)
+node_def:
   l = list(node_local_decl);
   LET;
   e = list(node_equation);
   TEL
   option(node_sep)
 
-  { (n, 
-     p,
-     List.flatten i, 
-     List.flatten o, 
-     (List.flatten l), 
-     e,
-     r)  }
+  { (List.flatten l, e) }
 
 
 contract_ghost_var:

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -583,7 +583,8 @@ let slice_all_of_node
     ?(keep_props = true)
     ?(keep_contracts = true)
     ?(keep_asserts = true)
-    { N.name; 
+    { N.name;
+      N.is_extern; 
       N.instance;
       N.init_flag;
       N.inputs; 
@@ -602,7 +603,8 @@ let slice_all_of_node
   (* Copy of the node with the same signature, but without local
      variables, equations, assertions and node calls. Keep signature,
      properties, assertions, contracts and main annotation *)
-  { N.name; 
+  { N.name;
+    N.is_extern;
     N.instance;
     N.init_flag;
     N.inputs;

--- a/src/strategy.mli
+++ b/src/strategy.mli
@@ -25,15 +25,33 @@
 
 module A = Analysis
 
+(** Information used by the strategy module. *)
+type info = {
+  (** Is the system refineable? ([extern] for lustre nodes.) *)
+  can_refine: bool ;
+  (** Does the system have a contract? *)
+  has_contract: bool ;
+  (** Does the system have modes? *)
+  has_modes: bool ;
+}
+
+(** Takes some results and some information about (sub)systems, and returns
+the next analysis to perform, if any.
+The information it takes is
+
+- a function which, given the scope of a system, returns the scope of its
+  direct subsystems and its strategy info;
+- a list of all the scopes of all the systems and their strategy info. *)
 val next_analysis:
   A.results ->
-  (Scope.t -> (Scope.t * bool * bool) list) ->
-  (Scope.t * bool * bool) list ->
+  (Scope.t -> (Scope.t * info) list) ->
+  (Scope.t * info) list ->
   A.param option
 
+(** Works almost the same as [next_analysis], but returns a single analysis
+parameter for a monolithic analysis. Only used for contract generation. *)
 val monolithic:
-  (Scope.t * bool * bool) list ->
-  A.param option
+  (Scope.t * info) list -> A.param option
 
 
 

--- a/src/subSystem.ml
+++ b/src/subSystem.ml
@@ -38,6 +38,15 @@ type 'a t = {
   subsystems : 'a t list ;
 }
 
+(* Strategy info of a subsystem. *)
+let strategy_info_of {
+  has_contract ; has_modes ; has_impl
+} = {
+  Strategy.can_refine = has_impl ;
+  Strategy.has_contract ;
+  Strategy.has_modes ;
+}
+
 
 (* Add all subsystems of the systems in the second argument to the accumulator
    in topological order with the top system at the head of the list. *)

--- a/src/subSystem.mli
+++ b/src/subSystem.mli
@@ -50,6 +50,9 @@ type 'a t = {
   subsystems : 'a t list ;
 }
 
+(** Strategy info of a subsystem. *)
+val strategy_info_of: 'a t -> Strategy.info
+
 (** Return all subsystems in topological order with the top system at
     the head of the list *)
 val all_subsystems : 'a t -> 'a t list

--- a/tests/regression/error/extern_fun_no_body.lus
+++ b/tests/regression/error/extern_fun_no_body.lus
@@ -1,0 +1,31 @@
+(* External node. *)
+extern node ext_node (in: int) returns (out: int) ;
+(*@contract
+  assume in >= 0 ;
+  guarantee out >= 0 ;
+*)
+
+(* External function. *)
+extern function ext_fun (in: int) returns (out: int) ;
+(*@contract
+  assume in >= 0 ;
+  guarantee out > 0 ;
+*)
+let
+  out = in ;
+tel
+
+(* Node combining the two. Note that Kind 2 can prove the guarantee, meaning
+the abstraction of the external components is forced indeed. *)
+node test (in_1, in_2: int) returns (out: int) ;
+(*@contract
+  assume in_1 >= 0 ;
+  assume in_2 >= 0 ;
+  guarantee out > 0 ;
+*)
+var tmp_1, tmp_2: int ;
+let
+  tmp_1 = 0 -> pre in_1 ;
+  tmp_2 = 0 -> pre in_2 ;
+  out = ext_node(tmp_1) + ext_fun(tmp_2) ;
+tel

--- a/tests/regression/error/extern_node_no_body.lus
+++ b/tests/regression/error/extern_node_no_body.lus
@@ -1,0 +1,31 @@
+(* External node. *)
+extern node ext_node (in: int) returns (out: int) ;
+(*@contract
+  assume in >= 0 ;
+  guarantee out >= 0 ;
+*)
+let
+  out = in ;
+tel
+
+(* External function. *)
+extern function ext_fun (in: int) returns (out: int) ;
+(*@contract
+  assume in >= 0 ;
+  guarantee out > 0 ;
+*)
+
+(* Node combining the two. Note that Kind 2 can prove the guarantee, meaning
+the abstraction of the external components is forced indeed. *)
+node test (in_1, in_2: int) returns (out: int) ;
+(*@contract
+  assume in_1 >= 0 ;
+  assume in_2 >= 0 ;
+  guarantee out > 0 ;
+*)
+var tmp_1, tmp_2: int ;
+let
+  tmp_1 = 0 -> pre in_1 ;
+  tmp_2 = 0 -> pre in_2 ;
+  out = ext_node(tmp_1) + ext_fun(tmp_2) ;
+tel

--- a/tests/regression/success/extern.lus
+++ b/tests/regression/success/extern.lus
@@ -1,0 +1,28 @@
+(* External node. *)
+extern node ext_node (in: int) returns (out: int) ;
+(*@contract
+  assume in >= 0 ;
+  guarantee out >= 0 ;
+*)
+
+(* External function. *)
+extern function ext_fun (in: int) returns (out: int) ;
+(*@contract
+  assume in >= 0 ;
+  guarantee out > 0 ;
+*)
+
+(* Node combining the two. Note that Kind 2 can prove the guarantee, meaning
+the abstraction of the external components is forced indeed. *)
+node test (in_1, in_2: int) returns (out: int) ;
+(*@contract
+  assume in_1 >= 0 ;
+  assume in_2 >= 0 ;
+  guarantee out > 0 ;
+*)
+var tmp_1, tmp_2: int ;
+let
+  tmp_1 = 0 -> pre in_1 ;
+  tmp_2 = 0 -> pre in_2 ;
+  out = ext_node(tmp_1) + ext_fun(tmp_2) ;
+tel


### PR DESCRIPTION
- `extern` keyword
- docs:
  - partially undefined nodes
  - extern + extern VS partially undefined nodes
  - functions + benefits (more precise abstraction)
- reg tests for `extern`

External nodes and functions are just like any other except for a flag. This flag is used during the strategy pass and forces to abstract them by their (potentially empty) contract.