### PR TITLE
Move reporting functions into their own module

### DIFF
--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -17,7 +17,8 @@
 *)
 
 open Lib
-
+open LustreReporting
+   
 module A = LustreAst
 
 module I = LustreIdent
@@ -187,51 +188,6 @@ let set_in_automaton ctx b = { ctx with in_automaton = b }
 let reset_in_automaton ctx = { ctx with in_automaton = false }
 
 let in_automaton ctx = ctx.in_automaton
-
-
-(* Raise parsing exception *)
-let fail_at_position_pt pos msg =
-  Log.log L_error "%a: Failure cause: @[<v>%s@] "
-    Lib.pp_print_position pos msg
-
-let fail_at_position pos msg =
-  (match Log.get_log_format () with
-   | Log.F_pt -> fail_at_position_pt pos msg
-   | Log.F_xml -> Log.parse_log_xml L_error pos msg
-   | Log.F_json -> Log.parse_log_json L_error pos msg
-   | Log.F_relay -> ()
-  );
-  raise A.Parser_error
-
-
-let warn_at_position_pt level pos msg =
-  Log.log level "Parser warning at %a: %s" Lib.pp_print_position pos msg
-
-let warn_at_position pos msg =
-  match Log.get_log_format () with
-  | Log.F_pt -> warn_at_position_pt L_warn pos msg
-  | Log.F_xml -> Log.parse_log_xml L_warn pos msg
-  | Log.F_json -> Log.parse_log_json L_warn pos msg
-  | Log.F_relay -> ()
-
-
-let note_at_position pos msg = 
-  match Log.get_log_format () with
-  | Log.F_pt -> warn_at_position_pt L_note pos msg
-  | Log.F_xml -> Log.parse_log_xml L_note pos msg
-  | Log.F_json -> Log.parse_log_json L_note pos msg
-  | Log.F_relay -> ()
-
-
-(* Raise parsing exception *)
-let fail_no_position msg =
-  Log.log L_error "Parser error: %s" msg;
-  raise A.Parser_error
-
-  
-
-(* Raise parsing exception *)
-let warn_no_position msg = Log.log L_warn "Parser warning: %s" msg
 
 
 (* ********************************************************************** *)

--- a/src/lustre/lustreContext.mli
+++ b/src/lustre/lustreContext.mli
@@ -351,18 +351,6 @@ val check_vars_defined : t -> unit
 
 (** {1 Helpers} *)
 
-(** Output a fatal error at position and raise an error *)
-val fail_at_position : Lib.position -> string -> 'a
-
-(** Output a warning at position *)
-val warn_at_position : Lib.position -> string -> unit 
-
-(** Output a fatal error without reporting a position and raise an error *)
-val fail_no_position : string -> 'a
-
-(** Output a warning without a position *)
-val warn_no_position : string -> unit 
-
 (** Returns true if new definitions are allowed in the context *)
 val are_definitions_allowed : t -> bool
 

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -17,13 +17,13 @@
 *)
 
 open Lib
+open LustreReporting
 open Lexing
 open MenhirLib.General
    
 module LA = LustreAst
 module LH = LustreAstHelpers
 module LN = LustreNode
-module LC = LustreContext
 module LD = LustreDeclarations
 
 module LPI = LustreParser.Incremental
@@ -62,7 +62,7 @@ let build_parse_error_msg env =
 let fail env lexbuf =
   let emsg = build_parse_error_msg env in
   let pos = position_of_lexing lexbuf.lex_curr_p in
-  LC.fail_at_position pos emsg
+  fail_at_position pos emsg
 
 (* Incremental Parsing *)
 let rec parse lexbuf (chkpnt : LA.t LPMI.checkpoint) =
@@ -81,7 +81,7 @@ let rec parse lexbuf (chkpnt : LA.t LPMI.checkpoint) =
      fail env lexbuf
   | LPMI.Accepted v -> success v
   | LPMI.Rejected ->
-     LC.fail_no_position "Parser Error: Parser rejected the input."
+     fail_no_position "Parser Error: Parser rejected the input."
   
 
 (* Parses input channel to generate an AST *)
