### PR TITLE
Fix a couple of issues with candidate properties

### DIFF
--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -523,7 +523,7 @@ let process_invgen_mach_modules sys (modules: Lib.kind_module list) : Lib.kind_m
 let analyze msg_setup save_results ignore_props stop_if_falsified modules in_sys param sys =
   Stat.start_timer Stat.analysis_time ;
 
-  ( if TSys.has_properties sys |> not && not ignore_props then
+  ( if TSys.has_real_properties sys |> not && not ignore_props then
       KEvent.log L_note
         "System %a has no property, skipping verification step." fmt_sys sys
     else

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -661,7 +661,9 @@ let call_terms_of_node_call mk_fresh_state_var globals
 
           (* Property is instantiated *)
           let prop_source =
-            P.Instantiated (I.to_scope call_node_name, p)
+            match p.P.prop_source with
+            | P.Candidate src -> P.Candidate src
+            | _ -> P.Instantiated (I.to_scope call_node_name, p)
           in
 
           (* Property status is unknown *)

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -1379,10 +1379,15 @@ let get_prop_status_all_unknown t =
     t.properties
 
 
-(** Returns true iff sys has at least one property. *)
-let has_properties = function
-| { properties = [] } -> false
-| _ -> true
+(** Returns true iff sys has at least one real (not candidate) property. *)
+let has_real_properties { properties } =
+  List.exists
+    (fun p ->
+      match p.P.prop_source with
+      | P.Candidate _ -> false
+      | _ -> true
+    )
+    properties
 
 let rec set_subsystem_properties t scope ps =
   let aux (t, instances) =

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -542,8 +542,8 @@ val set_prop_unknown : t -> string -> unit
 (* Set the list of properties of a subsystem *)
 val set_subsystem_properties : t -> Scope.t -> Property.t list -> t
 
-(** Returns true iff sys has at least one property. *)
-val has_properties : t -> bool
+(** Returns true iff sys has at least one real (not candidate) property. *)
+val has_real_properties : t -> bool
 
 (** Return true if all properties which are not candidates are either valid or
     invalid *)


### PR DESCRIPTION
* Candidate properties instantiated in parent nodes remain candidate properties.
* No verification is done if all properties are candidate.