### PR TITLE
Add support for Boolector as a backend engine for Kind2.

### DIFF
--- a/src/flags.ml
+++ b/src/flags.ml
@@ -233,10 +233,10 @@ module Smt = struct
   let short_names () = !short_names
 
   (* Boolector binary. *)
-  let boolector_bin_default = "Boolector"
+  let boolector_bin_default = "boolector"
   let boolector_bin = ref boolector_bin_default
   let _ = add_spec
-    "--Boolector_bin"
+    "--boolector_bin"
     (Arg.Set_string boolector_bin)
     (fun fmt ->
       Format.fprintf fmt
@@ -355,11 +355,6 @@ module Smt = struct
     (* User did not choose SMT solver *)
     | `detect ->
       try
-        let exec = find_solver ~fail:false "Boolector" (boolector_bin ()) in
-        set_solver `Boolector_SMTLIB;
-        set_boolector_bin exec;
-      with Not_found ->
-      try
         let exec = find_solver ~fail:false "Z3" (z3_bin ()) in
         set_solver `Z3_SMTLIB;
         set_z3_bin exec;
@@ -378,6 +373,11 @@ module Smt = struct
         let exec = find_solver ~fail:false "Yices" (yices_bin ()) in
         set_solver `Yices_native;
         set_yices_bin exec;
+      with Not_found ->
+      try
+        let exec = find_solver ~fail:false "Boolector" (boolector_bin ()) in
+        set_solver `Boolector_SMTLIB;
+        set_boolector_bin exec;
       with Not_found ->
         Log.log L_fatal "No SMT Solver found.";
         exit 2

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -138,7 +138,7 @@ module Smt = struct
     | `Yices_SMTLIB -> "Yices2"
     | `Yices_native -> "Yices"
     | `detect -> "detect"
-  let solver_values = "Boolector, Z3, CVC4, Yices, Yices2"
+  let solver_values = "Z3, CVC4, Yices, Yices2, Boolector"
   let solver_default = `detect
   let solver = ref solver_default
   let _ = add_spec

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -117,6 +117,7 @@ module Smt = struct
 
   (* Active SMT solver. *)
   type solver = [
+    | `Boolector_SMTLIB
     | `Z3_SMTLIB
     | `CVC4_SMTLIB
     | `Yices_SMTLIB
@@ -124,18 +125,20 @@ module Smt = struct
     | `detect
   ]
   let solver_of_string = function
+    | "Boolector" -> `Boolector_SMTLIB
     | "Z3" -> `Z3_SMTLIB
     | "CVC4" -> `CVC4_SMTLIB
     | "Yices2" -> `Yices_SMTLIB
     | "Yices" -> `Yices_native
     | _ -> Arg.Bad "Bad value for --smt_solver" |> raise
   let string_of_solver = function
+    | `Boolector_SMTLIB -> "Boolector"
     | `Z3_SMTLIB -> "Z3"
     | `CVC4_SMTLIB -> "CVC4"
     | `Yices_SMTLIB -> "Yices2"
     | `Yices_native -> "Yices"
     | `detect -> "detect"
-  let solver_values = "Z3, CVC4, Yices, Yices2"
+  let solver_values = "Boolector, Z3, CVC4, Yices, Yices2"
   let solver_default = `detect
   let solver = ref solver_default
   let _ = add_spec
@@ -229,6 +232,20 @@ module Smt = struct
   let set_short_names b = short_names := b
   let short_names () = !short_names
 
+  (* Boolector binary. *)
+  let boolector_bin_default = "Boolector"
+  let boolector_bin = ref boolector_bin_default
+  let _ = add_spec
+    "--Boolector_bin"
+    (Arg.Set_string boolector_bin)
+    (fun fmt ->
+      Format.fprintf fmt
+        "@[<v>Executable of Boolector solver@ Default: \"%s\"@]"
+        boolector_bin_default
+    )
+  let set_boolector_bin str = boolector_bin := str
+  let boolector_bin () = !boolector_bin
+
   (* Z3 binary. *)
   let z3_bin_default = "z3"
   let z3_bin = ref z3_bin_default
@@ -320,6 +337,9 @@ module Smt = struct
   
   (* Check which SMT solver is available *)
   let check_smtsolver () = match solver () with
