### PR TITLE
Filename displayed in error messages

### DIFF
--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -101,10 +101,7 @@ let setup : unit -> any_input = fun () ->
   with (* Could not create input system. *)
   | LustreAst.Parser_error  ->
      (* terminate log after printing file name and exit as the error is already on the log file *)
-     KEvent.log L_fatal "While parsing %s" (classify_input_stream (Flags.input_file ())); 
-     KEvent.terminate_log () ; exit ExitCodes.error
-  | LustreLexer.Lexer_error err ->
-     KEvent.log L_fatal "While parsing %s\n Lexing error: %s" (classify_input_stream (Flags.input_file ())) err;
+     (* KEvent.log L_fatal "While parsing %s" (classify_input_stream (Flags.input_file ())); *) 
      KEvent.terminate_log () ; exit ExitCodes.error
   | e ->
     let backtrace = Printexc.get_raw_backtrace () in

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -191,7 +191,7 @@ let in_automaton ctx = ctx.in_automaton
 
 (* Raise parsing exception *)
 let fail_at_position_pt pos msg =
-  Log.log L_error "Failure at %a: @[<v>%s@]"
+  Log.log L_error "%a: Failure at @[<v>%s@] "
     Lib.pp_print_position pos msg
 
 let fail_at_position pos msg =

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -191,7 +191,7 @@ let in_automaton ctx = ctx.in_automaton
 
 (* Raise parsing exception *)
 let fail_at_position_pt pos msg =
-  Log.log L_error "%a: Failure at @[<v>%s@] "
+  Log.log L_error "%a: Failure cause: @[<v>%s@] "
     Lib.pp_print_position pos msg
 
 let fail_at_position pos msg =

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -32,6 +32,11 @@ module LL = LustreLexer
 module LPMI = LustreParser.MenhirInterpreter
 module LPE = LustreParserErrors
 
+
+(** set the filename in lexing buffer*)
+let set_filename lexbuf fname =
+  lexbuf.lex_curr_p <- {lexbuf.lex_curr_p with pos_fname = fname}
+           
 (* The parser has succeeded and produced a semantic value.*)
 let success (v : LustreAst.t): LustreAst.t =
   Log.log L_debug "Parsed :\n=========\n\n%a\n@." LustreAst.pp_print_program v;
@@ -78,15 +83,24 @@ let rec parse lexbuf (chkpnt : LA.t LPMI.checkpoint) =
 
 (* Parses input channel to generate an AST *)
 let ast_of_channel(in_ch: in_channel): LustreAst.t =
+
+  let input_source = Flags.input_file () in
   (* Create lexing buffer *)
   let lexbuf = Lexing.from_function LustreLexer.read_from_lexbuf_stack in
+
   (* Initialize lexing buffer with channel *)
   LustreLexer.lexbuf_init 
     in_ch
-    (try Filename.dirname (Flags.input_file ())
+    (try Filename.dirname (input_source)
      with Failure _ -> Sys.getcwd ());
+  (* Set the file name in lex buffer *)
+  set_filename lexbuf (input_source);
+
   (* Create lexing buffer and incrementally parse it*)
-  parse lexbuf (LPI.main lexbuf.lex_curr_p)
+  try
+    (parse lexbuf (LPI.main lexbuf.lex_curr_p))
+  with
+  | LustreLexer.Lexer_error err -> LC.fail_at_position (Lib.position_of_lexing lexbuf.lex_curr_p) err  
          
 (* Parse from input channel *)
 let of_channel in_ch =

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -521,11 +521,8 @@ rule token = parse
 
   (* Unrecognized character *)
   | _ as c {
-       let (lno, cnum, b) = (lexbuf.lex_curr_p.pos_lnum, lexbuf.lex_curr_p.pos_cnum, lexbuf.lex_curr_p.pos_bol) in
-       let msg = Format.sprintf
-                   "Unrecognized token %c (0x%X) found at line %d, column %d"
-                   c (Char.code c) lno (cnum - b) in
-    raise (Lexer_error msg)
+       let msg = Format.sprintf "Unrecognized token %c (0x%X)" c (Char.code c) in
+       raise (Lexer_error msg)
   }
 
 (* Parse until end of comment, count newlines and otherwise discard


### PR DESCRIPTION
### Text format
```
$ ./bin/kind2 --only_parse true -- tests/lustre/syntax-errors/array-syntax.lus
 kind2 3646f46-dirty

tests/lustre/syntax-errors/array-syntax.lus:4:5: Failure cause: Unrecognized token % (0x25)
```

### Json log format 
```
$ ./bin/kind2 -json --only_parse true -- tests/lustre/syntax-errors/array-syntax.lus
[
{
  "objectType" : "log",
  "level" : "info",
  "source" : "parse",
  "value" : "kind2 3646f46-dirty"
}
,
{
  "objectType" : "kind2Options",
  "enabled" :
  [
    "bmc",
    "ind",
    "ind2",
    "ic3",
    "invgents",
    "invgenos",
    "invgenintos",
    "invgenintos"
  ],
  "timeout" : 0.000000,
  "bmcMax" : 0,
  "compositional" : false,
  "modular" : false
}
,
{
  "objectType" : "log",
  "level" : "error",
  "source" : "parse",
  "file" : "tests/lustre/syntax-errors/array-syntax.lus",
  "line" : 4,
  "column" : 5,
  "value" : "Unrecognized token % (0x25)"
}
]
```

Xml log format
```
$ ./bin/kind2 -xml --only_parse true -- tests/lustre/syntax-errors/array-syntax.lus
<?xml version="1.0"?>
<Results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" enabled="bmc,ind,ind2,ic3,invgents,invgenos,invgenintos,invgenintos" timeout="0.000000" bmc_max="0" compositional="false" modular="false">


<Log class="info" source="parse">kind2 3646f46-dirty</Log>
<Log class="error" source="parse" line="4" column="5" file="tests/lustre/syntax-errors/array-syntax.lus">Unrecognized token % (0x25)</Log>


</Results>
```