### PR TITLE
Interpreter

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -10,7 +10,7 @@ export OPAMYES=1
 eval $(opam config env)
 
 # Install ocaml packages needed for Kind 2.
-opam install ocamlfind camlp4 menhir
+opam install ocamlfind camlp4 menhir yojson
 
 # Build the PR's Kind 2.
 ./autogen.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN wget -qq https://github.com/ocaml/opam/releases/download/2.0.1/opam-2.0.1-x8
   && opam init --disable-sandboxing --yes --comp 4.04.0 && eval $(opam env)
 
 # Install ocaml packages needed for Kind 2.
-RUN opam install --yes ocamlfind camlp4 menhir
+RUN opam install --yes ocamlfind camlp4 menhir yojson
 
 # Force to use opam version of ocamlc.
 ENV PATH="/root/.opam/4.04.0/bin:${PATH}"

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ Requirements
 * pkg-config,
 * OCaml 4.04 or later,
 * `Ocamlbuild <https://github.com/ocaml/ocamlbuild>`_\ , Ocamlfind, `Camlp4 <https://github.com/ocaml/camlp4>`_\ ,
+* `Yojson <https://github.com/ocaml-community/yojson>`_\ ,
 * `num <https://github.com/ocaml/num>`_ (part of OCaml distribution until 4.06),
 * `Menhir <http://gallium.inria.fr/~fpottier/menhir/>`_ parser generator, and
 * a supported SMT solver

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@
 Kind 2
 ======
 
-A multi-engine, parallel, SMT-based automatic model checker for safety properties of Lustre programs.
+`Kind 2 <http://kind.cs.uiowa.edu/>`_ \ is a multi-engine, parallel, SMT-based automatic model checker for safety properties of Lustre programs.
 
 Kind 2 takes as input a Lustre file annotated with properties to be proven
 invariant (see `Lustre Input <doc/usr/source/2_input/1_lustre.rst>`_), and

--- a/doc/usr/source/9_other/8_interpreter.md
+++ b/doc/usr/source/9_other/8_interpreter.md
@@ -1,0 +1,102 @@
+## Interpreter
+
+The interpreter is a special mode where Kind 2 reads inputs from a
+file and prints the outputs of the system at each step.
+
+To use the interpreter, run
+
+```
+kind2 --enable interpreter <lustre_file> --interpreter_input_file <input_file>
+```
+
+You can specify the number of steps to run with the option `--interpreter_steps <int>`.
+By default, the number of steps is determined by the input file.
+
+### Structure of the input file
+
+The inputs must be specified in a JSON file.
+
+The overall structure is as follows:
+
+```json
+[
+  {
+    "var1": "42",
+    "var2": true,
+    "var3": "0.5"
+  },
+  {
+    "var1": "24",
+    "var2": false,
+    "var3": "0.5"
+  },
+  ...
+]
+```
+
+The top-level JSON array corresponds to the successive time steps.
+Each time step is described by a JSON object associating to each input variable its value for this time step.
+
+*NOTE: Kind2 also accepts the CSV format for backward compatibility reasons. However,
+it does not support records, arrays and tuples. Please give your input file the adequate extension (\*.json or \*.csv) in order to indicate to Kind2 which format you are using.*
+
+### Integers and reals
+
+As in the above example, integers and reals should be written as strings in order to avoid a potential loss of precision or an integer overflow while parsing the file.
+Nevertheless, small integers can be written as native JSON integers without problem.
+
+### Records
+
+Record values can be expressed using a JSON object.
+
+For instance, a variable `c` of type `{ re: real; im: real }`
+can be assigned as follows:
+
+```json
+[
+  {
+    "c": { "re": "-1.0", "im": "0.25" }
+  }
+]
+```
+
+### Arrays
+
+Array values can be expressed using a JSON array.
+
+For instance, a variable `a` of type `bool^3^2`
+can be assigned as follows:
+
+```json
+[
+  {
+    "a": [[true, true, false], [false, true, true]]
+  }
+]
+```
+
+### Tuples
+
+The JSON format does not support tuples by default.
+However, Kind2 extends the JSON syntax so that tuples can be easily expressed.
+
+For instance, a variable `t` of type `[int, bool, real]`
+can be assigned as follows:
+
+```json
+[
+  {
+    "t": ("36", false, "5.0")
+  }
+]
+```
+
+An alternative syntax using a JSON object is allowed in case you want to produce a valid JSON file:
+
+```json
+[
+  {
+    "t": { "0":"36", "1": false, "2":"5.0" }
+  }
+]
+```

