### PR TITLE
Fix soundness issue in path compression when inputs are temporally constrained

### DIFF
--- a/src/certif/certifChecker.ml
+++ b/src/certif/certifChecker.ml
@@ -2462,6 +2462,12 @@ let merge_systems lustre_vars kind2_sys jkind_sys =
       Var.mk_state_var_instance sv Numeral.one)
       state_vars in
 
+  let unconstrained_inputs =
+     StateVar.StateVarSet.union
+       (TS.unconstrained_inputs kind2_sys)
+       (TS.unconstrained_inputs jkind_sys)
+  in
+
   (* Symbol for initial predicate of new system *)
   let init_uf =
     UfSymbol.mk_uf_symbol
@@ -2525,6 +2531,7 @@ let merge_systems lustre_vars kind2_sys jkind_sys =
       init_flag
       []
       state_vars
+      unconstrained_inputs
       bounds
       []
       []

--- a/src/certif/jkindParser.ml
+++ b/src/certif/jkindParser.ml
@@ -453,6 +453,7 @@ let of_channel in_ch =
       jk_init_flag
       []
       allstatevars
+      StateVar.StateVarSet.empty (* underapproximation *)
       (StateVar.StateVarHashtbl.create 3)
       []
       []

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -592,6 +592,14 @@ let order_equations
     node_state_var_dependencies' init output_input_deps node [] state_vars
   in
 
+  let deps =
+    List.map
+     (fun (sv, deps) ->
+       (sv, SVM.fold (fun sv' _ acc -> SVS.add sv' acc) deps SVS.empty)
+     )
+     dependencies
+  in
+
   (* Order state variables by dependencies *)
   let state_vars_ordered = order_state_vars [] [] dependencies in
 
@@ -611,7 +619,7 @@ let order_equations
     output_input_dep_of_dependencies dependencies inputs outputs
   in
 
-  equations', output_input_dep
+  equations', deps, output_input_dep
 
           
 (* ********************************************************************** *)

--- a/src/lustre/lustreSlicing.mli
+++ b/src/lustre/lustreSlicing.mli
@@ -31,9 +31,12 @@
     the equations of [n] ordered such that each equation comes after
     the equations defining the variables occurring on its right-hand.
 
-    Along with the list of equations return a map that for each output
-    identified by its position indicates which positions in the inputs
-    it depends on. The input parameter [d] must contain such a map for
+    Along with the list of equations, it returns a list and a map.
+    The list contains pairs consisting of a variable and a set of
+    variables the first variable depends on.
+    The map is such that for each output identified by its position
+    indicates which positions in the inputs it depends on.
+    The input parameter [d] must contain such a map for
     each called node.
 
     If the flag [i] is true, consider the equations for the inital
@@ -76,6 +79,7 @@ val order_equations : bool -> (
 ) list ->
 LustreNode.t ->
 LustreNode.equation list *
+(StateVar.t * StateVar.StateVarSet.t) list *
 LustreIndex.index list LustreIndex.t
 
 (** {1 Cone of influence reduction} *)

--- a/src/nativeInput.ml
+++ b/src/nativeInput.ml
@@ -472,6 +472,7 @@ let of_channel in_ch =
             init_flag
             []
             state_vars
+            StateVar.StateVarSet.empty (* underapproximation *)
             (StateVar.StateVarHashtbl.create 7)
             []
             [] (* ufs *)

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -94,6 +94,9 @@ type t =
        Also contains [instance_state_var] unless it is None, but not
        state variables in [global_state_vars]. *)
 
+    unconstrained_inputs: StateVar.StateVarSet.t;
+    (** Input variables whose value is not constrained by assumptions or asserts *)
+
     state_var_bounds : 
       (LustreExpr.expr LustreExpr.bound_or_fixed list)
         StateVar.StateVarHashtbl.t;
@@ -815,6 +818,9 @@ module Hashtbl = Hashtbl.Make (T)
 
 (* Return state variables of the transition system *)
 let state_vars { state_vars } = state_vars
+
+(* Return unconstrained inputs variables of a transition system *)
+let unconstrained_inputs { unconstrained_inputs } = unconstrained_inputs
 
 (* Add a global constant to a transition system *)
 let rec add_global_constant t v =
@@ -1559,8 +1565,9 @@ let mk_trans_sys
   init_flag_state_var
   global_state_vars
   state_vars
-    state_var_bounds
-    global_consts
+  unconstrained_inputs
+  state_var_bounds
+  global_consts
   ufs
   init_uf_symbol
   init_formals
@@ -1718,6 +1725,7 @@ let mk_trans_sys
       instance_var_bindings;
       global_state_vars;
       state_vars;
+      unconstrained_inputs;
       state_var_bounds;
       subsystems;
       global_consts;

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -230,6 +230,9 @@ val mk_trans_sys :
   (* All state variables including globals and instance identifier *)
   StateVar.t list ->
 
+  (* Input variables whose value is not constrained by assumptions or asserts *)
+  StateVar.StateVarSet.t ->
+
   (* indexes of state variables *)
   (LustreExpr.expr LustreExpr.bound_or_fixed list) StateVar.StateVarHashtbl.t ->
 
@@ -372,6 +375,9 @@ val map_cex_prop_to_subsystem : (Scope.t -> instance -> (StateVar.t * Model.valu
 
 (** Return the state variables of a transition system *)
 val state_vars : t -> StateVar.t list
+
+(** Return unconstrained inputs variables of a transition system *)
+val unconstrained_inputs : t -> StateVar.StateVarSet.t
 
 (** Add a global constant to the transition system and all the subnodes *)
 val add_global_constant : t -> Var.t -> t

--- a/tests/regression/falsifiable/test-issue-715.lus
+++ b/tests/regression/falsifiable/test-issue-715.lus
@@ -1,0 +1,35 @@
+node model(a, b: int) returns (r : bool);
+(*@contract
+
+    var pre_a: int = 0 -> pre(a);
+    var pre_b: int = 0 -> pre(b);
+
+    assume "a increments with reset at 2"
+        if pre_a = 0 then
+            a = 1
+        else if pre_a = 1 then
+            a = 2
+        else
+            a = 0;
+
+    assume "b increments with reset at 6"
+        if pre_b = 0 then
+            b = 1
+        else if pre_b = 1 then
+            b = 2
+        else if pre_b = 2 then
+            b = 3
+        else if pre_b = 3 then
+            b = 4
+        else if pre_b = 4 then
+            b = 5
+        else if pre_b = 5 then
+            b = 6
+        else
+            b = 0;
+*)
+let
+    r = (a = 0 and b = 0);
+
+    check "witness r" not r;
+tel


### PR DESCRIPTION
The current solution only distinguishes between constrained and unconstrained inputs.
ToDo: Refine set of constrained inputs to consider only inputs _temporally_ constrained.
This should be enough to ensure existence of equal successors in path compression.

See issue #715 for more information.