### PR TITLE
Uncomment exception handling in invGen

### DIFF
--- a/src/invgen/invGen.ml
+++ b/src/invgen/invGen.ml
@@ -739,11 +739,11 @@ module Make (Graph : GraphSig) : Out = struct
 
     ) with
     | KEvent.Terminate -> exit ()
-    (*| e -> (
-      KEvent.log L_fatal "caught exception %s" (Printexc.to_string e) ;
+    | e -> (
+      KEvent.log L_fatal "Caught exception %s" (Printexc.to_string e) ;
       minisleep 0.5 ;
       exit ()
-    )*)
+    )
 
 end
 


### PR DESCRIPTION
It was closing unproperly in case of a SMT exception (without killing SMT instances)