@@ -106,7 +106,7 @@ let ast_of_channel(in_ch: in_channel): LustreAst.t =
   try
     (parse lexbuf (LPI.main lexbuf.lex_curr_p))
   with
-  | LustreLexer.Lexer_error err -> LC.fail_at_position (Lib.position_of_lexing lexbuf.lex_curr_p) err  
+  | LustreLexer.Lexer_error err -> fail_at_position (Lib.position_of_lexing lexbuf.lex_curr_p) err  
 
 (* Parse from input channel *)
 let of_channel in_ch =
@@ -160,7 +160,7 @@ let of_channel in_ch =
        | Ok d -> Log.log L_note "Type checking done"
                ; Log.log L_trace "========\n%a\n==========\n" LA.pp_print_program d
                ;   (if Flags.only_tc () then exit 0); d  
-       | Error (pos, err) -> LC.fail_at_position pos err in 
+       | Error (pos, err) -> fail_at_position pos err in 
   
   (* Simplify declarations to a list of nodes *)
   let nodes, globals = LD.declarations_to_nodes declarations' in

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -19,9 +19,9 @@
 
 %{
 open Lib
-
+open LustreReporting
+   
 module A = LustreAst
-module LC = LustreContext
           
 let mk_pos = position_of_lexing 
 
@@ -831,7 +831,7 @@ pexpr(Q):
   (* Tuple projection (not quantified) *)
   | e = pexpr(Q); DOTPERCENT; i = NUMERAL 
   { let idx = try (int_of_string i) with
-              | _ -> LC.fail_at_position (mk_pos $startpos(i)) "Tuple projection index exceeds int range" in
+              | _ -> fail_at_position (mk_pos $startpos(i)) "Tuple projection index exceeds int range" in
     A.TupleProject (mk_pos $startpos, e, idx) }
 
   (* An array slice (not quantified) *)
@@ -895,7 +895,7 @@ pexpr(Q):
     %prec prec_forall
     { let pos = mk_pos $startpos in
       if not q then
-        LustreContext.fail_at_position
+        fail_at_position
           pos "Quantifiers not allowed in this position";
       A.Quantifier (pos, A.Forall, List.flatten vars, e) }
   | EXISTS; q = Q;
@@ -903,7 +903,7 @@ pexpr(Q):
     %prec prec_exists
     { let pos = mk_pos $startpos in
       if not q then
-        LustreContext.fail_at_position
+        fail_at_position
           pos "Quantifiers not allowed in this position";
       A.Quantifier (pos, A.Exists, List.flatten vars, e) }
                                                                        
@@ -1063,7 +1063,7 @@ pexpr(Q):
   | PRE; e = pexpr(Q) { A.Pre (mk_pos $startpos, e) }
   | FBY LPAREN; e1 = pexpr(Q) COMMA; s = NUMERAL; COMMA; e2 = pexpr(Q) RPAREN
     { let idx = try (int_of_string s) with
-                | _ -> LC.fail_at_position (mk_pos $startpos(s)) "Fby argument exceeds int range" in
+                | _ -> fail_at_position (mk_pos $startpos(s)) "Fby argument exceeds int range" in
       A.Fby (mk_pos $startpos, e1, idx, e2) }
 
   | e1 = pexpr(Q); ARROW; e2 = pexpr(Q) { A.Arrow (mk_pos $startpos, e1, e2) }

--- a/src/lustre/lustreReporting.ml
+++ b/src/lustre/lustreReporting.ml
@@ -1,0 +1,65 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+(** 
+    Error and warning Reporting functions 
+
+ *)
+
+(* Raise parsing exception *)
+let fail_at_position_pt pos msg =
+  Log.log L_error "%a: Failure cause: @[<v>%s@] "
+    Lib.pp_print_position pos msg
+
+let fail_at_position pos msg =
+  (match Log.get_log_format () with
+   | Log.F_pt -> fail_at_position_pt pos msg
+   | Log.F_xml -> Log.parse_log_xml L_error pos msg
+   | Log.F_json -> Log.parse_log_json L_error pos msg
+   | Log.F_relay -> ()
+  );
+  raise LustreAst.Parser_error
+
+
+let warn_at_position_pt level pos msg =
+  Log.log level "Parser warning at %a: %s" Lib.pp_print_position pos msg
+
+let warn_at_position pos msg =
+  match Log.get_log_format () with
+  | Log.F_pt -> warn_at_position_pt L_warn pos msg
+  | Log.F_xml -> Log.parse_log_xml L_warn pos msg
+  | Log.F_json -> Log.parse_log_json L_warn pos msg
+  | Log.F_relay -> ()
+
+
+let note_at_position pos msg = 
+  match Log.get_log_format () with
+  | Log.F_pt -> warn_at_position_pt L_note pos msg
+  | Log.F_xml -> Log.parse_log_xml L_note pos msg
+  | Log.F_json -> Log.parse_log_json L_note pos msg
+  | Log.F_relay -> ()
+
+
+(* Raise parsing exception *)
+let fail_no_position msg =
+  Log.log L_error "Parser error: %s" msg;
+  raise LustreAst.Parser_error
+
+ 
+(* Raise parsing exception *)
+let warn_no_position msg = Log.log L_warn "Parser warning: %s" msg

--- a/src/lustre/lustreReporting.mli
+++ b/src/lustre/lustreReporting.mli
@@ -1,0 +1,43 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2015 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+(** 
+    Error and warning Reporting functions 
+
+ *)
+
+val fail_at_position_pt: Lib.position -> string -> unit
+(** Ouput a fail message  *)
+
+val fail_at_position : Lib.position -> string -> 'a
+(** Output a fatal error at position and raise an error *)
+
+val warn_at_position_pt: Lib.log_level -> Lib.position -> string -> unit 
+(** Output a warning at position at a given level  *)
+  
+val warn_at_position : Lib.position -> string -> unit 
+(** Output a warning at position *)
+
+val fail_no_position : string -> 'a
+(** Output a fatal error without reporting a position and raise an error *)
+
+val warn_no_position : string -> unit 
+(** Output a warning without a position *)
+
+val note_at_position: Lib.position -> string -> unit
+(**  Ouput a note *)

--- a/src/lustre/lustreSimplify.ml
+++ b/src/lustre/lustreSimplify.ml
@@ -17,7 +17,7 @@
 *)
 
 open Lib
