### PR TITLE
Print values of ghost variables in counterexamples

### DIFF
--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1254,7 +1254,7 @@ let mk_local_for_expr
                 ctx
               with Not_found -> {
                 ctx with node = Some (
-                  N.set_state_var_source node state_var N.Ghost
+                  N.set_state_var_source node state_var N.KGhost
                 )
               }
             ) else ctx
@@ -1586,6 +1586,7 @@ let trace_svars_of ctx expr = match ctx with
           | N.Local
           | N.KLocal
           | N.Ghost
+          | N.KGhost
           (* | N.Alias (_,_) *)
           | N.Call -> (
             let svars =

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1586,8 +1586,8 @@ let trace_svars_of ctx expr = match ctx with
           | N.Local
           | N.KLocal
           | N.Ghost
-          | N.Call
-          | N.Alias (_,_) -> (
+          (* | N.Alias (_,_) *)
+          | N.Call -> (
             let svars =
               (* Do we have an equation for svar? *)
               match N.equation_of_svar node svar with

--- a/src/lustre/lustreContractGen.ml
+++ b/src/lustre/lustreContractGen.ml
@@ -119,8 +119,8 @@ module Contract = struct
       (* Found oracle , illegal invariant. *)
       | Some Node.Oracle -> None
 
-      | Some Node.Alias (_, source) ->
-         analyze_by_source known locals svar tail source
+      (* | Some Node.Alias (_, source) ->
+         analyze_by_source known locals svar tail source *)
 
       | _ -> (
         let locals = SvSet.add svar locals in

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1181,7 +1181,7 @@ let rec eval_node_equation inputs outputs locals ctx = function
         fun ctx ((sv, b), e) ->
           (* Is [e] a state variable in the current state? *)
           let ctx =
-            if E.is_var e then (
+            if E.is_var e && b = [] then (
               let alias = E.state_var_of_expr e in
               (* Format.printf "%a is an alias for %a@.@."
                 StateVar.pp_print_state_var alias

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -1179,8 +1179,9 @@ let rec eval_node_equation inputs outputs locals ctx = function
     (* Add equations for each index *)
       List.fold_left (
         fun ctx ((sv, b), e) ->
-          (* Is [e] a state variable in the current state? *)
+          (*
           let ctx =
+            (* Is [e] a state variable in the current state? *)
             if E.is_var e && b = [] then (
               let alias = E.state_var_of_expr e in
               (* Format.printf "%a is an alias for %a@.@."
@@ -1190,7 +1191,7 @@ let rec eval_node_equation inputs outputs locals ctx = function
                 fun node -> N.set_state_var_alias node alias sv
               )
             ) else ctx
-          in
+          in*)
           C.add_node_equation ctx pos sv b indexes e
       ) ctx equations
 

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -80,6 +80,9 @@ type state_var_source =
   (* Local ghost stream *)
   | Ghost
 
+  (* Invisble Kind 2 ghost stream *)
+  | KGhost
+
   (* Oracle input stream *)
   | Oracle
 
@@ -692,6 +695,7 @@ let pp_print_node_debug
       | (sv, KLocal) -> p sv "k-loc"
       | (sv, Call) -> p sv "cl"
       | (sv, Ghost) -> p sv "gh"
+      | (sv, KGhost) -> p sv "k-gh"
       | (sv, Oracle) -> p sv "or"
       (* | (sv, Alias (sub, _)) -> p sv (
         Format.asprintf "al(%a)"
@@ -1347,6 +1351,7 @@ let pp_print_state_var_source ppf = function
   | KLocal -> Format.fprintf ppf "invisible local"
   | Call -> Format.fprintf ppf "call"
   | Ghost -> Format.fprintf ppf "ghost"
+  | KGhost -> Format.fprintf ppf "invisble ghost"
   (* | Alias (sv, _) ->
     Format.fprintf ppf "alias(%a)" StateVar.pp_print_state_var sv *)
 
@@ -1403,13 +1408,14 @@ let state_var_is_visible node state_var =
   let visible_of_src = function
     (* Oracle inputs and abstracted streams are invisible *)
     | Call
-    | Ghost
     | Oracle
+    | KGhost
     | KLocal -> false
 
     (* Inputs, outputs and defined locals are visible *)
     | Input
     | Output
+    | Ghost
     | Local -> true
 
     (* (* Alias depends on source of alias. *)

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -84,8 +84,8 @@ type state_var_source =
   | Oracle
 
   (* Alias for another state variable. *)
-  | Alias of
-    StateVar.t * state_var_source option
+  (*| Alias of
+    StateVar.t * state_var_source option*)
 
 type call_cond =
   | CActivate of StateVar.t
@@ -693,10 +693,10 @@ let pp_print_node_debug
       | (sv, Call) -> p sv "cl"
       | (sv, Ghost) -> p sv "gh"
       | (sv, Oracle) -> p sv "or"
-      | (sv, Alias (sub, _)) -> p sv (
+      (* | (sv, Alias (sub, _)) -> p sv (
         Format.asprintf "al(%a)"
           StateVar.pp_print_state_var sub
-      )
+      )*)
 
   in
 
@@ -1347,8 +1347,8 @@ let pp_print_state_var_source ppf = function
   | KLocal -> Format.fprintf ppf "invisible local"
   | Call -> Format.fprintf ppf "call"
   | Ghost -> Format.fprintf ppf "ghost"
-  | Alias (sv, _) ->
-    Format.fprintf ppf "alias(%a)" StateVar.pp_print_state_var sv
+  (* | Alias (sv, _) ->
+    Format.fprintf ppf "alias(%a)" StateVar.pp_print_state_var sv *)
 
 
 (* Set source of state variable *)
@@ -1371,12 +1371,12 @@ let get_state_var_source { state_var_source_map } state_var =
     state_var
     state_var_source_map
 
-(* Sets a state variable as alias for another one. *)
+(* (* Sets a state variable as alias for another one. *)
 let set_state_var_alias node alias svar =
   Alias (
     svar,
     try Some (get_state_var_source node alias) with Not_found -> None
-  ) |> set_state_var_source node alias
+  ) |> set_state_var_source node alias*)
 
 (* Set source of state variable if not already defined. *)
 let set_state_var_source_if_undef node svar source =
@@ -1400,7 +1400,7 @@ let get_state_var_expr_map { state_var_expr_map } = state_var_expr_map
 let state_var_is_visible node state_var =
   let open Lib.ReservedIds in
 
-  let rec visible_of_src = function
+  let visible_of_src = function
     (* Oracle inputs and abstracted streams are invisible *)
     | Call
     | Ghost
@@ -1412,9 +1412,9 @@ let state_var_is_visible node state_var =
     | Output
     | Local -> true
 
-    (* Alias depends on source of alias. *)
+    (* (* Alias depends on source of alias. *)
     | Alias (_, None) -> false
-    | Alias (_, Some src) -> visible_of_src src
+    | Alias (_, Some src) -> visible_of_src src *)
   in
   
   (match get_state_var_source node state_var with

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -110,6 +110,7 @@ type state_var_source =
 | KLocal  (** Kind 2 invisible local variable *)
 | Call    (** Tied to a node call. *)
 | Ghost   (** Declared ghost variable *)
+| KGhost  (** Kind 2 invisible ghost variable *)
 | Oracle  (** Generated non-deterministic input *)
 (*| Alias of
   StateVar.t * state_var_source option (** Alias for another state variable. *) *)

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -111,8 +111,8 @@ type state_var_source =
 | Call    (** Tied to a node call. *)
 | Ghost   (** Declared ghost variable *)
 | Oracle  (** Generated non-deterministic input *)
-| Alias of
-  StateVar.t * state_var_source option (** Alias for another state variable. *)
+(*| Alias of
+  StateVar.t * state_var_source option (** Alias for another state variable. *) *)
 
 
 (** A contract. *)
@@ -386,8 +386,8 @@ val set_state_var_source_if_undef : t -> StateVar.t -> state_var_source -> t
 (** Get source of state variable *)
 val get_state_var_source : t -> StateVar.t -> state_var_source
 
-(** Sets the first svar as alias for the second svar. *)
-val set_state_var_alias : t -> StateVar.t -> StateVar.t -> t
+(* (** Sets the first svar as alias for the second svar. *)
+val set_state_var_alias : t -> StateVar.t -> StateVar.t -> t *)
 
 (** Register state var as tied to a node call if not already registered. *)
 val set_state_var_node_call : t -> StateVar.t -> t

--- a/src/lustre/lustrePath.ml
+++ b/src/lustre/lustrePath.ml
@@ -1255,7 +1255,7 @@ let pp_print_stream_ident_xml = pp_print_stream_ident_pt
 
 
 (* Pretty-print a property of a stream as XML attributes *)
-let rec pp_print_stream_prop_xml ppf = function 
+let pp_print_stream_prop_xml ppf = function 
 
   | N.Input -> Format.fprintf ppf "@ class=\"input\""
 
@@ -1263,7 +1263,7 @@ let rec pp_print_stream_prop_xml ppf = function
 
   | N.Local -> Format.fprintf ppf "@ class=\"local\""
 
-  | N.Alias (_, Some src) -> pp_print_stream_prop_xml ppf src
+  (*| N.Alias (_, Some src) -> pp_print_stream_prop_xml ppf src*)
 
   (* Any other streams should have been culled out *)
   | _ -> assert false 
@@ -1553,7 +1553,7 @@ let pp_print_stream_ident_json = pp_print_stream_ident_pt
 
 
 (* Pretty-print a property of a stream as JSON attributes *)
-let rec pp_print_stream_prop_json ppf = function
+let pp_print_stream_prop_json ppf = function
 
   | N.Input -> Format.fprintf ppf "\"class\" : \"input\",@,"
 
@@ -1561,7 +1561,7 @@ let rec pp_print_stream_prop_json ppf = function
 
   | N.Local -> Format.fprintf ppf "\"class\" : \"local\",@,"
 
-  | N.Alias (_, Some src) -> pp_print_stream_prop_json ppf src
+  (* | N.Alias (_, Some src) -> pp_print_stream_prop_json ppf src *)
 
   (* Any other streams should have been culled out *)
   | _ -> assert false

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -144,7 +144,7 @@ let rec describe_cycle node accum = function
      (* Skip oracles and calls *)
      | N.KLocal
      | N.Call
-     | N.Alias (_,_)
+     (*| N.Alias (_,_)*)
      | N.Oracle -> describe_cycle node accum tl
 
         (* State variable from abstraction *)

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -142,6 +142,7 @@ let rec describe_cycle node accum = function
          tl
 
      (* Skip oracles and calls *)
+     | N.KGhost
      | N.KLocal
      | N.Call
      (*| N.Alias (_,_)*)


### PR DESCRIPTION
Note: svar aliasing tracing was associating variables with different origin (e.g. input <-> output) and different types (int <-> subrange). This could lead to errors, so I commented it out.