### PR TITLE
Add span information to declarations and file name to program

### DIFF
--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -27,7 +27,7 @@ module SVS = SVar.StateVarSet
 module SVM = SVar.StateVarMap
 
 type _ t =
-| Lustre : (LustreNode.t S.t * LustreGlobals.t * LustreAst.declaration list) -> LustreNode.t t
+| Lustre : (LustreNode.t S.t * LustreGlobals.t * LustreAst.t) -> LustreNode.t t
 | Native : TransSys.t S.t -> TransSys.t t
 | Horn : unit S.t -> unit t
 

--- a/src/ivcMcs.ml
+++ b/src/ivcMcs.ml
@@ -467,6 +467,7 @@ let fill_input_types_hashtbl ast =
   List.iter aux_decl ast
 
 let minimize_lustre_ast ?(valid_lustre=false) in_sys (_,loc_core,_) ast =
+  let { A.decls = ast; A.file = filename } = ast in
   fill_input_types_hashtbl ast ;
   let undef_expr =
     if valid_lustre
@@ -497,11 +498,9 @@ let minimize_lustre_ast ?(valid_lustre=false) in_sys (_,loc_core,_) ast =
     | n -> aux ((rand_node n)::acc) (nb-1)
   in
   aux minimized (!max_nb_args)*)
-  Hashtbl.fold (fun ts n acc ->
-    (rand_node n ts)::acc
-  )
-  rand_functions
-  minimized
+  let result = Hashtbl.fold
+    (fun ts n acc -> (rand_node n ts)::acc) rand_functions minimized in
+  { A.decls = result; A.file = filename }
 
 (* ---------- UTILITIES ---------- *)
 

--- a/src/ivcMcs.ml
+++ b/src/ivcMcs.ml
@@ -204,7 +204,7 @@ let parametric_rand_node nb_outputs =
     dpos,out,A.UserType (dpos, t),A.ClockTrue) ts
   in
   let ts = List.map (fun str -> A.TypeParam str) ts in