-
+open LustreReporting
 
 (* The main function {!declarations_to_nodes} iterates over the list
    of declarations obtained from parsing Lustre input and returns a
@@ -59,7 +59,7 @@ let select_from_arrayintindex pos bound_e index expr =
   if bound_e <> None && E.is_numeral (get bound_e) &&
      (E.numeral_of_expr (get bound_e) |> Numeral.to_int) > size
   then
-    C.fail_at_position pos
+    fail_at_position pos
       (Format.asprintf "Size of indexes on left of equation (%a) \
                         is larger than size on the right (%d)"
          (E.pp_print_expr false) (get bound_e)
@@ -147,7 +147,7 @@ let rec eval_ast_expr bounds ctx =
       )
     in
     let fail () =
-      C.fail_at_position pos (
+      fail_at_position pos (
         Format.asprintf
           "reference to unknown mode '::%a'"
           (pp_print_list Format.pp_print_string "::") p4th
@@ -372,7 +372,7 @@ let rec eval_ast_expr bounds ctx =
          then 
 
            (* Expression has array bounds *)
-           C.fail_at_position
+           fail_at_position
              pos
              "Extensional array equality not supported")
       expr;
@@ -409,7 +409,7 @@ let rec eval_ast_expr bounds ctx =
   | A.Last (pos, i)  -> 
     (* Translate to pre *)
     (if not (C.in_automaton ctx) then
-      C.warn_at_position pos "Not in a state, last was replaced by pre"
+      warn_at_position pos "Not in a state, last was replaced by pre"
     else ());
     eval_ast_expr bounds ctx (A.Pre (pos, A.Ident (pos, i)))
 
@@ -496,7 +496,7 @@ let rec eval_ast_expr bounds ctx =
     in
     let cases = List.map fst merge_cases in
     if List.sort String.compare cases <> List.sort String.compare cases_to_have
-    then C.fail_at_position pos "Cases of merge must be exhaustive and unique";
+    then fail_at_position pos "Cases of merge must be exhaustive and unique";
     
 
     let cond_of_clock_value clock_value = match clock_value with
@@ -522,7 +522,7 @@ let rec eval_ast_expr bounds ctx =
           | A.ClockNeg c when clock_value = "false" && c = clock_ident -> ()
           | A.ClockConstr (cs, c) when clock_value = cs && c = clock_ident -> ()
           (* Clocks must be identical identifiers *)
-          | _ -> C.fail_at_position pos "Clock mismatch for argument of merge");
+          | _ -> fail_at_position pos "Clock mismatch for argument of merge");
 
         (* Evaluate expression under [when] *)
           eval_ast_expr bounds ctx expr
