### PR TITLE
Fix JSON printing of execution path values

### DIFF
--- a/src/lustre/lustrePath.ml
+++ b/src/lustre/lustrePath.ml
@@ -1546,25 +1546,27 @@ let rec pp_print_stream_prop_json ppf = function
 
 
 (* Pretty-print a single value of a stream at an instant *)
-let pp_print_stream_value_json ty ppf i show v =
-  if show then
-    Format.fprintf ppf
-      "@,[%d, %a]"
-      i (Model.pp_print_value_json ~as_type:ty) v
+let pp_print_stream_value_json ty ppf i v =
+  Format.fprintf ppf
+    "@,[%d, %a]"
+    i (Model.pp_print_value_json ~as_type:ty) v
 
 
 let pp_print_stream_values_json clock ty ppf l =
   match clock with
   | None ->
     (* Show all values if no clock *)
-    pp_print_listi (fun ppf i -> pp_print_stream_value_json ty ppf i true) "," ppf l
+    pp_print_listi (fun ppf i -> pp_print_stream_value_json ty ppf i) "," ppf l
   | Some c ->
-    (* Filter out values according to the clock *)
-    let trues = List.map2 (fun v c -> (v, c)) l c
-      |> List.filter (fun (v,c) -> c)
-      |> List.map fst
+    (* Pair each value with its index and clock, and then filter out undefined ones.
+     * This must be done before printing, because otherwise we print commas in-between
+     * filtered elements, which is invalid json. *)
+    let values_on_clock =
+      List.mapi (fun i c -> (i, c)) c
+      |> List.map2 (fun v (i, c) -> (i, v, c)) l
+      |> List.filter (fun (i, v, c) -> c)
     in
-      pp_print_listi (fun ppf i -> pp_print_stream_value_json ty ppf i true) "," ppf trues
+      pp_print_list (fun ppf (i, v, _c) -> pp_print_stream_value_json ty ppf i v) "," ppf values_on_clock
 
 
 (* Pretty-print a single stream *)

--- a/src/lustre/lustrePath.ml
+++ b/src/lustre/lustrePath.ml
@@ -1559,8 +1559,12 @@ let pp_print_stream_values_json clock ty ppf l =
     (* Show all values if no clock *)
     pp_print_listi (fun ppf i -> pp_print_stream_value_json ty ppf i true) "," ppf l
   | Some c ->
-    (* Show values sampled on the clock *)
-    pp_print_list2i (pp_print_stream_value_json ty) "," ppf c l
+    (* Filter out values according to the clock *)
+    let trues = List.map2 (fun v c -> (v, c)) l c
+      |> List.filter (fun (v,c) -> c)
+      |> List.map fst
+    in
+      pp_print_listi (fun ppf i -> pp_print_stream_value_json ty ppf i true) "," ppf trues
 
 
 (* Pretty-print a single stream *)


### PR DESCRIPTION
Hi Daniel,
We came across a tiny bug in the JSON printing of interpreter output. When a stream has a clock, the undefined values were being filtered out just before they were printed. However, the comma between elements was still being printed - so you'd end up with multiple commas in a row like `value,,,,,`.

I fixed this by filtering out the undefined values earlier; I also removed the "show" flag from `pp_print_stream_value_json` since it was not used any more.

If you'd like a concrete test case, a simple automaton can trigger it:
```
node Ping (in : bool) returns (ping: bool)
let
  automaton 
  state S1
  let
   ping = true;
  tel
  until if in resume S2;
  initial state S2
  let
    ping = false;
  tel
  until if in resume S1;
tel
```

Running that in the interpreter with JSON output gave a result containing the multiple commas:
```
            "blockType" : "state",
            "name" : "S1",
            "streams" :
            [
              {
                "name" : "in",
                "type" : "bool",
                "class" : "input",
                "instantValues" :
                [,
                  [1, false],
                  [2, true],,
                  [4, true],,,,
                  [8, true],
                ]
              },
              {
                "name" : "ping",
                "type" : "bool",
                "class" : "output",
                "instantValues" :
                [,
                  [1, true],
                  [2, true],,
                  [4, true],,,,
                  [8, true],
                ]
              }
            ]
```

Thanks!
Amos