+    (* User chose Boolector *)
+    | `Boolector_SMTLIB ->
+      find_solver ~fail:true "Boolector" (boolector_bin ()) |> ignore
     (* User chose Z3 *)
     | `Z3_SMTLIB ->
       find_solver ~fail:true "Z3" (z3_bin ()) |> ignore
@@ -334,6 +354,11 @@ module Smt = struct
       find_solver ~fail:true "Yices2 SMT2" (yices2smt2_bin ()) |> ignore
     (* User did not choose SMT solver *)
     | `detect ->
+      try
+        let exec = find_solver ~fail:false "Boolector" (boolector_bin ()) in
+        set_solver `Boolector_SMTLIB;
+        set_boolector_bin exec;
+      with Not_found ->
       try
         let exec = find_solver ~fail:false "Z3" (z3_bin ()) in
         set_solver `Z3_SMTLIB;
@@ -3154,6 +3179,18 @@ let solver_dependant_actions () =
   in
 
   match Smt.solver () with
+  | `Boolector_SMTLIB -> (
+    let cmd = Format.asprintf "%s --version" (Smt.boolector_bin ()) in
+    match get_version false cmd with
+    | Some (major_rev, minor_rev, _) ->
+      if major_rev < 3 then (
+        if Smt.check_sat_assume () then (
+          Log.log L_warn "Detected Boolector 2.4.1 or older: disabling check_sat_assume";
+          Smt.set_check_sat_assume false
+        )
+      )
+    | None -> Log.log L_warn "Couldn't determine Boolector version"
+  )
   | `Z3_SMTLIB -> (
     let cmd = Format.asprintf "%s -version" (Smt.z3_bin ()) in
     match get_version false cmd with

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -229,6 +229,7 @@ module Smt : sig
 
   (** Legal SMT solvers. *)
   type solver = [
+    | `Boolector_SMTLIB
     | `Z3_SMTLIB
     | `CVC4_SMTLIB
     | `Yices_SMTLIB

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -254,6 +254,9 @@ module Smt : sig
   (** Change sending of short names to SMT solver *)
   val set_short_names : bool -> unit
 
+  (** Executable of Boolector solver *)
+  val boolector_bin : unit -> string
+
   (** Executable of Z3 solver *)
   val z3_bin : unit -> string
 

--- a/src/ic3/IC3.ml
+++ b/src/ic3/IC3.ml
@@ -3015,11 +3015,18 @@ let main_ic3 input_sys aparam trans_sys =
   Stat.start_timer Stat.ic3_total_time;
 
   (* Determine logic for the SMT solver: add LIA for some clauses of IC3 *)
-  let logic = match TransSys.get_logic trans_sys with
-    | `Inferred fs ->
-      `Inferred
-        (TermLib.FeatureSet.add TermLib.IA
-           (TermLib.FeatureSet.add TermLib.LA fs))
+  let logic =
+    let open TermLib.FeatureSet in
+    match TransSys.get_logic trans_sys with
+    | `Inferred fs when mem BV fs ->
+        raise
+          (UnsupportedFeature
+             "Disabling IC3: The current implementation does not support BV \
+              problems.")
+    | `Inferred fs when not (subset fs (of_list [ Q; UF; A ])) ->
+        `Inferred
+          (TermLib.FeatureSet.add TermLib.IA
+             (TermLib.FeatureSet.add TermLib.LA fs))
     | l -> l
   in
 

--- a/src/induction/compress.ml
+++ b/src/induction/compress.ml
@@ -193,7 +193,7 @@ let only_bv trans_sys =
   | `SMTLogic "QF_AUFBV" -> true
   | `SMTLogic _
   | `None -> false
-  | `Inferred l -> TermLib.FeatureSet.(mem BV l && not(mem IA l))
+  | `Inferred l -> TermLib.FeatureSet.(subset l (of_list [ Q; UF; A; BV ]))
 
 
 (* Declare uninterpreted function symbol *)

--- a/src/induction/step.ml
+++ b/src/induction/step.ml
@@ -622,15 +622,17 @@ let launch input_sys aparam trans =
     (TransSys.props_list_of_bound trans Numeral.zero)
   in
 
-  (* compression uses integers and uf *)
+  (* compression uses bitvectors/integers and uf *)
   let logic =
     match TransSys.get_logic trans with
     | `Inferred fs when Flags.BmcKind.compress () ->
