### PR TITLE
Hexadecimal notations for numerical constants

### DIFF
--- a/examples/syntax-test.lus
+++ b/examples/syntax-test.lus
@@ -84,7 +84,6 @@ type l = int^3^5; -- ^ is left-associative
 -- const h = 2;
 -- type m = int^5*h;
 
-
 -- ------------------------------------------------------------
 -- Global constant declarations
 -- ------------------------------------------------------------
@@ -102,6 +101,12 @@ const b01 = 1;
 const c1 : bool = true;
       c2 = 5;
 
+-- Use decimal or hexa-decimal notations for numerical constants
+
+const size = 0xA0f ;
+      e1 = .45e-45 ;
+      e2 = 0.2E+3 ;
+      e3 = 0x3.1f4p-5 ;
 
 -- ------------------------------------------------------------
 -- Node declarations

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -335,14 +335,22 @@ let printable = ['+' '-' '*' '/' '>' '<' '=' ]+
 (* Floating point decimal 
 
    Don't allow floats like "2." this will conflict with array slicing "2..3" *)
-let decimal = ['0'-'9']+ '.' ['0'-'9']+ ('E' ('+'|'-')? ['0'-'9']+)?
+let decimal = ['0'-'9']* '.' ['0'-'9']+ (('E'|'e') ('+'|'-')? ['0'-'9']+)?
 
 (* Floating-point decimal with exponent only *)
-let exponent_decimal = ['0'-'9']+ 'E' ('+'|'-')? ['0'-'9']+
+let exponent_decimal = ['0'-'9']+ '.'? ('E'|'e') ('+'|'-')? ['0'-'9']+
 
 (* Integer numeral *)
 let numeral = ['0'-'9']+
 
+(* Hexadecimal numerals *)
+let hexdigit = ['0'-'9' 'a'-'f' 'A'-'F']
+let hexpo = 'p' ('+'|'-')? ['0'-'9']+
+
+let hex_num  = "0x" hexdigit+ 
+let hex_dec1 = "0x" hexdigit+ ('.' hexdigit*)? hexpo?
+let hex_dec2 = "0x" '.' hexdigit+ hexpo?
+              
 (* Whitespace *)
 let whitespace = [' ' '\t']
 
@@ -462,6 +470,10 @@ rule token = parse
   | decimal as p { DECIMAL p }
   | exponent_decimal as p { DECIMAL p }
   | numeral as p { NUMERAL p }
+
+  | hex_num as p { NUMERAL p }
+  | hex_dec1 as p { DECIMAL p }
+  | hex_dec2 as p { DECIMAL p }
 
   (* Keyword *)
   | id as p {

--- a/src/terms/decimal.ml
+++ b/src/terms/decimal.ml
@@ -167,7 +167,7 @@ let string_of_decimal = string_of_t pp_print_decimal
 let of_int n = N (Num.num_of_int n)
 
 (* Convert a string to a rational number *)
-let of_string s =
+let of_decimal_string s =
   (* Buffer for integer part, initialize to length of whole string *)
   let int_buf = Buffer.create (String.length s) in
 
@@ -217,7 +217,7 @@ let of_string s =
       match String.get s (start_pos + pos) with
 
         (* Continue parsing exponent part *)
-        | 'E' when pos > 0 -> scan_exp (start_pos + (succ pos)) 0
+        | 'E' | 'e' when pos > 0 -> scan_exp (start_pos + (succ pos)) 0
 
         (* Allow digits, append to buffer *)
         | '0'..'9' as c -> 
@@ -248,7 +248,7 @@ let of_string s =
         | '.' -> scan_frac (succ pos) 0
 
         (* Continue parsing exponent part *)
-        | 'E'  when pos > 0 -> scan_exp (succ pos) 0
+        | 'E' | 'e'  when pos > 0 -> scan_exp (succ pos) 0
 
         (* Allow digits, append to buffer *)
         | '0'..'9' as c -> 
@@ -331,7 +331,10 @@ let of_string s =
 
   N res
 
-
+let of_string s =
+  match Hexadecimal.to_decimal s with
+  | Some res -> N res
+  | None -> of_decimal_string s
 
 (* Division symbol *)
 let s_div = HString.mk_hstring "/"

--- a/src/terms/hexadecimal.ml
+++ b/src/terms/hexadecimal.ml
@@ -1,0 +1,86 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+let has_prefix s =
+  String.length s > 2 && s.[0] = '0' && s.[1] = 'x'
+
+let hex_digit = function
+  | '0' .. '9' as c -> int_of_char c - int_of_char '0'
+  | 'a' .. 'f' as c -> 10 + int_of_char c - int_of_char 'a'
+  | 'A' .. 'F' as c -> 10 + int_of_char c - int_of_char 'A'
+  | _ -> failwith "hex_digit"
+
+let add_hexdigit v h =
+  Big_int.add_int_big_int (hex_digit h) (Big_int.mult_int_big_int 16 v)
+
+let to_numeral s =
+  if has_prefix s then
+    let rec scan value s k =
+      if k < String.length s then
+        scan (add_hexdigit value s.[k]) s (succ k)
+      else Some value
+    in scan Big_int.zero_big_int s 2
+  else None
+
+let to_decimal s =
+  if has_prefix s then
+
+    let rec vexp n s k =
+      if k < String.length s then
+        vexp ( n * 10 + hex_digit s.[k] ) s (succ k)
+      else n
+    in
+
+    let expo s k =
+      if k < String.length s then
+        if s.[k] = '+' then + (vexp 0 s (succ k)) else
+        if s.[k] = '-' then - (vexp 0 s (succ k)) else
+          vexp 0 s k
+      else 0
+    in
+
+    let exponent fk k p =
+      (* each fractional digit in base 16 = 2^4 *)
+      if fk > 0 then p - 4 * (k - fk - 1) else p in
+    
+    let rec scan value fk s k =
+      if k < String.length s then
+        match s.[k] with
+        | '.' -> scan value k s (succ k)
+        | 'p' -> value , exponent fk k (expo s (succ k))
+        | _ -> scan (add_hexdigit value s.[k]) fk s (succ k)
+      else value , exponent fk k 0
+    in
+
+    let value , fp = scan Big_int.zero_big_int 0 s 2 in
+    let num =
+
+      if fp > 0 then
+        let ep = Big_int.power_int_positive_int 2 fp in
+        Num.num_of_big_int (Big_int.mult_big_int value ep)
+      else
+      
+      if fp < 0 then
+        let ep = Big_int.power_int_positive_int 2 (-fp) in
+        Num.num_of_ratio (Ratio.create_ratio value ep)
+      else
+          
+        Num.num_of_big_int value
+
+    in Some num
+  else None

--- a/src/terms/hexadecimal.mli
+++ b/src/terms/hexadecimal.mli
@@ -1,0 +1,25 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+(** Arbitrary precision hexa-decimals
+
+    @author Loïc Correnson
+*)
+
+val to_numeral : string -> Big_int.big_int option
+val to_decimal : string -> Num.num option

--- a/src/terms/numeral.ml
+++ b/src/terms/numeral.ml
@@ -62,13 +62,14 @@ let of_int i = Big_int.big_int_of_int i
 (* Convert an big integer to a numeral *)
 let of_big_int i = i
 
-
 (* Convert a string to a numeral *)
 let of_string s = 
 
-  try 
+  try
 
-    Big_int.big_int_of_string s 
+    match Hexadecimal.to_numeral s with
+    | Some res -> res
+    | None -> Big_int.big_int_of_string s 
 
   with Failure _ -> raise (Invalid_argument "of_string")
 

--- a/tests/regression/success/test-hex.lus
+++ b/tests/regression/success/test-hex.lus
@@ -1,0 +1,12 @@
+node test () returns ()
+let
+  --%MAIN ;
+  --%PROPERTY 0x1fe4E = 130638 ;
+  --%PROPERTY 0x1p-3 = 0.125 ;
+  --%PROPERTY 0x1p+3 = 8.0 ;
+  --%PROPERTY 0x.1 = (real 1 / real 16) ;
+  --%PROPERTY 0x1234.    = (real 4660) ;
+  --%PROPERTY 0x123.4    = (real 1165 / real 4) ;
+  --%PROPERTY 0x12.34p+4 = (real 1165 / real 4) ;
+  --%PROPERTY 0x12.34p-3 = (real 1165 / real 512) ;
+tel;


### PR DESCRIPTION
Hello,
I'm experimenting Kind-2 for proving numerical properties of Lustre programs extracted from C code.
This is how I discovered the missing simplifications of #504.

Writing large or precise numerical constants can be an issue. However, according to Lustre v6 specification §2.2 : 

> _Floating_ and _Integer_ stands for decimal floating point and integer notations, following C standard

Hence, I suggest this pull request thats allows users of Kind-2 to use C hexadecimal notations for both numerals and decimals constants.

Examples have been added to `examples/syntax-test.lus` and basic unit tests in `tests/regression/success/test-hex.lus`.

Any comment welcome,
Best regards.




