### PR TITLE
Fix subrange revert to ints inside arrays

### DIFF
--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -806,6 +806,11 @@ let pp_print_term_as_expr_mvar ?as_type safe map ppf expr =
     )
     ppf expr
 
+let pp_print_expr_bound_or_fixed ?as_type ppf = function
+  | Bound   e -> Format.fprintf ppf   "Bound %a" (pp_print_expr true) e
+  | Fixed   e -> Format.fprintf ppf   "Fixed %a" (pp_print_expr true) e
+  | Unbound e -> Format.fprintf ppf "Unbound %a" (pp_print_expr true) e
+
 (* Pretty-print a hashconsed term to the standard formatter *)
 let print_expr ?as_type safe =
   pp_print_expr ?as_type safe Format.std_formatter

--- a/src/lustre/lustreExpr.mli
+++ b/src/lustre/lustreExpr.mli
@@ -172,6 +172,9 @@ val pp_print_term_as_expr_mvar :
   (string StateVar.StateVarMap.t) ->
   Format.formatter -> Term.t -> unit
 
+val pp_print_expr_bound_or_fixed :
+  ?as_type:Type.t ->
+    Format.formatter -> expr bound_or_fixed -> unit
 
 (** {1 Predicates} *)
 

--- a/src/terms/stateVar.ml
+++ b/src/terms/stateVar.ml
@@ -187,6 +187,11 @@ let pp_print_state_var_node ppf (n, s) =
 let pp_print_state_var ppf { Hashcons.node = (n, s) } =
   pp_print_state_var_node ppf (n, s)
 
+let pp_print_state_var_with_type ppf ({ Hashcons.node = (n, s); Hashcons.prop = { var_type = t } } : t) : unit =
+  Format.fprintf ppf "%a (type %a)"
+    pp_print_state_var_node (n, s)
+    Type.pp_print_type t
+
 (* Return a string representation of a hashconsed state variable *)
 let string_of_state_var s = string_of_t pp_print_state_var s
 

--- a/src/terms/stateVar.mli
+++ b/src/terms/stateVar.mli
@@ -158,6 +158,9 @@ val get_select_ufs : unit -> UfSymbol.t list
 (** Pretty-print a state variable *)
 val pp_print_state_var : Format.formatter -> t -> unit
 
+(** Pretty-print a state variable with type *)
+val pp_print_state_var_with_type : Format.formatter -> t -> unit
+
 (** Return a string representation of a symbol *)
 val string_of_state_var : t -> string
 

--- a/tests/regression/success/array-subrange.lus
+++ b/tests/regression/success/array-subrange.lus
@@ -1,0 +1,11 @@
+type percent = subrange [0, 100] of int;
+node test_subrange( 
+  input  : percent; 
+) returns (
+  output : percent^2;
+)
+let
+    output = [input, input -> pre (output[0])];
+    --%PROPERTY output[1] = (input -> pre input);
+tel
+


### PR DESCRIPTION
Hi Daniel,

More small array fixes.

When defining an array where the expression has a subrange type, if
the bounds are not obviously satisfied then the type is reverted to
`int` and the bounds are added as properties. However, for arrays
this reversion was replacing the whole type with `int` rather than
just the subrange - so `(subrange [0,5] of int)^10` had its type
changed to just `int` rather than `int^10`.

I also added some pretty-printing functions, which I found useful
while debugging.

This fixes issue #707.