--- a/doc/usr/source/9_other/8_interpreter.rst
+++ b/doc/usr/source/9_other/8_interpreter.rst
@@ -1,38 +1,41 @@
-## Interpreter
+.. _9_other/8_interpreter:
+
+Interpreter
+===========
 
 The interpreter is a special mode where Kind 2 reads inputs from a
 file and prints the outputs of the system at each step.
 
 To use the interpreter, run
 
-```
-kind2 --enable interpreter <lustre_file> --interpreter_input_file <input_file>
-```
+.. code-block:: none
 
-You can specify the number of steps to run with the option `--interpreter_steps <int>`.
+  kind2 --enable interpreter <lustre_file> --interpreter_input_file <input_file>
+
+You can specify the number of steps to run with the option ``--interpreter_steps <int>``.
 By default, the number of steps is determined by the input file.
 
-### Structure of the input file
+Structure of the input file
+---------------------------
 
 The inputs must be specified in a JSON file.
 
 The overall structure is as follows:
 
-```json
-[
-  {
-    "var1": "42",
-    "var2": true,
-    "var3": "0.5"
-  },
-  {
-    "var1": "24",
-    "var2": false,
-    "var3": "0.5"
-  },
-  ...
-]
-```
+.. code-block:: json
+
+  [
+    {
+      "var1": "42",
+      "var2": true,
+      "var3": "0.5"
+    },
+    {
+      "var1": "24",
+      "var2": false,
+      "var3": "0.5"
+    }
+  ]
 
 The top-level JSON array corresponds to the successive time steps.
 Each time step is described by a JSON object associating to each input variable its value for this time step.
@@ -40,63 +43,67 @@ Each time step is described by a JSON object associating to each input variable 
 *NOTE: Kind2 also accepts the CSV format for backward compatibility reasons. However,
 it does not support records, arrays and tuples. Please give your input file the adequate extension (\*.json or \*.csv) in order to indicate to Kind2 which format you are using.*
 
-### Integers and reals
+Integers and reals
+------------------
 
 As in the above example, integers and reals should be written as strings in order to avoid a potential loss of precision or an integer overflow while parsing the file.
 Nevertheless, small integers can be written as native JSON integers without problem.
 
-### Records
+Records
+-------
 
 Record values can be expressed using a JSON object.
 
-For instance, a variable `c` of type `{ re: real; im: real }`
+For instance, a variable ``c`` of type ``{ re: real; im: real }``
 can be assigned as follows:
 
-```json
-[
-  {
-    "c": { "re": "-1.0", "im": "0.25" }
-  }
-]
-```
+.. code-block:: json
 
-### Arrays
+  [
+    {
+      "c": { "re": "-1.0", "im": "0.25" }
+    }
+  ]
+
+Arrays
+------
 
 Array values can be expressed using a JSON array.
 
-For instance, a variable `a` of type `bool^3^2`
+For instance, a variable ``a`` of type ``bool^3^2``
 can be assigned as follows:
 
-```json
-[
-  {
-    "a": [[true, true, false], [false, true, true]]
-  }
-]
-```
+.. code-block:: json
 