@@ -543,7 +543,7 @@ let rec eval_ast_expr bounds ctx =
             when clock_value = cv && c = clock_ident -> ()
              
           (* Clocks must be identical identifiers *)
-          | _ -> C.fail_at_position pos "Clock mismatch for argument of merge");
+          | _ -> fail_at_position pos "Clock mismatch for argument of merge");
         
         (* Evaluate node call without defaults *)
         try_eval_node_call
@@ -614,13 +614,13 @@ let rec eval_ast_expr bounds ctx =
 
         | Invalid_argument _ ->
 
-          C.fail_at_position
+          fail_at_position
             pos
             "Index mismatch for expressions in merge" 
 
         | E.Type_mismatch ->
 
-          C.fail_at_position
+          fail_at_position
             pos
             "Type mismatch for expressions in merge" 
 
@@ -793,7 +793,7 @@ let rec eval_ast_expr bounds ctx =
 
     else
 
-      C.fail_at_position
+      fail_at_position
         pos
         "Type mismatch in record"
 
@@ -824,7 +824,7 @@ let rec eval_ast_expr bounds ctx =
 
         else
 
-          C.fail_at_position
+          fail_at_position
             pos
             (Format.asprintf "Invalid index %s for expression" index)
 
@@ -888,7 +888,7 @@ let rec eval_ast_expr bounds ctx =
 
               else
 
-                C.fail_at_position
+                fail_at_position
                   pos
                   "Invalid index for expression"
 
@@ -911,7 +911,7 @@ let rec eval_ast_expr bounds ctx =
 
               else
 
-                C.fail_at_position
+                fail_at_position
                   pos
                   "Invalid index for expression"
 
@@ -921,7 +921,7 @@ let rec eval_ast_expr bounds ctx =
             | D.AbstractTypeIndex _ :: _, _
             | [], _ ->
 
-              C.fail_at_position
+              fail_at_position
                 pos
                 "Invalid index for expression")
           end
@@ -1186,7 +1186,7 @@ let rec eval_ast_expr bounds ctx =
         (* if bound_e <> None && E.is_numeral (get bound_e) && E.is_numeral s && *)
         (*    Numeral.geq (E.numeral_of_expr (get bound_e)) (E.numeral_of_expr s) *)
         (* then *)