-      `Inferred
-        TermLib.FeatureSet.(sup_logics [fs; of_list [IA; LA; UF]])
+        let open TermLib.FeatureSet in
+        if subset fs (of_list [ Q; UF; A; BV ]) then
+          `Inferred (sup_logics [ fs; of_list [ BV; UF ] ])
+        else `Inferred (sup_logics [ fs; of_list [ IA; LA; UF ] ])
     | l -> l
   in
-    
+
   (* Creating solver. *)
   let solver =
     SMTSolver.create_instance ~produce_assignments:true

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -1778,6 +1778,10 @@ let mk_to_int expr = mk_unary eval_to_int type_of_to_int expr
 
 (* ********************************************************************** *)
 
+let is_negative term = match Term.destruct term with
+  | Term.T.App (s, _) when s == Symbol.s_minus -> true
+  | _ -> false
+
 (* Evaluate conversion to unsigned integer8 *)
 let eval_to_uint8 expr =
 
@@ -1786,7 +1790,12 @@ let eval_to_uint8 expr =
     | Term.T.Const c when Symbol.is_numeral c ->
 
       Term.mk_ubv (Bitvector.num_to_ubv8 (Symbol.numeral_of_symbol c))
-    
+
+    | Term.T.App (op, [ sub_expr ])
+      when is_negative expr && Term.is_numeral sub_expr ->
+        Term.mk_ubv
+          (Bitvector.num_to_ubv8 (Numeral.neg (Term.numeral_of_term sub_expr)))
+
     | _ -> let tt = Term.type_of_term expr in
             if (Type.is_int tt) then
               Term.mk_to_uint8 expr
@@ -1825,7 +1834,12 @@ let eval_to_uint16 expr =
     | Term.T.Const c when Symbol.is_numeral c ->
 
       Term.mk_ubv (Bitvector.num_to_ubv16 (Symbol.numeral_of_symbol c))
-    
+
+    | Term.T.App (op, [ sub_expr ])
+      when is_negative expr && Term.is_numeral sub_expr ->
+        Term.mk_ubv
+          (Bitvector.num_to_ubv16 (Numeral.neg (Term.numeral_of_term sub_expr)))
+
     | _ -> let tt = Term.type_of_term expr in
                       if (Type.is_int tt) then
                         Term.mk_to_uint16 expr
@@ -1865,7 +1879,12 @@ let eval_to_uint32 expr =
     | Term.T.Const c when Symbol.is_numeral c ->
 
       Term.mk_ubv (Bitvector.num_to_ubv32 (Symbol.numeral_of_symbol c))
-    
+
+    | Term.T.App (op, [ sub_expr ])
+      when is_negative expr && Term.is_numeral sub_expr ->
+        Term.mk_ubv
+          (Bitvector.num_to_ubv32 (Numeral.neg (Term.numeral_of_term sub_expr)))
+
     | _ -> let tt = Term.type_of_term expr in
             if (Type.is_int tt) then
               Term.mk_to_uint32 expr
@@ -1909,7 +1928,12 @@ let eval_to_uint64 expr =
     | Term.T.Const c when Symbol.is_numeral c ->
 
       Term.mk_ubv (Bitvector.num_to_ubv64 (Symbol.numeral_of_symbol c))
-    
+
+    | Term.T.App (op, [ sub_expr ])
+      when is_negative expr && Term.is_numeral sub_expr ->
+        Term.mk_ubv
+          (Bitvector.num_to_ubv64 (Numeral.neg (Term.numeral_of_term sub_expr)))
+
     | _ -> let tt = Term.type_of_term expr in
             if (Type.is_int tt) then
               Term.mk_to_uint64 expr
@@ -1951,7 +1975,12 @@ let eval_to_int8 expr =
     | Term.T.Const c when Symbol.is_numeral c ->
 
       Term.mk_bv (Bitvector.num_to_bv8 (Symbol.numeral_of_symbol c))
-    
+
+    | Term.T.App (op, [ sub_expr ])
+      when is_negative expr && Term.is_numeral sub_expr ->
+        Term.mk_ubv
+          (Bitvector.num_to_bv8 (Numeral.neg (Term.numeral_of_term sub_expr)))
+
     | _ -> let tt = Term.type_of_term expr in
             if (Type.is_int tt) then
               Term.mk_to_int8 expr
@@ -1990,7 +2019,12 @@ let eval_to_int16 expr =
     | Term.T.Const c when Symbol.is_numeral c ->
 
       Term.mk_bv (Bitvector.num_to_bv16 (Symbol.numeral_of_symbol c))
-    
+
+    | Term.T.App (op, [ sub_expr ])
+      when is_negative expr && Term.is_numeral sub_expr ->
+        Term.mk_ubv
+          (Bitvector.num_to_bv16 (Numeral.neg (Term.numeral_of_term sub_expr)))
+
     | _ -> let tt = Term.type_of_term expr in
             if (Type.is_int tt) then
               Term.mk_to_int16 expr
@@ -2030,7 +2064,12 @@ let eval_to_int32 expr =
     | Term.T.Const c when Symbol.is_numeral c ->
 
       Term.mk_bv (Bitvector.num_to_bv32 (Symbol.numeral_of_symbol c))
-    
+
+    | Term.T.App (op, [ sub_expr ])
+      when is_negative expr && Term.is_numeral sub_expr ->
+        Term.mk_ubv
+          (Bitvector.num_to_bv32 (Numeral.neg (Term.numeral_of_term sub_expr)))
+
     | _ -> let tt = Term.type_of_term expr in
             if (Type.is_int tt) then
               Term.mk_to_int32 expr
@@ -2072,7 +2111,12 @@ let eval_to_int64 expr =
     | Term.T.Const c when Symbol.is_numeral c ->
 
       Term.mk_bv (Bitvector.num_to_bv64 (Symbol.numeral_of_symbol c))
-    
+
+    | Term.T.App (op, [ sub_expr ])
+      when is_negative expr && Term.is_numeral sub_expr ->
+        Term.mk_ubv
+          (Bitvector.num_to_bv64 (Numeral.neg (Term.numeral_of_term sub_expr)))
+
     | _ -> let tt = Term.type_of_term expr in
             if (Type.is_int tt) then
               Term.mk_to_int64 expr

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -1778,9 +1778,6 @@ let mk_to_int expr = mk_unary eval_to_int type_of_to_int expr
 
 (* ********************************************************************** *)
 
-let is_negative term = match Term.destruct term with
-  | Term.T.App (s, _) when s == Symbol.s_minus -> true
-  | _ -> false
 
 (* Evaluate conversion to unsigned integer8 *)
 let eval_to_uint8 expr =
@@ -1791,8 +1788,8 @@ let eval_to_uint8 expr =
 
       Term.mk_ubv (Bitvector.num_to_ubv8 (Symbol.numeral_of_symbol c))
 
-    | Term.T.App (op, [ sub_expr ])
-      when is_negative expr && Term.is_numeral sub_expr ->
+    | Term.T.App (_, [ sub_expr ])
+      when Term.is_negative_numeral expr ->
         Term.mk_ubv
           (Bitvector.num_to_ubv8 (Numeral.neg (Term.numeral_of_term sub_expr)))
 
@@ -1835,8 +1832,8 @@ let eval_to_uint16 expr =
 
       Term.mk_ubv (Bitvector.num_to_ubv16 (Symbol.numeral_of_symbol c))
 
-    | Term.T.App (op, [ sub_expr ])
-      when is_negative expr && Term.is_numeral sub_expr ->
+    | Term.T.App (_, [ sub_expr ])
+      when Term.is_negative_numeral expr ->
         Term.mk_ubv
           (Bitvector.num_to_ubv16 (Numeral.neg (Term.numeral_of_term sub_expr)))
 
@@ -1880,8 +1877,8 @@ let eval_to_uint32 expr =
 
       Term.mk_ubv (Bitvector.num_to_ubv32 (Symbol.numeral_of_symbol c))
 
-    | Term.T.App (op, [ sub_expr ])
-      when is_negative expr && Term.is_numeral sub_expr ->
+    | Term.T.App (_, [ sub_expr ])
+      when Term.is_negative_numeral expr ->
         Term.mk_ubv
           (Bitvector.num_to_ubv32 (Numeral.neg (Term.numeral_of_term sub_expr)))
 
@@ -1929,8 +1926,8 @@ let eval_to_uint64 expr =
 
       Term.mk_ubv (Bitvector.num_to_ubv64 (Symbol.numeral_of_symbol c))
 
-    | Term.T.App (op, [ sub_expr ])
-      when is_negative expr && Term.is_numeral sub_expr ->
+    | Term.T.App (_, [ sub_expr ])
+      when Term.is_negative_numeral expr ->
         Term.mk_ubv
           (Bitvector.num_to_ubv64 (Numeral.neg (Term.numeral_of_term sub_expr)))
 
@@ -1976,8 +1973,8 @@ let eval_to_int8 expr =
 
       Term.mk_bv (Bitvector.num_to_bv8 (Symbol.numeral_of_symbol c))
 
-    | Term.T.App (op, [ sub_expr ])
-      when is_negative expr && Term.is_numeral sub_expr ->
+    | Term.T.App (_, [ sub_expr ])
+      when Term.is_negative_numeral expr ->
         Term.mk_ubv
           (Bitvector.num_to_bv8 (Numeral.neg (Term.numeral_of_term sub_expr)))
 
@@ -2020,8 +2017,8 @@ let eval_to_int16 expr =
 
       Term.mk_bv (Bitvector.num_to_bv16 (Symbol.numeral_of_symbol c))
 
-    | Term.T.App (op, [ sub_expr ])
-      when is_negative expr && Term.is_numeral sub_expr ->
+    | Term.T.App (_, [ sub_expr ])
+      when Term.is_negative_numeral expr ->
         Term.mk_ubv
           (Bitvector.num_to_bv16 (Numeral.neg (Term.numeral_of_term sub_expr)))
 
@@ -2065,8 +2062,8 @@ let eval_to_int32 expr =
 
       Term.mk_bv (Bitvector.num_to_bv32 (Symbol.numeral_of_symbol c))
 
-    | Term.T.App (op, [ sub_expr ])
-      when is_negative expr && Term.is_numeral sub_expr ->
+    | Term.T.App (_, [ sub_expr ])
+      when Term.is_negative_numeral expr ->
         Term.mk_ubv
           (Bitvector.num_to_bv32 (Numeral.neg (Term.numeral_of_term sub_expr)))
 
@@ -2112,8 +2109,8 @@ let eval_to_int64 expr =
 
       Term.mk_bv (Bitvector.num_to_bv64 (Symbol.numeral_of_symbol c))
 
-    | Term.T.App (op, [ sub_expr ])
-      when is_negative expr && Term.is_numeral sub_expr ->
+    | Term.T.App (_, [ sub_expr ])
+      when Term.is_negative_numeral expr ->
         Term.mk_ubv
           (Bitvector.num_to_bv64 (Numeral.neg (Term.numeral_of_term sub_expr)))
 

--- a/src/smt/BoolectorDriver.ml
+++ b/src/smt/BoolectorDriver.ml
@@ -1,6 +1,6 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2020 by the Board of Trustees of the University of Iowa
 
    Licensed under the Apache License, Version 2.0 (the "License"); you
    may not use this file except in compliance with the License.  You

--- a/src/smt/BoolectorDriver.ml
+++ b/src/smt/BoolectorDriver.ml
@@ -1,0 +1,55 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+include GenericSMTLIBDriver
+
+(* Configuration for Boolector *)
+let cmd_line logic timeout produce_assignments produce_proofs produce_cores
+    minimize_cores produce_interpolants =
+  (* Path and name of Boolector executable *)
+  let boolector_bin = Flags.Smt.boolector_bin () in
+
+  (* Timeout based on Flags.timeout_wall has been disabled because
+     it seems to cause performance regressions on some models... *)
+  let timeout_global =
+    None
+    (* if Flags.timeout_wall () > 0.
+       then Some (Stat.remaining_timeout () +. 1.0)
+       else None*)
+  in
+  let timeout_local =
+    if timeout > 0 then Some (float_of_int timeout) else None
+  in
+  let timeout = Lib.min_option timeout_global timeout_local in
+
+  let base_cmd = [| boolector_bin; "--smt2"; "--incremental" |] in
+  match timeout with
+  | None -> base_cmd
+  | Some timeout ->
+      let timeout = Format.sprintf "--time=%.0f" (timeout |> ceil) in
+      Array.append base_cmd [| timeout |]
+
+(* Command to limit check-sat in Z3 to run for the given numer of ms
+   at most *)
+let check_sat_limited_cmd ms =
+  failwith "check-sat with timeout not implemented for Boolector"
+
+(*TODO: modify to use QFBV/BV *)
+let string_of_logic l = GenericSMTLIBDriver.string_of_logic l
+
+let pp_print_logic fmt l = Format.pp_print_string fmt (string_of_logic l)

--- a/src/smt/BoolectorDriver.ml
+++ b/src/smt/BoolectorDriver.ml
@@ -49,7 +49,23 @@ let cmd_line logic timeout produce_assignments produce_proofs produce_cores
 let check_sat_limited_cmd ms =
   failwith "check-sat with timeout not implemented for Boolector"
 
-(*TODO: modify to use QFBV/BV *)
-let string_of_logic l = GenericSMTLIBDriver.string_of_logic l
+let string_of_logic l =
+  let open TermLib in
+  let open TermLib.FeatureSet in
+  match l with
+  | `Inferred fs ->
+      if mem IA fs || mem RA fs then
+        failwith "Boolector only supports BV logics"
+      else
+        (* We add BV because Boolector does not support UF and QF_UF logics *)
+        GenericSMTLIBDriver.string_of_logic (`Inferred (add BV fs))
+  | `None -> "ALL"
+  | `SMTLogic s ->
+      if String.contains s 'I' || String.contains s 'R' then
+        failwith "Boolector only supports BV logics"
+      else if not (String.contains s 'B') then
+        (* We add BV because Boolector does not support UF and QF_UF logics *)
+        String.concat "" [ s; "BV" ]
+      else s
 
 let pp_print_logic fmt l = Format.pp_print_string fmt (string_of_logic l)

--- a/src/smt/BoolectorDriver.ml
+++ b/src/smt/BoolectorDriver.ml
@@ -57,14 +57,14 @@ let string_of_logic l =
       if mem IA fs || mem RA fs then
         failwith "Boolector only supports BV logics"
       else
-        (* We add BV because Boolector does not support UF and QF_UF logics *)
+        (* We add BV because Boolector does not support QF_UF logic *)
         GenericSMTLIBDriver.string_of_logic (`Inferred (add BV fs))
   | `None -> "ALL"
   | `SMTLogic s ->
       if String.contains s 'I' || String.contains s 'R' then
         failwith "Boolector only supports BV logics"
       else if not (String.contains s 'B') then
