### PR TITLE
Change analysis settings

### DIFF
--- a/doc/usr/source/1_techniques/1_techniques.rst
+++ b/doc/usr/source/1_techniques/1_techniques.rst
@@ -22,8 +22,8 @@ which in addition to its own state contains that of its subnodes recursively.
 Compositional reasoning thus improves the scalability of Kind 2 by taking
 advantage of information provided by the user to abstract the complexity away.
 When in compositional mode (\ ``--composition true``\ ), Kind 2 will abstract all
-calls (to subnodes that have a contract) in the top node and verify the
-resulting, abstract system.
+calls (to subnodes that have a contract with at least one guarantee or one mode)
+in the top node and verify the resulting, abstract system.
 
 A successful compositional proof of a node does not guarantee the correctness
 of the concrete (un-abstracted) node though, since the subnodes have not been

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -2936,7 +2936,7 @@ module Global = struct
   let slice_nodes () = !slice_nodes
 
 
-  let check_subproperties_default = false
+  let check_subproperties_default = true
   let check_subproperties = ref check_subproperties_default
   let _ = add_spec
     "--check_subproperties"
@@ -2944,8 +2944,7 @@ module Global = struct
     (fun fmt ->
       Format.fprintf fmt
         "\
-          Check properties of subnodes that are relevant for the analysis@ \
-          of the top node. Only available with monolithic analysis@ \
+          Check properties of subnodes in addition to properties of the main node@ \
           Default: %a\
         "
         fmt_bool check_subproperties_default

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -575,20 +575,6 @@ let analyze msg_setup save_results ignore_props stop_if_falsified modules in_sys
   KEvent.log L_info "Result: %a" Analysis.pp_print_result result
 
 
-let check_analysis_flags () =
-  if Flags.check_subproperties () then (
-    let show_msg_and_exit arg =
-      KEvent.log L_fatal
-        "Subproperty checking is not compatible with %s analysis." arg;
-      KEvent.terminate_log () ;
-      exit ExitCodes.error
-    in
-    if Flags.modular () then
-      show_msg_and_exit "modular"
-    else if Flags.Contracts.compositional () then
-      show_msg_and_exit "compositional"
-  )
-
 let handle_exception in_sys process e =
   (* Get backtrace now, Printf changes it *)
   let backtrace = Printexc.get_raw_backtrace () in
@@ -710,8 +696,6 @@ let run in_sys =
   (* MCS is active. *)
   | modules when List.mem `MCS modules -> (
 
-    check_analysis_flags ();
-
     try (
       let msg_setup = KEvent.setup () in
       KEvent.set_module `Supervisor ;
@@ -747,8 +731,6 @@ let run in_sys =
   (* Some analysis modules. *)
   (* Some modules, not including the interpreter. *)
   | modules ->
-
-    check_analysis_flags ();
 
     KEvent.log L_info
       "@[<hov>Running in parallel mode: @[<v>- %a@]@]"

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -875,8 +875,10 @@ let rec ident_of_top = function
   | h :: tl -> ident_of_top tl
 
 
-(* Node has a contract if it has a global or at least one mode contract *)
-let has_contract { contract } = contract != None
+(* Node has a contract if it has at least one guarantee or one mode *)
+let has_contract = function
+| { contract = None } -> false
+| { contract = Some { C.guarantees;  C.modes } } -> guarantees != [] || modes != []
 
 let has_modes = function
 | { contract = None } -> false

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -689,15 +689,12 @@ let call_terms_of_node_call mk_fresh_state_var globals
 
   (* Instantiate assumptions from contracts in this node. *)
   let node_props =
-    if Flags.Contracts.compositional () then
-      match contract with
-      | None -> node_props
-      | Some contract -> (
-        subrequirements_of_contract
-          call_pos (I.to_scope call_node_name) state_var_map_up contract
-      ) @ node_props
-    else
-      node_props
+    match contract with
+    | None -> node_props
+    | Some contract -> (
+      subrequirements_of_contract
+        call_pos (I.to_scope call_node_name) state_var_map_up contract
+    ) @ node_props
   in
 
   (* Return actual parameters of initial state constraint at bound in


### PR DESCRIPTION
* Always check node calls are safe (arguments satisfy assumptions).
  * This was the behavior until v1.2.0. Newer versions only checked it in compositional mode.
* Set `check_subproperties` flag to true by default.
  * This was also the behavior until v1.2.0 (although there was no flag).
* A node is abstracted by its contract only if the contract contains at least one guarantee or one mode.
  * See issue #645 for further details.