### PR TITLE
flatten node calls while finding reachable vars for contract guarantees

### DIFF
--- a/tests/lustre/typechecking/shouldFail/test_output_in_assume2.lus
+++ b/tests/lustre/typechecking/shouldFail/test_output_in_assume2.lus
@@ -1,0 +1,13 @@
+node b (x:int) returns (y:int);
+let
+y = x;
+tel
+
+node top(x: int) returns (y: int);
+(*@contract
+  var g: int = b(y) + 1;
+  assume g>0;
+*)
+let
+  y = x + 1;
+tel


### PR DESCRIPTION
There was a missing peace in the previous PR. It is fixed here. 

For reachability we should be flattening node calls using the node summary for the equations in contract guarantees and
mode requires. 