### PR TITLE
Qualified names for Lustre Identifiers

### DIFF
--- a/src/lustre/contractsToProps.ml
+++ b/src/lustre/contractsToProps.ml
@@ -89,7 +89,7 @@ let rec collect_contracts (locals, asserts, props) = function
       in
       locals, asserts, props
 
-    | Ast.ContractCall (pos,_,_,_) ->
+    | Ast.ContractCall (pos,_,_,_,_) ->
       Format.asprintf "\
         [contracts translator] %a: contract calls are unsupported\
       " pp_print_pos pos

--- a/src/lustre/contractsToProps.ml
+++ b/src/lustre/contractsToProps.ml
@@ -19,6 +19,7 @@
 open Lib
 
 module Ast = LustreAst
+module QId = LustreAstIdent
            
 let blah txt pos = Format.asprintf "%s at %a" txt pp_print_pos pos
 let blah_opt txt name pos =
@@ -78,7 +79,7 @@ let rec collect_contracts (locals, asserts, props) = function
               blah
                 (Format.sprintf "%s from mode %s"
                   (blah_opt "Ensure" e_name e_pos)
-                  name
+                  (QId.to_string name)
                 )
                 pos,
               reqs,

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -267,7 +267,7 @@ type contract_mode =
   position * ident * (contract_require list) * (contract_ensure list)
 
 (* A contract call. *)
-type contract_call = position * ident * expr list * ident list
+type contract_call = position * ident * expr list * ident list * ident
 
 (* Equations that can appear in a contract node. *)
 type contract_node_equation =
@@ -1049,12 +1049,13 @@ let pp_print_contract_mode ppf (_, id, reqs, enss) =
     (pp_print_list pp_print_contract_ensure "@ ") enss
     (cond_new_line ((reqs,enss) <> ([],[]))) ()
 
-let pp_print_contract_call fmt (_, id, in_params, out_params) =
+let pp_print_contract_call fmt (_, id, in_params, out_params, id') =
   Format.fprintf
-    fmt "@[<hov 2>import %a (@,%a@,) returns (@,%a@,) ;@]"
+    fmt "@[<hov 2>import %a (@,%a@,) returns (@,%a@,) as %a;@]"
     QId.pp_print_ident id
     (pp_print_list pp_print_expr ", ") in_params
     (pp_print_list QId.pp_print_ident ", ") out_params
+    QId.pp_print_ident id'
 
 let all_empty = List.for_all (fun l -> l = [])
 

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -330,7 +330,15 @@ type declaration =
 
 (* A Lustre program *)
 type t = declaration list
+(* TODO: This is not a module that contains a list of declarations. i.e 
+package <package name>
 
+<list of imported packages>
+
+<list of declarations>
+
+end
+ *)
 
 (* ********************************************************************** *)
 (* Pretty-printing functions                                              *)

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -321,15 +321,18 @@ type declaration =
 
 (* A Lustre program *)
 type t = declaration list
-(* TODO: This is not a module that contains a list of declarations. i.e 
+
+(* TODO: This is now a module that contains a list of declarations. i.e 
+
 package <package name>
 
-<list of imported packages>
+  <list of imported packages>
 
-<list of declarations>
+  <list of declarations>
 
 end
- *)
+
+*)
 
 (* ********************************************************************** *)
 (* Pretty-printing functions                                              *)

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -87,7 +87,7 @@ type group_expr =
 and expr =
   (* Identifiers *)
   | Ident of position * ident
-  | ModeRef of position * ident list
+  | ModeRef of position * ident
   | RecordProject of position * expr * index
   | TupleProject of position * expr * int
   (* Values *)
@@ -409,10 +409,9 @@ let rec pp_print_expr ppf =
     
     | Ident (p, id) -> Format.fprintf ppf "%a%a" ppos p LustreAstIdent.pp_print_ident id
 
-    | ModeRef (p, ids) ->
-      Format.fprintf ppf "%a::%a" ppos p (
-        pp_print_list pp_print_ident "::"
-      ) ids
+    | ModeRef (p, ids) -> 
+      Format.fprintf ppf "::%a%a" ppos p
+        QId.pp_print_ident ids
  
     | GroupExpr (p, ExprList, l) -> Format.fprintf ppf "%a@[<hv 1>(%a)@]" ppos p pl l
 

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -28,16 +28,6 @@ exception Parser_error
 
 (* An identifier *)
 type ident = string
-
-module SI = struct
-  include (Set.Make (struct
-               type t = ident
-               let compare = Stdlib.compare
-             end))
-  let flatten: t list -> t = fun sets ->
-    List.fold_left union empty sets
-end
-
            
 type index = string
 

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -270,7 +270,7 @@ type contract_mode =
   position * ident * (contract_require list) * (contract_ensure list)
 
 (* A contract call. *)
-type contract_call = position * ident * expr list * ident list
+type contract_call = position * ident * expr list * ident list * ident
 
 (* Equations that can appear in a contract node. *)
 type contract_node_equation =

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -126,7 +126,7 @@ type lustre_type =
 and expr =
   (* Identifiers *)
   | Ident of position * ident
-  | ModeRef of position * ident list
+  | ModeRef of position * ident
   | RecordProject of position * expr * index
   | TupleProject of position * expr * int
   (* Values *)

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -38,8 +38,9 @@
 
     @author Christoph Sticksel *)
 
-open Lib
 module QId = LustreAstIdent
+open Lib
+
 (** Error while parsing *)
 exception Parser_error
 

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -39,14 +39,14 @@
     @author Christoph Sticksel *)
 
 open Lib
-
+module QId = LustreAstIdent
 (** Error while parsing *)
 exception Parser_error
 
 (** {1 Types} *)
 
 (** An identifier *)
-type ident = string
+type ident = QId.t
 
 (** A single index *)
 type index = string

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -48,11 +48,6 @@ exception Parser_error
 (** An identifier *)
 type ident = string
 
-module SI: sig
-  include (Set.S with type elt = ident)
-  val flatten: t list -> t
-end
-
 (** A single index *)
 type index = string
 

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -348,7 +348,7 @@ let rec get_node_call_from_expr: LA.expr -> (QId.t * Lib.position) list
 
 let  mk_graph_contract_node_eqn: LA.contract_node_equation -> dependency_analysis_data
   = function
-  | LA.ContractCall (pos, i, es, _) ->
+  | LA.ContractCall (pos, i, es, _, _) ->
      union_dependency_analysis_data
        (singleton_dependency_analysis_data contract_suffix i pos)
        (List.fold_left union_dependency_analysis_data empty_dependency_analysis_data
@@ -506,7 +506,7 @@ let rec mk_contract_eqn_map: LA.contract_node_equation IMap.t -> LA.contract -> 
     | (LA.GhostVar (UntypedConst (pos, i, _)) as gc) :: eqns
     | (LA.GhostVar (TypedConst (pos, i, _, _)) as gc) :: eqns -> 
      check_and_add m pos "" i gc >>= fun m' -> mk_contract_eqn_map m' eqns  
-  | (LA.ContractCall (pos, i, _, _ ) as cc ) :: eqns -> 
+  | (LA.ContractCall (pos, _, _, _, i) as cc ) :: eqns -> 
      check_and_add m pos contract_suffix i cc >>= fun m' -> mk_contract_eqn_map m' eqns  
   | (LA.Mode (pos, i, _, _) as mode) :: eqns ->
      check_and_add m pos mode_suffix i mode >>= fun m' -> mk_contract_eqn_map m' eqns  
@@ -623,7 +623,7 @@ let rec mk_graph_expr2: node_summary -> LA.expr -> dependency_analysis_data list
 let mk_graph_contract_node_eqn2: dependency_analysis_data -> LA.contract_node_equation -> dependency_analysis_data
   = fun ad ->
   function
-  | LA.ContractCall (pos, i, es, _) ->
+  | LA.ContractCall (pos, _, es, _, i) ->
      connect_g_pos 
        (List.fold_left union_dependency_analysis_data ad
           (List.map (fun e -> mk_graph_expr (LH.abstract_pre_subexpressions e)) es))
@@ -681,7 +681,7 @@ let mk_graph_contract_eqns: node_summary -> LA.contract -> dependency_analysis_d
        connect_g_pos g (QId.add_prefix mode_suffix i) pos 
     | LA.Assume _ 
       | LA.Guarantee _ -> empty_dependency_analysis_data 
-    | LA.ContractCall (_, i, ip_exps, ops) -> empty_dependency_analysis_data 
+    | LA.ContractCall (_, i, ip_exps, ops, _) -> empty_dependency_analysis_data 
   in
   fun eqns ->
   List.fold_left union_dependency_analysis_data empty_dependency_analysis_data (List.map mk_graph eqns)
@@ -953,7 +953,7 @@ let get_contract_exports: contract_summary -> LA.contract_node_equation -> LA.id
     | LA.GhostVar (LA.UntypedConst (_, i, _))
     | LA.GhostVar (LA.TypedConst (_, i, _, _)) -> [i]
   | LA.Mode (_, i, _, _) -> [i]
-  | LA.ContractCall (_, cc, _, _) ->
+  | LA.ContractCall (_, cc, _, _, _) ->
      (match (IMap.find_opt cc m) with
      | Some ids -> List.map (fun i -> QId.add_qualified_prefix (QId.to_string cc) i) ids
      | None -> failwith ("Undeclared contract " ^ QId.to_string cc ^ ". Should not happen!"))  

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -622,8 +622,8 @@ let rec mk_graph_expr2: node_summary -> LA.expr -> dependency_analysis_data list
 
 let rec mk_graph_expr3: LA.expr -> dependency_analysis_data
   = function
-  | LA.Ident (pos, i) ->
-     (match QId.path i with
+  | LA.Ident (pos, i) -> 
+     (match QId.get_parent i with
       | None -> singleton_dependency_analysis_data "" i pos
       | Some p -> singleton_dependency_analysis_data contract_suffix p pos) 
   | LA.Const _ -> empty_dependency_analysis_data

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -743,11 +743,13 @@ let sort_and_check_contract_eqns: dependency_analysis_data
     (try (R.ok (G.topological_sort ad'.graph_data)) with
      | Graph.CyclicGraphException ids ->
         if List.length ids > 1
-        then (match (find_id_pos ad'.id_pos_data (QId.from_string (List.hd ids))) with
+        then
+          let one_id = QId.from_string (List.hd ids) in
+          (match (find_id_pos ad'.id_pos_data one_id) with
               | None ->
                  Log.log L_trace "Position map: %a" pp_print_id_pos ad'.id_pos_data
-                 ; failwith ("Cyclic dependency found but Cannot find position for identifier "
-                                  ^ (List.hd ids) ^ " This should not happen!") 
+                 ; failwith ("Cyclic dependency found but cannot find position for identifier "
+                                  ^ (QId.to_string one_id) ^ " This should not happen!") 
               | Some p -> graph_error p
                             ("Cyclic dependency detected in definition of identifiers: "
                              ^ Lib.string_of_t (Lib.pp_print_list Format.pp_print_string ", ") ids))

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -799,7 +799,7 @@ let sort_and_check_contract_eqns: dependency_analysis_data
     >>= fun sorted_ids ->
 
     let equational_vars = List.filter (fun i -> not (QISet.mem i ids_to_skip)) (List.rev sorted_ids) in
-    let (to_sort_eqns, assums_grantees) = split_contract_eqations contract in
+    let (to_sort_eqns, assums_grantees) = split_contract_equations contract in
     mk_contract_eqn_map IMap.empty to_sort_eqns >>= fun eqn_map ->
 
     extract_decls (eqn_map, ad'.id_pos_data) equational_vars >>= fun contract' ->
@@ -842,9 +842,6 @@ let sort_declarations: LA.t -> LA.t graph_result
     runs a topological sort on the ids extracted from the map and then 
     returns the sorted declarations (or an error if circular dependency is detected)  *)
                         
-let sort_declarations decls =
-  sort_decls mk_decl_map mk_graph_decls decls
-(** Returns a topological order of declarations *)  
   
 (************************************************************************
  * Type 3. Dependency Analysis of contract equations and node equations *

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -35,7 +35,7 @@
 module R = Res
 module LA = LustreAst
 module LH = LustreAstHelpers
-module SI = LA.SI
+module SI = Ident.IdentSet
 
 type 'a graph_result = ('a, Lib.position * string) result  
 
@@ -802,7 +802,7 @@ let sort_declarations: LA.t -> LA.t graph_result
  * Type 3. Dependency Analysis of contract equations and node equations *
  ************************************************************************)
 
-let rec vars_with_flattened_nodes: node_summary -> LA.expr -> LA.SI.t = fun m ->
+let rec vars_with_flattened_nodes: (int list) IMap.t -> LA.expr -> SI.t = fun m ->
   function
   | Ident (_ , i) -> SI.singleton i 
   | ModeRef _ -> SI.empty
@@ -901,8 +901,8 @@ let mk_node_summary: node_summary -> LA.node_decl -> node_summary
   let ip_vars = List.map (fun o -> LH.extract_ip_ty o |> fst) ips in
   let node_equations = List.concat (List.map LH.extract_node_equation items) in
   let process_one_eqn = fun (LA.StructDef (_, lhss), e) ->
-    let lhs_vars = LA.SI.elements (LA.SI.flatten (List.map LH.vars_of_struct_item lhss)) in
-    let ms = List.map (Lib.flip IMap.singleton (LA.SI.elements (vars_with_flattened_nodes s e))) lhs_vars in
+    let lhs_vars = SI.elements (SI.flatten (List.map LH.vars_of_struct_item lhss)) in
+    let ms = List.map (Lib.flip IMap.singleton (SI.elements (vars_with_flattened_nodes s e))) lhs_vars in
     List.fold_left (IMap.union (fun k v1 v2 -> Some v2)) IMap.empty ms in
   
   let node_equation_dependency_map = List.fold_left (IMap.union (fun k v1 v2 -> Some v2)) IMap.empty

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -973,7 +973,6 @@ let move_node_to_last: ident -> declaration list -> declaration list =
   | Some (mn, ds') -> ds' @ [mn]
   | None -> failwith ("Could not find main node " ^ n)
 
-
 let sort_typed_ident: typed_ident list -> typed_ident list = fun ty_idents ->
   List.sort (fun (_,i1,_) (_,i2,_) -> Stdlib.compare i1 i2) ty_idents
 (** Sort identifiers  *)

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -581,7 +581,7 @@ let contract_node_equation_has_pre_or_arrow = function
       List.map (fun (_, _, e) -> has_pre_or_arrow e) enss
       |> some_of_list
   )
-| ContractCall (_, _, ins, _) ->
+| ContractCall (_, _, ins, _, _) ->
   some_of_list (List.map has_pre_or_arrow ins) 
 
 

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -19,8 +19,9 @@
 open Lib
 
 open LustreAst
-
-type iset = LustreAst.SI.t
+module SI = Ident.IdentSet
+          
+type iset = Ident.IdentSet.t
           
 let error_at_position pos msg =
   match Log.get_log_format () with

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -596,7 +596,7 @@ let contract_has_pre_or_arrow l =
 (** returns all identifiers from the [expr] ast*)
 let rec vars: expr -> qiset = function
   | Ident (_, i) -> QISet.singleton  i
-  | ModeRef (_, is) -> QISet.singleton (QId.from_list (List.map QId.to_string is))
+  | ModeRef (_, is) -> QISet.singleton is
   | RecordProject (_, e, _) -> vars e 
   | TupleProject (_, e, _) -> vars e
   (* Values *)

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -19,8 +19,9 @@
 (** Some helper functions on the surface level parsed AST *)
 
 open LustreAst
+module QId = LustreAstIdent
+module QISet = QId.IdentSet
 
-module SI = Ident.IdentSet
 (** {1 Helpers} *)
 
 val pos_of_expr : expr -> Lib.position
@@ -43,24 +44,24 @@ val node_local_decl_has_pre_or_arrow : node_local_decl -> Lib.position option
 val node_item_has_pre_or_arrow : node_item -> Lib.position option
 (** Checks whether a node equation has a `pre` or a `->`. *)
 
-val replace_lasts : string list -> string -> SI.t -> expr -> expr * SI.t
+val replace_lasts : QId.t list -> string -> QISet.t -> expr -> expr * QISet.t
 (** [replace_lasts allowed prefix acc e] replaces [last x] expressions in AST
     [e] by abstract identifiers prefixed with [prefix]. Only identifiers that
     appear in the list [allowed] are allowed to appear under a last. It returns
     the new AST expression and a set of identifers for which the last
     application was replaced. *)
 
-val vars: expr -> SI.t
+val vars: expr -> QISet.t
 (** returns all the [ident] that appear in the expr ast*)
 
-val vars_of_struct_item: struct_item -> SI.t
+val vars_of_struct_item: struct_item -> QISet.t
 (** returns all variables that appear in a [struct_item]   *)
 
-val vars_lhs_of_eqn: node_item -> SI.t
+val vars_lhs_of_eqn: node_item -> QISet.t
 (** returns all the variables that appear in the lhs of the equation of the node body *)
 
-val vars_of_ty_ids: typed_ident -> SI.t
-(**  returns all the variables that occur in the expression of a typed identifier declaration *)
+val var_of_ty_id: typed_ident -> QId.t
+(**  returns the variables that occurs the typed identifier expression declaration *)
 
 val add_exp: Lib.position -> expr -> expr -> expr
 (** Return an AST that adds two expressions*)

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -113,7 +113,6 @@ val get_last_node_name: declaration list -> ident option
 (** Gets the name of the last node declared in the file. *)
 
 val move_node_to_last: ident -> declaration list -> declaration list
-(** Moves the node with given name to the end of the list *)
 
 val sort_typed_ident: typed_ident list -> typed_ident list
 (** Sort typed identifiers  *)

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -20,6 +20,7 @@
 
 open LustreAst
 
+module SI = Ident.IdentSet
 (** {1 Helpers} *)
 
 val pos_of_expr : expr -> Lib.position

--- a/src/lustre/lustreAstIdent.ml
+++ b/src/lustre/lustreAstIdent.ml
@@ -37,11 +37,10 @@ module Ident = struct
 
   let rec compare: t -> t -> int = fun i1 i2 ->
     match i1, i2 with
-    | UIdent s1, UIdent s2 -> String.compare s1 s2
+    | UIdent s1, UIdent s2 -> Stdlib.compare s1 s2
     | PIdent (p1, s1), PIdent (p2, s2) ->
-       if (String.compare s1 s2 > 0) then 1
-       else if (String.compare s1 s2 < 0) then -1
-       else compare p1 p2 
+       if (Stdlib.compare s1 s2 = 0) then compare p1 p2
+       else Stdlib.compare s1 s2
     | PIdent _, UIdent _ -> 1
     | UIdent _, PIdent _ -> -1
                           
@@ -83,7 +82,7 @@ module Ident = struct
   let rec pp_print_ident ppf =
     function
     | UIdent s ->
-       Format.fprintf ppf "'%a'"
+       Format.fprintf ppf "%a"
          Format.pp_print_string s
     | PIdent (p, s) ->
        Format.fprintf ppf "%a::%a"

--- a/src/lustre/lustreAstIdent.ml
+++ b/src/lustre/lustreAstIdent.ml
@@ -1,0 +1,106 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2020 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+ *)
+
+(** encapsulate identifier details.
+    This represents a qualified name.
+
+    eg. M::N::t is represented as PIdent (M, PIdent (N, (UIdent t))) 
+  
+  @author Apoorv Ingle *)
+
+module Ident = struct 
+  type t = UIdent of string | PIdent of t * string
+
+  let rec equal: t -> t -> bool =  fun i1 i2 ->
+    match (i1, i2) with
+    | UIdent s1, UIdent s2 -> s1 = s2
+    | PIdent (p1, s1), PIdent (p2, s2) ->
+       if (s1 = s2)
+       then equal p1 p2
+       else false
+    | _, _ -> false
+
+  let rec compare: t -> t -> int = fun i1 i2 ->
+    match i1, i2 with
+    | UIdent s1, UIdent s2 -> String.compare s1 s2
+    | PIdent (p1, s1), PIdent (p2, s2) ->
+       if (String.compare s1 s2 > 0) then 1
+       else if (String.compare s1 s2 < 0) then -1
+       else compare p1 p2 
+    | PIdent _, UIdent _ -> 1
+    | UIdent _, PIdent _ -> -1
+                          
+                          
+  let rec to_list: t -> string list =
+    function
+    | UIdent s -> [s]
+    | PIdent (p, s) -> s :: (to_list p)
+
+  let rec from_list: string list -> t =
+    function
+    | [] -> failwith "Cannot have empty list for identifer"
+    | [s] -> UIdent s
+    | a :: t -> PIdent ((from_list t), a) 
+
+  let rec to_string: t -> string =
+    function
+    | UIdent s -> s
+    | PIdent (p, s) -> s ^ "::" ^ to_string p
+
+
+  let from_string: string -> t = fun s ->
+    let ss = String.split_on_char ':' s |> List.filter (fun s -> s <> "") in
+    from_list ss
+
+  let rec add_prefix: string -> t -> t = fun prefix ->
+    function
+    | UIdent s -> UIdent (prefix ^ s)
+    | PIdent (p, s) -> PIdent (add_prefix prefix p, s) 
+
+  let rec add_suffix: string -> t -> t = fun suffix ->
+    function
+    | UIdent s -> UIdent (s ^ suffix)
+    | PIdent (p, s) -> PIdent (add_suffix suffix p, s) 
+                     
+  let add_qualified_prefix: string -> t -> t = fun p i ->
+    PIdent (i, p)  
+      
+  let rec pp_print_ident ppf =
+    function
+    | UIdent s ->
+       Format.fprintf ppf "'%a'"
+         Format.pp_print_string s
+    | PIdent (p, s) ->
+       Format.fprintf ppf "'%a'::%a"
+         Format.pp_print_string s
+         pp_print_ident p
+
+end                               
+
+include Ident
+
+module IdentSet = struct
+  include Set.Make (Ident)
+  let flatten: t list -> t = fun sets ->
+    List.fold_left union empty sets
+end 
+
+module IdentMap = struct
+  include Map.Make (Ident)
+  let keys: 'a t -> key list = fun m -> List.map fst (bindings m)
+end

--- a/src/lustre/lustreAstIdent.ml
+++ b/src/lustre/lustreAstIdent.ml
@@ -44,7 +44,6 @@ module Ident = struct
     | PIdent _, UIdent _ -> 1
     | UIdent _, PIdent _ -> -1
                           
-                          
   let rec to_list: t -> string list =
     function
     | UIdent s -> [s]
@@ -60,7 +59,6 @@ module Ident = struct
     function
     | UIdent s -> s
     | PIdent (p, s) -> s ^ "::" ^ to_string p
-
 
   let from_string: string -> t = fun s ->
     let ss = String.split_on_char ':' s |> List.filter (fun s -> s <> "") in
@@ -78,7 +76,15 @@ module Ident = struct
                      
   let add_qualified_prefix: string -> t -> t = fun p i ->
     PIdent (i, p)  
-      
+    
+  let path: t -> t option = function
+    | UIdent s ->
+       None
+    | qid ->
+       let pl = to_list qid in
+       let p = List.rev (List.tl (List.rev pl)) |> from_list in
+       Some p
+       
   let rec pp_print_ident ppf =
     function
     | UIdent s ->

--- a/src/lustre/lustreAstIdent.ml
+++ b/src/lustre/lustreAstIdent.ml
@@ -86,7 +86,7 @@ module Ident = struct
        Format.fprintf ppf "'%a'"
          Format.pp_print_string s
     | PIdent (p, s) ->
-       Format.fprintf ppf "'%a'::%a"
+       Format.fprintf ppf "%a::%a"
          Format.pp_print_string s
          pp_print_ident p
 

--- a/src/lustre/lustreAstIdent.ml
+++ b/src/lustre/lustreAstIdent.ml
@@ -84,6 +84,10 @@ module Ident = struct
        let pl = to_list qid in
        let p = List.rev (List.tl (List.rev pl)) |> from_list in
        Some p
+
+  let get_parent: t -> t option = function
+    | UIdent s -> None
+    | PIdent (p, s) -> Some (UIdent s)
        
   let rec pp_print_ident ppf =
     function

--- a/src/lustre/lustreAstIdent.mli
+++ b/src/lustre/lustreAstIdent.mli
@@ -57,6 +57,9 @@ val add_qualified_prefix: string -> t -> t
 
 val path: t -> t option
 (** Path of an identifier. It is None if it is in local scope *)
+
+val get_parent: t -> t option
+(** Gets the top most scope of the qualified identifier, None if the it is defined in the current scope *)
   
 module IdentSet: sig
     include (Set.S with type elt = t)

--- a/src/lustre/lustreAstIdent.mli
+++ b/src/lustre/lustreAstIdent.mli
@@ -54,6 +54,9 @@ val add_suffix: string -> t -> t
 
 val add_qualified_prefix: string -> t -> t
 (** increases the scope  *)
+
+val path: t -> t option
+(** Path of an identifier. It is None if it is in local scope *)
   
 module IdentSet: sig
     include (Set.S with type elt = t)

--- a/src/lustre/lustreAstIdent.mli
+++ b/src/lustre/lustreAstIdent.mli
@@ -1,0 +1,68 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2020 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+ *)
+
+(** encapsulate identifier details.
+    This represents a qualified name.
+
+    eg. M::N::t is represented as PIdent (M, PIdent (N, (UIdent t))) 
+  
+  @author Apoorv Ingle *)
+
+type t
+
+val equal: t -> t -> bool
+(** Returns true if the two Identifiers are equal *)
+
+val compare: t -> t -> int
+(** Compare two identifiers *)
+  
+val to_list: t -> string list
+(** Returns a list of identifers of the qualified identifiers *)
+
+val from_list: string list -> t
+(** Builds a qalified identifier from a list of strings  *)
+  
+val to_string: t -> string
+(** Converts the identifier to a string *)
+
+val from_string: string -> t
+(** builds an identifier from the string *)
+
+val pp_print_ident: Format.formatter -> t -> unit
+(** print the identifer *)
+
+val add_prefix: string -> t -> t
+(** adds a prefix to the base of the identifier *)
+  
+val add_suffix: string -> t -> t
+(** adds a suffix to the base of the identifer *)
+
+val add_qualified_prefix: string -> t -> t
+(** increases the scope  *)
+  
+module IdentSet: sig
+    include (Set.S with type elt = t)
+    val flatten: t list -> t
+end
+(** Set of identifiers *)
+
+module IdentMap: sig
+  include (Map.S with type key = t)
+  val keys: 'a t -> key list
+end
+(** Map of identifiers *)

--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -25,6 +25,7 @@ exception Out_of_bounds of (Lib.position * string)
 module TC = TypeCheckerContext
 module LA = LustreAst
 module LH = LustreAstHelpers
+module QId = LustreAstIdent
 
 module R = Res
 let (>>=) = R.(>>=)
@@ -78,10 +79,10 @@ let rec eval_int_expr: tc_context -> LA.expr -> int inline_result = fun ctx ->
                | LA.Ident (_, i') as e ->
                   if Stdlib.compare i i' = 0
                   then inline_error pos ("Cannot evaluate a free int const "
-                                       ^ i ^ ".")
+                                       ^ QId.to_string i ^ ".")
                   else eval_int_expr ctx e 
                | _ -> eval_int_expr ctx const_expr)
-      | None -> inline_error pos ("Not a constant identifier" ^ i))  
+      | None -> inline_error pos ("Not a constant identifier" ^ QId.to_string i))  
   | LA.Const _ as c -> int_value_of_const c
   | LA.BinaryOp (pos, bop, e1, e2) -> eval_int_binary_op ctx pos bop e1 e2
   | LA.TernaryOp (pos, top, e1, e2, e3) -> eval_int_ternary_op ctx pos top e1 e2 e3
@@ -114,10 +115,10 @@ and eval_bool_expr: tc_context -> LA.expr -> bool inline_result = fun ctx ->
                | LA.Ident (_, i') as e ->
                   if (Stdlib.compare i i' = 0)
                   then inline_error pos ("Cannot evaluate a free bool const "
-                                       ^ i ^ ".")
+                                       ^ QId.to_string i ^ ".")
                   else eval_bool_expr ctx e 
                | _ ->  eval_bool_expr ctx const_expr)
-      | None -> inline_error pos ("Not a constant cannot evaluate identifier " ^ i))
+      | None -> inline_error pos ("Not a constant cannot evaluate identifier " ^ QId.to_string i))
   | LA.Const _ as c -> bool_value_of_const c
   | LA.BinaryOp (pos, bop, e1, e2) -> eval_bool_binary_op ctx pos bop e1 e2
   | LA.TernaryOp (pos, top, e1, e2, e3) -> eval_bool_ternary_op ctx pos top e1 e2 e3

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -20,7 +20,8 @@ open Lib
 open LustreReporting
    
 module A = LustreAst
