### PR TITLE
Provide decimal approximations in models

### DIFF
--- a/src/flags.ml
+++ b/src/flags.ml
@@ -1901,6 +1901,43 @@ module Global = struct
   let output_dir () = !output_dir
 
 
+  (* Real precision. *)
+  type real_precision = [
+    `Rational | `Float
+  ]
+  let real_precision_of_string = function
+    | "rational" -> `Rational
+    | "float" -> `Float
+    | _ -> raise (Arg.Bad "Bad value for --real_precision")
+  let string_of_real_precision = function
+    | `Rational -> "rational"
+    | `Float -> "float"
+  let real_precision_values = [
+    `Rational ; `Float
+  ] |> List.map string_of_real_precision |> String.concat ", "
+  let real_precision_default = `Rational
+
+  let real_precision = ref real_precision_default
+  let _ = add_spec
+    "--real_precision"
+    (Arg.String
+      (fun str -> real_precision := real_precision_of_string str)
+    )
+    (fun fmt ->
+      Format.fprintf fmt
+      "\
+        where <string> can be %s@ \
+        Adjust precision of real values in model output@ \
+        In floating-point format f<nn> means a relative error less than 2^-nn@ \
+        Default: %s\
+      "
+      real_precision_values
+      (string_of_real_precision real_precision_default)
+    )
+
+  let real_precision () = !real_precision
+
+
   (* Log invariants. *)
   let log_invs_default = false
   let log_invs = ref log_invs_default
@@ -2294,6 +2331,7 @@ end
 (* Re-exports. *)
 type enable = Global.enable
 type input_format = Global.input_format
+type real_precision = Global.real_precision
 
 
 (* ********************************************************************** *)
@@ -2316,6 +2354,7 @@ let log_level = Global.log_level
 let log_format_xml = Global.log_format_xml
 let log_format_json = Global.log_format_json
 let input_format = Global.input_format
+let real_precision = Global.real_precision
 let timeout_wall = Global.timeout_wall
 let timeout_analysis = Global.timeout_analysis
 let input_file = Global.input_file

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -146,6 +146,9 @@ val input_format : unit -> input_format
 (** Output directory for the files Kind 2 generates. *)
 val output_dir : unit -> string
 
+type real_precision = [`Rational | `Float]
+val real_precision : unit -> real_precision
+
 (** Minimizes and logs invariants as contracts. *)
 val log_invs : unit -> bool
 

--- a/src/model.ml
+++ b/src/model.ml
@@ -81,7 +81,7 @@ let pp_print_term ppf term =
   else if Term.is_decimal term then 
     
     (* Pretty-print as a decimal *)
-    Decimal.pp_print_decimal 
+    Decimal.pp_print_decimal_approximation
       ppf
       (Term.decimal_of_term term)
       

--- a/src/model.ml
+++ b/src/model.ml
@@ -58,6 +58,13 @@ type t = value VT.t
 (* A path is a map of state variables to assignments *)
 type path = value list SVT.t
 
+
+let pp_print_decimal =
+  match (Flags.real_precision ()) with
+  | `Rational -> Decimal.pp_print_decimal
+  | `Float -> Decimal.pp_print_decimal_approximation
+
+
 (* Pretty-print a value *)
 let pp_print_term ppf term =
   (* if Term.is_bool term then *)
@@ -81,7 +88,7 @@ let pp_print_term ppf term =
   else if Term.is_decimal term then 
     
     (* Pretty-print as a decimal *)
-    Decimal.pp_print_decimal_approximation
+    pp_print_decimal
       ppf
       (Term.decimal_of_term term)
       

--- a/src/terms/decimal.ml
+++ b/src/terms/decimal.ml
@@ -548,18 +548,24 @@ let pp_print_decimal_approximation fmt dec =
   match dec with
   | InfPos | InfNeg | Undef | N (Num.Int _ | Num.Big_int _) ->
       pp_print_decimal fmt dec
-  | N (Num.Ratio r) ->
+  | N (Num.Ratio _ as r) ->
       try
-        let approx = Printf.sprintf "%g" (Ratio.float_of_ratio r) in
-        let delta = sub dec (of_string approx) in
-        let p = magnitude delta in
-        if p = 0 then
-          Format.pp_print_string fmt approx
-        else
-          let s = if sign delta >= 0 then '+' else '-' in
-          Format.fprintf fmt "%s@{<black_b>%cp%d@}" approx s p
+        let s = Num.sign_num r in
+        if s = 0 then Format.pp_print_string fmt "0.0" else
+          let value = abs dec in
+          let approx = Printf.sprintf "%g" (to_float value) in
+          let appro = of_string approx in
+          let delta = sub value appro in
+          let alpha = div delta appro in
+          let p = magnitude alpha in
+          if p = 0 then
+            Format.pp_print_string fmt approx
+          else
+            let sr = if s >= 0 then '+' else '-' in
+            let se = if (sign delta >= 0) = (s >= 0) then '+' else '-' in
+            Format.fprintf fmt "%c%s@{<black_b>%cf%d@}" sr approx se (-p)
       with _ -> (* Fallback *) pp_print_decimal fmt dec
-
+                                 
 (* ********************************************************************** *)
 (* Infix operators                                                        *)
 (* ********************************************************************** *)

--- a/src/terms/decimal.ml
+++ b/src/terms/decimal.ml
@@ -502,11 +502,8 @@ let rem l r = match l, r with
 | N l, N r -> Num.mod_num l r |> of_num
 | _ -> Undef
 
-(* ********************************************************************** *)
-(* Approximation Printing (need others operations)                        *)
-(* ********************************************************************** *)
-
-let epsilon p =
+(* Computes the rational 2^p with signed p *)
+let epsilon_ratio p =
   if p > 0 then
     Ratio.ratio_of_big_int (Big_int.power_int_positive_int 2 p)
   else
@@ -516,6 +513,9 @@ let epsilon p =
   else
     Ratio.ratio_of_int 1
 
+let epsilon p = N (Num.Ratio (epsilon_ratio p))
+
+(* Computes n such that 2^n <= | dec | < 2^n ; returns 0 is dec is null *)
 let magnitude = function
   | InfPos | InfNeg | Undef -> failwith "magnitude of infinite"
   | N (Num.Int n) -> Big_int.num_bits_big_int (Big_int.big_int_of_int n)
@@ -529,7 +529,7 @@ let magnitude = function
         (* have  2^(n-1)  <= |a| < 2^n *)
         (* have  2^(d-1)  <= |b| < 2^d *)
         (* hence 2^(n-d-1) < |r| < 2^(n-d+1) *)
-        let p = epsilon (n-d) in
+        let p = epsilon_ratio (n-d) in
         if Ratio.lt_ratio r p then n-d else n-d+1
 
 let sign = function
@@ -539,6 +539,10 @@ let sign = function
   | N (Num.Int n) -> Pervasives.compare n 0
   | N (Num.Big_int n) -> Big_int.sign_big_int n
   | N (Num.Ratio r) -> Ratio.sign_ratio r
+
+(* ********************************************************************** *)
+(* Approximation Printing (need others operations)                        *)
+(* ********************************************************************** *)
 
 let pp_print_decimal_approximation fmt dec =
   match dec with

--- a/src/terms/decimal.mli
+++ b/src/terms/decimal.mli
@@ -74,6 +74,16 @@ val to_big_int : t -> Big_int.big_int
 (** Return true if decimal coincides with an integer *)
 val is_int : t -> bool
 
+(** Returns 0 on zero, 1 for positives and -1 for negatives.
+    Works also on infinites but fails on undefined. *)
+val sign : t -> int
+
+(** Returns the rational [2^p] with signed p. *)
+val epsilon : int -> t
+
+(** Returns a signed integer [n] such that [2^(n-1) < |dec| < 2^n ]
+    or [0] if [dec] is null. *)
+val magnitude : t -> int
 
 (** {1 Constants} *)
 

--- a/src/terms/decimal.mli
+++ b/src/terms/decimal.mli
@@ -35,6 +35,9 @@ val pp_print_decimal_as_float : Format.formatter -> t -> unit
 (** Pretty-print a rational as an f64 (used by contract generation) *)
 val pp_print_decimal_as_lus_real: Format.formatter -> t -> unit
 
+(** Pretty-print a rational in scientific format with the error magnitude *)
+val pp_print_decimal_approximation: Format.formatter -> t -> unit
+
 (** Pretty-print a rational as an S-expression *)
 val pp_print_decimal_sexpr : Format.formatter -> t -> unit
 

--- a/src/terms/numeral.ml
+++ b/src/terms/numeral.ml
@@ -24,7 +24,6 @@
 (* Arbitrary precision numerals are big integers *)
 type t = Big_int.big_int
 
-
 (* The numeral zero *)
 let zero = Big_int.zero_big_int 
 


### PR DESCRIPTION
When Kind-2 outputs counter examples, decimal values are represented by rationals which are, in my opinion,  cumbersome to read. By the way, those rationals are messy Lustre values, since _eg._ `1/8` is actually the _integer_ `0` and not the expected _real_ `0.125` value.

Indeed, the code documentation (which is quite excellent, I must say) for printing model values contains this note (file `model.ml`, line 71):

> `(* TODO do we not want legal lustre values? *)`

Hence, I experimented printing an approximation of rationals in models, plus an upper bound of the « rounding » error. For instance, instead of reading decimal `1215678/251162565001`,
you would read now `+4.8402e-06+f22`, which means: approximate value `+4.8402e-06` with a (positive) _relative_ error less than `2^-22` (which fits on floating point number with 22-bits mantissa).

I found those informations much more useful than the rational notations when interpreting models in textual mode. But probably you would like to add some flags to control such a display.

My suggestion (_not_ implemented yet) for such a new flag would be:

```
--model-precision (R|E|P)
        adjust precision of decimals in models
        R: print rational value (eg. 1/8)
        E: print scientific value (eg. 3.4e-6)
        P: print relative error (eg. 3.4e-6+f21) 
            (f<nn> means a relative error less than 2^-nn)
```



     
