### PR TITLE
Reverting changes for adding file name/filepath into lexing buffer

### DIFF
--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -88,8 +88,11 @@ let ast_of_channel(in_ch: in_channel): LustreAst.t =
     in_ch
     (try Filename.dirname (input_source)
      with Failure _ -> Sys.getcwd ());
+
   (* Set the relative file name in lex buffer *)
-  Lib.set_lexer_filename lexbuf (Lib.get_relative_path input_source);
+  (* Lib.set_lexer_filename lexbuf (input_source); *)
+  (* Setting the name in the lexer buffer causes issues with the way we display properties.
+   * For the time being we would not want to change this behaviour *)
 
   (* Create lexing buffer and incrementally parse it*)
   try

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -31,11 +31,6 @@ module LPI = LustreParser.Incremental
 module LL = LustreLexer          
 module LPMI = LustreParser.MenhirInterpreter
 module LPE = LustreParserErrors
-
-
-(** set the filename in lexing buffer*)
-let set_filename lexbuf fname =
-  lexbuf.lex_curr_p <- {lexbuf.lex_curr_p with pos_fname = fname}
            
 (* The parser has succeeded and produced a semantic value.*)
 let success (v : LustreAst.t): LustreAst.t =
@@ -93,8 +88,8 @@ let ast_of_channel(in_ch: in_channel): LustreAst.t =
     in_ch
     (try Filename.dirname (input_source)
      with Failure _ -> Sys.getcwd ());
-  (* Set the file name in lex buffer *)
-  set_filename lexbuf (input_source);
+  (* Set the relative file name in lex buffer *)
+  Lib.set_lexer_filename lexbuf (Lib.get_relative_path input_source);
 
   (* Create lexing buffer and incrementally parse it*)
   try

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -989,14 +989,6 @@ let rec find_file filename = function
     let path = Filename.concat dir filename in
     if Sys.file_exists path then Some path
     else find_file filename include_dirs
-
-
-(* Gets the relative path of the file name given a file path *)
-let get_relative_path fpath =
-  if Filename.is_relative fpath
-  then fpath
-  else let pwd = Sys.getcwd () in
-       String.sub fpath (1 + String.length pwd) (String.length fpath - String.length pwd - 1) 
     
 
 (* ********************************************************************** *)
@@ -1111,11 +1103,6 @@ let file_row_col_of_pos = function
 
   (* Return tuple of filename, line and column *)
   | { pos_fname; pos_lnum; pos_cnum } -> (pos_fname, pos_lnum, pos_cnum)
-
-
-(** set the filename in lexing buffer*)
-let set_lexer_filename lexbuf fname =
-  lexbuf.Lexing.lex_curr_p <- {lexbuf.Lexing.lex_curr_p with pos_fname = fname}
                                        
 
 let print_backtrace fmt bt =
@@ -1166,7 +1153,6 @@ let create_dir dir =
 
    Implementation adapted from "Unix system programming in OCaml" by Xavier
    Leroy and Didier Remy*)
-
 
 
 let copy_fds fd_in fd_out =

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -49,7 +49,7 @@ let false_of_any _ = false
 let mk_dir dir =
   try Unix.mkdir dir 0o740 with Unix.Unix_error(Unix.EEXIST, _, _) -> ()
 
-
+                                                                    
 (* ********************************************************************** *)
 (* Arithmetic functions                                                   *)
 (* ********************************************************************** *)
@@ -991,6 +991,14 @@ let rec find_file filename = function
     else find_file filename include_dirs
 
 
+(* Gets the relative path of the file name given a file path *)
+let get_relative_path fpath =
+  if Filename.is_relative fpath
+  then fpath
+  else let pwd = Sys.getcwd () in
+       String.sub fpath (1 + String.length pwd) (String.length fpath - String.length pwd - 1) 
+    
+
 (* ********************************************************************** *)
 (* Parser and lexer functions                                             *)
 (* ********************************************************************** *)