-### Tuples
+  [
+    {
+      "a": [[true, true, false], [false, true, true]]
+    }
+  ]
+
+Tuples
+------
 
 The JSON format does not support tuples by default.
 However, Kind2 extends the JSON syntax so that tuples can be easily expressed.
 
-For instance, a variable `t` of type `[int, bool, real]`
+For instance, a variable ``t`` of type ``[int, bool, real]``
 can be assigned as follows:
 
-```json
-[
-  {
-    "t": ("36", false, "5.0")
-  }
-]
-```
+.. code-block:: none
+
+  [
+    {
+      "t": ("36", false, "5.0")
+    }
+  ]
 
 An alternative syntax using a JSON object is allowed in case you want to produce a valid JSON file:
 
-```json
-[
-  {
-    "t": { "0":"36", "1": false, "2":"5.0" }
-  }
-]
-```
+.. code-block:: json
+
+  [
+    {
+      "t": { "0":"36", "1": false, "2":"5.0" }
+    }
+  ]

--- a/doc/usr/source/home.rst
+++ b/doc/usr/source/home.rst
@@ -50,6 +50,7 @@ Requirements
 * pkg-config,
 * OCaml 4.04 or later,
 * `Ocamlbuild <https://github.com/ocaml/ocamlbuild>`_\ , Ocamlfind, `Camlp4 <https://github.com/ocaml/camlp4>`_\ ,
+* `Yojson <https://github.com/ocaml-community/yojson>`_\ ,
 * `num <https://github.com/ocaml/num>`_ (part of OCaml distribution until 4.06),
 * `Menhir <http://gallium.inria.fr/~fpottier/menhir/>`_ parser generator, and
 * a supported SMT solver

--- a/doc/usr/source/index.rst
+++ b/doc/usr/source/index.rst
@@ -36,6 +36,7 @@ Table of Contents
     9_other/5_proofs
     9_other/6_contract_generation
     9_other/7_invariant_logging
+    9_other/8_interpreter
 
 .. toctree::
     :maxdepth: 2

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1,4 +1,4 @@
-OCAMLBUILD=@OCAMLBUILD@ -j 0 -cflags -w,@P@U@F
+OCAMLBUILD=@OCAMLBUILD@ -j 0 -pkg yojson -cflags -w,@P@U@F
 
 # Check if git is installed and use output of git describe as version
 # number, else use version number from configure