-        (*   C.fail_at_position pos *)
+        (*   fail_at_position pos *)
         (*     (Format.asprintf "Size of indexes on left of equation (%a) \ *)
         (*                       is larger than size on the right (%a)" *)
         (*     (E.pp_print_expr false) (get bound_e) *)
@@ -1216,7 +1216,7 @@ let rec eval_ast_expr bounds ctx =
 
         select_from_arrayintindex pos bound_e index expr'
 
-        (*   C.fail_at_position  *)
+        (*   fail_at_position  *)
         (*     pos *)
         (*     "Cannot use a constant array in a recursive definition" *)
 
@@ -1242,7 +1242,7 @@ let rec eval_ast_expr bounds ctx =
           expr'
 
       (* Other or no index *)
-        | [], _ -> C.fail_at_position pos "Selection not from an array"
+        | [], _ -> fail_at_position pos "Selection not from an array"
       in
 
       push expr', ctx
@@ -1251,7 +1251,7 @@ let rec eval_ast_expr bounds ctx =
   (* Array slice [A[i..j,k..l]] *)
   | A.ArraySlice (pos, _, _) -> 
 
-    C.fail_at_position pos "Array slices not implemented"
+    fail_at_position pos "Array slices not implemented"
 
   (* ****************************************************************** *)
   (* Not implemented                                                    *)
@@ -1262,52 +1262,52 @@ let rec eval_ast_expr bounds ctx =
   (* Concatenation of arrays [A|B] *)
   | A.ArrayConcat (pos, _, _) -> 
 
-    C.fail_at_position pos "Array concatenation not implemented"
+    fail_at_position pos "Array concatenation not implemented"
 
   (* Interpolation to base clock *)
   | A.Current (pos, A.When (_, _, _)) -> 
 
-    C.fail_at_position pos "Current expression not supported"
+    fail_at_position pos "Current expression not supported"
 
   (* Boolean at-most-one constaint *)
   | A.NArityOp (pos, A.OneHot, _) -> 
 
-    C.fail_at_position pos "One-hot expression not supported"
+    fail_at_position pos "One-hot expression not supported"
 
   (* Followed by operator *)
   | A.Fby (pos, _, _, _) -> 
 
-    C.fail_at_position pos "Fby operator not implemented" 
+    fail_at_position pos "Fby operator not implemented" 
 
   (* Projection on clock *)
   | A.When (pos, _, _) -> 
 
-    C.fail_at_position 
+    fail_at_position 
       pos
       "When expression must be the argument of a current operator"
 
   (* Interpolation to base clock *)
   | A.Current (pos, _) -> 
 
-    C.fail_at_position 
+    fail_at_position 
       pos
       "Current operator must have a when expression as argument"
 
   | A.Activate (pos, _, _, _, _) -> 
 
-    C.fail_at_position 
+    fail_at_position 
       pos
       "Activate operator only supported in merge"
 
   (* With operator for recursive node calls *)
   | A.TernaryOp (pos, A.With, _, _, _) -> 
 
-    C.fail_at_position pos "Recursive nodes not supported"
+    fail_at_position pos "Recursive nodes not supported"
 
   (* Node call to a parametric node *)
   | A.CallParam (pos, _, _, _) -> 
 
-    C.fail_at_position pos "Parametric nodes not supported" 
+    fail_at_position pos "Parametric nodes not supported" 
 
 
 
@@ -1387,12 +1387,12 @@ and const_int_of_ast_expr ctx pos expr =
 
        else
 
-         C.fail_at_position pos "Expression must be an integer")
+         fail_at_position pos "Expression must be an integer")
 
     (* Expression is not a constant integer *)
     | _ ->       
 
-      C.fail_at_position pos "Expression must be constant"
+      fail_at_position pos "Expression must be constant"
 
 
 (* Evaluate expression to an Boolean *)
@@ -1414,7 +1414,7 @@ and eval_bool_ast_expr bounds ctx pos expr =
     (* Expression is not Boolean or is indexed *)
     | _ -> 
 
-      C.fail_at_position pos "Expression is not of Boolean type")
+      fail_at_position pos "Expression is not of Boolean type")
 
 
 and eval_clock_ident ctx pos ident =
@@ -1435,7 +1435,7 @@ and eval_clock_ident ctx pos ident =
     (* Expression is not Boolean or is indexed *)
     | _ -> 
 
-      C.fail_at_position pos "Clock identifier is not Boolean or of \
+      fail_at_position pos "Clock identifier is not Boolean or of \
                               an enumerated datatype")
 
 
@@ -1476,7 +1476,7 @@ and static_int_of_ast_expr ctx pos expr =
     (* Expression is not a constant integer *)
     | _ ->       
 
-      C.fail_at_position pos "Expression must be constant"
+      fail_at_position pos "Expression must be constant"
 
 
 (* Return the trie for the identifier *)
@@ -1531,7 +1531,7 @@ and eval_unary_ast_expr bounds ctx pos mk expr =
 
     | E.Type_mismatch ->
 
-      C.fail_at_position
+      fail_at_position
         pos
         "Type mismatch for expression"
 
@@ -1578,7 +1578,7 @@ and eval_binary_ast_expr bounds ctx pos mk expr1 expr2 =
 
       | Invalid_argument s ->
 