@@ -1104,6 +1112,11 @@ let file_row_col_of_pos = function
   (* Return tuple of filename, line and column *)
   | { pos_fname; pos_lnum; pos_cnum } -> (pos_fname, pos_lnum, pos_cnum)
 
+
+(** set the filename in lexing buffer*)
+let set_lexer_filename lexbuf fname =
+  lexbuf.Lexing.lex_curr_p <- {lexbuf.Lexing.lex_curr_p with pos_fname = fname}
+                                       
 
 let print_backtrace fmt bt =
   match Printexc.backtrace_slots bt with

--- a/src/utils/lib.mli
+++ b/src/utils/lib.mli
@@ -371,9 +371,6 @@ val find_on_path : string -> string
 (** Return full path to file if the file is found in
     the list of directories, or None otherwise **)
 val find_file : string -> string list -> string option
-
-(** Returns a relative path if the given filepath is absolute *)
-val get_relative_path: string -> string
   
 (** {1 Positions in the input} *)
 
@@ -406,9 +403,6 @@ val pos_of_file_row_col : string * int * int -> position
 
 (** Convert a position of the lexer to a position *)
 val position_of_lexing : Lexing.position -> position
-
-(** set the filename in lexing buffer*)
-val set_lexer_filename: Lexing.lexbuf -> string -> unit
 
 (** Pretty print a backtrace *)
 val print_backtrace : Format.formatter -> Printexc.raw_backtrace -> unit

--- a/src/utils/lib.mli
+++ b/src/utils/lib.mli
@@ -372,6 +372,9 @@ val find_on_path : string -> string
     the list of directories, or None otherwise **)
 val find_file : string -> string list -> string option
 
+(** Returns a relative path if the given filepath is absolute *)
+val get_relative_path: string -> string
+  
 (** {1 Positions in the input} *)
 
 (** A position in the input *)
@@ -404,6 +407,8 @@ val pos_of_file_row_col : string * int * int -> position
 (** Convert a position of the lexer to a position *)
 val position_of_lexing : Lexing.position -> position
 
+(** set the filename in lexing buffer*)
+val set_lexer_filename: Lexing.lexbuf -> string -> unit
 
 (** Pretty print a backtrace *)
 val print_backtrace : Format.formatter -> Printexc.raw_backtrace -> unit

--- a/tests/lustre/StopWatchSpec.lus
+++ b/tests/lustre/StopWatchSpec.lus
@@ -1,0 +1,60 @@
+-------------------------
+-- Auxiliary operators --
+-------------------------
+node Even (N: int) returns (B: bool) ;
+let
+  B = (N mod 2 = 0) ; 
+tel
+
+node ToInt (X: bool) returns (N: int) ;
+let
+  N = if X then 1 else 0 ;
+tel
+
+node Count (X: bool) returns (N: int) ;
+let
+  N = ToInt(X) -> ToInt(X) + pre N ;  
+tel
+
+node Sofar ( X : bool ) returns ( Y : bool ) ;
+let
+ Y = X -> (X and (pre Y)) ;
+tel
+
+node Since ( X, Y : bool ) returns ( Z : bool ) ;
+let
+  Z =  X or (Y and (false -> pre Z)) ;
+tel
+
+
+node SinceIncl ( X, Y : bool ) returns ( Z : bool ) ;
+let
+  Z =  Y and (X or (false -> pre Z)) ;
+tel
+
+node Increased (N: int) returns (B: bool) ;
+let
+  B = true -> N > pre N ;
+tel
+
+node Stable (N: int) returns (B: bool) ;
+let
+  B = true -> N = pre N ;
+tel
+
+include "contract_stopwatch_spec.lus"
+
+------------------------------
+-- Stopwatch low-level spec --
+------------------------------
+
+node stopwatch ( toggle, reset : bool ) returns ( count : int );
+(*@contract import stopwatchSpec(toggle, reset ) returns (count) ; *)
+  var running : bool;
+let
+  running = (false -> pre running) <> toggle ;
+  count =
+    if reset then 0
+    else if running then 1 -> pre count + 1
+    else 0 -> pre count ;
+tel

