### PR TITLE
Don't forget to terminate the log if only_parse option is passed.

### DIFF
--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -130,8 +130,9 @@ let main () =
   let Input input_sys = setup () in
 
   if Flags.only_parse () then (
-    KEvent.log L_note "No parse errors found!"; exit 0
-  );
+    KEvent.log L_note "No parse errors found!";
+    KEvent.terminate_log ();
+    exit 0 );
 
   (* Notify user of silent contract loading. *)
   (try


### PR DESCRIPTION
This PR ensures that the logs terminate (e.g., a closing bracket is added in `-json` mode) before kind2 terminates if `--only_parse true` option is passed.