-        (* We add BV because Boolector does not support UF and QF_UF logics *)
+        (* We add BV because Boolector does not support QF_UF logic *)
         String.concat "" [ s; "BV" ]
       else s
 

--- a/src/smt/SMTSolver.ml
+++ b/src/smt/SMTSolver.ml
@@ -36,6 +36,7 @@ let gentag =
 
 
 (* Instantiate module for SMTLIB2 solvers with drivers *)
+module BoolectorSMTLIB : SolverSig.S = SMTLIBSolver.Make (BoolectorDriver)
 module Z3SMTLIB : SolverSig.S = SMTLIBSolver.Make (Z3Driver)
 module CVC4SMTLIB : SolverSig.S = SMTLIBSolver.Make (CVC4Driver)
 module Yices2SMTLIB : SolverSig.S = SMTLIBSolver.Make (Yices2SMT2Driver)
@@ -153,6 +154,7 @@ let create_instance
   (* Module for solver from options *)
   let fomodule =
     match kind with
+    | `Boolector_SMTLIB -> (module BoolectorSMTLIB.Create(Params) : SolverSig.Inst)
     | `Z3_SMTLIB -> (module Z3SMTLIB.Create(Params) : SolverSig.Inst)
     | `CVC4_SMTLIB -> (module CVC4SMTLIB.Create(Params) : SolverSig.Inst)
     | `Yices_SMTLIB ->  (module Yices2SMTLIB.Create(Params) : SolverSig.Inst)