--- a/tests/lustre/contract_stopwatch_spec.lus
+++ b/tests/lustre/contract_stopwatch_spec.lus
@@ -1,0 +1,60 @@
+-------------------------------
+-- Stopwatch high-level spec --
+-------------------------------
+contract stopwatchSpec ( toggle, reset : bool ) returns ( time : int ) ;
+let
+  -- the watch is activated initially if the toggle button is pressed
+  -- afterwards, it is activated iff 
+  --   it was activated before and the toggle button is unpressed or
+  --   it was not activated before and the toggle button is pressed 
+  var on: bool = toggle ->    (pre on and not toggle) 
+                           or (not pre on and toggle) ;
+  
+  -- we can assume that the two buttons are never pressed together
+  assume not (toggle and reset) ; 
+  
+  -- the elapsed time starts at 1 or 0 depending 
+  -- on whether the watch is activated or not
+  guarantee (on => time = 1) -> true ;
+  guarantee (not on => time = 0) -> true ;
+  -- the elapsed time is always non-negative
+  guarantee time >= 0 ;
+  
+  -- if there is no reset now and there was an even number of counts since the last reset
+  -- then the current elapsed time is the same as the previous one
+  guarantee not reset and Since(reset, Even(Count(toggle))) 
+            => Stable(time) ;
+  -- if there is no reset now and there was an odd number of counts since the last reset
+  -- then the current elapsed time is greater than previous one
+  guarantee not reset and Since(reset, not Even(Count(toggle))) 
+            => Increased(time) ;
+
+
+--  guarantee true -> not Even(Count(toggle)) and Count(reset) = 0 => time > pre time ;
+
+  
+  -- the watch is in resetting mode if the reset button is pressed
+  -- while in that mode, the elapsed time is 0
+  mode resetting ( 
+    require reset ; 
+    ensure time = 0 ; 
+  ) ;
+
+  -- the watch is in running mode if is activated and 
+  -- the reset button is unpressed.
+  -- while in that mode, the elapsed time increases by 1
+  mode running ( 
+    require on ; 
+    require not reset ; 
+    ensure true -> time = pre time + 1 ; 
+  ) ;
+
+  -- the watch is in stopped mode if is not activated and 
+  -- the reset button is unpressed
+  -- while in that mode, the elapsed time remains the same
+  mode stopped ( 
+    require not reset ; 
+    require not on ; 
+    ensure true -> time = pre time ; 
+  ) ;
+tel


### PR DESCRIPTION
Error messages display style
============================

## Happy execution

- TEXT

```
$ bin/kind2 -- tests/lustre/StopWatchSpec.lus
 kind2 d991734



================================================================================================================================================================================================================================================================================
Analyzing stopwatch
  with ContractCheck top: 'stopwatch'
                     subsystems
                       | concrete: ToInt, Stable, Since, Increased, Even, Count

<Success> Property stopwatchSpec._one_mode_active is valid by property directed reachability after 0.186s.

--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Summary of properties:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
stopwatchSpec._one_mode_active: valid (at 1)
================================================================================================================================================================================================================================================================================



================================================================================================================================================================================================================================================================================
Analyzing stopwatch
  with First top: 'stopwatch'
             subsystems
               | concrete: ToInt, Stable, Since, Increased, Even, Count

<Success> Property stopwatchSpec[l52c12].resetting.ensure[contract_stopwatch_spec.lus|l40c4][1] is valid by inductive step after 0.169s.

<Success> Property stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l18c2][1] is valid by inductive step after 0.169s.

<Success> Property stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l19c2][2] is valid by inductive step after 0.169s.

<Success> Property stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l21c2][3] is valid by 2-induction after 0.333s.

<Success> Property stopwatchSpec[l52c12].running.ensure[contract_stopwatch_spec.lus|l49c4][1] is valid by inductive step after 0.445s.

<Success> Property stopwatchSpec[l52c12].stopped.ensure[contract_stopwatch_spec.lus|l58c4][1] is valid by inductive step after 0.445s.

<Success> Property stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l25c2][4] is valid by one state invariant generator (bool) after 2.311s.

<Success> Property stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l29c2][5] is valid by one state invariant generator (bool) after 2.311s.

--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Summary of properties:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
stopwatchSpec[l52c12].stopped.ensure[contract_stopwatch_spec.lus|l58c4][1]: valid (at 4)
stopwatchSpec[l52c12].running.ensure[contract_stopwatch_spec.lus|l49c4][1]: valid (at 4)
stopwatchSpec[l52c12].resetting.ensure[contract_stopwatch_spec.lus|l40c4][1]: valid (at 2)
stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l18c2][1]: valid (at 2)
stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l19c2][2]: valid (at 2)
stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l21c2][3]: valid (at 1)
stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l25c2][4]: valid (at 2)
stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l29c2][5]: valid (at 2)
================================================================================================================================================================================================================================================================================

```

