### PR TITLE
Two small array bugs

### DIFF
--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1051,9 +1051,10 @@ let fresh_state_var_for_expr
 
   else if reuse && E.is_select_array_var expr && present_bounds <> [] then
 
-      let v = E.var_of_array_select expr in
+      let (v, ixes) = E.indexes_and_var_of_array_select expr in
       let sv = Var.state_var_of_state_var_instance v in
-      (sv, present_bounds), ctx
+      let ixes' = List.map (fun i -> E.Unbound i) ixes in
+      (sv, ixes'), ctx
 
   else
 

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -3445,6 +3445,19 @@ let var_of_array_select e =
   if not (Var.equal_vars v1 v2) then invalid_arg ("var_of_array_select");
   v1
 
+(* For an array select expression, get variable and list of indexes.
+ * XXX: We could implement var_of_array_select in terms of this, but this
+ * is stricter than var_of_array_select and will fail on different
+ * indexes in init vs step. Maybe that should be the case anyway? *)
+let indexes_and_var_of_array_select e =
+  let v1, ixes1 = Term.indexes_and_var_of_select e.expr_init in
+  let v2, ixes2 = Term.indexes_and_var_of_select e.expr_step in
+  if not (Var.equal_vars v1 v2) then
+    invalid_arg ("indexes_and_var_of_array_select.var");
+  if not (List.for_all2 Term.equal ixes1 ixes2) then
+    invalid_arg ("indexes_and_var_of_array_select.indexes");
+  (v1, ixes1)
+
 (* ********************************************************************** *)
 
 (* Apply let binding for state variable at current instant to

--- a/src/lustre/lustreExpr.mli
+++ b/src/lustre/lustreExpr.mli
@@ -500,6 +500,9 @@ val is_select : t -> bool
 val is_select_array_var : t -> bool
 
 val var_of_array_select : t -> Var.t
+
+(* For an array select expression, get variable and list of indexes *)
+val indexes_and_var_of_array_select : t -> Var.t * expr list
   
 (** Store in an array *)
 val mk_store : t -> t -> t -> t

--- a/tests/regression/success/array-literal-arrow.lus
+++ b/tests/regression/success/array-literal-arrow.lus
@@ -1,0 +1,14 @@
+node bad_array_lit( 
+    ignored : real;
+) returns (
+    ones_then_zeros : real^2;
+)
+var
+  zeros : real^2;
+let
+  zeros = 0.0^2;
+  ones_then_zeros = 1.0^2 -> zeros;
+  --%PROPERTY ones_then_zeros[0] = 1.0 -> ones_then_zeros[0] = 0.0;
+  --%PROPERTY ones_then_zeros[0] = (1.0 -> 0.0);
+tel
+

--- a/tests/regression/success/array-pre-indexing.lus
+++ b/tests/regression/success/array-pre-indexing.lus
@@ -1,0 +1,21 @@
+const len : int = 3;
+
+node array_pre( 
+    ins : real;
+) returns (
+    prevs1, prevs2 : real^len;
+)
+var
+  zeros : real^len;
+let
+  -- Workaround for typechecker bug: (0.0^len -> pre prevs1)[i] fails.
+  zeros = 0.0^len;
+  -- These two definitions should be equivalent:
+  prevs1[i] = if i = 0 then ins else (zeros -> pre prevs1)[i - 1];
+  prevs2[i] = if i = 0 then ins else (0.0 -> pre (prevs2[i - 1]));
+  --%PROPERTY prevs1[0] = prevs2[0];
+  --%PROPERTY prevs1[1] = prevs2[1];
+  --%PROPERTY prevs1[2] = prevs2[2];
+tel
+
+


### PR DESCRIPTION
Hi Daniel,

I'm looking into some bugs in the array support at the moment. I have some fixes for two small bugs. I'm looking into another one now, which is that you can't call nodes or functions inside an array definition like `x[i] = f(y[i])`. This one seems a bit hairier though.

## Array indexing reuse:
Creating a new state var for an array select would reuse the existing
definition, but with the array indices from the environment rather
than what the select expression used.

The nested select in the following equation:
```
  prevs2[i] = if i = 0 then ins else (0.0 -> pre (prevs2[i - 1]));
```
was translated as `prevs2[i]`, somehow losing the `i-1`.

## Array constructor typechecking:
Array constructors (of the form `x^n`) were causing type errors in
arrows.

For a definition like:
```
const_zero = 0.0^5 -> pre const_zero;
```

This was being simplified to the following in LustreExpr:
```
abs_0 = 0.0;
const_zero[i0] = (abs_0 -> pre const_zero);
```

But this is a type error, because one side of the arrow is a real
and the other is an array. This commit inserts array selects to
make the types line up like so:
```
abs_0 = 0.0;
const_zero[i0] = (abs_0 -> pre const_zero[i0]);
```