-
+module QId = LustreAstIdent
+           
 module I = LustreIdent
 module IT = LustreIdent.Hashtbl
 
@@ -513,7 +514,7 @@ let contract_node_decl_of_ident { contract_nodes } ident =
     
     (* Return contract node by name *)
     List.find
-      (function (_, (i, _, _, _, _)) -> i = ident)
+      (function (_, (i, _, _, _, _)) -> QId.equal i ident)
       contract_nodes
 
   (* Raise error again for more precise backtrace *)
@@ -532,7 +533,7 @@ let add_contract_node_decl_to_context
 
     (* Check if contract of with the same identifier exists *)
     List.exists
-      (function (_, (i, _, _, _, _)) -> i = ident)
+      (function (_, (i, _, _, _, _)) -> QId.equal i ident)
       contract_nodes
 
   then

--- a/src/lustre/lustreContext.mli
+++ b/src/lustre/lustreContext.mli
@@ -23,6 +23,7 @@
 
 open Lib
 module QId = LustreAstIdent
+
 (** Context *)
 type t
 

--- a/src/lustre/lustreContext.mli
+++ b/src/lustre/lustreContext.mli
@@ -22,7 +22,7 @@
     @author Christoph Sticksel *)
 
 open Lib
-
+module QId = LustreAstIdent
 (** Context *)
 type t
 
@@ -178,7 +178,7 @@ val add_contract_node_decl_to_context :
 
 (** Return a contract node by its identifier *)
 val contract_node_decl_of_ident :
-  t -> string -> Lib.position * LustreAst.contract_node_decl
+  t -> QId.t -> Lib.position * LustreAst.contract_node_decl
 
 (** Return a context that raises an error when defining an
     expression.

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1554,7 +1554,7 @@ let rec check_no_contract_in_node_calls ctx = function
 (* Evaluates contract calls. *)
 and eval_node_contract_call 
   known ctx scope inputs outputs locals is_candidate (
-    call_pos, id, in_params, out_params, _
+    call_pos, id, in_params, out_params, id'
   ) = 
   let ident = I.mk_string_ident (QId.to_string id) in
 
@@ -1577,9 +1577,9 @@ and eval_node_contract_call
   ) ;
 
   (* Push scope for contract svars. *)
-  let svar_scope = (call_pos, (QId.to_string id)) :: scope in
+  let svar_scope = (call_pos, (QId.to_string id')) :: scope in
   (* Push scope for contract call. *)
-  let ctx = C.push_contract_scope ctx (QId.to_string id) in
+  let ctx = C.push_contract_scope ctx (QId.to_string id') in
   (* Retrieve contract node from context. *)
   let pos, (id, params, in_formals, out_formals, contract) =
     try C.contract_node_decl_of_ident ctx id

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1554,7 +1554,7 @@ let rec check_no_contract_in_node_calls ctx = function
 (* Evaluates contract calls. *)
 and eval_node_contract_call 
   known ctx scope inputs outputs locals is_candidate (
-    call_pos, id, in_params, out_params
+    call_pos, id, in_params, out_params, _
   ) = 
   let ident = I.mk_string_ident (QId.to_string id) in
 
@@ -2458,7 +2458,7 @@ and parse_implicit_contract scope inputs outputs ctx file contract_name = try (
             |> fun (ok, outs) -> ok, List.rev outs
           in
           if ok then Some (
-            A.ContractCall (pos, id, ins, outs)
+            A.ContractCall (pos, id, ins, outs, id)
           ) else call
         ) with _ -> call
       )

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -38,7 +38,7 @@ module S = LustreSimplify
 module G = LustreGlobals
 
 module SVS = StateVar.StateVarSet
-module ISet = Set.Make (String)
+module ISet = Ident.IdentSet
 
 module Deps = LustreDependencies
 
@@ -1968,9 +1968,9 @@ and eval_automaton pos aname states auto_outputs inputs outputs locals ctx =
       List.fold_left (fun (states, lasts) s ->
           let s, lasts = replace_lasts_state allowed_l name lasts s in
           s :: states, lasts
-        ) ([], A.SI.empty) states in
+        ) ([], ISet.empty) states in
     let states = List.rev states in
-    let lasts = A.SI.elements lasts in
+    let lasts = ISet.elements lasts in
 
     (* Construct new inputs for the handler nodes for values of [last]
        applications on the base clock (i.e. outside the state) *)

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1260,9 +1260,15 @@ and eval_ghost_var
         let ctx = C.add_node_local ~ghost:true ctx ident pos type_expr in
 
         let ctx =
-          eval_node_equation inputs outputs locals ctx (
-            A.Equation (pos, A.StructDef (pos, [A.SingleIdent (pos, QId.add_qualified_prefix (QId.to_string as_id) i)]), expr)
-          )
+          eval_node_equation inputs outputs locals
+            ctx (
+              A.Equation (pos,
+                          A.StructDef
+                            (pos
+                            , [A.SingleIdent (pos, QId.add_qualified_prefix (QId.to_string as_id) i)]
+                            )
+                          , expr)
+            )
         in
 
         ctx

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1554,7 +1554,7 @@ let rec check_no_contract_in_node_calls ctx = function
 (* Evaluates contract calls. *)
 and eval_node_contract_call 
   known ctx scope inputs outputs locals is_candidate (
-    call_pos, id, in_params, out_params, id'
+    call_pos, id, in_params, out_params, as_id
   ) = 
   let ident = I.mk_string_ident (QId.to_string id) in
 
@@ -1577,9 +1577,9 @@ and eval_node_contract_call
   ) ;
 
   (* Push scope for contract svars. *)