- JSON

```
$ bin/kind2 -json -- tests/lustre/StopWatchSpec.lus
[
{
  "objectType" : "log",
  "level" : "info",
  "source" : "parse",
  "value" : "kind2 d991734"
}
,
{
  "objectType" : "kind2Options",
  "enabled" :
  [
    "bmc",
    "ind",
    "ind2",
    "ic3",
    "invgents",
    "invgenos",
    "invgenintos",
    "invgenintos"
  ],
  "timeout" : 0.000000,
  "bmcMax" : 0,
  "compositional" : false,
  "modular" : false
}
,
{
  "objectType" : "analysisStart",
  "top" : "stopwatch",
  "concrete" :
  [
    "ToInt",
    "Stable",
    "Since",
    "Increased",
    "Even",
    "Count"
  ],
  "abstract" : [],
  "assumptions" : []
}
,
{
  "objectType" : "property",
  "name" : "stopwatchSpec._one_mode_active",
  "scope" : "stopwatch",
  "line" : 38,
  "column" : 2,
  "source" : "OneModeActive",
  "runtime" : {"unit" : "sec", "timeout" : false, "value" : 0.131},
  "answer" : {"source" : "ic3", "value" : "valid"}
}
,
{"objectType" : "analysisStop"}
,
{
  "objectType" : "analysisStart",
  "top" : "stopwatch",
  "concrete" :
  [
    "ToInt",
    "Stable",
    "Since",
    "Increased",
    "Even",
    "Count"
  ],
  "abstract" : [],
  "assumptions" : []
}
,
{
  "objectType" : "property",
  "name" : "stopwatchSpec[l52c12].resetting.ensure[contract_stopwatch_spec.lus|l40c4][1]",
  "scope" : "stopwatch",
  "line" : 40,
  "column" : 4,
  "source" : "Ensure",
  "runtime" : {"unit" : "sec", "timeout" : false, "value" : 0.362},
  "answer" : {"source" : "ind", "value" : "valid"}
}
,
{
  "objectType" : "property",
  "name" : "stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l18c2][1]",
  "scope" : "stopwatch",
  "line" : 18,
  "column" : 2,
  "source" : "Guarantee",
  "runtime" : {"unit" : "sec", "timeout" : false, "value" : 0.362},
  "answer" : {"source" : "ind", "value" : "valid"}
}
,
{
  "objectType" : "property",
  "name" : "stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l19c2][2]",
  "scope" : "stopwatch",
  "line" : 19,
  "column" : 2,
  "source" : "Guarantee",
  "runtime" : {"unit" : "sec", "timeout" : false, "value" : 0.362},
  "answer" : {"source" : "ind", "value" : "valid"}
}
,
{
  "objectType" : "property",
  "name" : "stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l21c2][3]",
  "scope" : "stopwatch",
  "line" : 21,
  "column" : 2,
  "source" : "Guarantee",
  "runtime" : {"unit" : "sec", "timeout" : false, "value" : 0.405},
  "answer" : {"source" : "ind2", "value" : "valid"}
}
,
{
  "objectType" : "property",
  "name" : "stopwatchSpec[l52c12].running.ensure[contract_stopwatch_spec.lus|l49c4][1]",
  "scope" : "stopwatch",
  "line" : 49,
  "column" : 4,
  "source" : "Ensure",
  "runtime" : {"unit" : "sec", "timeout" : false, "value" : 0.707},
  "answer" : {"source" : "ind", "value" : "valid"}
}
,
{
  "objectType" : "property",
  "name" : "stopwatchSpec[l52c12].stopped.ensure[contract_stopwatch_spec.lus|l58c4][1]",
  "scope" : "stopwatch",
  "line" : 58,
  "column" : 4,
  "source" : "Ensure",
  "runtime" : {"unit" : "sec", "timeout" : false, "value" : 0.707},
  "answer" : {"source" : "ind", "value" : "valid"}
}
,
{
  "objectType" : "property",
  "name" : "stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l25c2][4]",
  "scope" : "stopwatch",
  "line" : 25,
  "column" : 2,
  "source" : "Guarantee",
  "runtime" : {"unit" : "sec", "timeout" : false, "value" : 3.304},
  "answer" : {"source" : "invgenos", "value" : "valid"}
}
,
{
  "objectType" : "property",
  "name" : "stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l29c2][5]",
  "scope" : "stopwatch",
  "line" : 29,
  "column" : 2,
  "source" : "Guarantee",
  "runtime" : {"unit" : "sec", "timeout" : false, "value" : 3.304},
  "answer" : {"source" : "invgenos", "value" : "valid"}
}
,
{"objectType" : "analysisStop"}
]

```

