### PR TITLE
Allow arrays in top-level constant declarations

### DIFF
--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -419,8 +419,9 @@ let eval_const_decl ?(ghost = false) ctx = function
 
         (try 
 
-           (* Evaluate type expression *)
-           let type_expr' = S.eval_ast_type ctx type_expr in 
+           (* Evaluate type expression. Flatten any arrays so that we check
+            * each element against its expected type *)
+           let type_expr' = S.eval_ast_type_flatten true ctx type_expr in
 
            (* Check if type of expression is a subtype of the defined
               type at each index *)
@@ -438,8 +439,7 @@ let eval_const_decl ?(ghost = false) ctx = function
                     raise E.Type_mismatch
              ) type_expr' res
 
-         with Invalid_argument _ | E.Type_mismatch -> 
-
+         with Invalid_argument _ | E.Type_mismatch ->
            (C.fail_at_position
               pos
               "Type mismatch in constant declaration"))

--- a/src/lustre/lustreSimplify.ml
+++ b/src/lustre/lustreSimplify.ml
@@ -2041,8 +2041,12 @@ let array_of_tuple pos index_vars expr =
 (* Type declarations                                                    *)
 (* ******************************************************************** *)
     
-(* Evalute a parsed type expression to a trie of types of indexes *)
-and eval_ast_type ctx = function
+(* Evaluate a parsed type expression to a trie of types of indexes *)
+and eval_ast_type ctx = eval_ast_type_flatten false ctx
+
+(* Evaluate a parsed type expression to a trie of types of indexes,
+   optionally flattening/unrolling arrays if 'flatten_arrays' is true. *)
+and eval_ast_type_flatten flatten_arrays ctx = function
 
   (* Basic type bool, add to empty trie with empty index *)
   | A.Bool pos -> D.singleton D.empty_index Type.t_bool
@@ -2139,7 +2143,7 @@ and eval_ast_type ctx = function
       (fun a (_, i, t) ->
          
          (* Evaluate type expression for field to a trie *)
-         let expr = eval_ast_type ctx t in
+         let expr = eval_ast_type_flatten flatten_arrays ctx t in
 
          (* Take all indexes and their defined types and add index of record
             field to index of type and add to trie *)
@@ -2163,7 +2167,7 @@ and eval_ast_type ctx = function
       (fun (i, a) t -> 
 
          (* Evaluate type expression for field to a trie *)
-         let expr = eval_ast_type ctx t in
+         let expr = eval_ast_type_flatten flatten_arrays ctx t in
 
          (* Take all indexes and their defined types and add index of tuple
             field to index of type and add to trie *)
@@ -2195,19 +2199,30 @@ and eval_ast_type ctx = function
          (E.pp_print_expr false) array_size);
     
     (* Evaluate type expression for elements *)
-    let element_type = eval_ast_type ctx type_expr in
+    let element_type = eval_ast_type_flatten flatten_arrays ctx type_expr in
 
-    (* Add array bounds to type *)
-    D.fold
-      (fun j t a -> 
-         D.add (j @ [D.ArrayVarIndex array_size])
-           (Type.mk_array t
-              (if E.is_numeral array_size then
-                 Type.mk_int_range Numeral.zero (E.numeral_of_expr array_size)
-               else Type.t_int))
-           a)
-      element_type
-      D.empty
+    if flatten_arrays
+    then
+      (* Loop through all the indices, adding array bounds for each element *)
+      let upper = E.numeral_of_expr array_size in
+      let result = ref D.empty in
+      for ix = 0 to (Numeral.to_int upper - 1) do
+        result := D.fold
+          (fun j t a -> D.add (j @ [D.ArrayIntIndex ix]) t a) element_type !result
+      done;
+      !result
+    else
+      (* Add array bounds to type *)
+      D.fold
+        (fun j t a ->
+           D.add (j @ [D.ArrayVarIndex array_size])
+             (Type.mk_array t
+                (if E.is_numeral array_size then
+                   Type.mk_int_range Numeral.zero (E.numeral_of_expr array_size)
+                 else Type.t_int))
+             a)
+        element_type
+        D.empty
 
 (*
 

--- a/src/lustre/lustreSimplify.mli
+++ b/src/lustre/lustreSimplify.mli
@@ -30,6 +30,9 @@ val eval_ast_expr :
 val eval_ast_type :
   LustreContext.t -> LustreAst.lustre_type -> Type.t LustreIndex.t
 
+val eval_ast_type_flatten :
+  bool -> LustreContext.t -> LustreAst.lustre_type -> Type.t LustreIndex.t
+
 val eval_bool_ast_expr :
   LustreExpr.expr LustreExpr.bound_or_fixed list ->  LustreContext.t ->
   Lib.position -> LustreAst.expr -> LustreExpr.t * LustreContext.t

--- a/tests/regression/success/array-const.lus
+++ b/tests/regression/success/array-const.lus
@@ -1,0 +1,16 @@
+const simple_array_literal : int^3
+  = [1, 5, 9];
+const simple_array_constr : int^3
+  = 0^3;
+const nested_array : int^2^2
+  = [0^2, 1^2];
+const tuple_of_ints : [int,int]
+  = {1,2};
+const tuple_of_array : [int^2,int]
+  = {[0,1], 1};
+
+function look_up_table(i : int) returns (v : int);
+let
+  v = simple_array_literal[i / 10];
+  --%PROPERTY 0 <= i and i < 30 => v = 1 or v = 5 or v = 9;
+tel


### PR DESCRIPTION
Hi Daniel,

There was a bug where a top-level constant declaration like
```
const simple_array_literal : int^3 = [1, 5, 9];
```
was treated as a type error. This was happening because the type checking
for constants expected the trie of the type to be the same shape as
the trie of the values. However, for arrays, the values had a shape like
`[0]: _, [1]: _, [2]: _`
but the array in the type trie hadn't been flattened out, so it had
no nesting. I've fixed this for now by flattening out the array in the
type trie, so in this example, the original type:
```
Array Int (IntRange 0 3)
```
becomes the trie:
```
[0]: Int, [1]: Int, [2]: Int
```
and then we can more easily match each element of the value trie against its corresponding entry in the type trie.

I couldn't find an obviously nicer way to do this, but I got a bit lost in the type checking for node equations. Let me know if you think it can be made cleaner.

Thanks,
Amos