--- a/src/inputParser.ml
+++ b/src/inputParser.ml
@@ -145,10 +145,7 @@ let group_by_var lst =
   List.fold_right
     (fun lst acc -> 
       List.fold_left (fun acc (var, term) ->
-          let old = match LHSMap.find_opt var acc with
-          | None -> []
-          | Some lst -> lst
-          in
+          let old = try LHSMap.find var acc with Not_found -> [] in
           let n = List.length old in
           if n < !steps_passed then raise (Missing_definition(n, var)) ;
           steps_passed := n ;

--- a/src/inputParser.ml
+++ b/src/inputParser.ml
@@ -15,7 +15,6 @@
    permissions and limitations under the License. 
 
 *)
-
 open Lib
 
 (* typing errors *)
@@ -111,10 +110,181 @@ let rec parse =
 
 
 (* Read in a csv file *)
-let read_file top_scope_index filename = 
+let read_csv_file top_scope_index filename = 
   let chan = open_in filename in
   parse top_scope_index chan []
 
+
+(* ====================== JSON ======================== *)
+
+open Yojson.Safe.Util
+
+module StringMap = Map.Make (String)
+module SVMap = StateVar.StateVarMap
+
+type statevar_at_index = StateVar.t * int list
+module StateVarIndex =
+struct
+  type t = statevar_at_index
+
+  let compare (a,b) (a',b') =
+    match StateVar.compare_state_vars a a' with
+    | 0 -> Pervasives.compare b b'
+    | i -> i
+end
+
+module SVIMap = Map.Make(StateVarIndex)
+
+exception Missing_definition of int * StateVarIndex.t
+
+let group_by_var lst =
+  let steps_passed = ref 0 in
+  List.fold_right
+    (fun lst acc -> 
+      List.fold_left (fun acc (var, term) ->
+          let old = match SVIMap.find_opt var acc with
+          | None -> []
+          | Some lst -> lst
+          in
+          let n = List.length old in
+          if n < !steps_passed then raise (Missing_definition(n, var)) ;
+          steps_passed := n ;
+          SVIMap.add var (term::old) acc
+        )
+        acc lst
+    ) lst SVIMap.empty
+  |> SVIMap.bindings
+
+exception Not_an_input of string
+exception Type_mismatch of string
+
+let record_to_tuple assoc =
+  try (
+    assoc
+    |> List.map (fun (str, elt) -> (int_of_string str, elt))
+    |> List.sort (fun (i,_) (j,_) -> compare i j)
+    |> List.map snd
+    |> (fun x -> Some x)
+  )
+  with Failure _ -> None
+
+let rec read_val scope name indexes arr_indexes json =
+  (* Can return multiple variables in the case of an array/record/tuple *)
+  match json with
+  | `Assoc lst ->
+    (* Can represent a record or a tuple *)
+    begin try (
+      lst |>
+      List.map (
+        fun (str, json) ->
+        read_val scope name ((LustreIndex.RecordIndex str)::indexes) arr_indexes json
+      )
+      |> List.flatten
+    )
+    with Not_an_input str -> (* If it is not a record, it must be a tuple *)
+      begin match record_to_tuple lst with
+      | None -> raise (Not_an_input str)
+      | Some lst -> read_val scope name indexes arr_indexes (`Tuple lst)
+      end
+    end
+  | `List lst -> lst |>
+    List.mapi (
+      fun i json ->
+      let new_index = LustreIndex.ArrayVarIndex (LustreExpr.mk_int_expr Numeral.one) in
+      read_val scope name (new_index::indexes) (i::arr_indexes) json
+    )
+    |> List.flatten
+  | `Tuple lst -> lst |>
+    List.mapi (
+      fun i json ->
+      read_val scope name ((LustreIndex.TupleIndex i)::indexes) arr_indexes json
+    )
+    |> List.flatten
+  | json ->
+    let indexes = List.rev indexes in
+    let arr_indexes = List.rev arr_indexes in
+    let full_scope = scope @ (LustreIndex.mk_scope_for_index indexes) in
+    (* Concatenate identifier and indexes *)
+    let full_name =
+      indexes
+      |>
+      List.filter
+        (function 
+          | LustreIndex.ArrayVarIndex _ 
+          | LustreIndex.ArrayIntIndex _ -> false
+          | LustreIndex.RecordIndex _
+          | LustreIndex.TupleIndex _
+          | LustreIndex.ListIndex _ -> true)
+      |>
+      Format.asprintf "%s%a" name (LustreIndex.pp_print_index true) 
+    in
+
+    let sv =
+      try (StateVar.state_var_of_string (full_name, full_scope))
+      with Not_found -> raise (Not_an_input full_name) in
+    if not (StateVar.is_input sv) then raise (Not_an_input full_name) ;
+    let typ = StateVar.type_of_state_var sv in
+    let sv = (sv, arr_indexes) in
+
+    let is_in_range n t =
+      match Type.node_of_type t with
+      | Int -> true
+      | IntRange (l, u, Range) ->
+        Numeral.leq l n && Numeral.leq n u
+      | _ -> false
+    in
+    let is_in_range_i i = is_in_range (Numeral.of_int i) in
+
+    let rec extract_element_type arr_indexes typ =
+      match arr_indexes, Type.node_of_type typ with
+      | [], _ -> typ
+      | i::arr_indexes, Array (elt, t) when is_in_range_i i t  ->
+        extract_element_type arr_indexes elt
+      | _, _ -> raise (Type_mismatch full_name)
+    in
+    let typ = extract_element_type arr_indexes typ in
+
+    try (
+      let open Type in
+      match Type.node_of_type typ, json with
+
+      | Bool, `Bool b -> [sv, Term.mk_bool b]
+
+      | IntRange (_, _, Enum), `String str when equal_types (enum_of_constr str) typ ->
+        [sv, Term.mk_constr str]
+
+      | Real, `Float f -> [sv, string_of_float f |> Decimal.of_string |> Term.mk_dec]
+      | Real, `Int i -> [sv, Decimal.of_int i |> Term.mk_dec]
+      | Real, `String str | Real, `Intlit str ->
+        [sv, Decimal.of_string str |> Term.mk_dec]
+
+      | _, `Int i                       when is_in_range_i i typ ->
+        [sv, Term.mk_num_of_int i]
+      | _, `Intlit str | _, `String str when is_in_range (Numeral.of_string str) typ ->
+        [sv, Numeral.of_string str |> Term.mk_num]
+
+      | _ -> raise (Type_mismatch full_name)
+    )
+    with Invalid_argument _ -> raise (Type_mismatch full_name)
+
+let read_vars scope json =
+  to_assoc json |> List.map (fun (name, json) -> read_val scope name [] [] json)
+
+let read_json_file top_scope_index filename =
+  (* try ( *)
+    let json = Yojson.Safe.from_file filename in
+    to_list json |> List.map (read_vars top_scope_index) |> List.flatten |> group_by_var
+  (* ) with
+  | _ -> raise Parsing.Parse_error *)
+
+
+let read_file top_scope_index filename =
+  if Filename.check_suffix filename ".json"
+  then
+    read_json_file top_scope_index filename
+  else
+    read_csv_file top_scope_index filename
+    |> List.map (fun (sv,vs) -> ((sv,[]),vs))
 
 (* 
    Local Variables:

--- a/src/inputParser.mli
+++ b/src/inputParser.mli
@@ -16,9 +16,12 @@
 
 *)
 
-type statevar_at_index = StateVar.t * int list
+(** Represents the lhs of an assignment. For non-array state vars, the index list is empty. 
+    For array state vars, the index list indicates which cell of the array must be assigned. *)
+type assignment_lhs = StateVar.t * int list
 
-val read_file: string list -> string -> (statevar_at_index * (Term.t list)) list
+(** Parse a JSON or CSV input file. The format is determined from the extension. *)
+val read_file: string list -> string -> (assignment_lhs * (Term.t list)) list
 
 (** Parser for a CSV input file 
 
@@ -28,7 +31,7 @@ val read_file: string list -> string -> (statevar_at_index * (Term.t list)) list
 val read_csv_file: string list -> string -> (StateVar.t * (Term.t list)) list
 
 (** Parse a JSON input file *)
-val read_json_file: string list -> string -> (statevar_at_index * (Term.t list)) list
+val read_json_file: string list -> string -> (assignment_lhs * (Term.t list)) list
 
 (* 
    Local Variables:

--- a/src/inputParser.mli
+++ b/src/inputParser.mli
@@ -16,13 +16,19 @@
 
 *)
 
+type statevar_at_index = StateVar.t * int list
+
+val read_file: string list -> string -> (statevar_at_index * (Term.t list)) list
+
 (** Parser for a CSV input file 
 
     @author Baoluo Meng, Christoph Sticksel *)
 
 (** Parse a CSV input file *)
-val read_file: string list -> string -> (StateVar.t * (Term.t list)) list
+val read_csv_file: string list -> string -> (StateVar.t * (Term.t list)) list
 
+(** Parse a JSON input file *)
+val read_json_file: string list -> string -> (statevar_at_index * (Term.t list)) list
 
 (* 
    Local Variables:


### PR DESCRIPTION
Add support for JSON inputs for the interpreter.
Arrays, tuples and records are supported.
A page about the interpreter has been added to the documentation.