- XML

```
$ bin/kind2 -xml -- tests/lustre/StopWatchSpec.lus
<?xml version="1.0"?>
<Results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" enabled="bmc,ind,ind2,ic3,invgents,invgenos,invgenintos,invgenintos" timeout="0.000000" bmc_max="0" compositional="false" modular="false">


<Log class="info" source="parse">kind2 d991734</Log>


<AnalysisStart top="stopwatch" concrete="ToInt,Stable,Since,Increased,Even,Count" abstract="" assumptions=""/>

<Property name="stopwatchSpec._one_mode_active" line="38" column="2" scope="stopwatch" source="OneModeActive" file="contract_stopwatch_spec.lus">
  <Runtime unit="sec" timeout="false">0.137</Runtime>
  <Answer source="ic3" comment="contract modes are exhaustive">valid</Answer>
</Property>

<AnalysisStop/>



<AnalysisStart top="stopwatch" concrete="ToInt,Stable,Since,Increased,Even,Count" abstract="" assumptions=""/>

<Property name="stopwatchSpec[l52c12].resetting.ensure[contract_stopwatch_spec.lus|l40c4][1]" line="40" column="4" scope="stopwatch" source="Ensure" file="contract_stopwatch_spec.lus">
  <Runtime unit="sec" timeout="false">0.172</Runtime>
  <Answer source="ind">valid</Answer>
</Property>
<Property name="stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l18c2][1]" line="18" column="2" scope="stopwatch" source="Guarantee" file="contract_stopwatch_spec.lus">
  <Runtime unit="sec" timeout="false">0.172</Runtime>
  <Answer source="ind">valid</Answer>
</Property>
<Property name="stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l19c2][2]" line="19" column="2" scope="stopwatch" source="Guarantee" file="contract_stopwatch_spec.lus">
  <Runtime unit="sec" timeout="false">0.172</Runtime>
  <Answer source="ind">valid</Answer>
</Property>
<Property name="stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l21c2][3]" line="21" column="2" scope="stopwatch" source="Guarantee" file="contract_stopwatch_spec.lus">
  <Runtime unit="sec" timeout="false">0.267</Runtime>
  <Answer source="ind2">valid</Answer>
</Property>
<Property name="stopwatchSpec[l52c12].running.ensure[contract_stopwatch_spec.lus|l49c4][1]" line="49" column="4" scope="stopwatch" source="Ensure" file="contract_stopwatch_spec.lus">
  <Runtime unit="sec" timeout="false">0.448</Runtime>
  <Answer source="ind">valid</Answer>
</Property>
<Property name="stopwatchSpec[l52c12].stopped.ensure[contract_stopwatch_spec.lus|l58c4][1]" line="58" column="4" scope="stopwatch" source="Ensure" file="contract_stopwatch_spec.lus">
  <Runtime unit="sec" timeout="false">0.448</Runtime>
  <Answer source="ind">valid</Answer>
</Property>
<Property name="stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l29c2][5]" line="29" column="2" scope="stopwatch" source="Guarantee" file="contract_stopwatch_spec.lus">
  <Runtime unit="sec" timeout="false">2.228</Runtime>
  <Answer source="invgenos">valid</Answer>
</Property>
<Property name="stopwatchSpec[l52c12].guarantee[contract_stopwatch_spec.lus|l25c2][4]" line="25" column="2" scope="stopwatch" source="Guarantee" file="contract_stopwatch_spec.lus">
  <Runtime unit="sec" timeout="false">2.239</Runtime>
  <Answer source="invgenos">valid</Answer>
</Property>

<AnalysisStop/>



</Results>
```

