### PR TITLE
Print enum types following Lustre syntax

### DIFF
--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -669,8 +669,7 @@ and pp_print_lustre_type ppf = function
       pp_print_expr e
   | EnumType (pos, n, l) -> 
     Format.fprintf ppf 
-      "enum %a @[<hv 2>{ %a }@]"
-      pp_print_ident n
+      "enum @[<hv 2>{ %a }@]"
       (pp_print_list Format.pp_print_string ",@ ") l
   | TArr (pos, arg_ty, ret_ty) ->
      Format.fprintf ppf "@[%a->@,%a@]"

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -254,8 +254,7 @@ let rec pp_print_lustre_type safe ppf t = match Type.node_of_type t with
 
   | Type.IntRange (i, j, Type.Enum) -> 
      let cs = Type.constructors_of_enum t in
-     Format.fprintf ppf "enum %s {%a}"
-       (Type.name_of_enum t)
+     Format.fprintf ppf "enum {%a}"
        (pp_print_list Format.pp_print_string ", ") cs
 
   | Type.UBV i -> 


### PR DESCRIPTION
This reverts a change introduced in commit 61fee4a. Some Kind 2 features, like printing the result of miniziming the source of a Lustre program according to a computed IVC, relies on printing types following the Lustre syntax.