-        C.fail_at_position
+        fail_at_position
           pos
           (Format.asprintf
              "Index mismatch for expressions %a and %a" 
@@ -1587,7 +1587,7 @@ and eval_binary_ast_expr bounds ctx pos mk expr1 expr2 =
 
       | E.Type_mismatch ->
 
-        C.fail_at_position
+        fail_at_position
           pos
           (Format.asprintf
              "Type mismatch for expressions %a and %a" 
@@ -1596,7 +1596,7 @@ and eval_binary_ast_expr bounds ctx pos mk expr1 expr2 =
 
       | E.NonConstantShiftOperand ->
 
-        C.fail_at_position
+        fail_at_position
           pos
           (Format.asprintf
              "Second argument %a to shift operation 
@@ -1629,7 +1629,7 @@ and eval_ast_projection bounds ctx pos expr = function
 
      with Not_found ->
 
-       C.fail_at_position 
+       fail_at_position 
          pos
          (Format.asprintf 
             "Expression %a does not have index %a" 
@@ -1721,7 +1721,7 @@ and eval_node_call
       D.fold2
         (fun i state_var ({ E.expr_type } as expr) (accum, ctx) ->
           if E.has_indexes expr
-          then C.fail_at_position pos "Call with implicitely quantified index";
+          then fail_at_position pos "Call with implicitely quantified index";
           (* Expression must be of a subtype of input type *)
           if Type.check_type expr_type (StateVar.type_of_state_var state_var)
              &&
@@ -1772,9 +1772,9 @@ and eval_node_call
     (* Type checking error or one expression has more indexes *)
     with
     | Invalid_argument _ -> 
-      C.fail_at_position pos "Index mismatch for input parameters"
+      fail_at_position pos "Index mismatch for input parameters"
     | E.Type_mismatch -> 
-      C.fail_at_position pos "Type mismatch for input parameters"
+      fail_at_position pos "Type mismatch for input parameters"
   in
 
   (* Type check defaults against outputs, return state variable for
@@ -1814,12 +1814,12 @@ and eval_node_call
            D.iter2 (fun i sv { E.expr_type = t } -> 
                (* Type of default must match type of respective output *)
                if not (Type.check_type t (StateVar.type_of_state_var sv)) then
-                 C.fail_at_position pos
+                 fail_at_position pos
                    "Type mismatch between default arguments and outputs")
              node_outputs
              defaults'
          with Invalid_argument _ -> 
-           C.fail_at_position pos
+           fail_at_position pos
              "Number of default arguments must match number of outputs");
         (* Return state variable and changed context *)
         Some state_var, Some defaults', ctx
@@ -2117,7 +2117,7 @@ and eval_ast_type_flatten flatten_arrays ctx = function
     in
 
     if Numeral.lt const_ubound const_lbound then
-      C.fail_at_position pos
+      fail_at_position pos
         (Format.asprintf "Invalid range %a" A.pp_print_lustre_type t);
     
     (* Add to empty trie with empty index *)
@@ -2221,7 +2221,7 @@ and eval_ast_type_flatten flatten_arrays ctx = function
     let array_size = static_int_of_ast_expr ctx pos size_expr in
 
     if not (Flags.Arrays.var_size () || E.is_const_expr array_size) then
-      C.fail_at_position pos
+      fail_at_position pos
       (Format.asprintf "Size of array (%a) has to be constant."
          (E.pp_print_expr false) array_size);
     

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -17,6 +17,7 @@
 *)
 
 open Lib
+open LustreReporting 
 
 (* Abbreviations *)
 module I = LustreIdent
@@ -24,7 +25,6 @@ module D = LustreIndex
 module E = LustreExpr
 module Contract = LustreContract
 module N = LustreNode
-module C = LustreContext
 
 module A = Analysis
 module S = SubSystem
@@ -268,7 +268,7 @@ let rec node_state_var_dependencies' init output_input_deps
          that are not visible in the origial source *)
       let str_path = describe_cycle node [] ((state_var, None) :: path) in
 
-      C.fail_no_position
+      fail_no_position
         (Format.asprintf
            "Circular dependency for %a in %a: @[<hov>%a@]@."
            (E.pp_print_lustre_var false) state_var


### PR DESCRIPTION
`fail_at_position` etc functions get their own module.
We would like to use them in other places and need not pull `LustreContext` as a dependency