## Unhappy execution

### Syntax errors in main file

#### Lexing error

- TEXT

```
$ bin/kind2 -- tests/lustre/StopWatchSpec.lus
 kind2 d991734

<Error> line 55 col. 11: Failure cause: Unrecognized token % (0x25)
```

- JSON

```
$ bin/kind2 -json -- tests/lustre/StopWatchSpec.lus
[
{
  "objectType" : "log",
  "level" : "info",
  "source" : "parse",
  "value" : "kind2 d991734"
}
,
{
  "objectType" : "kind2Options",
  "enabled" :
  [
    "bmc",
    "ind",
    "ind2",
    "ic3",
    "invgents",
    "invgenos",
    "invgenintos",
    "invgenintos"
  ],
  "timeout" : 0.000000,
  "bmcMax" : 0,
  "compositional" : false,
  "modular" : false
}
,
{
  "objectType" : "log",
  "level" : "error",
  "source" : "parse",
  "line" : 55,
  "column" : 11,
  "value" : "Unrecognized token % (0x25)"
}
]
```

- XML

```
$ bin/kind2 -xml -- tests/lustre/StopWatchSpec.lus
<?xml version="1.0"?>
<Results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" enabled="bmc,ind,ind2,ic3,invgents,invgenos,invgenintos,invgenintos" timeout="0.000000" bmc_max="0" compositional="false" modular="false">


<Log class="info" source="parse">kind2 d991734</Log>
<Log class="error" source="parse" line="55" column="11">Unrecognized token % (0x25)</Log>


</Results>
```

#### Generic Parser error

- TEXT

```
$ bin/kind2 -- tests/lustre/StopWatchSpec.lus
 kind2 d991734

<Error> line 51 col. 40: Failure cause: Syntax Error! Perhaps a missing or incomplete `return` clause in node specification.
```

- JSON

```
$ bin/kind2 -json -- tests/lustre/StopWatchSpec.lus
[
{
  "objectType" : "log",
  "level" : "info",
  "source" : "parse",
  "value" : "kind2 d991734"
}
,
{
  "objectType" : "kind2Options",
  "enabled" :
  [
    "bmc",
    "ind",
    "ind2",
    "ic3",
    "invgents",
    "invgenos",
    "invgenintos",
    "invgenintos"
  ],
  "timeout" : 0.000000,
  "bmcMax" : 0,
  "compositional" : false,
  "modular" : false
}
,
{
  "objectType" : "log",
  "level" : "error",
  "source" : "parse",
  "line" : 51,
  "column" : 40,
  "value" : "Syntax Error! Perhaps a missing or incomplete `return` clause in node specification.\n"
}
]
```