-  let svar_scope = (call_pos, (QId.to_string id')) :: scope in
+  let svar_scope = (call_pos, (QId.to_string as_id)) :: scope in
   (* Push scope for contract call. *)
-  let ctx = C.push_contract_scope ctx (QId.to_string id') in
+  let ctx = C.push_contract_scope ctx (QId.to_string as_id) in
   (* Retrieve contract node from context. *)
   let pos, (id, params, in_formals, out_formals, contract) =
     try C.contract_node_decl_of_ident ctx id

--- a/src/lustre/lustreDependencies.ml
+++ b/src/lustre/lustreDependencies.ml
@@ -20,6 +20,8 @@ module I = LustreIdent
 module ISet = I.Set
 module IMap = I.Hashtbl
 
+module QId = LustreAstIdent
+            
 module A = LustreAst
 
 (** Enum over declaration types. *)
@@ -116,24 +118,24 @@ let mem deps (key_type, key_ident) (val_type, val_ident) =
 (** Identifier corresponding to a declaration. *)
 let info_of_decl = function
 | A.TypeDecl (pos, A.AliasType (_, ident, _)) ->
-  pos, ident |> I.mk_string_ident, Type
+  pos, QId.to_string ident |> I.mk_string_ident, Type
 | A.TypeDecl (pos, A.FreeType (_, ident)) ->
-  pos, ident |> I.mk_string_ident, Type
+  pos, QId.to_string ident |> I.mk_string_ident, Type
 
 | A.ConstDecl (pos, A.FreeConst(_, ident, _)) ->
-  pos, ident |> I.mk_string_ident, Const
+  pos, QId.to_string ident |> I.mk_string_ident, Const
 | A.ConstDecl (pos, A.UntypedConst(_, ident, _)) ->
-  pos, ident |> I.mk_string_ident, Const
+  pos, QId.to_string ident |> I.mk_string_ident, Const
 | A.ConstDecl (pos, A.TypedConst(_, ident, _, _)) ->
-  pos, ident |> I.mk_string_ident, Const
+  pos, QId.to_string ident |> I.mk_string_ident, Const
 
 | A.NodeDecl (pos, (ident, _, _, _, _, _, _, _)) ->
-  pos, ident |> I.mk_string_ident, NodeOrFun
+  pos, QId.to_string ident |> I.mk_string_ident, NodeOrFun
 | A.FuncDecl (pos, (ident, _, _, _, _, _, _, _)) ->
-  pos, ident |> I.mk_string_ident, NodeOrFun
+  pos, QId.to_string ident |> I.mk_string_ident, NodeOrFun
 
 | A.ContractNodeDecl (pos, (ident, _, _, _, _)) ->
-  pos, ident |> I.mk_string_ident, Contract
+  pos, QId.to_string ident |> I.mk_string_ident, Contract
 
 | decl ->
   Format.asprintf
@@ -148,26 +150,26 @@ let insert_decl decl (f_type, f_ident) decls =
   let has_ident = match f_type with
     | NodeOrFun -> (
       function
-      | A.NodeDecl (_, (i, _, _, _, _, _, _, _)) -> i = ident
-      | A.FuncDecl (_, (i, _, _, _, _, _, _, _)) -> i = ident
+      | A.NodeDecl (_, (i, _, _, _, _, _, _, _)) -> QId.to_string i = ident
+      | A.FuncDecl (_, (i, _, _, _, _, _, _, _)) -> QId.to_string i = ident
       | _ -> false
     )
     | Type -> (
       function
-      | A.TypeDecl (_, A.AliasType(_, i, _)) -> i = ident
-      | A.TypeDecl (_, A.FreeType(_, i)) -> i = ident
+      | A.TypeDecl (_, A.AliasType(_, i, _)) -> QId.to_string i = ident
+      | A.TypeDecl (_, A.FreeType(_, i)) -> QId.to_string i = ident
       | _ -> false
     )
     | Contract -> (
       function
-      | A.ContractNodeDecl (_, (i, _, _, _, _)) -> i = ident
+      | A.ContractNodeDecl (_, (i, _, _, _, _)) -> QId.to_string i = ident
       | _ -> false
     )
     | Const -> (
       function
-      | A.ConstDecl (_, A.FreeConst(_, i, _)) -> i = ident
-      | A.ConstDecl (_, A.UntypedConst(_, i, _)) -> i = ident
-      | A.ConstDecl (_, A.TypedConst(_, i, _, _)) -> i = ident
+      | A.ConstDecl (_, A.FreeConst(_, i, _)) -> QId.to_string i = ident
+      | A.ConstDecl (_, A.UntypedConst(_, i, _)) -> QId.to_string i = ident
+      | A.ConstDecl (_, A.TypedConst(_, i, _, _)) -> QId.to_string i = ident
       | _ -> false
     )
   in

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -30,6 +30,8 @@ module LPI = LustreParser.Incremental
 module LL = LustreLexer          
 module LPMI = LustreParser.MenhirInterpreter
 module LPE = LustreParserErrors
+
+module RN = LustreAstRenamer
 module TC = LustreTypeChecker
 module TCContext = TypeCheckerContext
 module IC = LustreAstInlineConstants
@@ -120,7 +122,6 @@ let of_channel in_ch =
      else 
        let tc_res =  
          (Log.log L_note "(Experimental) Typechecking enabled."
-
          (* Step 0. Split program into top level const and type delcs, and node/contract decls *)
          ; let (const_type_decls, node_contract_src) = LH.split_program declarations in
 

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -31,7 +31,6 @@ module LL = LustreLexer
 module LPMI = LustreParser.MenhirInterpreter
 module LPE = LustreParserErrors
 
-module RN = LustreAstRenamer
 module TC = LustreTypeChecker
 module TCContext = TypeCheckerContext
 module IC = LustreAstInlineConstants

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -334,7 +334,10 @@ let keyword_table = mk_hashtbl [
    C syntax: alphanumeric characters including the underscore, starting 
    with a letter or the underscore *)
 let id = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '_' '0'-'9']*
-         
+
+let qual_id = id (':' ':' id)*
+(* a qualified id is an id or id::qual_id *)
+                
 (* Keep these separated from alphabetic characters, otherwise a->b would 
    be one token *)
 let printable = ['+' '-' '*' '/' '>' '<' '=' ]+
@@ -497,12 +500,12 @@ rule token = parse
   | hex_dec2 as p { DECIMAL p }
 
   (* Keyword *)
-  | id as p {
+  | qual_id as p {
     try Hashtbl.find keyword_table p with Not_found -> (SYM p)
   }
 
   (* Identifier with quote, throw quote away *)
-  | '\'' (id as p) { QUOTSYM p }
+  | '\'' (qual_id as p) { QUOTSYM p }
 
   (* Whitespace *)
   | whitespace { token lexbuf }

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -273,6 +273,7 @@ let keyword_table = mk_hashtbl [
   (* Contract related things. *)
   "contract", CONTRACT ;
   "import", IMPORTCONTRACT ;
+  "as", AS;
 
   (* Boolean operators *)
   "true", TRUE ;

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -336,7 +336,7 @@ let keyword_table = mk_hashtbl [
    with a letter or the underscore *)
 let id = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '_' '0'-'9']*
 
-let qual_id = id (':' ':' id)*
+(* let qual_id = id (':' ':' id)* *)
 (* a qualified id is an id or id::qual_id *)
                 
 (* Keep these separated from alphabetic characters, otherwise a->b would 
@@ -501,12 +501,12 @@ rule token = parse
   | hex_dec2 as p { DECIMAL p }
 
   (* Keyword *)
-  | qual_id as p {
+  | id as p {
     try Hashtbl.find keyword_table p with Not_found -> (SYM p)
   }
 
   (* Identifier with quote, throw quote away *)
-  | '\'' (qual_id as p) { QUOTSYM p }
+  | '\'' (id as p) { QUOTSYM p }
 
   (* Whitespace *)
   | whitespace { token lexbuf }

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -336,9 +336,6 @@ let keyword_table = mk_hashtbl [
    with a letter or the underscore *)
 let id = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '_' '0'-'9']*
 
-(* let qual_id = id (':' ':' id)* *)
-(* a qualified id is an id or id::qual_id *)
-                
 (* Keep these separated from alphabetic characters, otherwise a->b would 
    be one token *)
 let printable = ['+' '-' '*' '/' '>' '<' '=' ]+

--- a/src/lustre/lustreParser.messages
+++ b/src/lustre/lustreParser.messages
@@ -4349,7 +4349,7 @@ one_expr: WEAKLY LPARAMBRACKET WEAKLY CARET WEAKLY WITH
 ## In state 109, spurious reduction of production pexpr(nonquantified) -> ident 
 ##
 
-Syntax Error! Perhaps a missing identifier in type.
+Syntax Error!
 
 one_expr: WEAKLY LPARAMBRACKET WEAKLY CARET XOR
 ##
@@ -5284,7 +5284,7 @@ Syntax Error!
 
 one_expr: WEAKLY WITH
 ##
-## Ends in an error in state: 1001.
+## Ends in an error in state: 1004.
 ##
 ## one_expr -> pexpr(nonquantified) . EOF [ # ]
 ## pexpr(nonquantified) -> pexpr(nonquantified) . CARET pexpr(nonquantified) [ XOR WHEN RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS EOF DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -5550,7 +5550,7 @@ Syntax Error!
 
 one_expr: XOR
 ##
-## Ends in an error in state: 1000.
+## Ends in an error in state: 1003.
 ##
 ## one_expr' -> . one_expr [ # ]
 ##
@@ -5562,7 +5562,7 @@ Syntax Error!
 
 main: CONST WEAKLY COLON ASSUME EQUALS WEAKLY WITH
 ##
-## Ends in an error in state: 799.
+## Ends in an error in state: 802.
 ##
 ## const_decl_body -> typed_ident EQUALS pexpr(nonquantified) . SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
 ## pexpr(nonquantified) -> pexpr(nonquantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -5608,7 +5608,7 @@ Syntax Error!
 
 main: CONST WEAKLY COLON ASSUME EQUALS XOR
 ##
-## Ends in an error in state: 798.
+## Ends in an error in state: 801.
 ##
 ## const_decl_body -> typed_ident EQUALS . pexpr(nonquantified) SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
 ##
@@ -5620,7 +5620,7 @@ Syntax Error!
 
 main: CONST WEAKLY COLON WEAKLY XOR
 ##
-## Ends in an error in state: 812.
+## Ends in an error in state: 815.
 ##
 ## array_type -> lustre_type . CARET pexpr(nonquantified) [ SEMICOLON EQUALS CARET ]
 ## const_decl_body -> ident COLON lustre_type . SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
@@ -5634,7 +5634,7 @@ Syntax Error!
 
 main: CONST WEAKLY COLON XOR
 ##
-## Ends in an error in state: 811.
+## Ends in an error in state: 814.
 ##
 ## const_decl_body -> ident COLON . lustre_type SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
 ## typed_ident -> ident COLON . lustre_type [ EQUALS ]
@@ -5647,7 +5647,7 @@ Syntax Error!
 
 main: CONST WEAKLY COMMA WEAKLY COLON WEAKLY XOR
 ##
-## Ends in an error in state: 809.
+## Ends in an error in state: 812.
 ##
 ## array_type -> lustre_type . CARET pexpr(nonquantified) [ SEMICOLON CARET ]
 ## const_decl_body -> ident COMMA ident_list COLON lustre_type . SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
@@ -5660,7 +5660,7 @@ Syntax Error!
 
 main: CONST WEAKLY COMMA WEAKLY COLON XOR
 ##
-## Ends in an error in state: 808.
+## Ends in an error in state: 811.
 ##
 ## const_decl_body -> ident COMMA ident_list COLON . lustre_type SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
 ##
@@ -5672,7 +5672,7 @@ Syntax Error!
 
 main: CONST WEAKLY COMMA WEAKLY SEMICOLON
 ##
-## Ends in an error in state: 807.
+## Ends in an error in state: 810.
 ##
 ## const_decl_body -> ident COMMA ident_list . COLON lustre_type SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
 ##
@@ -5691,7 +5691,7 @@ Syntax Error!
 
 main: CONST WEAKLY COMMA XOR
 ##
-## Ends in an error in state: 806.
+## Ends in an error in state: 809.
 ##
 ## const_decl_body -> ident COMMA . ident_list COLON lustre_type SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
 ##
@@ -5703,7 +5703,7 @@ Syntax Error!
 
 main: CONST WEAKLY EQUALS ASSUME SEMICOLON XOR
 ##
-## Ends in an error in state: 814.
+## Ends in an error in state: 817.
 ##
 ## nonempty_list(const_decl_body) -> const_decl_body . [ VAR TYPE NODE LET FUNCTION EOF CONTRACT CONST ]
 ## nonempty_list(const_decl_body) -> const_decl_body . nonempty_list(const_decl_body) [ VAR TYPE NODE LET FUNCTION EOF CONTRACT CONST ]
@@ -5716,7 +5716,7 @@ Syntax Error!
 
 main: CONST WEAKLY EQUALS WEAKLY WITH
 ##
-## Ends in an error in state: 804.
+## Ends in an error in state: 807.
 ##
 ## const_decl_body -> ident EQUALS pexpr(nonquantified) . SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
 ## pexpr(nonquantified) -> pexpr(nonquantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -5762,7 +5762,7 @@ Syntax Error!
 
 main: CONST WEAKLY EQUALS XOR
 ##
-## Ends in an error in state: 803.
+## Ends in an error in state: 806.
 ##
 ## const_decl_body -> ident EQUALS . pexpr(nonquantified) SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
 ##
@@ -5774,7 +5774,7 @@ Syntax Error!
 
 main: CONST WEAKLY XOR
 ##
-## Ends in an error in state: 802.
+## Ends in an error in state: 805.
 ##
 ## const_decl_body -> ident . COLON lustre_type SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
 ## const_decl_body -> ident . COMMA ident_list COLON lustre_type SEMICOLON [ WEAKLY VAR TYPE SYM REQUIRE NODE MODE LET GUARANTEE FUNCTION EOF ENSURE CONTRACT CONST ASSUME ]
@@ -5789,7 +5789,7 @@ Syntax Error!
 
 main: CONST XOR
 ##
-## Ends in an error in state: 796.
+## Ends in an error in state: 799.
 ##
 ## const_decl -> CONST . nonempty_list(const_decl_body) [ VAR TYPE NODE LET FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5801,7 +5801,7 @@ Syntax Error! Incomplete constant declaration.
 
 main: CONTRACT WEAKLY LPARAMBRACKET RPARAMBRACKET XOR
 ##
-## Ends in an error in state: 982.
+## Ends in an error in state: 985.
 ##
 ## contract_decl -> CONTRACT ident loption(static_params) . tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) SEMICOLON LET contract_in_block TEL option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5813,7 +5813,7 @@ Syntax Error!
 
 main: CONTRACT WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN SEMICOLON LET GUARANTEE WEAKLY SEMICOLON SSBLOCKEND
 ##
-## Ends in an error in state: 988.
+## Ends in an error in state: 991.
 ##
 ## contract_decl -> CONTRACT ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) SEMICOLON LET contract_in_block . TEL option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5824,15 +5824,15 @@ main: CONTRACT WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN SEMICOLON LET GUARANTE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 775, spurious reduction of production nonempty_list(contract_item) -> contract_item 
-## In state 773, spurious reduction of production contract_in_block -> nonempty_list(contract_item) 
+## In state 778, spurious reduction of production nonempty_list(contract_item) -> contract_item 
+## In state 776, spurious reduction of production contract_in_block -> nonempty_list(contract_item) 
 ##
 
 Syntax Error!
 
 main: CONTRACT WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN SEMICOLON LET GUARANTEE WEAKLY SEMICOLON TEL XOR
 ##
-## Ends in an error in state: 989.
+## Ends in an error in state: 992.
 ##
 ## contract_decl -> CONTRACT ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) SEMICOLON LET contract_in_block TEL . option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5844,7 +5844,7 @@ Syntax Error!
 
 main: CONTRACT WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN SEMICOLON LET XOR
 ##
-## Ends in an error in state: 987.
+## Ends in an error in state: 990.
 ##
 ## contract_decl -> CONTRACT ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) SEMICOLON LET . contract_in_block TEL option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5856,7 +5856,7 @@ Syntax Error!
 
 main: CONTRACT WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN SEMICOLON XOR
 ##
-## Ends in an error in state: 986.
+## Ends in an error in state: 989.
 ##
 ## contract_decl -> CONTRACT ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) SEMICOLON . LET contract_in_block TEL option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5868,7 +5868,7 @@ Syntax Error!
 
 main: CONTRACT WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN XOR
 ##
-## Ends in an error in state: 985.
+## Ends in an error in state: 988.
 ##
 ## contract_decl -> CONTRACT ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) . SEMICOLON LET contract_in_block TEL option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5880,7 +5880,7 @@ Syntax Error!
 
 main: CONTRACT WEAKLY LPAREN RPAREN RETURNS XOR
 ##
-## Ends in an error in state: 984.
+## Ends in an error in state: 987.
 ##
 ## contract_decl -> CONTRACT ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS . tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) SEMICOLON LET contract_in_block TEL option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5892,7 +5892,7 @@ Syntax Error! Perhaps a missing/unbalanced parenthesis in contract declaration.
 
 main: CONTRACT WEAKLY LPAREN RPAREN XOR
 ##
-## Ends in an error in state: 983.
+## Ends in an error in state: 986.
 ##
 ## contract_decl -> CONTRACT ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) . RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) SEMICOLON LET contract_in_block TEL option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5904,7 +5904,7 @@ Syntax Error!
 
 main: CONTRACT WEAKLY XOR
 ##
-## Ends in an error in state: 981.
+## Ends in an error in state: 984.
 ##
 ## contract_decl -> CONTRACT ident . loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) SEMICOLON LET contract_in_block TEL option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5916,7 +5916,7 @@ Syntax Error!
 
 main: CONTRACT XOR
 ##
-## Ends in an error in state: 980.
+## Ends in an error in state: 983.
 ##
 ## contract_decl -> CONTRACT . ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) SEMICOLON LET contract_in_block TEL option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5928,7 +5928,7 @@ Syntax Error!
 
 main: FUNCTION IMPORTED XOR
 ##
-## Ends in an error in state: 976.
+## Ends in an error in state: 979.
 ##
 ## decl -> FUNCTION IMPORTED . node_decl [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5940,7 +5940,7 @@ Syntax Error!
 
 main: FUNCTION WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 978.
+## Ends in an error in state: 981.
 ##
 ## decl -> FUNCTION node_decl . node_def [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -5953,7 +5953,7 @@ main: FUNCTION WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN TYPE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 459, spurious reduction of production option(SEMICOLON) -> 
 ## In state 461, spurious reduction of production option(contract_spec) -> 
-## In state 787, spurious reduction of production node_decl -> ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) option(SEMICOLON) option(contract_spec) 
+## In state 790, spurious reduction of production node_decl -> ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) option(SEMICOLON) option(contract_spec) 
 ##
 
 Syntax Error! Perhaps a missing function definition body.
@@ -5972,7 +5972,7 @@ Syntax Error!
 
 main: FUNCTION XOR
 ##
-## Ends in an error in state: 975.
+## Ends in an error in state: 978.
 ##
 ## decl -> FUNCTION . node_decl node_def [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ## decl -> FUNCTION . IMPORTED node_decl [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
@@ -5997,7 +5997,7 @@ Syntax Error!
 
 main: NODE WEAKLY EQUALS WEAKLY LPARAMBRACKET RPARAMBRACKET XOR
 ##
-## Ends in an error in state: 973.
+## Ends in an error in state: 976.
 ##
 ## node_param_inst -> NODE ident EQUALS ident tlist(LPARAMBRACKET,SEMICOLON,RPARAMBRACKET,node_call_static_param) . SEMICOLON [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -6009,7 +6009,7 @@ Syntax Error!
 
 main: NODE WEAKLY EQUALS WEAKLY XOR
 ##
-## Ends in an error in state: 972.
+## Ends in an error in state: 975.
 ##
 ## node_param_inst -> NODE ident EQUALS ident . tlist(LPARAMBRACKET,SEMICOLON,RPARAMBRACKET,node_call_static_param) SEMICOLON [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -6021,7 +6021,7 @@ Syntax Error!
 
 main: NODE WEAKLY EQUALS XOR
 ##
-## Ends in an error in state: 971.
+## Ends in an error in state: 974.
 ##
 ## node_param_inst -> NODE ident EQUALS . ident tlist(LPARAMBRACKET,SEMICOLON,RPARAMBRACKET,node_call_static_param) SEMICOLON [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -6326,7 +6326,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONST ASSUME EQUALS ASSUME SEMICOLON TYPE
 ##
-## Ends in an error in state: 817.
+## Ends in an error in state: 820.
 ##
 ## list(node_local_decl) -> node_local_decl . list(node_local_decl) [ LET ]
 ##
@@ -6337,16 +6337,16 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONST ASSUME EQUALS ASSUME
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 814, spurious reduction of production nonempty_list(const_decl_body) -> const_decl_body 
-## In state 801, spurious reduction of production const_decl -> CONST nonempty_list(const_decl_body) 
-## In state 819, spurious reduction of production node_local_decl -> const_decl 
+## In state 817, spurious reduction of production nonempty_list(const_decl_body) -> const_decl_body 
+## In state 804, spurious reduction of production const_decl -> CONST nonempty_list(const_decl_body) 
+## In state 822, spurious reduction of production node_local_decl -> const_decl 
 ##
 
 Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_PSATBLOCK GUARANTEE WEAKLY SEMICOLON TEL
 ##
-## Ends in an error in state: 785.
+## Ends in an error in state: 788.
 ##
 ## contract_spec -> CONTRACT_PSATBLOCK contract_in_block . PSBLOCKEND [ VAR TYPE NODE LET FUNCTION EOF CONTRACT CONST ]
 ##
@@ -6357,15 +6357,15 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_PSATBLOCK GUARANT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 775, spurious reduction of production nonempty_list(contract_item) -> contract_item 
-## In state 773, spurious reduction of production contract_in_block -> nonempty_list(contract_item) 
+## In state 778, spurious reduction of production nonempty_list(contract_item) -> contract_item 
+## In state 776, spurious reduction of production contract_in_block -> nonempty_list(contract_item) 
 ##
 
 Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_PSATBLOCK XOR
 ##
-## Ends in an error in state: 784.
+## Ends in an error in state: 787.
 ##
 ## contract_spec -> CONTRACT_PSATBLOCK . contract_in_block PSBLOCKEND [ VAR TYPE NODE LET FUNCTION EOF CONTRACT CONST ]
 ##
@@ -6373,11 +6373,11 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_PSATBLOCK XOR
 ## CONTRACT_PSATBLOCK
 ##
 
-Syntax Error! Perhaps a unknown keyword. 
+Syntax Error! Perhaps a unknown keyword.
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK ASSUME STRING ASSERT
 ##
-## Ends in an error in state: 770.
+## Ends in an error in state: 773.
 ##
 ## contract_assume -> ASSUME option(STRING) . pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
@@ -6389,7 +6389,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK ASSUME WEAKLY WITH
 ##
-## Ends in an error in state: 771.
+## Ends in an error in state: 774.
 ##
 ## contract_assume -> ASSUME option(STRING) pexpr(quantified) . SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -6435,7 +6435,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK ASSUME XOR
 ##
-## Ends in an error in state: 769.
+## Ends in an error in state: 772.
 ##
 ## contract_assume -> ASSUME . option(STRING) pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
@@ -6447,7 +6447,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK CONST WEAKLY COLON WEAKLY EQUALS WEAKLY WITH
 ##
-## Ends in an error in state: 767.
+## Ends in an error in state: 770.
 ##
 ## contract_ghost_const -> CONST ident COLON lustre_type EQUALS pexpr(quantified) . SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -6493,7 +6493,7 @@ Syntax Error! Perhaps a missing statement delimiter such as a semicolon at the e
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK CONST WEAKLY COLON WEAKLY EQUALS XOR
 ##
-## Ends in an error in state: 766.
+## Ends in an error in state: 769.
 ##
 ## contract_ghost_const -> CONST ident COLON lustre_type EQUALS . pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
@@ -6505,7 +6505,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK CONST WEAKLY COLON WEAKLY XOR
 ##
-## Ends in an error in state: 765.
+## Ends in an error in state: 768.
 ##
 ## array_type -> lustre_type . CARET pexpr(nonquantified) [ EQUALS CARET ]
 ## contract_ghost_const -> CONST ident COLON lustre_type . EQUALS pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
@@ -6518,7 +6518,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK CONST WEAKLY COLON XOR
 ##
-## Ends in an error in state: 764.
+## Ends in an error in state: 767.
 ##
 ## contract_ghost_const -> CONST ident COLON . lustre_type EQUALS pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
@@ -6530,7 +6530,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK CONST WEAKLY EQUALS WEAKLY WITH
 ##
-## Ends in an error in state: 762.
+## Ends in an error in state: 765.
 ##
 ## contract_ghost_const -> CONST ident EQUALS pexpr(quantified) . SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -6576,7 +6576,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK CONST WEAKLY EQUALS XOR
 ##
-## Ends in an error in state: 761.
+## Ends in an error in state: 764.
 ##
 ## contract_ghost_const -> CONST ident EQUALS . pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
@@ -6588,7 +6588,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK CONST WEAKLY XOR
 ##
-## Ends in an error in state: 760.
+## Ends in an error in state: 763.
 ##
 ## contract_ghost_const -> CONST ident . COLON lustre_type EQUALS pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ## contract_ghost_const -> CONST ident . EQUALS pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
@@ -6601,7 +6601,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK CONST XOR
 ##
-## Ends in an error in state: 759.
+## Ends in an error in state: 762.
 ##
 ## contract_ghost_const -> CONST . ident COLON lustre_type EQUALS pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ## contract_ghost_const -> CONST . ident EQUALS pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
@@ -6614,7 +6614,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK GUARANTEE ASSUME SEMICOLON TEL
 ##
-## Ends in an error in state: 782.
+## Ends in an error in state: 785.
 ##
 ## contract_spec -> CONTRACT_SSATBLOCK contract_in_block . SSBLOCKEND [ VAR TYPE NODE LET FUNCTION EOF CONTRACT CONST ]
 ##
@@ -6625,15 +6625,15 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK GUARANT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 775, spurious reduction of production nonempty_list(contract_item) -> contract_item 
-## In state 773, spurious reduction of production contract_in_block -> nonempty_list(contract_item) 
+## In state 778, spurious reduction of production nonempty_list(contract_item) -> contract_item 
+## In state 776, spurious reduction of production contract_in_block -> nonempty_list(contract_item) 
 ##
 
 Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK GUARANTEE ASSUME SEMICOLON XOR
 ##
-## Ends in an error in state: 775.
+## Ends in an error in state: 778.
 ##
 ## nonempty_list(contract_item) -> contract_item . [ TEL SSBLOCKEND PSBLOCKEND ]
 ## nonempty_list(contract_item) -> contract_item . nonempty_list(contract_item) [ TEL SSBLOCKEND PSBLOCKEND ]
@@ -6646,7 +6646,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK GUARANTEE STRING ASSERT
 ##
-## Ends in an error in state: 756.
+## Ends in an error in state: 759.
 ##
 ## contract_guarantee -> GUARANTEE option(STRING) . pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
@@ -6658,7 +6658,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK GUARANTEE WEAKLY WITH
 ##
-## Ends in an error in state: 757.
+## Ends in an error in state: 760.
 ##
 ## contract_guarantee -> GUARANTEE option(STRING) pexpr(quantified) . SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -6704,7 +6704,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK GUARANTEE XOR
 ##
-## Ends in an error in state: 755.
+## Ends in an error in state: 758.
 ##
 ## contract_guarantee -> GUARANTEE . option(STRING) pexpr(quantified) SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
@@ -6714,11 +6714,36 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK GUARANT
 
 Syntax Error!
 
+main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK IMPORTCONTRACT WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN AS WEAKLY XOR
+##
+## Ends in an error in state: 756.
+##
+## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN AS ident . SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
+##
+## The known suffix of the stack is as follows:
+## IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN AS ident
+##
+
+Syntax Error!
+
+main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK IMPORTCONTRACT WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN AS XOR
+##
+## Ends in an error in state: 755.
+##
+## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN AS . ident SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
+##
+## The known suffix of the stack is as follows:
+## IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN AS
+##
+
+Syntax Error!
+
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK IMPORTCONTRACT WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN XOR
 ##
 ## Ends in an error in state: 753.
 ##
 ## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN . SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
+## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN . AS ident SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN
@@ -6731,6 +6756,7 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK IMPORTC
 ## Ends in an error in state: 752.
 ##
 ## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) . RPAREN SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
+## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) . RPAREN AS ident SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident))
@@ -6750,6 +6776,7 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK IMPORTC
 ## Ends in an error in state: 750.
 ##
 ## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN . loption(separated_nonempty_list(COMMA,ident)) RPAREN SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
+## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN . loption(separated_nonempty_list(COMMA,ident)) RPAREN AS ident SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN
@@ -6762,6 +6789,7 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK IMPORTC
 ## Ends in an error in state: 749.
 ##
 ## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS . LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
+## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS . LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN AS ident SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS
@@ -6774,6 +6802,7 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK IMPORTC
 ## Ends in an error in state: 748.
 ##
 ## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN . RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
+## contract_import -> IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN . RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN AS ident SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORTCONTRACT ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN
@@ -6839,6 +6868,7 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK IMPORTC
 ## Ends in an error in state: 742.
 ##
 ## contract_import -> IMPORTCONTRACT ident LPAREN . loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
+## contract_import -> IMPORTCONTRACT ident LPAREN . loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN AS ident SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORTCONTRACT ident LPAREN
@@ -6851,6 +6881,7 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK IMPORTC
 ## Ends in an error in state: 741.
 ##
 ## contract_import -> IMPORTCONTRACT ident . LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
+## contract_import -> IMPORTCONTRACT ident . LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN AS ident SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORTCONTRACT ident
@@ -6863,6 +6894,7 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN CONTRACT_SSATBLOCK IMPORTC
 ## Ends in an error in state: 740.
 ##
 ## contract_import -> IMPORTCONTRACT . ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
+## contract_import -> IMPORTCONTRACT . ident LPAREN loption(separated_nonempty_list(COMMA,qexpr)) RPAREN RETURNS LPAREN loption(separated_nonempty_list(COMMA,ident)) RPAREN AS ident SEMICOLON [ WEAKLY VAR TEL SSBLOCKEND PSBLOCKEND MODE IMPORTCONTRACT GUARANTEE CONST ASSUME ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORTCONTRACT
@@ -11722,7 +11754,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET ASSERT WEAKLY WITH
 ##
-## Ends in an error in state: 935.
+## Ends in an error in state: 938.
 ##
 ## node_equation -> ASSERT pexpr(quantified) . SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -11988,7 +12020,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET ASSERT XOR
 ##
-## Ends in an error in state: 934.
+## Ends in an error in state: 937.
 ##
 ## node_equation -> ASSERT . pexpr(quantified) SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12000,7 +12032,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON INITIAL STATE XOR
 ##
-## Ends in an error in state: 892.
+## Ends in an error in state: 895.
 ##
 ## state_decl -> INITIAL STATE . ident [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST COLON CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12012,7 +12044,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON INITIAL XOR
 ##
-## Ends in an error in state: 891.
+## Ends in an error in state: 894.
 ##
 ## state_decl -> INITIAL . STATE ident [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST COLON CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12024,7 +12056,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON RETURNS DOTDOT XOR
 ##
-## Ends in an error in state: 953.
+## Ends in an error in state: 956.
 ##
 ## node_equation -> AUTOMATON option(ident) list(state) RETURNS DOTDOT . SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12036,7 +12068,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON RETURNS WEAKLY RPAREN
 ##
-## Ends in an error in state: 955.
+## Ends in an error in state: 958.
 ##
 ## node_equation -> AUTOMATON option(ident) list(state) RETURNS ident_list . SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12055,7 +12087,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON RETURNS XOR
 ##
-## Ends in an error in state: 952.
+## Ends in an error in state: 955.
 ##
 ## node_equation -> AUTOMATON option(ident) list(state) RETURNS . ident_list SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## node_equation -> AUTOMATON option(ident) list(state) RETURNS . DOTDOT SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -12066,9 +12098,9 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON RETURNS XOR
 
 Syntax Error!
 
-main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY COLON ARROW
+main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY COLON AS
 ##
-## Ends in an error in state: 896.
+## Ends in an error in state: 899.
 ##
 ## state -> state_decl option(COLON) . unless_transitions list(node_local_decl) LET list(node_equation) TEL until_transitions [ WEAKLY TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN INITIAL GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## state -> state_decl option(COLON) . unless_transitions until_transitions [ WEAKLY TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN INITIAL GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -12081,7 +12113,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY LET AUTOMATON STATE WEAKLY PROPERTY_SSBLOCKSTART
 ##
-## Ends in an error in state: 938.
+## Ends in an error in state: 941.
 ##
 ## list(node_equation) -> node_equation . list(node_equation) [ TEL ]
 ##
@@ -12092,19 +12124,19 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 894, spurious reduction of production option(COLON) -> 
-## In state 896, spurious reduction of production unless_transitions -> 
-## In state 927, spurious reduction of production until_transitions -> 
-## In state 931, spurious reduction of production state -> state_decl option(COLON) unless_transitions until_transitions 
-## In state 947, spurious reduction of production nonempty_list(state) -> state 
-## In state 950, spurious reduction of production node_equation -> AUTOMATON option(ident) nonempty_list(state) 
+## In state 897, spurious reduction of production option(COLON) -> 
+## In state 899, spurious reduction of production unless_transitions -> 
+## In state 930, spurious reduction of production until_transitions -> 
+## In state 934, spurious reduction of production state -> state_decl option(COLON) unless_transitions until_transitions 
+## In state 950, spurious reduction of production nonempty_list(state) -> state 
+## In state 953, spurious reduction of production node_equation -> AUTOMATON option(ident) nonempty_list(state) 
 ##
 
 Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY LET TEL XOR
 ##
-## Ends in an error in state: 945.
+## Ends in an error in state: 948.
 ##
 ## state -> state_decl option(COLON) unless_transitions list(node_local_decl) LET list(node_equation) TEL . until_transitions [ WEAKLY TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN INITIAL GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12116,7 +12148,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY LET XOR
 ##
-## Ends in an error in state: 933.
+## Ends in an error in state: 936.
 ##
 ## state -> state_decl option(COLON) unless_transitions list(node_local_decl) LET . list(node_equation) TEL until_transitions [ WEAKLY TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN INITIAL GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12128,7 +12160,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF WEAKLY IF WEAKLY RESUME ASSUME XOR
 ##
-## Ends in an error in state: 908.
+## Ends in an error in state: 911.
 ##
 ## branch -> IF pexpr(nonquantified) branch . END [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE SEMICOLON RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE END ELSIF ELSE CONST CHECK AUTOMATON ASSUME ASSERT ]
 ## branch -> IF pexpr(nonquantified) branch . elsif_branch END [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE SEMICOLON RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE END ELSIF ELSE CONST CHECK AUTOMATON ASSUME ASSERT ]
@@ -12141,7 +12173,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF WEAKLY IF WEAKLY WITH
 ##
-## Ends in an error in state: 906.
+## Ends in an error in state: 909.
 ##
 ## branch -> IF pexpr(nonquantified) . branch END [ END ELSIF ELSE ]
 ## branch -> IF pexpr(nonquantified) . branch elsif_branch END [ END ELSIF ELSE ]
@@ -12188,7 +12220,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF WEAKLY IF XOR
 ##
-## Ends in an error in state: 905.
+## Ends in an error in state: 908.
 ##
 ## branch -> IF . pexpr(nonquantified) branch END [ END ELSIF ELSE ]
 ## branch -> IF . pexpr(nonquantified) branch elsif_branch END [ END ELSIF ELSE ]
@@ -12201,7 +12233,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF WEAKLY RESUME ASSUME ELSE RESTART ASSUME XOR
 ##
-## Ends in an error in state: 916.
+## Ends in an error in state: 919.
 ##
 ## branch -> IF pexpr(nonquantified) branch elsif_branch . END [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE SEMICOLON RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE END ELSIF ELSE CONST CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12213,7 +12245,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF WEAKLY RESUME ASSUME ELSE XOR
 ##
-## Ends in an error in state: 913.
+## Ends in an error in state: 916.
 ##
 ## elsif_branch -> ELSE . branch [ END ]
 ##
@@ -12225,7 +12257,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF WEAKLY RESUME ASSUME ELSIF WEAKLY RESUME ASSUME XOR
 ##
-## Ends in an error in state: 912.
+## Ends in an error in state: 915.
 ##
 ## elsif_branch -> ELSIF pexpr(nonquantified) branch . [ END ]
 ## elsif_branch -> ELSIF pexpr(nonquantified) branch . elsif_branch [ END ]
@@ -12238,7 +12270,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF WEAKLY RESUME ASSUME ELSIF WEAKLY WITH
 ##
-## Ends in an error in state: 911.
+## Ends in an error in state: 914.
 ##
 ## elsif_branch -> ELSIF pexpr(nonquantified) . branch [ END ]
 ## elsif_branch -> ELSIF pexpr(nonquantified) . branch elsif_branch [ END ]
@@ -12285,7 +12317,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF WEAKLY RESUME ASSUME ELSIF XOR
 ##
-## Ends in an error in state: 910.
+## Ends in an error in state: 913.
 ##
 ## elsif_branch -> ELSIF . pexpr(nonquantified) branch [ END ]
 ## elsif_branch -> ELSIF . pexpr(nonquantified) branch elsif_branch [ END ]
@@ -12298,7 +12330,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF WEAKLY RESUME ASSUME XOR
 ##
-## Ends in an error in state: 918.
+## Ends in an error in state: 921.
 ##
 ## branch -> target . [ END ELSIF ELSE ]
 ## transition_branch -> IF pexpr(nonquantified) target . option(SEMICOLON) [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST CHECK AUTOMATON ASSUME ASSERT ]
@@ -12311,7 +12343,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF WEAKLY WITH
 ##
-## Ends in an error in state: 904.
+## Ends in an error in state: 907.
 ##
 ## branch -> IF pexpr(nonquantified) . branch END [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE SEMICOLON RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST CHECK AUTOMATON ASSUME ASSERT ]
 ## branch -> IF pexpr(nonquantified) . branch elsif_branch END [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE SEMICOLON RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST CHECK AUTOMATON ASSUME ASSERT ]
@@ -12360,7 +12392,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS IF XOR
 ##
-## Ends in an error in state: 903.
+## Ends in an error in state: 906.
 ##
 ## branch -> IF . pexpr(nonquantified) branch END [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE SEMICOLON RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST CHECK AUTOMATON ASSUME ASSERT ]
 ## branch -> IF . pexpr(nonquantified) branch elsif_branch END [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE SEMICOLON RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST CHECK AUTOMATON ASSUME ASSERT ]
@@ -12375,7 +12407,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS RESTART XOR
 ##
-## Ends in an error in state: 901.
+## Ends in an error in state: 904.
 ##
 ## target -> RESTART . target_state [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE SEMICOLON RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE END ELSIF ELSE CONST CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12387,7 +12419,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS RESUME WEAKLY SEMICOLON XOR
 ##
-## Ends in an error in state: 920.
+## Ends in an error in state: 923.
 ##
 ## unless_transitions -> UNLESS transition_branch . unless_transitions [ WEAKLY VAR UNTIL TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12399,7 +12431,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS RESUME WEAKLY XOR
 ##
-## Ends in an error in state: 925.
+## Ends in an error in state: 928.
 ##
 ## transition_branch -> branch . option(SEMICOLON) [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12411,7 +12443,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS RESUME XOR
 ##
-## Ends in an error in state: 898.
+## Ends in an error in state: 901.
 ##
 ## target -> RESUME . target_state [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE SEMICOLON RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE END ELSIF ELSE CONST CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12423,7 +12455,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS WEAKLY RESUME ASSUME XOR
 ##
-## Ends in an error in state: 923.
+## Ends in an error in state: 926.
 ##
 ## transition_branch -> pexpr(nonquantified) target . option(SEMICOLON) [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12435,7 +12467,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS WEAKLY WITH
 ##
-## Ends in an error in state: 922.
+## Ends in an error in state: 925.
 ##
 ## pexpr(nonquantified) -> pexpr(nonquantified) . CARET pexpr(nonquantified) [ XOR WHEN RSH RESUME RESTART PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
 ## pexpr(nonquantified) -> pexpr(nonquantified) . DOTPERCENT NUMERAL [ XOR WHEN RSH RESUME RESTART PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -12481,7 +12513,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNLESS XOR
 ##
-## Ends in an error in state: 897.
+## Ends in an error in state: 900.
 ##
 ## unless_transitions -> UNLESS . transition_branch unless_transitions [ WEAKLY VAR UNTIL TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12493,7 +12525,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNTIL RESUME ASSUME VAR
 ##
-## Ends in an error in state: 929.
+## Ends in an error in state: 932.
 ##
 ## until_transitions -> UNTIL transition_branch . until_transitions [ WEAKLY TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN INITIAL GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12504,15 +12536,15 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 925, spurious reduction of production option(SEMICOLON) -> 
-## In state 926, spurious reduction of production transition_branch -> branch option(SEMICOLON) 
+## In state 928, spurious reduction of production option(SEMICOLON) -> 
+## In state 929, spurious reduction of production transition_branch -> branch option(SEMICOLON) 
 ##
 
 Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY UNTIL XOR
 ##
-## Ends in an error in state: 928.
+## Ends in an error in state: 931.
 ##
 ## until_transitions -> UNTIL . transition_branch until_transitions [ WEAKLY TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN INITIAL GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12524,7 +12556,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE WEAKLY XOR
 ##
-## Ends in an error in state: 894.
+## Ends in an error in state: 897.
 ##
 ## state -> state_decl . option(COLON) unless_transitions list(node_local_decl) LET list(node_equation) TEL until_transitions [ WEAKLY TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN INITIAL GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## state -> state_decl . option(COLON) unless_transitions until_transitions [ WEAKLY TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN INITIAL GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -12537,7 +12569,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON STATE XOR
 ##
-## Ends in an error in state: 889.
+## Ends in an error in state: 892.
 ##
 ## state_decl -> STATE . ident [ WEAKLY VAR UNTIL UNLESS TEL SYM STATE RETURNS REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN LET INITIAL GUARANTEE ENSURE CONST COLON CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12549,7 +12581,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON WEAKLY IMPORTED
 ##
-## Ends in an error in state: 888.
+## Ends in an error in state: 891.
 ##
 ## node_equation -> AUTOMATON option(ident) . list(state) RETURNS ident_list SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## node_equation -> AUTOMATON option(ident) . list(state) RETURNS DOTDOT SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -12564,7 +12596,7 @@ Array indexing is done using square brackets e.g. `A[i]`.
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET AUTOMATON XOR
 ##
-## Ends in an error in state: 887.
+## Ends in an error in state: 890.
 ##
 ## node_equation -> AUTOMATON . option(ident) list(state) RETURNS ident_list SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## node_equation -> AUTOMATON . option(ident) list(state) RETURNS DOTDOT SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -12579,7 +12611,7 @@ Array indexing is done using square brackets e.g. `A[i]`.
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET CHECK STRING ASSERT
 ##
-## Ends in an error in state: 884.
+## Ends in an error in state: 887.
 ##
 ## check -> CHECK option(STRING) . pexpr(quantified) SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12591,7 +12623,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET CHECK WEAKLY WITH
 ##
-## Ends in an error in state: 885.
+## Ends in an error in state: 888.
 ##
 ## check -> CHECK option(STRING) pexpr(quantified) . SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -12637,7 +12669,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET CHECK XOR
 ##
-## Ends in an error in state: 883.
+## Ends in an error in state: 886.
 ##
 ## check -> CHECK . option(STRING) pexpr(quantified) SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12649,7 +12681,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET LPAREN WEAKLY EQUALS
 ##
-## Ends in an error in state: 870.
+## Ends in an error in state: 873.
 ##
 ## left_side -> LPAREN struct_item_list . RPAREN [ EQUALS ]
 ##
@@ -12660,16 +12692,16 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET LPAREN WEAKLY EQUALS
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 875, spurious reduction of production struct_item -> ident 
-## In state 872, spurious reduction of production separated_nonempty_list(COMMA,struct_item) -> struct_item 
-## In state 882, spurious reduction of production struct_item_list -> separated_nonempty_list(COMMA,struct_item) 
+## In state 878, spurious reduction of production struct_item -> ident 
+## In state 875, spurious reduction of production separated_nonempty_list(COMMA,struct_item) -> struct_item 
+## In state 885, spurious reduction of production struct_item_list -> separated_nonempty_list(COMMA,struct_item) 
 ##
 
 Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET LPAREN XOR
 ##
-## Ends in an error in state: 868.
+## Ends in an error in state: 871.
 ##
 ## left_side -> LPAREN . struct_item_list RPAREN [ EQUALS ]
 ## left_side -> LPAREN . RPAREN [ EQUALS ]
@@ -12682,7 +12714,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_B_ANNOT COLON TRUE XOR
 ##
-## Ends in an error in state: 866.
+## Ends in an error in state: 869.
 ##
 ## main_annot -> MAIN_B_ANNOT COLON boolean . SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12694,7 +12726,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_B_ANNOT COLON XOR
 ##
-## Ends in an error in state: 865.
+## Ends in an error in state: 868.
 ##
 ## main_annot -> MAIN_B_ANNOT COLON . boolean SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12706,7 +12738,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_B_ANNOT XOR
 ##
-## Ends in an error in state: 864.
+## Ends in an error in state: 867.
 ##
 ## main_annot -> MAIN_B_ANNOT . COLON boolean SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12718,7 +12750,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_PSBLOCKSTART COLON TRUE SEMICOLON PROPERTY_SSBLOCKSTART
 ##
-## Ends in an error in state: 860.
+## Ends in an error in state: 863.
 ##
 ## main_annot -> MAIN_PSBLOCKSTART COLON boolean option(SEMICOLON) . PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12730,7 +12762,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_PSBLOCKSTART COLON TRUE XOR
 ##
-## Ends in an error in state: 859.
+## Ends in an error in state: 862.
 ##
 ## main_annot -> MAIN_PSBLOCKSTART COLON boolean . option(SEMICOLON) PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12742,7 +12774,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_PSBLOCKSTART COLON XOR
 ##
-## Ends in an error in state: 858.
+## Ends in an error in state: 861.
 ##
 ## main_annot -> MAIN_PSBLOCKSTART COLON . boolean option(SEMICOLON) PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12754,7 +12786,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_PSBLOCKSTART SEMICOLON PROPERTY_SSBLOCKSTART
 ##
-## Ends in an error in state: 862.
+## Ends in an error in state: 865.
 ##
 ## main_annot -> MAIN_PSBLOCKSTART option(SEMICOLON) . PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12766,7 +12798,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_PSBLOCKSTART XOR
 ##
-## Ends in an error in state: 857.
+## Ends in an error in state: 860.
 ##
 ## main_annot -> MAIN_PSBLOCKSTART . option(SEMICOLON) PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## main_annot -> MAIN_PSBLOCKSTART . COLON boolean option(SEMICOLON) PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -12779,7 +12811,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_P_ANNOT XOR
 ##
-## Ends in an error in state: 855.
+## Ends in an error in state: 858.
 ##
 ## main_annot -> MAIN_P_ANNOT . SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12787,11 +12819,11 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_P_ANNOT XOR
 ## MAIN_P_ANNOT
 ##
 
-Syntax Error! Perhaps a missing semicolon at the end of the statement.
+Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_SSBLOCKSTART COLON TRUE SEMICOLON XOR
 ##
-## Ends in an error in state: 851.
+## Ends in an error in state: 854.
 ##
 ## main_annot -> MAIN_SSBLOCKSTART COLON boolean option(SEMICOLON) . SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12803,7 +12835,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_SSBLOCKSTART COLON TRUE XOR
 ##
-## Ends in an error in state: 850.
+## Ends in an error in state: 853.
 ##
 ## main_annot -> MAIN_SSBLOCKSTART COLON boolean . option(SEMICOLON) SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12815,7 +12847,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_SSBLOCKSTART COLON XOR
 ##
-## Ends in an error in state: 847.
+## Ends in an error in state: 850.
 ##
 ## main_annot -> MAIN_SSBLOCKSTART COLON . boolean option(SEMICOLON) SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12827,7 +12859,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_SSBLOCKSTART SEMICOLON XOR
 ##
-## Ends in an error in state: 853.
+## Ends in an error in state: 856.
 ##
 ## main_annot -> MAIN_SSBLOCKSTART option(SEMICOLON) . SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12839,7 +12871,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_SSBLOCKSTART SSBLOCKEND XOR
 ##
-## Ends in an error in state: 959.
+## Ends in an error in state: 962.
 ##
 ## list(node_item) -> node_item . list(node_item) [ TEL ]
 ##
@@ -12851,7 +12883,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET MAIN_SSBLOCKSTART XOR
 ##
-## Ends in an error in state: 846.
+## Ends in an error in state: 849.
 ##
 ## main_annot -> MAIN_SSBLOCKSTART . option(SEMICOLON) SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## main_annot -> MAIN_SSBLOCKSTART . COLON boolean option(SEMICOLON) SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -12864,7 +12896,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_ANNOT STRING ASSERT
 ##
-## Ends in an error in state: 843.
+## Ends in an error in state: 846.
 ##
 ## property -> PROPERTY_ANNOT option(STRING) . pexpr(quantified) SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12876,7 +12908,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_ANNOT WEAKLY WITH
 ##
-## Ends in an error in state: 844.
+## Ends in an error in state: 847.
 ##
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
 ## pexpr(quantified) -> pexpr(quantified) . DOTPERCENT NUMERAL [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -12922,7 +12954,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_ANNOT XOR
 ##
-## Ends in an error in state: 842.
+## Ends in an error in state: 845.
 ##
 ## property -> PROPERTY_ANNOT . option(STRING) pexpr(quantified) SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12934,7 +12966,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_PSBLOCKSTART COLON WEAKLY SEMICOLON XOR
 ##
-## Ends in an error in state: 837.
+## Ends in an error in state: 840.
 ##
 ## property -> PROPERTY_PSBLOCKSTART option(STRING) COLON pexpr(quantified) SEMICOLON . PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -12946,7 +12978,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_PSBLOCKSTART COLON WEAKLY WITH
 ##
-## Ends in an error in state: 836.
+## Ends in an error in state: 839.
 ##
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
 ## pexpr(quantified) -> pexpr(quantified) . DOTPERCENT NUMERAL [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -12992,7 +13024,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_PSBLOCKSTART COLON XOR
 ##
-## Ends in an error in state: 835.
+## Ends in an error in state: 838.
 ##
 ## property -> PROPERTY_PSBLOCKSTART option(STRING) COLON . pexpr(quantified) SEMICOLON PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## two_colons -> COLON . COLON [ WEAKLY SYM REQUIRE MODE GUARANTEE ENSURE ASSUME ]
@@ -13005,7 +13037,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_PSBLOCKSTART STRING ASSERT
 ##
-## Ends in an error in state: 834.
+## Ends in an error in state: 837.
 ##
 ## property -> PROPERTY_PSBLOCKSTART option(STRING) . pexpr(quantified) SEMICOLON PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## property -> PROPERTY_PSBLOCKSTART option(STRING) . COLON pexpr(quantified) SEMICOLON PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -13018,7 +13050,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_PSBLOCKSTART WEAKLY SEMICOLON XOR
 ##
-## Ends in an error in state: 840.
+## Ends in an error in state: 843.
 ##
 ## property -> PROPERTY_PSBLOCKSTART option(STRING) pexpr(quantified) SEMICOLON . PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -13030,7 +13062,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_PSBLOCKSTART WEAKLY WITH
 ##
-## Ends in an error in state: 839.
+## Ends in an error in state: 842.
 ##
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
 ## pexpr(quantified) -> pexpr(quantified) . DOTPERCENT NUMERAL [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -13076,7 +13108,7 @@ Syntax Error! Probably a missing delimiter such as a semicolon at the end of the
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_PSBLOCKSTART XOR
 ##
-## Ends in an error in state: 833.
+## Ends in an error in state: 836.
 ##
 ## property -> PROPERTY_PSBLOCKSTART . option(STRING) pexpr(quantified) SEMICOLON PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## property -> PROPERTY_PSBLOCKSTART . option(STRING) COLON pexpr(quantified) SEMICOLON PSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -13089,7 +13121,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_SSBLOCKSTART COLON COLON XOR
 ##
-## Ends in an error in state: 826.
+## Ends in an error in state: 829.
 ##
 ## two_colons -> COLON . COLON [ WEAKLY SYM REQUIRE MODE GUARANTEE ENSURE ASSUME ]
 ## two_colons -> COLON COLON . [ WEAKLY SYM REQUIRE MODE GUARANTEE ENSURE ASSUME ]
@@ -13102,7 +13134,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_SSBLOCKSTART COLON WEAKLY SEMICOLON XOR
 ##
-## Ends in an error in state: 828.
+## Ends in an error in state: 831.
 ##
 ## property -> PROPERTY_SSBLOCKSTART option(STRING) COLON pexpr(quantified) SEMICOLON . SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -13114,7 +13146,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_SSBLOCKSTART COLON WEAKLY WITH
 ##
-## Ends in an error in state: 827.
+## Ends in an error in state: 830.
 ##
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
 ## pexpr(quantified) -> pexpr(quantified) . DOTPERCENT NUMERAL [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -13160,7 +13192,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_SSBLOCKSTART COLON XOR
 ##
-## Ends in an error in state: 825.
+## Ends in an error in state: 828.
 ##
 ## property -> PROPERTY_SSBLOCKSTART option(STRING) COLON . pexpr(quantified) SEMICOLON SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## two_colons -> COLON . COLON [ WEAKLY SYM REQUIRE MODE GUARANTEE ENSURE ASSUME ]
@@ -13173,7 +13205,7 @@ Syntax Error! Perhaps missing variable assignment for expression.
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_SSBLOCKSTART STRING ASSERT
 ##
-## Ends in an error in state: 824.
+## Ends in an error in state: 827.
 ##
 ## property -> PROPERTY_SSBLOCKSTART option(STRING) . pexpr(quantified) SEMICOLON SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## property -> PROPERTY_SSBLOCKSTART option(STRING) . COLON pexpr(quantified) SEMICOLON SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -13186,7 +13218,7 @@ Syntax Error! Perhaps missing variable assignment for expression.
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_SSBLOCKSTART WEAKLY SEMICOLON XOR
 ##
-## Ends in an error in state: 831.
+## Ends in an error in state: 834.
 ##
 ## property -> PROPERTY_SSBLOCKSTART option(STRING) pexpr(quantified) SEMICOLON . SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -13198,7 +13230,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_SSBLOCKSTART WEAKLY WITH
 ##
-## Ends in an error in state: 830.
+## Ends in an error in state: 833.
 ##
 ## pexpr(quantified) -> pexpr(quantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
 ## pexpr(quantified) -> pexpr(quantified) . DOTPERCENT NUMERAL [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -13244,7 +13276,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET PROPERTY_SSBLOCKSTART XOR
 ##
-## Ends in an error in state: 823.
+## Ends in an error in state: 826.
 ##
 ## property -> PROPERTY_SSBLOCKSTART . option(STRING) pexpr(quantified) SEMICOLON SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## property -> PROPERTY_SSBLOCKSTART . option(STRING) COLON pexpr(quantified) SEMICOLON SSBLOCKEND [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
@@ -13257,7 +13289,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET TEL XOR
 ##
-## Ends in an error in state: 965.
+## Ends in an error in state: 968.
 ##
 ## node_def -> list(node_local_decl) LET list(node_item) TEL . option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -13269,7 +13301,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET WEAKLY COMMA XOR
 ##
-## Ends in an error in state: 873.
+## Ends in an error in state: 876.
 ##
 ## separated_nonempty_list(COMMA,struct_item) -> struct_item COMMA . separated_nonempty_list(COMMA,struct_item) [ RPAREN EQUALS ]
 ##
@@ -13281,7 +13313,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET WEAKLY EQUALS WEAKLY WITH
 ##
-## Ends in an error in state: 942.
+## Ends in an error in state: 945.
 ##
 ## node_equation -> left_side EQUALS pexpr(nonquantified) . SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ## pexpr(nonquantified) -> pexpr(nonquantified) . CARET pexpr(nonquantified) [ XOR WHEN SEMICOLON RSH PLUS PIPE OR NEQ MULT MOD MINUS LTE LT LSQBRACKET LSH INTDIV IMPL GTE GT EQUALS DOTPERCENT DOT DIV CARET BVOR BVAND ARROW AND ]
@@ -13327,7 +13359,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET WEAKLY EQUALS XOR
 ##
-## Ends in an error in state: 941.
+## Ends in an error in state: 944.
 ##
 ## node_equation -> left_side EQUALS . pexpr(nonquantified) SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -13339,7 +13371,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET WEAKLY LSQBRACKET WEAKLY RSQBRACKET XOR
 ##
-## Ends in an error in state: 880.
+## Ends in an error in state: 883.
 ##
 ## nonempty_list(index_var) -> index_var . [ RPAREN EQUALS COMMA ]
 ## nonempty_list(index_var) -> index_var . nonempty_list(index_var) [ RPAREN EQUALS COMMA ]
@@ -13352,7 +13384,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET WEAKLY LSQBRACKET WEAKLY XOR
 ##
-## Ends in an error in state: 877.
+## Ends in an error in state: 880.
 ##
 ## index_var -> LSQBRACKET ident . RSQBRACKET [ RPAREN LSQBRACKET EQUALS COMMA ]
 ##
@@ -13364,7 +13396,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET WEAKLY LSQBRACKET XOR
 ##
-## Ends in an error in state: 876.
+## Ends in an error in state: 879.
 ##
 ## index_var -> LSQBRACKET . ident RSQBRACKET [ RPAREN LSQBRACKET EQUALS COMMA ]
 ##
@@ -13376,7 +13408,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET WEAKLY RPAREN
 ##
-## Ends in an error in state: 940.
+## Ends in an error in state: 943.
 ##
 ## node_equation -> left_side . EQUALS pexpr(nonquantified) SEMICOLON [ WEAKLY TEL SYM REQUIRE PROPERTY_SSBLOCKSTART PROPERTY_PSBLOCKSTART PROPERTY_ANNOT MODE MAIN_SSBLOCKSTART MAIN_P_ANNOT MAIN_PSBLOCKSTART MAIN_B_ANNOT LPAREN GUARANTEE ENSURE CHECK AUTOMATON ASSUME ASSERT ]
 ##
@@ -13387,17 +13419,17 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET WEAKLY RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 875, spurious reduction of production struct_item -> ident 
-## In state 872, spurious reduction of production separated_nonempty_list(COMMA,struct_item) -> struct_item 
-## In state 882, spurious reduction of production struct_item_list -> separated_nonempty_list(COMMA,struct_item) 
-## In state 937, spurious reduction of production left_side -> struct_item_list 
+## In state 878, spurious reduction of production struct_item -> ident 
+## In state 875, spurious reduction of production separated_nonempty_list(COMMA,struct_item) -> struct_item 
+## In state 885, spurious reduction of production struct_item_list -> separated_nonempty_list(COMMA,struct_item) 
+## In state 940, spurious reduction of production left_side -> struct_item_list 
 ##
 
 Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET WEAKLY XOR
 ##
-## Ends in an error in state: 875.
+## Ends in an error in state: 878.
 ##
 ## struct_item -> ident . [ RPAREN EQUALS COMMA ]
 ## struct_item -> ident . nonempty_list(index_var) [ RPAREN EQUALS COMMA ]
@@ -13411,7 +13443,7 @@ Array indexing is done using square brackets e.g. `A[i]`.
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN LET XOR
 ##
-## Ends in an error in state: 822.
+## Ends in an error in state: 825.
 ##
 ## node_def -> list(node_local_decl) LET . list(node_item) TEL option(node_sep) [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -13435,7 +13467,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 789.
+## Ends in an error in state: 792.
 ##
 ## decl -> NODE node_decl . node_def [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
 ##
@@ -13448,14 +13480,14 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN TYPE
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 459, spurious reduction of production option(SEMICOLON) -> 
 ## In state 461, spurious reduction of production option(contract_spec) -> 
-## In state 787, spurious reduction of production node_decl -> ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) option(SEMICOLON) option(contract_spec) 
+## In state 790, spurious reduction of production node_decl -> ident loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) option(SEMICOLON) option(contract_spec) 
 ##
 
 Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN VAR WEAKLY COLON ASSUME RPAREN
 ##
-## Ends in an error in state: 793.
+## Ends in an error in state: 796.
 ##
 ## var_decl -> clocked_typed_idents . SEMICOLON [ WEAKLY VAR SYM REQUIRE MODE LPAREN LET GUARANTEE ENSURE CONST ASSUME ]
 ##
@@ -13474,7 +13506,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN VAR WEAKLY COLON ASSUME SEMICOLON XOR
 ##
-## Ends in an error in state: 791.
+## Ends in an error in state: 794.
 ##
 ## nonempty_list(var_decl) -> var_decl . [ VAR LET CONST ]
 ## nonempty_list(var_decl) -> var_decl . nonempty_list(var_decl) [ VAR LET CONST ]
@@ -13487,7 +13519,7 @@ Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN RPAREN VAR XOR
 ##
-## Ends in an error in state: 790.
+## Ends in an error in state: 793.
 ##
 ## var_decls -> VAR . nonempty_list(var_decl) [ VAR LET CONST ]
 ##
@@ -13571,7 +13603,7 @@ main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN WEAKLY COLON ASSUME WHEN XOR
 ## typed_idents WHEN
 ##
 
-Syntax Error! Perhaps a missing `returns` statement in node declaration.
+Syntax Error!
 
 main: NODE WEAKLY LPAREN RPAREN RETURNS LPAREN XOR
 ##
@@ -13690,7 +13722,7 @@ Syntax Error!
 
 main: NODE WEAKLY XOR
 ##
-## Ends in an error in state: 970.
+## Ends in an error in state: 973.
 ##
 ## node_decl -> ident . loption(static_params) tlist(LPAREN,SEMICOLON,RPAREN,const_clocked_typed_idents) RETURNS tlist(LPAREN,SEMICOLON,RPAREN,clocked_typed_idents) option(SEMICOLON) option(contract_spec) [ VAR LET CONST ]
 ## node_param_inst -> NODE ident . EQUALS ident tlist(LPARAMBRACKET,SEMICOLON,RPARAMBRACKET,node_call_static_param) SEMICOLON [ TYPE NODE FUNCTION EOF CONTRACT CONST ]
@@ -13902,7 +13934,7 @@ Syntax Error!
 
 main: TYPE WEAKLY SEMICOLON XOR
 ##
-## Ends in an error in state: 996.
+## Ends in an error in state: 999.
 ##
 ## list(decl) -> decl . list(decl) [ EOF ]
 ##

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -22,7 +22,7 @@ open Lib
 open LustreReporting
    
 module A = LustreAst
-          
+
 let mk_pos = position_of_lexing 
 
 
@@ -786,7 +786,7 @@ pexpr(Q):
 
   (* A mode reference. *)
   | two_colons ; mode_ref = separated_nonempty_list(two_colons, ident) {
-    A.ModeRef (mk_pos $startpos, mode_ref)
+    A.ModeRef (mk_pos $startpos, mode_ref )
   }
 
   (* A propositional constant *)
@@ -844,7 +844,7 @@ pexpr(Q):
     
   (* A record field projection (not quantified) *)
   | s = pexpr(Q); DOT; t = ident 
-    { A.RecordProject (mk_pos $startpos, s, t) }
+    { A.RecordProject (mk_pos $startpos, s, QId.to_string t) }
 
   (* A record (not quantified) *)
   | t = ident; 
@@ -1051,7 +1051,7 @@ pexpr(Q):
     c = ident; SEMICOLON;
     pos = pexpr(Q); SEMICOLON;
     neg = pexpr(Q); RPAREN 
-    { A.Merge (mk_pos $startpos, c, ["true", pos; "false", neg]) }
+    { A.Merge (mk_pos $startpos, c, [QId.from_string "true", pos; QId.from_string "false", neg]) }
 
   (* N-way merge operator *)
   | MERGE; 
@@ -1127,8 +1127,8 @@ clock_expr:
   | TRUE { A.ClockTrue }
 
 merge_case_id:
-  | TRUE { "true" }
-  | FALSE { "false" }
+  | TRUE { QId.from_string "true" }
+  | FALSE { QId.from_string "false" }
   | c = ident { c }
 
 merge_case :
@@ -1141,17 +1141,17 @@ merge_case :
 (* An identifier *)
 ident:
   (* Contract tokens are not keywords. *)
-  | MODE { "mode" }
-  | ASSUME { "assume" }
-  | GUARANTEE { "guarantee" }
-  | REQUIRE { "require" }
-  | ENSURE { "ensure" }
-  | WEAKLY { "weakly" }
-  | s = SYM { s }
+  | MODE { QId.from_string "mode" }
+  | ASSUME { QId.from_string  "assume" }
+  | GUARANTEE { QId.from_string  "guarantee" }
+  | REQUIRE { QId.from_string  "require" }
+  | ENSURE { QId.from_string  "ensure" }
+  | WEAKLY { QId.from_string  "weakly" }
+  | s = SYM { QId.from_string  s }
 
 ident_or_quotident:
   | id = ident { id }
-  | s = QUOTSYM { s }
+  | s = QUOTSYM { QId.from_string s }
 
 (* An identifier with a type *)
 typed_ident: s = ident; COLON; t = lustre_type { (mk_pos $startpos, s, t) }
@@ -1303,7 +1303,7 @@ label_or_index:
 
   (* An index into a record *)
   | DOT; i = ident
-     { A.Label (mk_pos $startpos, i) } 
+     { A.Label (mk_pos $startpos, QId.to_string i) } 
 
   (* An index into an array with a variable or constant *)
   | LSQBRACKET; e = expr; RSQBRACKET

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -1170,6 +1170,10 @@ typed_ident: s = ident; COLON; t = lustre_type { (mk_pos $startpos, s, t) }
 ident_list:
   | l = separated_nonempty_list(COMMA, ident) { l }
 
+(* A comma-separated list of identifiers *)
+qual_ident_list:
+  | l = separated_nonempty_list(two_colons, ident) { l }
+          
 
 (* A comma-separated list of types *)
 lustre_type_list:

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -786,7 +786,7 @@ pexpr(Q):
 
   (* A mode reference. *)
   | two_colons ; mode_ref = separated_nonempty_list(two_colons, ident) {
-    A.ModeRef (mk_pos $startpos, mode_ref )
+    A.ModeRef (mk_pos $startpos, QId.from_list (List.concat (List.map QId.to_list mode_ref)))
   }
 
   (* A propositional constant *)

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -22,7 +22,8 @@ open Lib
 open LustreReporting
    
 module A = LustreAst
-
+module QId = LustreAstIdent
+           
 let mk_pos = position_of_lexing 
 
 

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -128,6 +128,7 @@ let merge_branches transitions =
 (* Contract annotations. *)
 %token CONTRACT
 %token IMPORTCONTRACT
+%token AS
 (* %token IMPORTMODE *)
 %token ASSUME
 %token GUARANTEE
@@ -473,12 +474,16 @@ mode_equation:
   }
 
 contract_import:
-  IMPORTCONTRACT ; n = ident ;
-  LPAREN ; in_params = separated_list(COMMA, qexpr) ; RPAREN ; RETURNS ;
-  LPAREN ; out_params = separated_list(COMMA, ident) ; RPAREN ; SEMICOLON ; {
-    A.ContractCall (mk_pos $startpos, QId.from_string n, in_params, List.map QId.from_string out_params)
-  }
-
+  | IMPORTCONTRACT ; n = ident ;
+    LPAREN ; in_params = separated_list(COMMA, qexpr) ; RPAREN ; RETURNS ;
+    LPAREN ; out_params = separated_list(COMMA, ident) ; RPAREN ; SEMICOLON ; {
+    A.ContractCall (mk_pos $startpos, QId.from_string n, in_params, List.map QId.from_string out_params, QId.from_string n)
+    }
+  | IMPORTCONTRACT ; n = ident ;
+    LPAREN ; in_params = separated_list(COMMA, qexpr) ; RPAREN ; RETURNS ;
+    LPAREN ; out_params = separated_list(COMMA, ident) ; RPAREN ; AS ; n2 = ident ; SEMICOLON ; {
+    A.ContractCall (mk_pos $startpos, QId.from_string n, in_params, List.map QId.from_string out_params, QId.from_string n2)
+    }
 
 contract_item:
   | v = contract_ghost_var { v } 

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -788,14 +788,12 @@ two_colons:
 pexpr(Q): 
   
   (* An identifier *)
-  | s = ident { A.Ident (mk_pos $startpos, QId.from_string s) } 
+  | s = qual_ident_list { A.Ident (mk_pos $startpos, QId.from_list s) } 
 
   (* A mode reference. *)
-  | two_colons ; mode_ref = separated_nonempty_list(two_colons, ident) {
-    A.ModeRef (mk_pos $startpos,
-               QId.from_list (List.concat (List.map (fun i -> QId.to_list (QId.from_string i)) mode_ref)))
+  | two_colons ; mode_ref = qual_ident_list {
+    A.ModeRef (mk_pos $startpos, QId.from_list mode_ref)
     }
-  (* TODO: Fix this parsing nonsense. The problem is a::b is parsed as 'a::b' instead of 'a'::'b'*)
 
   (* A propositional constant *)
   | TRUE { A.Const (mk_pos $startpos, A.True) }

--- a/src/lustre/lustreParserErrors.ml
+++ b/src/lustre/lustreParserErrors.ml
@@ -12,7 +12,7 @@ let message =
         "Syntax Error! Incomplete type declaration.\n"
     | 373 ->
         "Syntax Error! Perhaps an illegal expression in contract call.\n"
-    | 996 ->
+    | 999 ->
         "Syntax Error! Perhaps an illegal declaration for imported node or function.\n"
     | 10 ->
         "Syntax Error!\n"
@@ -42,7 +42,7 @@ let message =
         "Syntax Error!\n"
     | 392 ->
         "Syntax Error! Perhaps a missing node name.\n"
-    | 970 ->
+    | 973 ->
         "Syntax Error!\n"
     | 409 ->
         "Syntax Error!\n"
@@ -61,7 +61,7 @@ let message =
     | 439 ->
         "Syntax Error! Perhaps a missing `returns` statement in node declaration.\n"
     | 451 ->
-        "Syntax Error! Perhaps a missing `returns` statement in node declaration.\n"
+        "Syntax Error!\n"
     | 454 ->
         "Syntax Error!\n"
     | 455 ->
@@ -70,179 +70,179 @@ let message =
         "Syntax Error!\n"
     | 459 ->
         "Syntax Error! Perhaps a missing/unbalanced parenthesis.\n"
-    | 790 ->
-        "Syntax Error! Illegal name for a variable declaration.\n"
-    | 791 ->
-        "Syntax Error!\n"
     | 793 ->
+        "Syntax Error! Illegal name for a variable declaration.\n"
+    | 794 ->
         "Syntax Error!\n"
-    | 789 ->
+    | 796 ->
+        "Syntax Error!\n"
+    | 792 ->
         "Syntax Error!\n"
     | 461 ->
         "Syntax Error!\n"
-    | 822 ->
+    | 825 ->
         "Syntax Error! Illegal left hand side of the equation.\n"
-    | 875 ->
+    | 878 ->
         "Syntax Error! Unexpected parenthesis found.\nArray indexing is done using square brackets e.g. `A[i]`.\n"
-    | 940 ->
+    | 943 ->
         "Syntax Error!\n"
-    | 876 ->
-        "Syntax Error!\n"
-    | 877 ->
+    | 879 ->
         "Syntax Error!\n"
     | 880 ->
         "Syntax Error!\n"
-    | 941 ->
+    | 883 ->
         "Syntax Error!\n"
-    | 942 ->
+    | 944 ->
         "Syntax Error!\n"
-    | 873 ->
+    | 945 ->
         "Syntax Error!\n"
-    | 965 ->
+    | 876 ->
         "Syntax Error!\n"
-    | 823 ->
-        "Syntax Error!\n"
-    | 830 ->
-        "Syntax Error!\n"
-    | 831 ->
-        "Syntax Error!\n"
-    | 824 ->
-        "Syntax Error! Perhaps missing variable assignment for expression.\n"
-    | 825 ->
-        "Syntax Error! Perhaps missing variable assignment for expression.\n"
-    | 827 ->
-        "Syntax Error!\n"
-    | 828 ->
+    | 968 ->
         "Syntax Error!\n"
     | 826 ->
         "Syntax Error!\n"
     | 833 ->
         "Syntax Error!\n"
-    | 839 ->
-        "Syntax Error! Probably a missing delimiter such as a semicolon at the end of the statement.\n"
-    | 840 ->
-        "Syntax Error!\n"
     | 834 ->
         "Syntax Error!\n"
-    | 835 ->
+    | 827 ->
+        "Syntax Error! Perhaps missing variable assignment for expression.\n"
+    | 828 ->
+        "Syntax Error! Perhaps missing variable assignment for expression.\n"
+    | 830 ->
+        "Syntax Error!\n"
+    | 831 ->
+        "Syntax Error!\n"
+    | 829 ->
         "Syntax Error!\n"
     | 836 ->
         "Syntax Error!\n"
-    | 837 ->
-        "Syntax Error!\n"
     | 842 ->
-        "Syntax Error!\n"
-    | 844 ->
-        "Syntax Error!\n"
+        "Syntax Error! Probably a missing delimiter such as a semicolon at the end of the statement.\n"
     | 843 ->
         "Syntax Error!\n"
-    | 846 ->
+    | 837 ->
         "Syntax Error!\n"
-    | 959 ->
+    | 838 ->
         "Syntax Error!\n"
-    | 853 ->
+    | 839 ->
+        "Syntax Error!\n"
+    | 840 ->
+        "Syntax Error!\n"
+    | 845 ->
         "Syntax Error!\n"
     | 847 ->
         "Syntax Error!\n"
+    | 846 ->
+        "Syntax Error!\n"
+    | 849 ->
+        "Syntax Error!\n"
+    | 962 ->
+        "Syntax Error!\n"
+    | 856 ->
+        "Syntax Error!\n"
     | 850 ->
         "Syntax Error!\n"
-    | 851 ->
+    | 853 ->
         "Syntax Error!\n"
-    | 855 ->
-        "Syntax Error! Perhaps a missing semicolon at the end of the statement.\n"
-    | 857 ->
-        "Syntax Error!\n"
-    | 862 ->
+    | 854 ->
         "Syntax Error!\n"
     | 858 ->
         "Syntax Error!\n"
-    | 859 ->
-        "Syntax Error!\n"
     | 860 ->
-        "Syntax Error!\n"
-    | 864 ->
         "Syntax Error!\n"
     | 865 ->
         "Syntax Error!\n"
-    | 866 ->
+    | 861 ->
+        "Syntax Error!\n"
+    | 862 ->
+        "Syntax Error!\n"
+    | 863 ->
+        "Syntax Error!\n"
+    | 867 ->
         "Syntax Error!\n"
     | 868 ->
         "Syntax Error!\n"
-    | 870 ->
+    | 869 ->
         "Syntax Error!\n"
-    | 883 ->
+    | 871 ->
         "Syntax Error!\n"
-    | 885 ->
+    | 873 ->
         "Syntax Error!\n"
-    | 884 ->
+    | 886 ->
+        "Syntax Error!\n"
+    | 888 ->
         "Syntax Error!\n"
     | 887 ->
+        "Syntax Error!\n"
+    | 890 ->
         "Syntax Error! Unexpected parenthesis found.\nArray indexing is done using square brackets e.g. `A[i]`. \n"
-    | 888 ->
+    | 891 ->
         "Syntax Error! Unexpected parenthesis found.\nArray indexing is done using square brackets e.g. `A[i]`.\n"
-    | 889 ->
-        "Syntax Error!\n"
-    | 894 ->
-        "Syntax Error!\n"
-    | 928 ->
-        "Syntax Error!\n"
-    | 929 ->
+    | 892 ->
         "Syntax Error!\n"
     | 897 ->
         "Syntax Error!\n"
-    | 922 ->
+    | 931 ->
         "Syntax Error!\n"
-    | 923 ->
+    | 932 ->
         "Syntax Error!\n"
-    | 898 ->
+    | 900 ->
         "Syntax Error!\n"
     | 925 ->
         "Syntax Error!\n"
-    | 920 ->
+    | 926 ->
         "Syntax Error!\n"
     | 901 ->
         "Syntax Error!\n"
-    | 903 ->
+    | 928 ->
+        "Syntax Error!\n"
+    | 923 ->
         "Syntax Error!\n"
     | 904 ->
         "Syntax Error!\n"
-    | 918 ->
+    | 906 ->
         "Syntax Error!\n"
-    | 910 ->
+    | 907 ->
         "Syntax Error!\n"
-    | 911 ->
-        "Syntax Error!\n"
-    | 912 ->
+    | 921 ->
         "Syntax Error!\n"
     | 913 ->
         "Syntax Error!\n"
+    | 914 ->
+        "Syntax Error!\n"
+    | 915 ->
+        "Syntax Error!\n"
     | 916 ->
         "Syntax Error!\n"
-    | 905 ->
-        "Syntax Error!\n"
-    | 906 ->
+    | 919 ->
         "Syntax Error!\n"
     | 908 ->
         "Syntax Error!\n"
-    | 933 ->
+    | 909 ->
         "Syntax Error!\n"
-    | 945 ->
+    | 911 ->
         "Syntax Error!\n"
-    | 938 ->
+    | 936 ->
         "Syntax Error!\n"
-    | 896 ->
+    | 948 ->
         "Syntax Error!\n"
-    | 952 ->
+    | 941 ->
+        "Syntax Error!\n"
+    | 899 ->
         "Syntax Error!\n"
     | 955 ->
         "Syntax Error!\n"
-    | 953 ->
+    | 958 ->
         "Syntax Error!\n"
-    | 891 ->
+    | 956 ->
         "Syntax Error!\n"
-    | 892 ->
+    | 894 ->
         "Syntax Error!\n"
-    | 934 ->
+    | 895 ->
+        "Syntax Error!\n"
+    | 937 ->
         "Syntax Error!\n"
     | 467 ->
         "Syntax Error!\n"
@@ -260,7 +260,7 @@ let message =
         "Syntax Error!\n"
     | 540 ->
         "Syntax Error!\n"
-    | 935 ->
+    | 938 ->
         "Syntax Error!\n"
     | 575 ->
         "Syntax Error!\n"
@@ -726,41 +726,45 @@ let message =
         "Syntax Error!\n"
     | 755 ->
         "Syntax Error!\n"
-    | 757 ->
-        "Syntax Error!\n"
     | 756 ->
         "Syntax Error!\n"
-    | 775 ->
-        "Syntax Error!\n"
-    | 782 ->
-        "Syntax Error!\n"
-    | 759 ->
+    | 758 ->
         "Syntax Error!\n"
     | 760 ->
         "Syntax Error!\n"
-    | 761 ->
+    | 759 ->
+        "Syntax Error!\n"
+    | 778 ->
+        "Syntax Error!\n"
+    | 785 ->
         "Syntax Error!\n"
     | 762 ->
+        "Syntax Error!\n"
+    | 763 ->
         "Syntax Error!\n"
     | 764 ->
         "Syntax Error!\n"
     | 765 ->
         "Syntax Error!\n"
-    | 766 ->
-        "Syntax Error!\n"
     | 767 ->
-        "Syntax Error! Perhaps a missing statement delimiter such as a semicolon at the end of the statement.\n"
+        "Syntax Error!\n"
+    | 768 ->
+        "Syntax Error!\n"
     | 769 ->
         "Syntax Error!\n"
-    | 771 ->
-        "Syntax Error!\n"
     | 770 ->
+        "Syntax Error! Perhaps a missing statement delimiter such as a semicolon at the end of the statement.\n"
+    | 772 ->
         "Syntax Error!\n"
-    | 784 ->
-        "Syntax Error! Perhaps a unknown keyword. \n"
-    | 785 ->
+    | 774 ->
         "Syntax Error!\n"
-    | 817 ->
+    | 773 ->
+        "Syntax Error!\n"
+    | 787 ->
+        "Syntax Error! Perhaps a unknown keyword.\n"
+    | 788 ->
+        "Syntax Error!\n"
+    | 820 ->
         "Syntax Error!\n"
     | 441 ->
         "Syntax Error!\n"
@@ -806,69 +810,69 @@ let message =
         "Syntax Error!\n"
     | 408 ->
         "Syntax Error!\n"
-    | 971 ->
-        "Syntax Error!\n"
-    | 972 ->
-        "Syntax Error!\n"
-    | 973 ->
-        "Syntax Error!\n"
-    | 393 ->
+    | 974 ->
         "Syntax Error!\n"
     | 975 ->
         "Syntax Error!\n"
-    | 395 ->
-        "Syntax Error!\n"
-    | 978 ->
-        "Syntax Error! Perhaps a missing function definition body.\n"
     | 976 ->
         "Syntax Error!\n"
-    | 980 ->
+    | 393 ->
+        "Syntax Error!\n"
+    | 978 ->
+        "Syntax Error!\n"
+    | 395 ->
         "Syntax Error!\n"
     | 981 ->
+        "Syntax Error! Perhaps a missing function definition body.\n"
+    | 979 ->
         "Syntax Error!\n"
     | 983 ->
         "Syntax Error!\n"
     | 984 ->
-        "Syntax Error! Perhaps a missing/unbalanced parenthesis in contract declaration.\n"
-    | 985 ->
         "Syntax Error!\n"
     | 986 ->
         "Syntax Error!\n"
     | 987 ->
+        "Syntax Error! Perhaps a missing/unbalanced parenthesis in contract declaration.\n"
+    | 988 ->
         "Syntax Error!\n"
     | 989 ->
         "Syntax Error!\n"
-    | 988 ->
+    | 990 ->
         "Syntax Error!\n"
-    | 982 ->
+    | 992 ->
         "Syntax Error!\n"
-    | 796 ->
+    | 991 ->
+        "Syntax Error!\n"
+    | 985 ->
+        "Syntax Error!\n"
+    | 799 ->
         "Syntax Error! Incomplete constant declaration.\n"
-    | 802 ->
-        "Syntax Error!\n"
-    | 803 ->
-        "Syntax Error!\n"
-    | 804 ->
-        "Syntax Error!\n"
-    | 814 ->
+    | 805 ->
         "Syntax Error!\n"
     | 806 ->
         "Syntax Error!\n"
     | 807 ->
         "Syntax Error!\n"
-    | 808 ->
+    | 817 ->
         "Syntax Error!\n"
     | 809 ->
+        "Syntax Error!\n"
+    | 810 ->
         "Syntax Error!\n"
     | 811 ->
         "Syntax Error!\n"
     | 812 ->
         "Syntax Error!\n"
-    | 798 ->
+    | 814 ->
         "Syntax Error!\n"
-    | 799 ->
+    | 815 ->
         "Syntax Error!\n"
-    | 1000 ->
+    | 801 ->
+        "Syntax Error!\n"
+    | 802 ->
+        "Syntax Error!\n"
+    | 1003 ->
         "Syntax Error!\n"
     | 19 ->
         "Syntax Error!\n"
@@ -886,7 +890,7 @@ let message =
         "Syntax Error!\n"
     | 99 ->
         "Syntax Error!\n"
-    | 1001 ->
+    | 1004 ->
         "Syntax Error!\n"
     | 113 ->
         "Syntax Error!\n"
@@ -971,7 +975,7 @@ let message =
     | 77 ->
         "Syntax Error!\n"
     | 235 ->
-        "Syntax Error! Perhaps a missing identifier in type.\n"
+        "Syntax Error!\n"
     | 17 ->
         "Syntax Error!\n"
     | 18 ->

--- a/src/lustre/lustreSimplify.ml
+++ b/src/lustre/lustreSimplify.ml
@@ -136,16 +136,16 @@ let rec eval_ast_expr bounds ctx =
 
   (* Mode ref *)
   | A.ModeRef (pos, mref) -> (
-    let mref_string = List.map QId.to_string mref in 
+    let mref_string_list = QId.to_list mref in 
     let p4th =
-      match mref_string with
+      match mref_string_list with
       | [] -> failwith "empty mode reference"
       | [_] -> (* Reference to own modes, append path. *)
-        List.rev_append (C.contract_scope_of ctx) mref_string
+        List.rev_append (C.contract_scope_of ctx) mref_string_list
       | _ -> (
         match C.contract_scope_of ctx with
-        | _ :: tail -> List.rev_append tail mref_string
-        | _ -> mref_string
+        | _ :: tail -> List.rev_append tail mref_string_list
+        | _ -> mref_string_list
       )
     in
     let fail () =

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -967,7 +967,7 @@ and tc_ctx_contract_eqn: tc_context -> LA.contract_node_equation -> tc_context t
      if (member_ty ctx mname)
      then type_error pos ("Mode " ^ QI.to_string mname ^ " is already declared")
      else R.ok (add_ty ctx mname (Bool pos))
-  | LA.ContractCall (_, cc, _, _) ->
+  | LA.ContractCall (_, cc, _, _, _) ->
      let imported_mode_bindings =
        (match (IMap.find_opt cc ctx.contract_export_ctx) with
         | None -> failwith ("cannot find imports for contract name" ^ QI.to_string cc)
@@ -1015,7 +1015,7 @@ and check_contract_node_eqn: QSI.t -> tc_context -> LA.contract_node_equation ->
                                  (List.map (fun (_,_, e) -> e) (reqs @ ensures)))
                  (Bool pos))
 
-    | ContractCall (pos, cname, args, rets) ->
+    | ContractCall (pos, cname, args, rets, _) ->
        let arg_ids = List.fold_left (fun a s -> QSI.union a s) QSI.empty (List.map LH.vars args) in
        let intersect_in_illegal = QSI.inter node_out_params arg_ids in
        if (not (QSI.is_empty intersect_in_illegal))
@@ -1147,7 +1147,7 @@ and extract_exports: LA.ident -> tc_context -> LA.contract -> tc_context tc_resu
          if (member_ty ctx mname)
          then type_error pos ("Mode " ^ QId.to_string mname ^ " is already declared")
          else R.ok [(mname, (LA.Bool pos))] 
-      | LA.ContractCall (p, cc, _, _) ->
+      | LA.ContractCall (p, cc, _, _, _) ->
          (match (IMap.find_opt cc ctx.contract_export_ctx) with
          | None -> type_error p ("Cannot find contract " ^ QId.to_string cc)
          | Some m ->

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1079,7 +1079,6 @@ and tc_ctx_const_decl: ?is_const: bool -> tc_context -> LA.const_decl -> tc_cont
                 else type_error pos ("Expression " ^ LA.string_of_expr e ^ " is not a constant expression")
               else R.ok(add_ty ctx i exp_ty))
 (** Fail if a duplicate constant is detected  *)
-
      
 and tc_ctx_of_ty_decl: tc_context -> LA.type_decl -> tc_context tc_result
   = fun ctx ->
@@ -1127,7 +1126,7 @@ and tc_ctx_of_node_decl: Lib.position -> tc_context -> LA.node_decl -> tc_contex
          Log.log L_trace "Built fun ty for %a " LA.pp_print_ident nname;
          R.ok (add_ty ctx nname fun_ty)
 (** computes the type signature of node or a function and its node summary*)
-                         
+
 and tc_ctx_of_contract: tc_context -> LA.contract -> tc_context tc_result
   = fun ctx con -> R.seq_chain (tc_ctx_contract_eqn) ctx con
 

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -65,17 +65,14 @@ let rec infer_type_expr: tc_context -> LA.expr -> tc_type tc_result
   | LA.Ident (pos, i) ->
      (match (lookup_ty ctx i) with
       | None ->
-         Log.log L_trace "In context: %a" pp_print_tc_context ctx
-         ; type_error pos ("Unbound identifier: " ^ Lib.string_of_t QId.pp_print_ident i)
-              
+         type_error pos ("Unbound identifier: " ^ Lib.string_of_t QId.pp_print_ident i)
       | Some ty -> R.ok ty) 
-  | LA.ModeRef (pos, ids) ->      
+  | LA.ModeRef (pos, i) ->      
      let lookup_mode_ty ctx ids =
-       let i = QId.from_list (List.concat (List.map QI.to_list ids)) in
        match (lookup_ty ctx i) with
        | None -> type_error pos ("Unbound mode identifier: " ^ Lib.string_of_t QId.pp_print_ident i)
        | Some ty -> R.ok ty in
-     lookup_mode_ty ctx ids
+     lookup_mode_ty ctx i
   | LA.RecordProject (pos, e, fld) ->
      (infer_type_expr ctx e)
      >>= (fun rec_ty ->
@@ -318,9 +315,8 @@ and check_type_expr: tc_context -> LA.expr -> tc_type -> unit tc_result
                         ^ string_of_tc_type exp_ty
                         ^ " with infered type "
                         ^ string_of_tc_type ty))
-  | ModeRef (pos, ids) ->
-     let id' = QId.from_list (List.concat (List.map QId.to_list ids)) in
-     check_type_expr ctx (LA.Ident (pos, id')) exp_ty
+  | ModeRef (pos, id) ->
+     check_type_expr ctx (LA.Ident (pos, id)) exp_ty
   | RecordProject (pos, expr, fld) -> check_type_record_proj pos ctx expr fld exp_ty
   | TupleProject (pos, e1, e2) -> Lib.todo __LOC__ 
 

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -924,7 +924,7 @@ and check_type_struct_def: tc_context -> LA.eq_lhs -> tc_type -> unit tc_result
      LA.pp_print_lustre_type exp_ty
      pp_print_tc_context ctx
   
-  (** check if the members of LHS are constants or enums before assignment *)
+  (* check if the members of LHS are constants or enums before assignment *)
   ; let lhs_vars = QSI.flatten (List.map LH.vars_of_struct_item lhss) in
     if (QSI.for_all (fun i -> not (member_val ctx i)) lhs_vars)
     then (match exp_ty with

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1149,11 +1149,11 @@ and extract_exports: LA.ident -> tc_context -> LA.contract -> tc_context tc_resu
          if (member_ty ctx mname)
          then type_error pos ("Mode " ^ QId.to_string mname ^ " is already declared")
          else R.ok [(mname, (LA.Bool pos))] 
-      | LA.ContractCall (p, cc, _, _, _) ->
+      | LA.ContractCall (p, cc, _, _, cc') ->
          (match (IMap.find_opt cc ctx.contract_export_ctx) with
           | None -> type_error p ("Cannot find contract " ^ QId.to_string cc)
           | Some m ->
-             R.ok (List.map (fun (k, v) -> (QId.add_qualified_prefix (QId.to_string cc) k, v))
+             R.ok (List.map (fun (k, v) -> (QId.add_qualified_prefix (QId.to_string cc') k, v))
                      (IMap.bindings m)))
       | _ -> R.ok [] in
     fun cname ctx contract ->

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -20,6 +20,7 @@
     @author Apoorv Ingle *)
 
 module LA = LustreAst
+
 open TypeCheckerContext
          
 type 'a tc_result = ('a, Lib.position * string) result

--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -18,6 +18,7 @@
 (** The type checker context use for typechecking the surface level language
   
      @author Apoorv Ingle *)
+
 module LA = LustreAst
 module LH = LustreAstHelpers          
 module QId = LustreAstIdent
@@ -38,8 +39,8 @@ type ty_store = tc_type IMap.t
 
 type const_store = (LA.expr * tc_type) IMap.t 
 (** A Store of constant identifier and their (const) values with types. 
- *  The values of the associated identifiers should be evaluated to a 
- *  Bool or an Int at constant propogation phase of type checking *)
+    The values of the associated identifiers should be evaluated to a 
+    Bool or an Int at constant propogation phase of type checking *)
 
 type ty_set = QISet.t
 (** set of valid user type identifiers *)

--- a/src/lustre/typeCheckerContext.mli
+++ b/src/lustre/typeCheckerContext.mli
@@ -20,7 +20,8 @@
      @author Apoorv Ingle *)
 
 module LA = LustreAst
-module SI = LA.SI
+module QId = LustreAstIdent
+module QISet = QId.IdentSet
           
 type tc_type  = LA.lustre_type
 (** Type alias for lustre type from LustreAst  *)
@@ -44,7 +45,7 @@ type const_store = (LA.expr * tc_type) IMap.t
  *  The values of the associated identifiers should be evaluated to a 
  *  Bool or an Int at constant propogation phase of type checking *)
 
-type ty_set = SI.t
+type ty_set = QISet.t
 (** set of valid user type identifiers *)
 
 type contract_exports = (ty_store) IMap.t
@@ -157,7 +158,7 @@ val pp_print_tymap: Format.formatter -> ty_store -> unit
 val pp_print_vstore: Format.formatter -> const_store -> unit
 (** Pretty print value store *)
 
-val pp_print_u_types: Format.formatter -> SI.t -> unit
+val pp_print_u_types: Format.formatter -> QISet.t -> unit
 (** Pretty print declared user types *)
 
 val pp_print_contract_exports: Format.formatter -> contract_exports -> unit

--- a/src/utils/graph.ml
+++ b/src/utils/graph.ml
@@ -31,7 +31,6 @@ exception IllegalGraphOperation
 exception CyclicGraphException of string list
 (** The exception raised when topological sort is tried on cyclic graph  *)
 
-
 module type S = sig 
   
   type vertex

--- a/src/utils/ident.ml
+++ b/src/utils/ident.ml
@@ -63,7 +63,11 @@ end
 
 include Ident
 
-module IdentSet = Set.Make (Ident)
+module IdentSet = struct
+  include Set.Make (Ident)
+  let flatten: t list -> t = fun sets ->
+    List.fold_left union empty sets
+end 
 
 module IdentMap = Map.Make (Ident)
 

--- a/src/utils/ident.ml
+++ b/src/utils/ident.ml
@@ -69,7 +69,10 @@ module IdentSet = struct
     List.fold_left union empty sets
 end 
 
-module IdentMap = Map.Make (Ident)
+module IdentMap = struct
+  include Map.Make(Ident)
+  let keys: 'a t -> key list = fun m -> List.map fst (bindings m)             
+end
 
 
 let pp_print_ident ppf i = Format.fprintf ppf "%s" i

--- a/src/utils/ident.mli
+++ b/src/utils/ident.mli
@@ -38,7 +38,11 @@ module IdentSet : sig
 end
 
 (** Map of identifiers *)
-module IdentMap : Map.S with type key = t
+module IdentMap : sig
+  include (Map.S with type key = t)
+  val keys: 'a t -> key list
+end
+                    
 
 (** Pretty-print an identifier *)
 val pp_print_ident : Format.formatter -> t -> unit

--- a/src/utils/ident.mli
+++ b/src/utils/ident.mli
@@ -32,7 +32,10 @@ val equal : t -> t -> bool
 val compare : t -> t -> int
 
 (** Set of identifiers *)
-module IdentSet : Set.S with type elt = t
+module IdentSet : sig
+    include (Set.S with type elt = t)
+    val flatten: t list -> t
+end
 
 (** Map of identifiers *)
 module IdentMap : Map.S with type key = t

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -622,6 +622,10 @@ let min_option f1 f2 = match f1, f2 with
   | Some f, None | None, Some f -> Some f
   | Some f1, Some f2 -> if f1 < f2 then Some f1 else Some f2
 
+let map_option f o = match o with
+  | None -> None
+  | Some v -> Some (f v)
+                      
 (* ********************************************************************** *)
 (* String                                                                 *)
 (* ********************************************************************** *)

--- a/src/utils/lib.mli
+++ b/src/utils/lib.mli
@@ -63,6 +63,9 @@ val get : 'a option -> 'a
 (** Return the min between two optional floats. Return None if both floats are None. *)
 val min_option : float option -> float option -> float option
 
+(** Maps a function over an optional value *)
+val map_option: ('a -> 'b) -> 'a option -> 'b option 
+  
 
 (** {1 Integer functions} *)
 

--- a/tests/lustre/typechecking/futurePass/test_import_contract.lus
+++ b/tests/lustre/typechecking/futurePass/test_import_contract.lus
@@ -1,0 +1,16 @@
+
+contract c(x:int) returns (y: int);
+let
+    guarantee y = x;
+tel
+
+
+node n(x: int) returns(y:int);
+(*@contract
+  import c(1) returns(y);
+  import c(2) returns(y);
+  guarantee y = pre x;
+*)
+let
+y = pre x;
+tel

--- a/tests/lustre/typechecking/futurePass/test_import_contract.lus
+++ b/tests/lustre/typechecking/futurePass/test_import_contract.lus
@@ -1,7 +1,14 @@
-
 contract c(x:int) returns (y: int);
 let
     guarantee y = x;
+    mode m1(
+      require x < 2;
+    );
+    mode m2(
+      require x < 4;
+    );
+    var z:int = x;
+    var v:int = x+1;
 tel
 
 
@@ -9,7 +16,15 @@ node n(x: int) returns(y:int);
 (*@contract
   import c(1) returns(y) as c1;
   import c(2) returns(y) as c2;
+  import c(1) returns(y) as c;
+
   guarantee y = pre x;
+  -- we should be able to refer to
+  -- contract ghost consts/vars
+
+  guarantee c2::z = 1;
+  guarantee c1::v = 3;
+  guarantee c::v = 2;
 *)
 let
 y = pre x;

--- a/tests/lustre/typechecking/futurePass/test_import_contract.lus
+++ b/tests/lustre/typechecking/futurePass/test_import_contract.lus
@@ -7,8 +7,8 @@ tel
 
 node n(x: int) returns(y:int);
 (*@contract
-  import c(1) returns(y);
-  import c(2) returns(y);
+  import c(1) returns(y) as c1;
+  import c(2) returns(y) as c2;
   guarantee y = pre x;
 *)
 let

--- a/tests/lustre/typechecking/futurePass/test_import_contract2.lus
+++ b/tests/lustre/typechecking/futurePass/test_import_contract2.lus
@@ -1,0 +1,50 @@
+contract b(x:int) returns (y:int);
+let
+ var bx:int = x;
+tel;
+
+contract c1(x:int) returns (y: int);
+let
+    import b(x)returns(y) as b1;
+    guarantee y = x;
+    mode m1(
+      require x < 2;
+    );
+    mode m2(
+      require x < 4;
+    );
+    var z:int = x;
+    var v:int = x+1;
+tel
+
+contract c2 (x:int) returns (y: int);
+let
+    import b(x)returns(y) as b1;
+    guarantee y = x;
+    mode m1(
+      require x < 2;
+    );
+    mode m2(
+      require x < 4;
+    );
+    var z:int = x;
+    var v:int = x+1;
+tel
+
+
+node n(x: int) returns(y:int);
+(*@contract
+  import c1(1) returns(y);
+  import c2(2) returns(y);
+  -- import c(1) returns(y) as c;
+
+  guarantee y = pre x;
+  -- we should be able to refer to
+  -- contract ghost consts/vars
+
+  -- guarantee c2::z = 1;
+ --  guarantee c1::v = 3;
+*)
+let
+y = pre x;
+tel

--- a/tests/lustre/typechecking/futurePass/test_import_contract2.lus
+++ b/tests/lustre/typechecking/futurePass/test_import_contract2.lus
@@ -1,34 +1,11 @@
-contract b(x:int) returns (y:int);
-let
- var bx:int = x;
-tel;
-
 contract c1(x:int) returns (y: int);
 let
-    import b(x)returns(y) as b1;
-    guarantee y = x;
-    mode m1(
-      require x < 2;
-    );
-    mode m2(
-      require x < 4;
-    );
     var z:int = x;
-    var v:int = x+1;
 tel
 
 contract c2 (x:int) returns (y: int);
 let
-    import b(x)returns(y) as b1;
-    guarantee y = x;
-    mode m1(
-      require x < 2;
-    );
-    mode m2(
-      require x < 4;
-    );
-    var z:int = x;
-    var v:int = x+1;
+    var z:int = x+1;
 tel
 
 
@@ -36,14 +13,6 @@ node n(x: int) returns(y:int);
 (*@contract
   import c1(1) returns(y);
   import c2(2) returns(y);
-  -- import c(1) returns(y) as c;
-
-  guarantee y = pre x;
-  -- we should be able to refer to
-  -- contract ghost consts/vars
-
-  -- guarantee c2::z = 1;
- --  guarantee c1::v = 3;
 *)
 let
 y = pre x;

--- a/tests/lustre/typechecking/futurePass/test_import_contract2.lus
+++ b/tests/lustre/typechecking/futurePass/test_import_contract2.lus
@@ -1,11 +1,13 @@
 contract c1(x:int) returns (y: int);
 let
     var z:int = x;
+    mode m1(require x=1;);
 tel
 
 contract c2 (x:int) returns (y: int);
 let
     var z:int = x+1;
+    mode m1(require x=2;);
 tel
 
 

--- a/tests/lustre/typechecking/futurePass/test_include.lus
+++ b/tests/lustre/typechecking/futurePass/test_include.lus
@@ -1,0 +1,6 @@
+include "to_include.lus"
+
+node n(x:int) returns (y:int)
+let
+ y = x;
+tel

--- a/tests/lustre/typechecking/futurePass/to_include.lus
+++ b/tests/lustre/typechecking/futurePass/to_include.lus
@@ -1,0 +1,4 @@
+node m(x:int) returns (y:int)
+let
+ y = x;
+tel

--- a/tests/lustre/typechecking/shouldFail/test_twice_import_contract.lus
+++ b/tests/lustre/typechecking/shouldFail/test_twice_import_contract.lus
@@ -1,0 +1,23 @@
+contract c(x:int) returns (y: int);
+let
+    guarantee y = x;
+    mode m1(
+      require x < 2;
+    );
+    mode m2(
+      require x < 4;
+    );
+    var z:int = x;
+    var v:int = x+1;
+tel
+
+
+node n(x: int) returns(y:int);
+(*@contract
+  -- This should fail
+  import c(1) returns(y);
+  import c(2) returns(y);
+*)
+let
+y = pre x;
+tel

--- a/tests/lustre/typechecking/shouldPass/test_import_contract.lus
+++ b/tests/lustre/typechecking/shouldPass/test_import_contract.lus
@@ -1,11 +1,5 @@
-contract b(x:int) returns (y:int);
-let
- var bx:int = x;
-tel;
-
 contract c(x:int) returns (y: int);
 let
-    import b(x)returns(y) as b1;
     guarantee y = x;
     mode m1(
       require x < 2;
@@ -31,7 +25,6 @@ node n(x: int) returns(y:int);
   guarantee c2::z = 1;
   guarantee c1::v = 3;
   guarantee c::v = 2;
-  guarantee c::b1::bx = 1;
 *)
 let
 y = pre x;

--- a/tests/ounit/lustre/testAstDependencies.ml
+++ b/tests/ounit/lustre/testAstDependencies.ml
@@ -22,6 +22,8 @@
 
 module LI = LustreInput
 module LA = LustreAst
+module QId = LustreAstIdent
+
 open OUnit2
 
 module AD = LustreAstDependencies
@@ -30,10 +32,10 @@ let dp = Lib.dummy_pos
 let (>>=) = Res.(>>=)
           
 let linear_decls = [
-    LA.TypeDecl (dp, LA.AliasType(dp, "t0", LA.UserType (dp, "t1")))
-  ; LA.TypeDecl (dp, LA.AliasType(dp, "t1", LA.UserType (dp, "t2")))
-  ; LA.TypeDecl (dp, LA.AliasType(dp, "t2", LA.Int dp))
-  ; LA.ConstDecl (dp, LA.TypedConst (dp, "c", LA.Const (dp, Num "1"), LA.UserType (dp, "t0")))
+    LA.TypeDecl (dp, LA.AliasType(dp, QId.from_string "t0", LA.UserType (dp, QId.from_string "t1")))
+  ; LA.TypeDecl (dp, LA.AliasType(dp, QId.from_string "t1", LA.UserType (dp, QId.from_string "t2")))
+  ; LA.TypeDecl (dp, LA.AliasType(dp, QId.from_string "t2", LA.Int dp))
+  ; LA.ConstDecl (dp, LA.TypedConst (dp, QId.from_string "c", LA.Const (dp, Num "1"), LA.UserType (dp, QId.from_string "t0")))
   ]
   
 let sorted_linear_decls = fun _ -> AD.sort_globals linear_decls
@@ -49,10 +51,10 @@ let tests_should_pass = [
 
 
 let circular_decls = [
-    LA.TypeDecl (dp, LA.AliasType(dp, "t0", LA.UserType (dp, "t1")))
-  ; LA.TypeDecl (dp, LA.AliasType(dp, "t1", LA.UserType (dp, "t2")))
-  ; LA.TypeDecl (dp, LA.AliasType(dp, "t2", LA.UserType (dp, "t0")))
-  ; LA.ConstDecl (dp, LA.TypedConst (dp, "c", LA.Const (dp, Num "1"), LA.UserType (dp, "t0")))  ]
+    LA.TypeDecl (dp, LA.AliasType(dp, QId.from_string "t0", LA.UserType (dp, QId.from_string "t1")))
+  ; LA.TypeDecl (dp, LA.AliasType(dp, QId.from_string "t1", LA.UserType (dp, QId.from_string "t2")))
+  ; LA.TypeDecl (dp, LA.AliasType(dp, QId.from_string "t2", LA.UserType (dp, QId.from_string "t0")))
+  ; LA.ConstDecl (dp, LA.TypedConst (dp, QId.from_string "c", LA.Const (dp, Num "1"), LA.UserType (dp, QId.from_string "t0")))  ]
 
 
 let failure_circular_decls = fun _ ->  AD.sort_globals circular_decls

--- a/tests/ounit/utils/testGraph.ml
+++ b/tests/ounit/utils/testGraph.ml
@@ -19,6 +19,8 @@
    
    @author Apoorv Ingle *)
 
+module QId = LustreAstIdent
+           
 open OUnit2
 
 module G = Graph.Make(struct
@@ -27,9 +29,9 @@ module G = Graph.Make(struct
                let pp_print_t = LustreAst.pp_print_ident 
              end)
 
-let v0 = "v0"
-let v1 = "v1"
-let v2 = "v2"
+let v0 = QId.from_string "v0"
+let v1 = QId.from_string "v1"
+let v2 = QId.from_string "v2"
                          
 let singleton_g = G.add_vertex G.empty v0
 let dos_g = G.add_vertex singleton_g v1
@@ -46,7 +48,7 @@ let basic_tests =
   
   ; "sorted dos" >:: (fun _ -> assert_equal [v0;v1] (G.topological_sort dos_connected_g))
   ; "cyclic dos" >:: (fun _ -> assert_raises
-                                 (Graph.CyclicGraphException [v0; v1])
+                                 (Graph.CyclicGraphException [QId.to_string v0; QId.to_string v1])
                                  (fun _ -> G.topological_sort dos_cycle_g))
   ]
 
@@ -54,13 +56,13 @@ let rechability_tests =
   [
     "reachable singleton" >:: (fun _ ->
       assert_equal [v0] (G.to_vertex_list (G.reachable singleton_g v0))
-        ~printer:(Lib.string_of_t (Format.pp_print_list Format.pp_print_string) ))
+        ~printer:(Lib.string_of_t (Format.pp_print_list QId.pp_print_ident) ))
   ; "reachable cycle graph" >:: (fun _ ->
     assert_equal [v0;v1] (G.to_vertex_list (G.reachable dos_cycle_g v0))
-      ~printer:(Lib.string_of_t (Format.pp_print_list Format.pp_print_string) ))
+      ~printer:(Lib.string_of_t (Format.pp_print_list QId.pp_print_ident) ))
   ; "reachable cycle graph2" >:: (fun _ ->
     assert_equal [v0;v1;v2] (G.to_vertex_list (G.reachable cycle_and_one_more v0))
-      ~printer:(Lib.string_of_t (Format.pp_print_list Format.pp_print_string)))
+      ~printer:(Lib.string_of_t (Format.pp_print_list QId.pp_print_ident)))
   ]
   
 let _ = run_test_tt_main ("test suite for graphs" >::: basic_tests @ rechability_tests) 


### PR DESCRIPTION
Features
-------

- AST identifiers are now qualified
- Modes are stored as a qualified identifier and not a list of strings
- ghost variables and constants of imported contracts can be accessed by a qualified manner.
- Contracts can be imported using `as` construct i.e. aliased imports. 
