### PR TITLE
Disallow shadowing and  separate namespaces for nodes and variables

### DIFF
--- a/examples/syntax-test.lus
+++ b/examples/syntax-test.lus
@@ -141,7 +141,7 @@ const c : int = 1; d = 2;
 -- Local variable declarations 
 var t : y_t;
     e, f: int;
-    j, k: bool;
+    jb, k: bool;
     -- Must not clash with previously declared constant 
     y_l: int;
     m: real;
@@ -162,7 +162,7 @@ let
   -- g, h, i = x(c);
 
   -- List can be in parentheses
-  (j, k, y_l, m) = (true, false, 1, 2.0);
+  (jb, k, y_l, m) = (true, false, 1, 2.0);
 
 /* TODO:  
   -- Structural assignment from array
@@ -600,7 +600,7 @@ type complex = [real, real];
 node x22 () returns ();
 var x, y: complex;
 let
-  x = [0.0, 1.0];
+  x = {0.0, 1.0};
   y = x;
 tel;
 

--- a/src/lustre/typeCheckerContext.mli
+++ b/src/lustre/typeCheckerContext.mli
@@ -50,16 +50,7 @@ type ty_set = SI.t
 type contract_exports = (ty_store) IMap.t
 (** Mapping for all the exports of the contract, modes and contract ghost const and vars *)
    
-type tc_context = { ty_syns: ty_alias_store (* store of the type alias mappings *)
-                  ; ty_ctx: ty_store        (* store of the types of identifiers and nodes *)
-                  ; contract_ctx: ty_store  (* store of the types of contracts *)
-                  ; vl_ctx: const_store     (* store of typed constants to its value *)
-                  ; u_types: ty_set         (* store of all declared user types,
-                                               this is poor mans kind (type of type) context *)
-                  ; contract_export_ctx:    (* stores all the export variables  of the contract *)
-                      contract_exports 
-                  }
-(** The type checker global context *)
+type tc_context
 
 val empty_tc_context: tc_context
 (** An empty typing context *)
@@ -95,6 +86,9 @@ val lookup_ty: tc_context -> LA.ident -> tc_type option
 val lookup_contract_ty: tc_context -> LA.ident -> tc_type option
 (** Lookup a contract type  *)
                           
+val lookup_node_ty: tc_context -> LA.ident -> tc_type option
+(** Lookup a node type *)
+
 val lookup_const: tc_context -> LA.ident -> (LA.expr * tc_type) option
 (** Lookup a constant identifier *)
 
@@ -104,6 +98,9 @@ val add_ty_syn: tc_context -> LA.ident -> tc_type -> tc_context
 val add_ty: tc_context -> LA.ident -> tc_type -> tc_context
 (** Add type binding into the typing context *)
 
+val add_ty_node: tc_context -> LA.ident -> tc_type -> tc_context
+(** Add node/function type binding into the typing context *)
+  
 val add_ty_contract: tc_context -> LA.ident -> tc_type -> tc_context
 (** Add the type of the contract *)
                   
@@ -136,6 +133,12 @@ val extract_consts: LA.const_clocked_typed_decl -> tc_context
 
 val get_constant_ids: tc_context -> LA.ident list
 (** Returns the constants declared in the typing context  *)
+
+val lookup_contract_exports: tc_context -> LA.ident -> ty_store option
+(** lookup the symbols exported by the contract *)
+
+val add_contract_exports: tc_context -> LA.ident -> ty_store -> tc_context
+(** Add the symbols that the contracts *)
   
 (** {1 Pretty Printers} *)
 

--- a/tests/lustre/typechecking/shouldFail/test_array_group.lus
+++ b/tests/lustre/typechecking/shouldFail/test_array_group.lus
@@ -1,0 +1,8 @@
+type complex = [real, real];
+
+node x22 () returns ();
+var x, y: complex;
+let
+  x = [0.0, 1.0]; -- this fails as it is an array not a tuple
+  y = x;
+tel;

--- a/tests/lustre/typechecking/shouldFail/test_shadowing.lus
+++ b/tests/lustre/typechecking/shouldFail/test_shadowing.lus
@@ -1,0 +1,8 @@
+const c = true;
+
+node n(x:int) returns (y:int); -- should fail as c has a name clash 
+var c:int;
+let
+y = x + c + 1; 
+c = pre x;
+tel.

--- a/tests/lustre/typechecking/shouldPass/test_array_group.lus
+++ b/tests/lustre/typechecking/shouldPass/test_array_group.lus
@@ -1,0 +1,8 @@
+type complex = [real, real];
+
+node x22 () returns ();
+var x, y: complex;
+let
+  x = {0.0, 1.0};
+  y = x;
+tel;

--- a/tests/lustre/typechecking/shouldPass/test_node_decl4.lus
+++ b/tests/lustre/typechecking/shouldPass/test_node_decl4.lus
@@ -1,0 +1,17 @@
+node y (const a: bool) returns (b: int);
+let
+    b = if a then 1 else 2;
+tel.
+
+
+-- A record type 
+type t = { one: int; two: real; three: bool };
+
+-- Another node 
+node X(x: int) returns (y: int);
+var v: t;
+let 
+  v = t { one=0; two=1.0; three = true }; 
+  -- Nested and unguarded pres 
+  y = pre pre x + v.one;
+tel;

--- a/tests/lustre/typechecking/shouldPass/test_node_decl5.lus
+++ b/tests/lustre/typechecking/shouldPass/test_node_decl5.lus
@@ -1,0 +1,20 @@
+
+-- node y(x:int) returns (f:int);
+-- let
+--   f = x + 1;
+-- tel
+
+-- node f(x:int) returns (y:int);
+-- let
+--   y = x + 1;
+-- tel
+
+
+node y(a:int) returns (c:int);
+let
+  c = a + 1;
+tel
+node f(x:int) returns (y:int);
+let
+  y = y(x) + 1;
+tel


### PR DESCRIPTION
- Do not allow shadowing.
- Improve interface for typechecker context for contract context exports
- Separate out node and identifier contexts