- XML

```
$ bin/kind2 -xml -- tests/lustre/StopWatchSpec.lus
<?xml version="1.0"?>
<Results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" enabled="bmc,ind,ind2,ic3,invgents,invgenos,invgenintos,invgenintos" timeout="0.000000" bmc_max="0" compositional="false" modular="false">


<Log class="info" source="parse">kind2 d991734</Log>
<Log class="error" source="parse" line="51" column="40">Syntax Error! Perhaps a missing or incomplete `return` clause in node specification.
</Log>


</Results>
```


### Syntax errors in included file

#### Lexing Error

- TEXT

```
$ bin/kind2 -- tests/lustre/StopWatchSpec.lus
 kind2 d991734

<Error> contract_stopwatch_spec.lus:10:16: Failure cause: Unrecognized token % (0x25)
```

- JSON

```
$ bin/kind2 -json -- tests/lustre/StopWatchSpec.lus
[
{
  "objectType" : "log",
  "level" : "info",
  "source" : "parse",
  "value" : "kind2 d991734"
}
,
{
  "objectType" : "kind2Options",
  "enabled" :
  [
    "bmc",
    "ind",
    "ind2",
    "ic3",
    "invgents",
    "invgenos",
    "invgenintos",
    "invgenintos"
  ],
  "timeout" : 0.000000,
  "bmcMax" : 0,
  "compositional" : false,
  "modular" : false
}
,
{
  "objectType" : "log",
  "level" : "error",
  "source" : "parse",
  "file" : "contract_stopwatch_spec.lus",
  "line" : 10,
  "column" : 16,
  "value" : "Unrecognized token % (0x25)"
}
]
```

- XML

```
$ bin/kind2 -xml -- tests/lustre/StopWatchSpec.lus
<?xml version="1.0"?>
<Results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" enabled="bmc,ind,ind2,ic3,invgents,invgenos,invgenintos,invgenintos" timeout="0.000000" bmc_max="0" compositional="false" modular="false">


<Log class="info" source="parse">kind2 d991734</Log>
<Log class="error" source="parse" line="10" column="16" file="contract_stopwatch_spec.lus">Unrecognized token % (0x25)</Log>


</Results>
```


#### Generic parser error

- TEXT

```
$ bin/kind2 -- tests/lustre/StopWatchSpec.lus
 kind2 d991734

<Error> contract_stopwatch_spec.lus:4:48: Failure cause: Syntax Error!

```

- JSON

```
$ bin/kind2 -json -- tests/lustre/StopWatchSpec.lus
[
{
  "objectType" : "log",
  "level" : "info",
  "source" : "parse",
  "value" : "kind2 d991734"
}
,
{
  "objectType" : "kind2Options",
  "enabled" :
  [
    "bmc",
    "ind",
    "ind2",
    "ic3",
    "invgents",
    "invgenos",
    "invgenintos",
    "invgenintos"
  ],
  "timeout" : 0.000000,
  "bmcMax" : 0,
  "compositional" : false,
  "modular" : false
}
,
{
  "objectType" : "log",
  "level" : "error",
  "source" : "parse",
  "file" : "contract_stopwatch_spec.lus",
  "line" : 4,
  "column" : 48,
  "value" : "Syntax Error!\n"
}
]
```

- XML

```
$ bin/kind2 -xml -- tests/lustre/StopWatchSpec.lus
<?xml version="1.0"?>
<Results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" enabled="bmc,ind,ind2,ic3,invgents,invgenos,invgenintos,invgenintos" timeout="0.000000" bmc_max="0" compositional="false" modular="false">


<Log class="info" source="parse">kind2 d991734</Log>
<Log class="error" source="parse" line="4" column="48" file="contract_stopwatch_spec.lus">Syntax Error!
</Log>


</Results>
```