--- a/src/terms/term.ml
+++ b/src/terms/term.ml
@@ -228,6 +228,12 @@ let rec is_numeral t = match destruct t with
 
   | _ -> false
 
+
+(** Return true if the term is a negative integer constant *)
+let is_negative_numeral term = match T.destruct term with
+  | T.App (s, [ sub_expr ]) -> s == Symbol.s_minus && is_numeral sub_expr
+  | _ -> false
+
 (* NOTE: Use these if you want to check whether
 the bitvector is a constant. If you want 
 to differentiate between signed and 

--- a/src/terms/term.mli
+++ b/src/terms/term.mli
@@ -500,6 +500,9 @@ val name_of_named : t -> int
 (** Return true if the term is an integer constant *)
 val is_numeral : t -> bool
 
+(** Return true if the term is a negative integer constant *)
+val is_negative_numeral : t -> bool
+
 (** Return integer constant of a term *)
 val numeral_of_term : t -> Numeral.t
 

--- a/src/terms/termLib.ml
+++ b/src/terms/termLib.ml
@@ -245,7 +245,7 @@ let pp_print_features fmt l =
   if L.mem NA l then fprintf fmt "N"
   else if L.mem LA l || L.mem IA l || L.mem RA l then fprintf fmt "L";
   if L.mem IA l then fprintf fmt "I";
-  if L.mem RA l then fprintf fmt "R"; 
+  if L.mem RA l then fprintf fmt "R";
   if L.mem IA l || L.mem RA l then fprintf fmt "A"
 
 
@@ -256,19 +256,23 @@ type logic = [ `None | `Inferred of features | `SMTLogic of string ]
 
 let pp_print_logic fmt = function
   | `None -> pp_print_string fmt "ALL"
-  | `Inferred l -> if (L.mem BV l) then 
-                    pp_print_string fmt "ALL"
-                   else 
-                    pp_print_features fmt l
+  | `Inferred l ->
+      if
+        L.mem BV l
+        && not (L.is_empty (L.inter l (L.of_list [ IA; RA; LA; NA ])))
+      then pp_print_string fmt "ALL"
+      else pp_print_features fmt l
   | `SMTLogic s -> pp_print_string fmt (if s = "" then "ALL" else s)
 
 
 let string_of_logic = function
   | `None -> "ALL"
-  | `Inferred l -> if (L.mem BV l) then 
-                    "ALL"
-                   else
-                    string_of_features l
+  | `Inferred l ->
+      if
+        L.mem BV l
+        && not (L.is_empty (L.inter l (L.of_list [ IA; RA; LA; NA ])))
+      then "ALL"
+      else string_of_features l
   | `SMTLogic s -> if s = "" then "ALL" else s
 
 

--- a/src/terms/termLib.ml
+++ b/src/terms/termLib.ml
@@ -262,12 +262,7 @@ let pp_print_logic fmt = function
   | `SMTLogic s -> pp_print_string fmt (if s = "" then "ALL" else s)
 
 
-let string_of_logic = function
-  | `None -> "ALL"
-  | `Inferred l ->
-      if L.mem BV l && (L.mem IA l || L.mem RA l) then "ALL"
-      else string_of_features l
-  | `SMTLogic s -> if s = "" then "ALL" else s
+let string_of_logic l = asprintf "%a" pp_print_logic l
 
 
 let logic_allow_arrays = function

--- a/src/terms/termLib.ml
+++ b/src/terms/termLib.ml
@@ -257,10 +257,7 @@ type logic = [ `None | `Inferred of features | `SMTLogic of string ]
 let pp_print_logic fmt = function
   | `None -> pp_print_string fmt "ALL"
   | `Inferred l ->
-      if
-        L.mem BV l
-        && not (L.is_empty (L.inter l (L.of_list [ IA; RA; LA; NA ])))
-      then pp_print_string fmt "ALL"
+      if L.mem BV l && (L.mem IA l || L.mem RA l) then pp_print_string fmt "ALL"
       else pp_print_features fmt l
   | `SMTLogic s -> pp_print_string fmt (if s = "" then "ALL" else s)
 
@@ -268,10 +265,7 @@ let pp_print_logic fmt = function
 let string_of_logic = function
   | `None -> "ALL"
   | `Inferred l ->
-      if
-        L.mem BV l
-        && not (L.is_empty (L.inter l (L.of_list [ IA; RA; LA; NA ])))
-      then "ALL"
+      if L.mem BV l && (L.mem IA l || L.mem RA l) then "ALL"
       else string_of_features l
   | `SMTLogic s -> if s = "" then "ALL" else s
 


### PR DESCRIPTION
This PR adds support for Boolector (an SMT solver) for Lustre problems with only machine integers. Since Boolector does not support IA/RA, an error is printed when those sub-logics are detected and Boolector is selected as the backend engine. Techniques using IA/RA are either disabled or modified to work with BV too. Finally, QF_UF logic is expanded to QF_UFBV as the former is not supported by Boolector.