-  A.NodeDecl (dpos,
+  A.NodeDecl (dpos, dpos,
     (rand_fun_ident nb_outputs, true, ts, [dpos,"id",A.Int dpos,A.ClockTrue, false],
     outs, [], [], None)
   )
@@ -218,7 +218,7 @@ let rand_node name ts =
   let outs = aux "out" [] (List.length ts)
   |> List.map2 (fun t out -> dpos,out,t,A.ClockTrue) ts
   in
-  A.NodeDecl (dpos,
+  A.NodeDecl (dpos, dpos,
     (name, true, [], [dpos,"id",A.Int dpos,A.ClockTrue, false],
     outs, [], [], None)
   )
@@ -447,12 +447,12 @@ let minimize_contract_decl ue loc_core (id, tparams, inputs, outputs, body) =
   (id, tparams, inputs, outputs, body)
 
 let minimize_decl ue loc_core = function
-  | A.NodeDecl (p, ndecl) ->
-    A.NodeDecl (p, minimize_node_decl ue loc_core ndecl)
-  | A.FuncDecl (p, ndecl) ->
-    A.FuncDecl (p, minimize_node_decl ue loc_core ndecl)
-  | A.ContractNodeDecl (p, cdecl) ->
-    A.ContractNodeDecl (p, minimize_contract_decl ue loc_core cdecl)
+  | A.NodeDecl (spos, epos, ndecl) ->
+    A.NodeDecl (spos, epos, minimize_node_decl ue loc_core ndecl)
+  | A.FuncDecl (spos, epos, ndecl) ->
+    A.FuncDecl (spos, epos, minimize_node_decl ue loc_core ndecl)
+  | A.ContractNodeDecl (spos, epos, cdecl) ->
+    A.ContractNodeDecl (spos, epos, minimize_contract_decl ue loc_core cdecl)
   | decl -> decl 
 
 let fill_input_types_hashtbl ast =
@@ -461,7 +461,7 @@ let fill_input_types_hashtbl ast =
     Hashtbl.replace nodes_input_types id (List.map typ_of_input inputs) ;
   in
   let aux_decl = function
-  | A.NodeDecl (_, ndecl) | A.FuncDecl (_, ndecl) -> aux_node_decl ndecl
+  | A.NodeDecl (_, _, ndecl) | A.FuncDecl (_, _, ndecl) -> aux_node_decl ndecl
   | _ -> ()
   in
   List.iter aux_decl ast

--- a/src/ivcMcs.ml
+++ b/src/ivcMcs.ml
@@ -125,6 +125,7 @@ let counter =
   (fun () -> last := !last + 1 ; !last)
 
 let dpos = Lib.dummy_pos
+let dspan = { A.start_pos = dpos; A.end_pos = dpos }
 let rand_fun_ident nb = "__rand"^(string_of_int nb)
 let new_rand_fun_ident () = rand_fun_ident (counter ())
 
@@ -204,7 +205,7 @@ let parametric_rand_node nb_outputs =
     dpos,out,A.UserType (dpos, t),A.ClockTrue) ts
   in
   let ts = List.map (fun str -> A.TypeParam str) ts in
-  A.NodeDecl (dpos, dpos,
+  A.NodeDecl (dspan,
     (rand_fun_ident nb_outputs, true, ts, [dpos,"id",A.Int dpos,A.ClockTrue, false],
     outs, [], [], None)
   )
@@ -218,7 +219,7 @@ let rand_node name ts =
   let outs = aux "out" [] (List.length ts)
   |> List.map2 (fun t out -> dpos,out,t,A.ClockTrue) ts
   in
-  A.NodeDecl (dpos, dpos,
+  A.NodeDecl (dspan,
     (name, true, [], [dpos,"id",A.Int dpos,A.ClockTrue, false],
     outs, [], [], None)
   )
@@ -447,12 +448,12 @@ let minimize_contract_decl ue loc_core (id, tparams, inputs, outputs, body) =
   (id, tparams, inputs, outputs, body)
 
 let minimize_decl ue loc_core = function
-  | A.NodeDecl (spos, epos, ndecl) ->
-    A.NodeDecl (spos, epos, minimize_node_decl ue loc_core ndecl)
-  | A.FuncDecl (spos, epos, ndecl) ->
-    A.FuncDecl (spos, epos, minimize_node_decl ue loc_core ndecl)
-  | A.ContractNodeDecl (spos, epos, cdecl) ->
-    A.ContractNodeDecl (spos, epos, minimize_contract_decl ue loc_core cdecl)
+  | A.NodeDecl (span, ndecl) ->
+    A.NodeDecl (span, minimize_node_decl ue loc_core ndecl)
+  | A.FuncDecl (span, ndecl) ->
+    A.FuncDecl (span, minimize_node_decl ue loc_core ndecl)
+  | A.ContractNodeDecl (span, cdecl) ->
+    A.ContractNodeDecl (span, minimize_contract_decl ue loc_core cdecl)
   | decl -> decl 
 
 let fill_input_types_hashtbl ast =
@@ -461,7 +462,7 @@ let fill_input_types_hashtbl ast =
     Hashtbl.replace nodes_input_types id (List.map typ_of_input inputs) ;
   in
   let aux_decl = function
-  | A.NodeDecl (_, _, ndecl) | A.FuncDecl (_, _, ndecl) -> aux_node_decl ndecl
+  | A.NodeDecl (_, ndecl) | A.FuncDecl (_, ndecl) -> aux_node_decl ndecl
   | _ -> ()
   in
   List.iter aux_decl ast

--- a/src/lustre/contractsToProps.ml
+++ b/src/lustre/contractsToProps.ml
@@ -182,13 +182,13 @@ let rec fmt_declarations fmt = function
 | dec :: tail -> (
   ( match dec with
 
-    | Ast.ContractNodeDecl (pos,_) ->
+    | Ast.ContractNodeDecl (spos, epos, _) ->
       Format.asprintf "\
-        [contracts translator] %a: contract node declarations are unsupported\
-      " pp_print_pos pos
+        [contracts translator] (%a;%a): contract node declarations are unsupported\
+      " pp_print_pos spos pp_print_pos epos
       |> failwith
 
-    | Ast.NodeDecl (pos, (wan, _, two,tri,far,fiv,six,contract)) -> (
+    | Ast.NodeDecl (_, _, (wan, _, two,tri,far,fiv,six,contract)) -> (
       let contract_info = match contract with
         | None -> ([],[],[])
         | Some c -> collect_contracts ([],[],[]) c

--- a/src/lustre/contractsToProps.ml
+++ b/src/lustre/contractsToProps.ml
@@ -182,13 +182,13 @@ let rec fmt_declarations fmt = function
 | dec :: tail -> (
   ( match dec with
 
-    | Ast.ContractNodeDecl (spos, epos, _) ->
+    | Ast.ContractNodeDecl ({Ast.start_pos = spos; Ast.end_pos = epos }, _) ->
       Format.asprintf "\
         [contracts translator] (%a;%a): contract node declarations are unsupported\
       " pp_print_pos spos pp_print_pos epos
       |> failwith
 
-    | Ast.NodeDecl (_, _, (wan, _, two,tri,far,fiv,six,contract)) -> (
+    | Ast.NodeDecl (_, (wan, _, two,tri,far,fiv,six,contract)) -> (
       let contract_info = match contract with
         | None -> ([],[],[])
         | Some c -> collect_contracts ([],[],[]) c

--- a/src/lustre/contractsToProps.ml
+++ b/src/lustre/contractsToProps.ml
@@ -209,7 +209,7 @@ let translate ast target =
   fmt_declarations fmt ast
 
 let translate_file file target =
-  let ast = LustreInput.ast_of_file file in
+  let {Ast.decls = ast} = LustreInput.ast_of_file file in
   translate ast target
 
 (* 

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -321,12 +321,12 @@ type node_param_inst = ident * ident * lustre_type list
   
 (* A declaration as parsed *)
 type declaration = 
-  | TypeDecl of position * type_decl
-  | ConstDecl of position * const_decl
-  | NodeDecl of position * node_decl
-  | FuncDecl of position * node_decl
-  | ContractNodeDecl of position * contract_node_decl
-  | NodeParamInst of position * node_param_inst
+  | TypeDecl of position * position * type_decl
+  | ConstDecl of position * position * const_decl
+  | NodeDecl of position * position * node_decl
+  | FuncDecl of position * position * node_decl
+  | ContractNodeDecl of position * position * contract_node_decl
+  | NodeParamInst of position * position * node_param_inst
 
 
 (* A Lustre program *)
@@ -1101,9 +1101,7 @@ let pp_print_contract_node_decl ppf (n,p,i,o,e)
        pp_print_contract e
 
 
-let pp_print_node_or_fun_decl is_fun ppf (
-  pos, (n, ext, p, i, o, l, e, r)
-) =
+let pp_print_node_or_fun_decl is_fun ppf (n, ext, p, i, o, l, e, r) =
     if e = [] then
       Format.fprintf ppf
         "@[<hv>@[<hv 2>%s%s %a%t@ \
@@ -1143,22 +1141,22 @@ let pp_print_node_or_fun_decl is_fun ppf (
 (* Pretty-print a declaration *)
 let pp_print_declaration ppf = function
 
-  | TypeDecl (pos, t) -> 
+  | TypeDecl (spos, epos, t) -> 
 
     Format.fprintf ppf "type %a;" pp_print_type_decl t
 
-  | ConstDecl (pos, c) -> pp_print_const_decl ppf c
+  | ConstDecl (spos, epos, c) -> pp_print_const_decl ppf c
 
-  | NodeDecl (pos, decl) ->
-    pp_print_node_or_fun_decl false ppf (pos, decl)
+  | NodeDecl (spos, epos, decl) ->
+    pp_print_node_or_fun_decl false ppf decl
 
-  | FuncDecl (pos, decl) ->
-    pp_print_node_or_fun_decl true ppf (pos, decl)
+  | FuncDecl (spos, epos, decl) ->
+    pp_print_node_or_fun_decl true ppf decl
 
-  | ContractNodeDecl (pos, decl) ->
+  | ContractNodeDecl (spos, epos, decl) ->
     pp_print_contract_node_decl ppf decl
 
-  | NodeParamInst (pos, (n, s, p)) -> 
+  | NodeParamInst (spos, epos, (n, s, p)) -> 
 
     Format.fprintf ppf
       "@[<hv>@[<hv 2>node %a =@ %a@[<hv 2><<%a>>@];@]" 

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -318,15 +318,20 @@ type contract_node_decl =
 
 (* An instance of a parameterized node *)
 type node_param_inst = ident * ident * lustre_type list
-  
+
+type span = {
+  start_pos : position;
+  end_pos : position;
+}
+
 (* A declaration as parsed *)
 type declaration = 
-  | TypeDecl of position * position * type_decl
-  | ConstDecl of position * position * const_decl
-  | NodeDecl of position * position * node_decl
-  | FuncDecl of position * position * node_decl
-  | ContractNodeDecl of position * position * contract_node_decl
-  | NodeParamInst of position * position * node_param_inst
+  | TypeDecl of span * type_decl
+  | ConstDecl of span * const_decl
+  | NodeDecl of span * node_decl
+  | FuncDecl of span * node_decl
+  | ContractNodeDecl of span * contract_node_decl
+  | NodeParamInst of span * node_param_inst
 
 
 (* A Lustre program *)
@@ -1144,22 +1149,22 @@ let pp_print_node_or_fun_decl is_fun ppf (n, ext, p, i, o, l, e, r) =
 (* Pretty-print a declaration *)
 let pp_print_declaration ppf = function
 
-  | TypeDecl (spos, epos, t) -> 
+  | TypeDecl (_, t) -> 
 
     Format.fprintf ppf "type %a;" pp_print_type_decl t
 
-  | ConstDecl (spos, epos, c) -> pp_print_const_decl ppf c
+  | ConstDecl (_, c) -> pp_print_const_decl ppf c
 
-  | NodeDecl (spos, epos, decl) ->
+  | NodeDecl (_, decl) ->
     pp_print_node_or_fun_decl false ppf decl
 
-  | FuncDecl (spos, epos, decl) ->
+  | FuncDecl (_, decl) ->
     pp_print_node_or_fun_decl true ppf decl
 
-  | ContractNodeDecl (spos, epos, decl) ->
+  | ContractNodeDecl (_, decl) ->
     pp_print_contract_node_decl ppf decl
 
-  | NodeParamInst (spos, epos, (n, s, p)) -> 
+  | NodeParamInst (_, (n, s, p)) -> 
 
     Format.fprintf ppf
       "@[<hv>@[<hv 2>node %a =@ %a@[<hv 2><<%a>>@];@]" 

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -330,7 +330,10 @@ type declaration =
 
 
 (* A Lustre program *)
-type t = declaration list
+type t = {
+  decls: declaration list;
+  file: string
+}
 
 
 (* ********************************************************************** *)
@@ -1164,9 +1167,14 @@ let pp_print_declaration ppf = function
       pp_print_ident n 
       (pp_print_list pp_print_lustre_type "@ ") p
 
-
+let pp_print_declaration_list ppf p =
+  Format.fprintf ppf
+    "@[<v>%a@]" 
+    (pp_print_list pp_print_declaration "@ ") 
+    p
+  
 let pp_print_program ppf p =
-
+  let {decls = p} = p in
   Format.fprintf ppf
     "@[<v>%a@]" 
     (pp_print_list pp_print_declaration "@ ") 

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -335,15 +335,20 @@ type contract_node_decl =
     type parameters *)
 type node_param_inst = ident * ident * lustre_type list
 
+type span = {
+  start_pos : position;
+  end_pos : position;
+}
+
 (** A declaration of a type, a constant, a node, a function or an
     instance of a parametric node *)
 type declaration =
-  | TypeDecl of position * position * type_decl
-  | ConstDecl of position * position * const_decl
-  | NodeDecl of position * position * node_decl
-  | FuncDecl of position * position * node_decl
-  | ContractNodeDecl of position * position * contract_node_decl
-  | NodeParamInst of position * position * node_param_inst
+  | TypeDecl of span * type_decl
+  | ConstDecl of span * const_decl
+  | NodeDecl of span * node_decl
+  | FuncDecl of span * node_decl
+  | ContractNodeDecl of span * contract_node_decl
+  | NodeParamInst of span * node_param_inst
 
 (** A Lustre program as a list of declarations *) 
 type t = {

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -338,12 +338,12 @@ type node_param_inst = ident * ident * lustre_type list
 (** A declaration of a type, a constant, a node, a function or an
     instance of a parametric node *)
 type declaration =
-  | TypeDecl of position * type_decl
-  | ConstDecl of position * const_decl
-  | NodeDecl of position * node_decl
-  | FuncDecl of position * node_decl
-  | ContractNodeDecl of position * contract_node_decl
-  | NodeParamInst of position * node_param_inst
+  | TypeDecl of position * position * type_decl
+  | ConstDecl of position * position * const_decl
+  | NodeDecl of position * position * node_decl
+  | FuncDecl of position * position * node_decl
+  | ContractNodeDecl of position * position * contract_node_decl
+  | NodeParamInst of position * position * node_param_inst
 
 (** A Lustre program as a list of declarations *) 
 type t = declaration list

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -346,7 +346,10 @@ type declaration =
   | NodeParamInst of position * position * node_param_inst
 
 (** A Lustre program as a list of declarations *) 
-type t = declaration list
+type t = {
+  decls: declaration list;
+  file: string
+}
 
 (** {1 Pretty-printers} *)
 val pp_print_node_param_list : Format.formatter -> node_param list -> unit
@@ -377,6 +380,7 @@ val pp_print_eq_lhs: Format.formatter -> eq_lhs -> unit
 val pp_print_node_body: Format.formatter -> node_equation -> unit
 val pp_print_node_item : Format.formatter -> node_item -> unit
 val pp_print_declaration : Format.formatter -> declaration -> unit
+val pp_print_declaration_list : Format.formatter -> declaration list -> unit
 val pp_print_program : Format.formatter -> t -> unit
 
 val pp_print_contract_item : Format.formatter -> contract_node_equation -> unit

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -438,36 +438,40 @@ let rec  mk_decl_map: LA.declaration IMap.t -> LA.declaration list -> (LA.declar
   function  
   | [] -> R.ok m 
 
-  | (LA.TypeDecl (pos, _, FreeType (_, i)) as tydecl) :: decls
-    | (LA.TypeDecl (pos, _, AliasType (_, i, _)) as tydecl) :: decls ->
-     check_and_add m pos ty_suffix i tydecl >>= fun m' ->
-     mk_decl_map m' decls 
+  | (LA.TypeDecl (span, FreeType (_, i)) as tydecl) :: decls
+  | (LA.TypeDecl (span, AliasType (_, i, _)) as tydecl) :: decls ->
+    let {LA.start_pos = pos} = span in
+    check_and_add m pos ty_suffix i tydecl >>= fun m' ->
+    mk_decl_map m' decls 
 
-  | (LA.ConstDecl (pos, _, FreeConst (_, i, _)) as cnstd) :: decls
-    | (LA.ConstDecl (pos, _, UntypedConst (_, i, _)) as cnstd) :: decls
-    | (LA.ConstDecl (pos, _, TypedConst (_, i, _, _)) as cnstd) :: decls -> 
-     check_and_add m pos const_suffix i cnstd  >>= fun m' ->
-     mk_decl_map m' decls 
+  | (LA.ConstDecl (span, FreeConst (_, i, _)) as cnstd) :: decls
+  | (LA.ConstDecl (span, UntypedConst (_, i, _)) as cnstd) :: decls
+  | (LA.ConstDecl (span, TypedConst (_, i, _, _)) as cnstd) :: decls -> 
+    let {LA.start_pos = pos} = span in
+    check_and_add m pos const_suffix i cnstd  >>= fun m' ->
+    mk_decl_map m' decls 
 
-  | (LA.NodeDecl (pos, _, (i, _, _, _, _, _, _, _)) as ndecl) :: decls
-    | (LA.FuncDecl (pos, _, (i, _, _, _, _, _, _, _)) as ndecl) :: decls ->
-     check_and_add m pos node_suffix i ndecl  >>= fun m' ->
-     mk_decl_map m' decls
+  | (LA.NodeDecl (span, (i, _, _, _, _, _, _, _)) as ndecl) :: decls
+  | (LA.FuncDecl (span, (i, _, _, _, _, _, _, _)) as ndecl) :: decls ->
+    let {LA.start_pos = pos} = span in
+    check_and_add m pos node_suffix i ndecl  >>= fun m' ->
+    mk_decl_map m' decls
 
-  | LA.ContractNodeDecl (pos, _, (i, _, _, _, _)) as cndecl :: decls ->
-     check_and_add m pos contract_suffix i cndecl >>= fun m' ->
-     mk_decl_map m' decls
+  | LA.ContractNodeDecl (span, (i, _, _, _, _)) as cndecl :: decls ->
+    let {LA.start_pos = pos} = span in
+    check_and_add m pos contract_suffix i cndecl >>= fun m' ->
+    mk_decl_map m' decls
 
   | LA.NodeParamInst _ :: _-> Lib.todo __LOC__
 (** builds an id :-> decl map  *)
                             
 let mk_graph_decls: LA.declaration list -> dependency_analysis_data 
   = let mk_graph: LA.declaration -> dependency_analysis_data = function
-      | TypeDecl (_, _, tydecl) -> mk_graph_type_decl tydecl 
-      | ConstDecl (_, _, cdecl) -> mk_graph_const_decl cdecl
-      | NodeDecl (pos, _, ndecl) -> mk_graph_node_decl pos ndecl
-      | FuncDecl (pos, _, ndecl) -> mk_graph_node_decl pos ndecl
-      | ContractNodeDecl (pos, _, cdecl) -> mk_graph_contract_decl pos cdecl
+      | TypeDecl (_, tydecl) -> mk_graph_type_decl tydecl 
+      | ConstDecl (_, cdecl) -> mk_graph_const_decl cdecl
+      | NodeDecl ({LA.start_pos = pos}, ndecl) -> mk_graph_node_decl pos ndecl
+      | FuncDecl ({LA.start_pos = pos}, ndecl) -> mk_graph_node_decl pos ndecl
+      | ContractNodeDecl ({LA.start_pos = pos}, cdecl) -> mk_graph_contract_decl pos cdecl
       | NodeParamInst  _ -> Lib.todo __LOC__ in
     fun decls ->
     List.fold_left union_dependency_analysis_data empty_dependency_analysis_data (List.map mk_graph decls)
@@ -1187,13 +1191,13 @@ let rec generate_summaries: dependency_analysis_data -> LA.declaration list -> d
   = fun ad ->
   function
   | [] -> ad
-  | LA.FuncDecl (_, _, ndecl) :: decls ->
+  | LA.FuncDecl (_, ndecl) :: decls ->
      let ns = mk_node_summary ad.nsummary ndecl in
      generate_summaries {ad with nsummary = IMap.union (fun k v1 v2 -> Some v2) ad.nsummary ns} decls
-  | LA.NodeDecl (_, _, ndecl) :: decls ->
+  | LA.NodeDecl (_, ndecl) :: decls ->
      let ns = mk_node_summary ad.nsummary ndecl in
      generate_summaries {ad with nsummary = IMap.union (fun k v1 v2 -> Some v2) ad.nsummary ns} decls
-  | LA.ContractNodeDecl (_, _, cdecl) :: decls ->
+  | LA.ContractNodeDecl (_, cdecl) :: decls ->
      let cs = mk_contract_summary ad.csummary cdecl in
      generate_summaries {ad with csummary = IMap.union (fun k v1 v2 -> Some v2) ad.csummary cs } decls
   | _ :: decls -> generate_summaries ad decls
@@ -1203,18 +1207,21 @@ let rec generate_summaries: dependency_analysis_data -> LA.declaration list -> d
 let rec sort_and_check_equations: dependency_analysis_data -> LA.declaration list -> LA.declaration list graph_result = 
   fun ad ->
   function
-  | LA.FuncDecl (spos, epos, ndecl) :: ds ->
-     check_node_equations ad spos ndecl >>= fun ndecl' ->
-     sort_and_check_equations ad ds >>= fun ds' ->
-     R.ok (LA.FuncDecl (spos, epos, ndecl') :: ds')
-  | LA.NodeDecl (spos, epos, ndecl) :: ds ->
-     check_node_equations ad spos ndecl >>= fun ndecl' ->
-     sort_and_check_equations ad ds >>= fun ds' ->
-     R.ok (LA.NodeDecl (spos, epos, ndecl') :: ds')
-  | LA.ContractNodeDecl (spos, epos, contract_body) :: ds ->
-     sort_and_check_contract_eqns ad spos contract_body >>= fun contract_body' ->
-     sort_and_check_equations ad ds >>= fun decls' ->
-     R.ok (LA.ContractNodeDecl (spos, epos, contract_body') :: decls' )  
+  | LA.FuncDecl (span, ndecl) :: ds ->
+    let {LA.start_pos = pos} = span in
+    check_node_equations ad pos ndecl >>= fun ndecl' ->
+    sort_and_check_equations ad ds >>= fun ds' ->
+    R.ok (LA.FuncDecl (span, ndecl') :: ds')
+  | LA.NodeDecl (span, ndecl) :: ds ->
+    let {LA.start_pos = pos} = span in
+    check_node_equations ad pos ndecl >>= fun ndecl' ->
+    sort_and_check_equations ad ds >>= fun ds' ->
+    R.ok (LA.NodeDecl (span, ndecl') :: ds')
+  | LA.ContractNodeDecl (span, contract_body) :: ds ->
+    let {LA.start_pos = pos} = span in
+    sort_and_check_contract_eqns ad pos contract_body >>= fun contract_body' ->
+    sort_and_check_equations ad ds >>= fun decls' ->
+    R.ok (LA.ContractNodeDecl (span, contract_body') :: decls' )  
   | d :: ds -> sort_and_check_equations ad ds >>= fun ds' -> R.ok (d :: ds')
   | [] -> R.ok ([])
 (** Sort equations for contracts and check if node and function equations have circular dependencies  *)

--- a/src/lustre/lustreAstDependencies.mli
+++ b/src/lustre/lustreAstDependencies.mli
@@ -43,11 +43,11 @@ module LA = LustreAst
 type 'a graph_result = ('a, Lib.position * string) result
 (** Result of the dependency analysis *)
 
-val sort_globals: LA.t -> LA.t graph_result
+val sort_globals: LA.declaration list -> LA.declaration list graph_result
 (** Returns a topological order to resolve forward references of globals. 
     This step processes 1. type declarations, and 2. constant declarations *)  
                      
-val sort_and_check_nodes_contracts: LA.t -> LA.t graph_result
+val sort_and_check_nodes_contracts: LA.declaration list -> LA.declaration list graph_result
 (** Returns a topological order of declarations to resolve all forward refernces.
     It also reorders contract equations and checks for circularity of node equations.
     This step processes 1. nodes, 2. contracts and 3. functions *)  

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -963,7 +963,7 @@ let get_last_node_name: declaration list -> ident option
   let rec get_first_node_name: declaration list -> ident option =
     function
     | [] -> None
-    | NodeDecl (_, (n, _, _, _, _, _, _, _)) :: rest -> Some n
+    | NodeDecl (_, _, (n, _, _, _, _, _, _, _)) :: rest -> Some n
     | _ :: rest -> get_first_node_name rest
   in get_first_node_name (List.rev ds)   
 
@@ -975,7 +975,7 @@ let rec remove_node_in_declarations:
   fun n pres ->
   function
   | [] -> None
-  | (NodeDecl (_, (n', _, _, _, _, _, _, _)) as mn) :: rest ->
+  | (NodeDecl (_, _, (n', _, _, _, _, _, _, _)) as mn) :: rest ->
      if Stdlib.compare n' n = 0
      then Some (mn, pres @ rest)
      else remove_node_in_declarations n (pres @ [mn]) rest 

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -963,7 +963,7 @@ let get_last_node_name: declaration list -> ident option
   let rec get_first_node_name: declaration list -> ident option =
     function
     | [] -> None
-    | NodeDecl (_, _, (n, _, _, _, _, _, _, _)) :: rest -> Some n
+    | NodeDecl (_, (n, _, _, _, _, _, _, _)) :: rest -> Some n
     | _ :: rest -> get_first_node_name rest
   in get_first_node_name (List.rev ds)   
 
@@ -975,7 +975,7 @@ let rec remove_node_in_declarations:
   fun n pres ->
   function
   | [] -> None
-  | (NodeDecl (_, _, (n', _, _, _, _, _, _, _)) as mn) :: rest ->
+  | (NodeDecl (_, (n', _, _, _, _, _, _, _)) as mn) :: rest ->
      if Stdlib.compare n' n = 0
      then Some (mn, pres @ rest)
      else remove_node_in_declarations n (pres @ [mn]) rest 

--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -312,24 +312,24 @@ let rec inline_constants_of_contract: TC.tc_context -> LA.contract -> LA.contrac
          
 let substitute: TC.tc_context -> LA.declaration -> (TC.tc_context * LA.declaration) = fun ctx ->
   function
-  | ConstDecl (spos, epos, FreeConst _) as c -> (ctx, c)
-  | ConstDecl (spos, epos, UntypedConst (pos', i, e)) ->
+  | ConstDecl (span, FreeConst _) as c -> (ctx, c)
+  | ConstDecl (span, UntypedConst (pos', i, e)) ->
      let e' = simplify_expr ctx e in
      let ty =
        (match (TC.lookup_ty ctx i) with 
        | None -> failwith "Cannot find constant type. Should not happen."
        | Some ty ->  ty) in
      (TC.add_const ctx i e' ty
-     , ConstDecl (spos, epos, UntypedConst (pos', i, e'))) 
-  | ConstDecl (spos, epos, TypedConst (pos', i, e, ty)) ->
+     , ConstDecl (span, UntypedConst (pos', i, e'))) 
+  | ConstDecl (span, TypedConst (pos', i, e, ty)) ->
      let e' = simplify_expr ctx e in 
-     (TC.add_const ctx i e' ty, ConstDecl (spos, epos, TypedConst (pos', i, e', ty)))
-  | (LA.NodeDecl (spos, epos, (i, imported, params, ips, ops, ldecls, items, contract))) ->
-     ctx, (LA.NodeDecl (spos, epos, (i, imported, params, ips, ops, ldecls, inline_constants_of_node_items ctx items, contract)))
-  | (LA.FuncDecl (spos, epos, (i, imported, params, ips, ops, ldecls, items, contract))) ->
-     ctx, (LA.FuncDecl (spos, epos, (i, imported, params, ips, ops, ldecls, inline_constants_of_node_items ctx items, contract)))
-  | (LA.ContractNodeDecl (spos, epos, (i, params, ips, ops, contract))) ->
-     ctx, (LA.ContractNodeDecl (spos, epos, (i, params, ips, ops, inline_constants_of_contract ctx contract)))
+     (TC.add_const ctx i e' ty, ConstDecl (span, TypedConst (pos', i, e', ty)))
+  | (LA.NodeDecl (span, (i, imported, params, ips, ops, ldecls, items, contract))) ->
+     ctx, (LA.NodeDecl (span, (i, imported, params, ips, ops, ldecls, inline_constants_of_node_items ctx items, contract)))
+  | (LA.FuncDecl (span, (i, imported, params, ips, ops, ldecls, items, contract))) ->
+     ctx, (LA.FuncDecl (span, (i, imported, params, ips, ops, ldecls, inline_constants_of_node_items ctx items, contract)))
+  | (LA.ContractNodeDecl (span, (i, params, ips, ops, contract))) ->
+     ctx, (LA.ContractNodeDecl (span, (i, params, ips, ops, inline_constants_of_contract ctx contract)))
   | e -> (ctx, e)
 (** propogate constants post type checking into the AST and constant store*)
 

--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -312,24 +312,24 @@ let rec inline_constants_of_contract: TC.tc_context -> LA.contract -> LA.contrac
          
 let substitute: TC.tc_context -> LA.declaration -> (TC.tc_context * LA.declaration) = fun ctx ->
   function
-  | ConstDecl (pos, FreeConst _) as c -> (ctx, c)
-  | ConstDecl (pos, UntypedConst (pos', i, e)) ->
+  | ConstDecl (spos, epos, FreeConst _) as c -> (ctx, c)
+  | ConstDecl (spos, epos, UntypedConst (pos', i, e)) ->
      let e' = simplify_expr ctx e in
      let ty =
        (match (TC.lookup_ty ctx i) with 
        | None -> failwith "Cannot find constant type. Should not happen."
        | Some ty ->  ty) in
      (TC.add_const ctx i e' ty
-     , ConstDecl (pos, UntypedConst (pos', i, e'))) 
-  | ConstDecl (pos, TypedConst (pos', i, e, ty)) ->
+     , ConstDecl (spos, epos, UntypedConst (pos', i, e'))) 
+  | ConstDecl (spos, epos, TypedConst (pos', i, e, ty)) ->
      let e' = simplify_expr ctx e in 
-     (TC.add_const ctx i e' ty, ConstDecl (pos, TypedConst (pos', i, e', ty)))
-  | (LA.NodeDecl (pos, (i, imported, params, ips, ops, ldecls, items, contract))) ->
-     ctx, (LA.NodeDecl (pos, (i, imported, params, ips, ops, ldecls, inline_constants_of_node_items ctx items, contract)))
-  | (LA.FuncDecl (pos, (i, imported, params, ips, ops, ldecls, items, contract))) ->
-     ctx, (LA.FuncDecl (pos, (i, imported, params, ips, ops, ldecls, inline_constants_of_node_items ctx items, contract)))
-  | (LA.ContractNodeDecl (pos, (i, params, ips, ops, contract))) ->
-     ctx, (LA.ContractNodeDecl (pos, (i, params, ips, ops, inline_constants_of_contract ctx contract)))
+     (TC.add_const ctx i e' ty, ConstDecl (spos, epos, TypedConst (pos', i, e', ty)))
+  | (LA.NodeDecl (spos, epos, (i, imported, params, ips, ops, ldecls, items, contract))) ->
+     ctx, (LA.NodeDecl (spos, epos, (i, imported, params, ips, ops, ldecls, inline_constants_of_node_items ctx items, contract)))
+  | (LA.FuncDecl (spos, epos, (i, imported, params, ips, ops, ldecls, items, contract))) ->
+     ctx, (LA.FuncDecl (spos, epos, (i, imported, params, ips, ops, ldecls, inline_constants_of_node_items ctx items, contract)))
+  | (LA.ContractNodeDecl (spos, epos, (i, params, ips, ops, contract))) ->
+     ctx, (LA.ContractNodeDecl (spos, epos, (i, params, ips, ops, inline_constants_of_contract ctx contract)))
   | e -> (ctx, e)
 (** propogate constants post type checking into the AST and constant store*)
 

--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -334,7 +334,7 @@ let substitute: TC.tc_context -> LA.declaration -> (TC.tc_context * LA.declarati
 (** propogate constants post type checking into the AST and constant store*)
 
 
-let rec inline_constants: tc_context -> LA.t -> (TC.tc_context * LA.t) inline_result = fun ctx ->
+let rec inline_constants: tc_context -> LA.declaration list -> (TC.tc_context * LA.declaration list) inline_result = fun ctx ->
   function
   | [] -> R.ok (ctx, [])
   | c :: rest ->

--- a/src/lustre/lustreAstInlineConstants.mli
+++ b/src/lustre/lustreAstInlineConstants.mli
@@ -26,7 +26,7 @@ module LA = LustreAst
 type 'a inline_result = ('a, Lib.position * string) result           
 (** Result of inlining a constant *)
 
-val inline_constants: TC.tc_context -> LA.t -> (TC.tc_context * LA.t) inline_result
+val inline_constants: TC.tc_context -> LA.declaration list -> (TC.tc_context * LA.declaration list) inline_result
 (** Best effort at inlining constants *)
 
 val eval_int_expr: TC.tc_context -> LA.expr -> int inline_result

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -2431,7 +2431,7 @@ and parse_implicit_contract scope inputs outputs ctx file contract_name = try (
     ast |> List.fold_left (
       fun call -> function
       | A.ContractNodeDecl (
-        pos, (id, _, cont_in, cont_out, _)
+        pos, _, (id, _, cont_in, cont_out, _)
       ) when id = contract_name -> (
         (* Verify signatures match and construct call. *)
         try (
@@ -2610,7 +2610,7 @@ and eval_node_decl
 (** Handle declaration and return context. *)
 and declaration_to_context ctx = function
 (* Declaration of a type as alias or free *)
-| A.TypeDecl (pos, type_rhs) ->
+| A.TypeDecl (pos, _, type_rhs) ->
 
   let (i, type_expr) = match type_rhs with
     (* Replace type aliases with their right-hand-side *)
@@ -2636,14 +2636,14 @@ and declaration_to_context ctx = function
   C.add_type_for_ident ctx ident res
 
 (* Declaration of a typed or untyped constant *)
-| A.ConstDecl (_, const_decl) ->
+| A.ConstDecl (_, _, const_decl) ->
 
   (* Add mapping of identifier to value to context *)
   eval_const_decl ctx const_decl
 
 (* Function declaration without parameters *)
 | A.FuncDecl (
-  pos, (i, ext, [], inputs, outputs, locals, items, contracts)
+  pos, _, (i, ext, [], inputs, outputs, locals, items, contracts)
 ) -> (
 
   (* Identifier of AST identifier *)
@@ -2723,7 +2723,7 @@ and declaration_to_context ctx = function
 
 (* Node declaration without parameters *)
 | A.NodeDecl (
-  pos, (i, ext, [], inputs, outputs, locals, items, contracts)
+  pos, _, (i, ext, [], inputs, outputs, locals, items, contracts)
 ) -> (
 
   (* Identifier of AST identifier *)
@@ -2832,7 +2832,7 @@ and declaration_to_context ctx = function
             (I.pp_print_ident false) called_ident)) *)
 
 (* Declaration of a contract node *)
-| A.ContractNodeDecl (pos, node_decl) ->
+| A.ContractNodeDecl (pos, _, node_decl) ->
 
   (* Add to context for later inlining *)
   C.add_contract_node_decl_to_context ctx (pos, node_decl)
@@ -2901,11 +2901,11 @@ and declaration_to_context ctx = function
 
 
 (* Parametric node declaration *)
-| A.NodeParamInst (pos, _)
-| A.NodeDecl (pos, _) ->
+| A.NodeParamInst (pos, _, _)
+| A.NodeDecl (pos, _, _) ->
   fail_at_position pos "Parametric nodes are not supported"
 (* Parametric function declaration *)
-| A.FuncDecl (pos, _) ->
+| A.FuncDecl (pos, _, _) ->
   fail_at_position pos "Parametric functions are not supported"
 
 (* Add declarations of program to context *)

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -2421,7 +2421,7 @@ and parse_implicit_contract scope inputs outputs ctx file contract_name = try (
     (try Filename.dirname (Flags.input_file ())
      with Failure _ -> Sys.getcwd ()) ;
 
-  let ast = LustreParser.main LustreLexer.token lexbuf in
+  let { A.decls = ast } = LustreParser.main LustreLexer.token lexbuf in
   (* Format.printf
     "contract: @[<v>%a@]@.@."
     (pp_print_list A.pp_print_declaration "@ ")  ast ; *)

--- a/src/lustre/lustreDeclarations.ml
+++ b/src/lustre/lustreDeclarations.ml
@@ -2431,7 +2431,7 @@ and parse_implicit_contract scope inputs outputs ctx file contract_name = try (
     ast |> List.fold_left (
       fun call -> function
       | A.ContractNodeDecl (
-        pos, _, (id, _, cont_in, cont_out, _)
+        {A.start_pos = pos}, (id, _, cont_in, cont_out, _)
       ) when id = contract_name -> (
         (* Verify signatures match and construct call. *)
         try (
@@ -2610,7 +2610,7 @@ and eval_node_decl
 (** Handle declaration and return context. *)
 and declaration_to_context ctx = function
 (* Declaration of a type as alias or free *)
-| A.TypeDecl (pos, _, type_rhs) ->
+| A.TypeDecl ({A.start_pos = pos}, type_rhs) ->
 
   let (i, type_expr) = match type_rhs with
     (* Replace type aliases with their right-hand-side *)
@@ -2636,14 +2636,14 @@ and declaration_to_context ctx = function
   C.add_type_for_ident ctx ident res
 
 (* Declaration of a typed or untyped constant *)
-| A.ConstDecl (_, _, const_decl) ->
+| A.ConstDecl ({A.start_pos = pos}, const_decl) ->
 
   (* Add mapping of identifier to value to context *)
   eval_const_decl ctx const_decl
 
 (* Function declaration without parameters *)
 | A.FuncDecl (
-  pos, _, (i, ext, [], inputs, outputs, locals, items, contracts)
+  {A.start_pos = pos}, (i, ext, [], inputs, outputs, locals, items, contracts)
 ) -> (
 
   (* Identifier of AST identifier *)
@@ -2723,7 +2723,7 @@ and declaration_to_context ctx = function
 
 (* Node declaration without parameters *)
 | A.NodeDecl (
-  pos, _, (i, ext, [], inputs, outputs, locals, items, contracts)
+  {A.start_pos = pos}, (i, ext, [], inputs, outputs, locals, items, contracts)
 ) -> (
 
   (* Identifier of AST identifier *)
@@ -2832,7 +2832,7 @@ and declaration_to_context ctx = function
             (I.pp_print_ident false) called_ident)) *)
 
 (* Declaration of a contract node *)
-| A.ContractNodeDecl (pos, _, node_decl) ->
+| A.ContractNodeDecl ({A.start_pos = pos}, node_decl) ->
 
   (* Add to context for later inlining *)
   C.add_contract_node_decl_to_context ctx (pos, node_decl)
@@ -2901,11 +2901,11 @@ and declaration_to_context ctx = function
 
 
 (* Parametric node declaration *)
-| A.NodeParamInst (pos, _, _)
-| A.NodeDecl (pos, _, _) ->
+| A.NodeParamInst ({A.start_pos = pos}, _)
+| A.NodeDecl ({A.start_pos = pos}, _) ->
   fail_at_position pos "Parametric nodes are not supported"
 (* Parametric function declaration *)
-| A.FuncDecl (pos, _, _) ->
+| A.FuncDecl ({A.start_pos = pos}, _) ->
   fail_at_position pos "Parametric functions are not supported"
 
 (* Add declarations of program to context *)

--- a/src/lustre/lustreDeclarations.mli
+++ b/src/lustre/lustreDeclarations.mli
@@ -20,7 +20,7 @@
 
     @author Christoph Sticksel *)
 
-val declarations_to_nodes : LustreAst.t -> LustreNode.t list * LustreGlobals.t
+val declarations_to_nodes : LustreAst.declaration list -> LustreNode.t list * LustreGlobals.t
 
 (* 
    Local Variables:

--- a/src/lustre/lustreDependencies.ml
+++ b/src/lustre/lustreDependencies.ml
@@ -115,24 +115,24 @@ let mem deps (key_type, key_ident) (val_type, val_ident) =
 
 (** Identifier corresponding to a declaration. *)
 let info_of_decl = function
-| A.TypeDecl (pos, _, A.AliasType (_, ident, _)) ->
+| A.TypeDecl ({A.start_pos=pos}, A.AliasType (_, ident, _)) ->
   pos, ident |> I.mk_string_ident, Type
-| A.TypeDecl (pos, _, A.FreeType (_, ident)) ->
+| A.TypeDecl ({A.start_pos=pos}, A.FreeType (_, ident)) ->
   pos, ident |> I.mk_string_ident, Type
 
-| A.ConstDecl (pos, _, A.FreeConst(_, ident, _)) ->
+| A.ConstDecl ({A.start_pos=pos}, A.FreeConst(_, ident, _)) ->
   pos, ident |> I.mk_string_ident, Const
-| A.ConstDecl (pos, _, A.UntypedConst(_, ident, _)) ->
+| A.ConstDecl ({A.start_pos=pos}, A.UntypedConst(_, ident, _)) ->
   pos, ident |> I.mk_string_ident, Const
-| A.ConstDecl (pos, _, A.TypedConst(_, ident, _, _)) ->
+| A.ConstDecl ({A.start_pos=pos}, A.TypedConst(_, ident, _, _)) ->
   pos, ident |> I.mk_string_ident, Const
 
-| A.NodeDecl (pos, _, (ident, _, _, _, _, _, _, _)) ->
+| A.NodeDecl ({A.start_pos=pos}, (ident, _, _, _, _, _, _, _)) ->
   pos, ident |> I.mk_string_ident, NodeOrFun
-| A.FuncDecl (pos, _, (ident, _, _, _, _, _, _, _)) ->
+| A.FuncDecl ({A.start_pos=pos}, (ident, _, _, _, _, _, _, _)) ->
   pos, ident |> I.mk_string_ident, NodeOrFun
 
-| A.ContractNodeDecl (pos, _, (ident, _, _, _, _)) ->
+| A.ContractNodeDecl ({A.start_pos=pos}, (ident, _, _, _, _)) ->
   pos, ident |> I.mk_string_ident, Contract
 
 | decl ->
@@ -148,26 +148,26 @@ let insert_decl decl (f_type, f_ident) decls =
   let has_ident = match f_type with
     | NodeOrFun -> (
       function
-      | A.NodeDecl (_, _, (i, _, _, _, _, _, _, _)) -> i = ident
-      | A.FuncDecl (_, _, (i, _, _, _, _, _, _, _)) -> i = ident
+      | A.NodeDecl (_, (i, _, _, _, _, _, _, _)) -> i = ident
+      | A.FuncDecl (_, (i, _, _, _, _, _, _, _)) -> i = ident
       | _ -> false
     )
     | Type -> (
       function
-      | A.TypeDecl (_, _, A.AliasType(_, i, _)) -> i = ident
-      | A.TypeDecl (_, _, A.FreeType(_, i)) -> i = ident
+      | A.TypeDecl (_, A.AliasType(_, i, _)) -> i = ident
+      | A.TypeDecl (_, A.FreeType(_, i)) -> i = ident
       | _ -> false
     )
     | Contract -> (
       function
-      | A.ContractNodeDecl (_, _, (i, _, _, _, _)) -> i = ident
+      | A.ContractNodeDecl (_, (i, _, _, _, _)) -> i = ident
       | _ -> false
     )
     | Const -> (
       function
-      | A.ConstDecl (_, _, A.FreeConst(_, i, _)) -> i = ident
-      | A.ConstDecl (_, _, A.UntypedConst(_, i, _)) -> i = ident
-      | A.ConstDecl (_, _, A.TypedConst(_, i, _, _)) -> i = ident
+      | A.ConstDecl (_, A.FreeConst(_, i, _)) -> i = ident
+      | A.ConstDecl (_, A.UntypedConst(_, i, _)) -> i = ident
+      | A.ConstDecl (_, A.TypedConst(_, i, _, _)) -> i = ident
       | _ -> false
     )
   in

--- a/src/lustre/lustreDependencies.ml
+++ b/src/lustre/lustreDependencies.ml
@@ -115,24 +115,24 @@ let mem deps (key_type, key_ident) (val_type, val_ident) =
 
 (** Identifier corresponding to a declaration. *)
 let info_of_decl = function
-| A.TypeDecl (pos, A.AliasType (_, ident, _)) ->
+| A.TypeDecl (pos, _, A.AliasType (_, ident, _)) ->
   pos, ident |> I.mk_string_ident, Type
-| A.TypeDecl (pos, A.FreeType (_, ident)) ->
+| A.TypeDecl (pos, _, A.FreeType (_, ident)) ->
   pos, ident |> I.mk_string_ident, Type
 
-| A.ConstDecl (pos, A.FreeConst(_, ident, _)) ->
+| A.ConstDecl (pos, _, A.FreeConst(_, ident, _)) ->
   pos, ident |> I.mk_string_ident, Const
-| A.ConstDecl (pos, A.UntypedConst(_, ident, _)) ->
+| A.ConstDecl (pos, _, A.UntypedConst(_, ident, _)) ->
   pos, ident |> I.mk_string_ident, Const
-| A.ConstDecl (pos, A.TypedConst(_, ident, _, _)) ->
+| A.ConstDecl (pos, _, A.TypedConst(_, ident, _, _)) ->
   pos, ident |> I.mk_string_ident, Const
 
-| A.NodeDecl (pos, (ident, _, _, _, _, _, _, _)) ->
+| A.NodeDecl (pos, _, (ident, _, _, _, _, _, _, _)) ->
   pos, ident |> I.mk_string_ident, NodeOrFun
-| A.FuncDecl (pos, (ident, _, _, _, _, _, _, _)) ->
+| A.FuncDecl (pos, _, (ident, _, _, _, _, _, _, _)) ->
   pos, ident |> I.mk_string_ident, NodeOrFun
 
-| A.ContractNodeDecl (pos, (ident, _, _, _, _)) ->
+| A.ContractNodeDecl (pos, _, (ident, _, _, _, _)) ->
   pos, ident |> I.mk_string_ident, Contract
 
 | decl ->
@@ -148,26 +148,26 @@ let insert_decl decl (f_type, f_ident) decls =
   let has_ident = match f_type with
     | NodeOrFun -> (
       function
-      | A.NodeDecl (_, (i, _, _, _, _, _, _, _)) -> i = ident
-      | A.FuncDecl (_, (i, _, _, _, _, _, _, _)) -> i = ident
+      | A.NodeDecl (_, _, (i, _, _, _, _, _, _, _)) -> i = ident
+      | A.FuncDecl (_, _, (i, _, _, _, _, _, _, _)) -> i = ident
       | _ -> false
     )
     | Type -> (
       function
-      | A.TypeDecl (_, A.AliasType(_, i, _)) -> i = ident
-      | A.TypeDecl (_, A.FreeType(_, i)) -> i = ident
+      | A.TypeDecl (_, _, A.AliasType(_, i, _)) -> i = ident
+      | A.TypeDecl (_, _, A.FreeType(_, i)) -> i = ident
       | _ -> false
     )
     | Contract -> (
       function
-      | A.ContractNodeDecl (_, (i, _, _, _, _)) -> i = ident
+      | A.ContractNodeDecl (_, _, (i, _, _, _, _)) -> i = ident
       | _ -> false
     )
     | Const -> (
       function
-      | A.ConstDecl (_, A.FreeConst(_, i, _)) -> i = ident
-      | A.ConstDecl (_, A.UntypedConst(_, i, _)) -> i = ident
-      | A.ConstDecl (_, A.TypedConst(_, i, _, _)) -> i = ident
+      | A.ConstDecl (_, _, A.FreeConst(_, i, _)) -> i = ident
+      | A.ConstDecl (_, _, A.UntypedConst(_, i, _)) -> i = ident
+      | A.ConstDecl (_, _, A.TypedConst(_, i, _, _)) -> i = ident
       | _ -> false
     )
   in

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -163,7 +163,7 @@ let of_channel in_ch =
          ; (if Flags.only_tc () then exit 0)
          ; d  
        | Error (pos, err) -> fail_at_position pos err in 
-  
+
   (* Simplify declarations to a list of nodes *)
   let nodes, globals = LD.declarations_to_nodes declarations' in
   (* Name of main node *)

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -244,7 +244,7 @@ one_expr: e = expr EOF { e }
 
 
 (* A Lustre program is a list of declarations *)
-main: p = list(decl) EOF { List.flatten p }
+main: p = list(decl) EOF { { decls = List.flatten p; file = "" } }
 
 
 (* A declaration is a type, a constant, a node or a function declaration *)

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -25,6 +25,9 @@ module A = LustreAst
           
 let mk_pos = position_of_lexing 
 
+let mk_span start_pos end_pos =
+  { A.start_pos = mk_pos start_pos;
+    A.end_pos = mk_pos end_pos }
 
 let rec add_else_branch b belse =
   match b with
@@ -250,31 +253,31 @@ main: p = list(decl) EOF { { decls = List.flatten p; file = "" } }
 (* A declaration is a type, a constant, a node or a function declaration *)
 decl:
   | d = const_decl { List.map 
-                       (function e -> A.ConstDecl (mk_pos $startpos, mk_pos $endpos, e)) 
+                       (function e -> A.ConstDecl (mk_span $startpos $endpos, e)) 
                        d }
   | d = type_decl { List.map 
-                      (function e -> A.TypeDecl (mk_pos $startpos, mk_pos $endpos, e)) 
+                      (function e -> A.TypeDecl (mk_span $startpos $endpos, e)) 
                       d }
   | NODE ; decl = node_decl ; def = node_def {
     let (n, p, i, o, r) = decl in
     let (l, e) = def in
-    [A.NodeDecl ( mk_pos $startpos, mk_pos $endpos, (n, false, p, i, o, l, e, r) )]
+    [A.NodeDecl ( mk_span $startpos $endpos, (n, false, p, i, o, l, e, r) )]
   }
   | FUNCTION ; decl = node_decl ; def = node_def {
     let (n, p, i, o, r) = decl in
     let (l, e) = def in
-    [A.FuncDecl (mk_pos $startpos, mk_pos $endpos, (n, false, p, i, o, l, e, r))]
+    [A.FuncDecl (mk_span $startpos $endpos, (n, false, p, i, o, l, e, r))]
   }
   | NODE ; IMPORTED ; decl = node_decl {
     let (n, p, i, o, r) = decl in
-    [A.NodeDecl ( mk_pos $startpos, mk_pos $endpos, (n, true, p, i, o, [], [], r) )]
+    [A.NodeDecl ( mk_span $startpos $endpos, (n, true, p, i, o, [], [], r) )]
   }
   | FUNCTION ; IMPORTED ; decl = node_decl {
     let (n, p, i, o, r) = decl in
-    [A.FuncDecl (mk_pos $startpos, mk_pos $endpos, (n, true, p, i, o, [], [], r))]
+    [A.FuncDecl (mk_span $startpos $endpos, (n, true, p, i, o, [], [], r))]
   }
-  | d = contract_decl { [A.ContractNodeDecl (mk_pos $startpos, mk_pos $endpos, d)] }
-  | d = node_param_inst { [A.NodeParamInst (mk_pos $startpos, mk_pos $endpos, d)] }
+  | d = contract_decl { [A.ContractNodeDecl (mk_span $startpos $endpos, d)] }
+  | d = node_param_inst { [A.NodeParamInst (mk_span $startpos $endpos, d)] }
 
 
 (* ********************************************************************** *)

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -250,31 +250,31 @@ main: p = list(decl) EOF { List.flatten p }
 (* A declaration is a type, a constant, a node or a function declaration *)
 decl:
   | d = const_decl { List.map 
-                       (function e -> A.ConstDecl (mk_pos $startpos, e)) 
+                       (function e -> A.ConstDecl (mk_pos $startpos, mk_pos $endpos, e)) 
                        d }
   | d = type_decl { List.map 
-                      (function e -> A.TypeDecl (mk_pos $startpos, e)) 
+                      (function e -> A.TypeDecl (mk_pos $startpos, mk_pos $endpos, e)) 
                       d }
   | NODE ; decl = node_decl ; def = node_def {
     let (n, p, i, o, r) = decl in
     let (l, e) = def in
-    [A.NodeDecl ( mk_pos $startpos, (n, false, p, i, o, l, e, r) )]
+    [A.NodeDecl ( mk_pos $startpos, mk_pos $endpos, (n, false, p, i, o, l, e, r) )]
   }
   | FUNCTION ; decl = node_decl ; def = node_def {
     let (n, p, i, o, r) = decl in
     let (l, e) = def in
-    [A.FuncDecl (mk_pos $startpos, (n, false, p, i, o, l, e, r))]
+    [A.FuncDecl (mk_pos $startpos, mk_pos $endpos, (n, false, p, i, o, l, e, r))]
   }
   | NODE ; IMPORTED ; decl = node_decl {
     let (n, p, i, o, r) = decl in
-    [A.NodeDecl ( mk_pos $startpos, (n, true, p, i, o, [], [], r) )]
+    [A.NodeDecl ( mk_pos $startpos, mk_pos $endpos, (n, true, p, i, o, [], [], r) )]
   }
   | FUNCTION ; IMPORTED ; decl = node_decl {
     let (n, p, i, o, r) = decl in
-    [A.FuncDecl (mk_pos $startpos, (n, true, p, i, o, [], [], r))]
+    [A.FuncDecl (mk_pos $startpos, mk_pos $endpos, (n, true, p, i, o, [], [], r))]
   }
-  | d = contract_decl { [A.ContractNodeDecl (mk_pos $startpos, d)] }
-  | d = node_param_inst { [A.NodeParamInst (mk_pos $startpos, d)] }
+  | d = contract_decl { [A.ContractNodeDecl (mk_pos $startpos, mk_pos $endpos, d)] }
+  | d = node_param_inst { [A.NodeParamInst (mk_pos $startpos, mk_pos $endpos, d)] }
 
 
 (* ********************************************************************** *)

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1278,12 +1278,12 @@ and tc_ctx_of_declaration: tc_context -> LA.declaration -> tc_context tc_result
        tc_ctx_of_contract_node_decl pos ctx' contract_decl
     | _ -> R.ok ctx'
 
-and tc_context_of: tc_context -> LA.t -> tc_context tc_result
+and tc_context_of: tc_context -> LA.declaration list -> tc_context tc_result
   = fun ctx decls ->
   R.seq_chain (tc_ctx_of_declaration) ctx decls 
 (** Obtain a global typing context, get constants and function decls*)
   
-and build_type_and_const_context: tc_context -> LA.t -> tc_context tc_result
+and build_type_and_const_context: tc_context -> LA.declaration list -> tc_context tc_result
   = fun ctx ->
   function
   | [] -> R.ok ctx
@@ -1449,7 +1449,7 @@ let scc: LA.t -> LA.t list
   = fun decls -> [decls]
 (** Compute the connected components for type checking *)
                                  
-let rec type_check_group: tc_context -> LA.t ->  unit tc_result list
+let rec type_check_group: tc_context -> LA.declaration list ->  unit tc_result list
   = fun global_ctx
   -> function
   | [] -> [R.ok ()]
@@ -1476,7 +1476,7 @@ let rec type_check_group: tc_context -> LA.t ->  unit tc_result list
  * the top most declaration should be able to access 
  * the types of all the forward referenced indentifiers from the context*)       
 
-let type_check_decl_grps: tc_context -> LA.t list -> unit tc_result list
+let type_check_decl_grps: tc_context -> LA.declaration list list -> unit tc_result list
   = fun ctx decls ->
       Log.log L_trace ("===============================================\n"
                        ^^ "Phase: Type checking declaration Groups\n"
@@ -1493,7 +1493,7 @@ let report_tc_result: unit tc_result list -> unit tc_result
  * The main functions of the file that kicks off type checking or type inference flow  *
  ***************************************************************************************)
    
-let type_check_infer_globals: tc_context -> LA.t -> tc_context tc_result
+let type_check_infer_globals: tc_context -> LA.declaration list -> tc_context tc_result
   = fun ctx prg ->
      (Log.log L_trace ("===============================================\n"
                        ^^ "Building TC Global Context\n"
@@ -1502,7 +1502,7 @@ let type_check_infer_globals: tc_context -> LA.t -> tc_context tc_result
      ; build_type_and_const_context ctx prg >>= fun global_ctx ->
        R.ok global_ctx)
    
-let type_check_infer_nodes_and_contracts: tc_context -> LA.t -> tc_context tc_result
+let type_check_infer_nodes_and_contracts: tc_context -> LA.declaration list -> tc_context tc_result
   = fun ctx prg -> 
 (* type check the nodes and contract decls using this base typing context  *)
      Log.log L_trace ("===============================================\n"

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1271,10 +1271,10 @@ and tc_ctx_of_contract_node_decl: Lib.position -> tc_context
 and tc_ctx_of_declaration: tc_context -> LA.declaration -> tc_context tc_result
     = fun ctx' ->
     function
-    | LA.ConstDecl (_, const_decl) -> tc_ctx_const_decl ctx' const_decl
-    | LA.NodeDecl (pos, node_decl) -> tc_ctx_of_node_decl pos ctx' node_decl
-    | LA.FuncDecl (pos, node_decl) -> tc_ctx_of_node_decl pos ctx' node_decl
-    | LA.ContractNodeDecl (pos, contract_decl) ->
+    | LA.ConstDecl (_, _, const_decl) -> tc_ctx_const_decl ctx' const_decl
+    | LA.NodeDecl (pos, _, node_decl) -> tc_ctx_of_node_decl pos ctx' node_decl
+    | LA.FuncDecl (pos, _, node_decl) -> tc_ctx_of_node_decl pos ctx' node_decl
+    | LA.ContractNodeDecl (pos, _, contract_decl) ->
        tc_ctx_of_contract_node_decl pos ctx' contract_decl
     | _ -> R.ok ctx'
 
@@ -1287,10 +1287,10 @@ and build_type_and_const_context: tc_context -> LA.t -> tc_context tc_result
   = fun ctx ->
   function
   | [] -> R.ok ctx
-  | TypeDecl (_, ty_decl) :: rest ->
+  | TypeDecl (_, _, ty_decl) :: rest ->
      tc_ctx_of_ty_decl ctx ty_decl
      >>= fun ctx' -> build_type_and_const_context ctx' rest
-  | ConstDecl (_, const_decl) :: rest ->
+  | ConstDecl (_, _, const_decl) :: rest ->
      tc_ctx_const_decl ctx const_decl
      >>= fun ctx' -> build_type_and_const_context ctx' rest                   
   | _ :: rest -> build_type_and_const_context ctx rest  
@@ -1456,19 +1456,19 @@ let rec type_check_group: tc_context -> LA.t ->  unit tc_result list
   (* skip over type declarations and const_decls*)
   | (LA.TypeDecl _ :: rest) 
     | LA.ConstDecl _ :: rest -> type_check_group global_ctx rest  
-  | LA.NodeDecl (pos, ((i, _,_, _, _, _, _, _) as node_decl)) :: rest ->
+  | LA.NodeDecl (pos, _, ((i, _,_, _, _, _, _, _) as node_decl)) :: rest ->
      (check_type_node_decl pos global_ctx node_decl
         (match (lookup_node_ty global_ctx i) with
          | None -> failwith "Node type lookup failed. Should not happen"
          | Some ty -> ty))
      :: type_check_group global_ctx rest
-  | LA.FuncDecl (pos, ((i, _,_, _, _, _, _, _) as node_decl)):: rest ->
+  | LA.FuncDecl (pos, _, ((i, _,_, _, _, _, _, _) as node_decl)):: rest ->
      (check_type_node_decl pos global_ctx node_decl
         (match (lookup_node_ty global_ctx i) with
          | None -> failwith "Function type lookup failed. Should not happen"
          | Some ty -> ty))
      :: type_check_group global_ctx rest
-  | LA.ContractNodeDecl (_, ((i, _, _, _, _) as contract_decl)) :: rest ->
+  | LA.ContractNodeDecl (_, _, ((i, _, _, _, _) as contract_decl)) :: rest ->
      (check_type_contract_decl global_ctx contract_decl)
      :: type_check_group global_ctx rest
   | LA.NodeParamInst  _ :: rest -> Lib.todo __LOC__

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -28,11 +28,11 @@ type 'a tc_result = ('a, Lib.position * string) result
 val type_error: Lib.position -> string -> 'a tc_result 
 (** [type_error] returns an [Error] of [tc_result] *)
      
-val type_check_infer_globals: tc_context -> LA.t -> tc_context tc_result  
+val type_check_infer_globals: tc_context -> LA.declaration list -> tc_context tc_result  
 (** Typechecks the toplevel globals i.e. constant decls and type decls. It returns 
     a [Ok (tc_context)] if it succeeds or and [Error of String] if the typechecker fails *)
 
-val type_check_infer_nodes_and_contracts: tc_context -> LA.t -> tc_context tc_result
+val type_check_infer_nodes_and_contracts: tc_context -> LA.declaration list -> tc_context tc_result
 (** Typechecks and infers type for the nodes and contracts. It returns
     a [Ok (tc_context)] if it succeeds or and [Error of String] if the typechecker fails *)
   

--- a/tests/ounit/lustre/testAstDependencies.ml
+++ b/tests/ounit/lustre/testAstDependencies.ml
@@ -27,13 +27,14 @@ open OUnit2
 module AD = LustreAstDependencies
 
 let dp = Lib.dummy_pos
+let dspan = { LA.start_pos = dp; LA.end_pos = dp }
 let (>>=) = Res.(>>=)
           
 let linear_decls = [
-    LA.TypeDecl (dp, LA.AliasType(dp, "t0", LA.UserType (dp, "t1")))
-  ; LA.TypeDecl (dp, LA.AliasType(dp, "t1", LA.UserType (dp, "t2")))
-  ; LA.TypeDecl (dp, LA.AliasType(dp, "t2", LA.Int dp))
-  ; LA.ConstDecl (dp, LA.TypedConst (dp, "c", LA.Const (dp, Num "1"), LA.UserType (dp, "t0")))
+    LA.TypeDecl (dspan, LA.AliasType(dp, "t0", LA.UserType (dp, "t1")))
+  ; LA.TypeDecl (dspan, LA.AliasType(dp, "t1", LA.UserType (dp, "t2")))
+  ; LA.TypeDecl (dspan, LA.AliasType(dp, "t2", LA.Int dp))
+  ; LA.ConstDecl (dspan, LA.TypedConst (dp, "c", LA.Const (dp, Num "1"), LA.UserType (dp, "t0")))
   ]
   
 let sorted_linear_decls = fun _ -> AD.sort_globals linear_decls
@@ -49,10 +50,10 @@ let tests_should_pass = [
 
 
 let circular_decls = [
-    LA.TypeDecl (dp, LA.AliasType(dp, "t0", LA.UserType (dp, "t1")))
-  ; LA.TypeDecl (dp, LA.AliasType(dp, "t1", LA.UserType (dp, "t2")))
-  ; LA.TypeDecl (dp, LA.AliasType(dp, "t2", LA.UserType (dp, "t0")))
-  ; LA.ConstDecl (dp, LA.TypedConst (dp, "c", LA.Const (dp, Num "1"), LA.UserType (dp, "t0")))  ]
+    LA.TypeDecl (dspan, LA.AliasType(dp, "t0", LA.UserType (dp, "t1")))
+  ; LA.TypeDecl (dspan, LA.AliasType(dp, "t1", LA.UserType (dp, "t2")))
+  ; LA.TypeDecl (dspan, LA.AliasType(dp, "t2", LA.UserType (dp, "t0")))
+  ; LA.ConstDecl (dspan, LA.TypedConst (dp, "c", LA.Const (dp, Num "1"), LA.UserType (dp, "t0")))  ]
 
 
 let failure_circular_decls = fun _ ->  AD.sort_globals circular_decls


### PR DESCRIPTION
For now span information is added to the declarations of a Lustre program (for outlining in the LSP under development) and the file name is recorded at the top level (replacing the top level list of declarations with a record, also for the LSP under development).