### PR TITLE
First pass for new node generation

### DIFF
--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -34,6 +34,14 @@ let expr_is_const = function
   | Const (_, _) -> true
   | _ -> false
 
+let expr_is_true = function
+  | Const (_, True) -> true
+  | _ -> false
+  
+let expr_is_false = function
+  | Const (_, False) -> true
+  | _ -> false
+
 let pos_of_expr = function
   | Ident (pos , _) | ModeRef (pos , _ ) | RecordProject (pos , _ , _)
     | TupleProject (pos , _ , _) | StructUpdate (pos , _ , _ , _) | Const (pos, _)

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -28,6 +28,12 @@ val expr_is_id : expr -> bool
 val expr_is_const : expr -> bool
 (** Returns whether or not the expression is a Const variant *)
 
+val expr_is_true : expr -> bool
+(** Returns whether or not the expression is a Bool Const variant with the True value *)
+
+val expr_is_false : expr -> bool
+(** Returns whether or not the expression is a Bool Const variant with the False value *)
+
 val pos_of_expr : expr -> Lib.position
 (** Returns the position of an expression *)
 

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -247,7 +247,8 @@ let rec normalize ctx (decls:LustreAst.t) =
   let over_declarations (nitems, node_maps) item =
     let (normal_item, node_map) = normalize_declaration ctx node_maps item in
     normal_item :: nitems, StringMap.merge union_keys node_map node_maps
-  in let ast, node_map = List.fold_left over_declarations ([], StringMap.empty) decls in
+  in let ast, node_map = List.fold_left over_declarations ([], StringMap.empty) decls
+  in let ast = List.rev ast in
   
   Log.log L_trace ("===============================================\n"
     ^^ "Generated Identifiers:\n%a\n\n"
@@ -262,7 +263,7 @@ let rec normalize ctx (decls:LustreAst.t) =
       (StringMap.bindings node_map)
     A.pp_print_program ast;
 
-  Res.ok (List.rev ast, node_map)
+  Res.ok (ast, node_map)
 
 and normalize_declaration ctx map = function
   | NodeDecl (pos, decl) ->

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -106,6 +106,11 @@ type generated_identifiers = {
     list
 }
 
+type info = {
+  context : Ctx.tc_context;
+  node_is_input_const : (bool list) StringMap.t
+}
+
 let pp_print_generated_identifiers ppf gids =
   let locals_list = StringMap.bindings gids.locals 
     |> List.map (fun (x, (y, z, w)) -> x, y, z, w)
@@ -135,11 +140,19 @@ let pp_print_generated_identifiers ppf gids =
     (pp_print_list pp_print_local "\n") gids.node_args
     (pp_print_list pp_print_call "\n") gids.calls
 
+let compute_node_input_constant_mask decls =
+  let over_decl map = function
+  | A.NodeDecl (pos, (id, _, _, inputs, _, _, _, _)) ->
+    let is_consts = List.map (fun (_, _, _, _, c) -> c) inputs in
+    StringMap.add id is_consts map
+  | FuncDecl (pos, (id, _, _, inputs, _, _, _, _)) ->
+    let is_consts = List.map (fun (_, _, _, _, c) -> c) inputs in
+    StringMap.add id is_consts map
+  | decl -> map
+  in List.fold_left over_decl StringMap.empty decls
 
 (* [i] is module state used to guarantee newly created identifiers are unique *)
 let i = ref 0
-
-let is_input_const = ref StringMap.empty
 
 let empty = {
     locals = StringMap.empty;
@@ -212,12 +225,6 @@ let compute_node_arity ctx ident =
       | _ -> 1)
     | _ -> assert false (* Nodes must have TArr type *)
 
-let unwrap result = match result with
-  | Ok x -> x
-  | Error (p, s) -> 
-    Format.eprintf "%s\n" s;
-    assert false
-
 let mk_fresh_call id map arity pos cond restart ident args defaults =
   let abstractions = List.init arity (fun x ->
     i := !i + 1;
@@ -254,8 +261,10 @@ let normalize_list f list =
   List.rev list, gids
 
 let rec normalize ctx (decls:LustreAst.t) =
-  let over_declarations (nitems, node_maps) item =
-    let (normal_item, node_map) = normalize_declaration ctx node_maps item in
+  let info = { context = ctx;
+    node_is_input_const = compute_node_input_constant_mask decls }
+  in let over_declarations (nitems, node_maps) item =
+    let (normal_item, node_map) = normalize_declaration info node_maps item in
     normal_item :: nitems, StringMap.merge union_keys node_map node_maps
   in let ast, node_map = List.fold_left over_declarations ([], StringMap.empty) decls
   in let ast = List.rev ast in
@@ -284,7 +293,7 @@ and normalize_declaration ctx map = function
     A.FuncDecl (pos, normal_decl), node_map
   | decl -> decl, StringMap.empty
 
-and normalize_node ctx map
+and normalize_node info map
     (id, is_func, params, inputs, outputs, locals, items, contracts) =
   (* It would be better if the type checker was elaborating
     (i.e. tracking the types associated with identifiers) so that
@@ -292,21 +301,22 @@ and normalize_node ctx map
     checking *)
   let input_ctx = inputs
     |> List.map Ctx.extract_arg_ctx
-    |> (List.fold_left Ctx.union ctx)
+    |> (List.fold_left Ctx.union info.context)
   in let output_ctx = outputs
     |> List.map Ctx.extract_ret_ctx
-    |> (List.fold_left Ctx.union ctx)
+    |> (List.fold_left Ctx.union info.context)
   in let ctx = List.fold_left
-    (fun ctx local -> Chk.local_var_binding ctx local |> unwrap)
-    (Ctx.union (Ctx.union input_ctx output_ctx) ctx)
+    (fun ctx local -> Chk.local_var_binding ctx local
+      |> Res.map_err (fun (_, s) -> fun ppf -> Format.pp_print_string ppf s)
+      |> Res.unwrap)
+    (Ctx.union (Ctx.union input_ctx output_ctx) info.context)
     locals
-  in let is_consts = List.map (fun (_, _, _, _, c) -> c) inputs in
-  is_input_const := StringMap.add id is_consts !is_input_const;
-  let nitems, gids1 = normalize_list (normalize_item ctx map) items in
+  in let info = { info with context = ctx } in
+  let nitems, gids1 = normalize_list (normalize_item info map) items in
   let ncontracts, gids2 = match contracts with
     | Some contracts ->
       let ncontracts, gids = normalize_list
-        (normalize_contract ctx map)
+        (normalize_contract info map)
         contracts in
       (Some ncontracts), gids
     | None -> None, empty
@@ -314,63 +324,67 @@ and normalize_node ctx map
   let node_map = StringMap.singleton id gids in
   (id, is_func, params, inputs, outputs, locals, nitems, ncontracts), node_map
 
-and normalize_item ctx map = function
+and normalize_item info map = function
   | Body equation ->
-    let nequation, gids = normalize_equation ctx map equation in
+    let nequation, gids = normalize_equation info map equation in
     Body nequation, gids
   | AnnotMain b -> AnnotMain b, empty
   | AnnotProperty (pos, name, expr) ->
-    let nexpr, gids = abstract_expr ctx map false expr in
+    let nexpr, gids = abstract_expr info map false expr in
     AnnotProperty (pos, name, nexpr), gids
 
-and normalize_contract ctx map = function
+and normalize_contract info map = function
   | Assume (pos, name, soft, expr) ->
-    let nexpr, gids = normalize_expr ctx map expr in
+    let nexpr, gids = normalize_expr info map expr in
     Assume (pos, name, soft, nexpr), gids
   | Guarantee (pos, name, soft, expr) -> 
-    let nexpr, gids = normalize_expr ctx map expr in
+    let nexpr, gids = normalize_expr info map expr in
     Guarantee (pos, name, soft, nexpr), gids
   | Mode (pos, name, requires, ensures) ->
-    let over_property ctx map (pos, name, expr) =
-      let nexpr, gids = normalize_expr ctx map expr in
+    let over_property info map (pos, name, expr) =
+      let nexpr, gids = normalize_expr info map expr in
       (pos, name, nexpr), gids
     in
-    let nrequires, gids1 = normalize_list (over_property ctx map) requires in
-    let nensures, gids2 = normalize_list (over_property ctx map) ensures in
+    let nrequires, gids1 = normalize_list (over_property info map) requires in
+    let nensures, gids2 = normalize_list (over_property info map) ensures in
     Mode (pos, name, nrequires, nensures), union gids1 gids2
   | ContractCall (pos, name, inputs, outputs) ->
-    let ninputs, gids = normalize_list (normalize_expr ctx map) inputs in
+    let ninputs, gids = normalize_list (normalize_expr info map) inputs in
     ContractCall (pos, name, ninputs, outputs), gids
   | decl -> decl, empty
 
-and normalize_equation ctx map = function
+and normalize_equation info map = function
   | Assert (pos, expr) ->
-    let nexpr, gids = abstract_expr ctx map true expr in
+    let nexpr, gids = abstract_expr info map true expr in
     Assert (pos, nexpr), gids
   | Equation (pos, lhs, expr) ->
-    let nexpr, gids = normalize_expr ctx map expr in
+    let nexpr, gids = normalize_expr info map expr in
     Equation (pos, lhs, nexpr), gids
   | Automaton (pos, id, states, auto) -> Lib.todo __LOC__
 
-and abstract_expr ctx map is_ghost ?guard expr = 
+and abstract_expr info map is_ghost ?guard expr = 
   (* If [expr] is already an id or const then we don't create a fresh local *)
   if AH.expr_is_id expr then
     expr, empty
   else
     let pos = AH.pos_of_expr expr in
-    let expr_type = Chk.infer_type_expr ctx expr |> unwrap in
-    let nexpr, gids1 = normalize_expr ctx map ?guard expr in
+    let expr_type = Chk.infer_type_expr info.context expr
+      |> Res.map_err (fun (_, s) -> fun ppf -> Format.pp_print_string ppf s)
+      |> Res.unwrap in
+    let nexpr, gids1 = normalize_expr info map ?guard expr in
     let iexpr, gids2 = mk_fresh_local pos is_ghost expr_type nexpr in
     iexpr, union gids1 gids2
 
-and normalize_expr ?guard ctx map =
-  let abstract_node_arg ?guard is_const ctx map  expr = 
+and normalize_expr ?guard info map =
+  let abstract_node_arg ?guard is_const info map  expr = 
     if AH.expr_is_id expr then
       expr, empty
     else
       let pos = AH.pos_of_expr expr in
-      let expr_type = Chk.infer_type_expr ctx expr |> unwrap in
-      let nexpr, gids1 = normalize_expr ?guard ctx map expr in
+      let expr_type = Chk.infer_type_expr info.context expr
+        |> Res.map_err (fun (_, s) -> fun ppf -> Format.pp_print_string ppf s)
+        |> Res.unwrap in
+      let nexpr, gids1 = normalize_expr ?guard info map expr in
       let iexpr, gids2 = mk_fresh_node_arg_local pos is_const expr_type nexpr in
       iexpr, union gids1 gids2
   in function
@@ -378,37 +392,37 @@ and normalize_expr ?guard ctx map =
   (* Node calls                                                               *)
   (* ************************************************************************ *)
   | Call (pos, id, args) ->
-    let arity = compute_node_arity ctx id in
+    let arity = compute_node_arity info.context id in
     let cond = A.Const (Lib.dummy_pos, A.True) in
     let restart =  A.Const (Lib.dummy_pos, A.False) in
     let nargs, gids1 = normalize_list
-      (fun (arg, is_const) -> abstract_node_arg ?guard is_const ctx map arg)
-      (List.combine args (StringMap.find id !is_input_const)) in
+      (fun (arg, is_const) -> abstract_node_arg ?guard is_const info map arg)
+      (List.combine args (StringMap.find id info.node_is_input_const)) in
     let nexpr, gids2 = mk_fresh_call id map arity pos cond restart id nargs None in
     nexpr, union gids1 gids2
   | Condact (pos, cond, restart, id, args, defaults) ->
-    let arity = compute_node_arity ctx id in
+    let arity = compute_node_arity info.context id in
     let ncond, gids1 = if AH.expr_is_true cond then cond, empty
-      else abstract_expr ?guard ctx map false cond in
+      else abstract_expr ?guard info map false cond in
     let nrestart, gids2 = if AH.expr_is_const restart then restart, empty
-      else abstract_expr ?guard ctx map false restart
+      else abstract_expr ?guard info map false restart
     in let nargs, gids3 = normalize_list
-      (fun (arg, is_const) -> abstract_node_arg ?guard is_const ctx map arg)
-      (List.combine args (StringMap.find id !is_input_const)) in
+      (fun (arg, is_const) -> abstract_node_arg ?guard is_const info map arg)
+      (List.combine args (StringMap.find id info.node_is_input_const)) in
     let ndefaults, gids4 = normalize_list
-      (normalize_expr ?guard ctx map)
+      (normalize_expr ?guard info map)
       defaults in
     let nexpr, gids5 = mk_fresh_call id map arity pos ncond nrestart id nargs (Some ndefaults) in
     let gids = union_list [gids1; gids2; gids3; gids4; gids5] in
     nexpr, gids
   | RestartEvery (pos, id, args, restart) ->
-    let arity = compute_node_arity ctx id in
+    let arity = compute_node_arity info.context id in
     let cond = A.Const (dummy_pos, A.True) in
     let nrestart, gids1 = if AH.expr_is_const restart then restart, empty
-      else abstract_expr ?guard ctx map false restart
+      else abstract_expr ?guard info map false restart
     in let nargs, gids2 = normalize_list
-      (fun (arg, is_const) -> abstract_node_arg ?guard is_const ctx map arg)
-      (List.combine args (StringMap.find id !is_input_const)) in
+      (fun (arg, is_const) -> abstract_node_arg ?guard is_const info map arg)
+      (List.combine args (StringMap.find id info.node_is_input_const)) in
     let nexpr, gids3 = mk_fresh_call id map arity pos cond nrestart id nargs None in
     let gids = union_list [gids1; gids2; gids3] in
     nexpr, gids
@@ -416,12 +430,12 @@ and normalize_expr ?guard ctx map =
   (* Guarding and abstracting pres                                            *)
   (* ************************************************************************ *)
   | Arrow (pos, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard:(Some nexpr1) ctx map expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard:(Some nexpr1) info map expr2 in
     let gids = union gids1 gids2 in
     Arrow (pos, nexpr1, nexpr2), gids
   | Pre (pos, expr) ->
-    let nexpr, gids1 = abstract_expr ?guard ctx map false expr in
+    let nexpr, gids1 = abstract_expr ?guard info map false expr in
     let guard, gids2, previously_guarded = match guard with
       | Some guard -> guard, empty, true
       | None -> let guard, gids = mk_fresh_oracle nexpr in
@@ -435,106 +449,106 @@ and normalize_expr ?guard ctx map =
   | Ident _ as expr -> expr, empty
   | ModeRef _ as expr -> expr, empty
   | RecordProject (pos, expr, i) ->
-    let nexpr, gids = normalize_expr ?guard ctx map expr in
+    let nexpr, gids = normalize_expr ?guard info map expr in
     RecordProject (pos, nexpr, i), gids
   | TupleProject (pos, expr, i) ->
-    let nexpr, gids = normalize_expr ?guard ctx map expr in
+    let nexpr, gids = normalize_expr ?guard info map expr in
     TupleProject (pos, nexpr, i), gids
   | Const _ as expr -> expr, empty
   | UnaryOp (pos, op, expr) ->
-    let nexpr, gids = normalize_expr ?guard ctx map expr in
+    let nexpr, gids = normalize_expr ?guard info map expr in
     UnaryOp (pos, op, nexpr), gids
   | BinaryOp (pos, op, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard ctx map expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard info map expr2 in
     BinaryOp (pos, op, nexpr1, nexpr2), union gids1 gids2
   | TernaryOp (pos, op, expr1, expr2, expr3) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard ctx map expr2 in
-    let nexpr3, gids3 = normalize_expr ?guard ctx map expr3 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard info map expr2 in
+    let nexpr3, gids3 = normalize_expr ?guard info map expr3 in
     let gids = union (union gids1 gids2) gids3 in
     TernaryOp (pos, op, nexpr1, nexpr2, nexpr3), gids
   | NArityOp (pos, op, expr_list) ->
     let nexpr_list, gids = normalize_list
-      (normalize_expr ?guard ctx map)
+      (normalize_expr ?guard info map)
       expr_list in
     NArityOp (pos, op, nexpr_list), gids
   | ConvOp (pos, op, expr) ->
-    let nexpr, gids = normalize_expr ?guard ctx map expr in
+    let nexpr, gids = normalize_expr ?guard info map expr in
     ConvOp (pos, op, nexpr), gids
   | CompOp (pos, op, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard ctx map expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard info map expr2 in
     CompOp (pos, op, nexpr1, nexpr2), union gids1 gids2
   | RecordExpr (pos, id, id_expr_list) ->
-    let normalize' ctx map ?guard (id, expr) =
-      let nexpr, gids = normalize_expr ?guard ctx map expr in
+    let normalize' info map ?guard (id, expr) =
+      let nexpr, gids = normalize_expr ?guard info map expr in
       (id, nexpr), gids
     in 
     let nid_expr_list, gids = normalize_list 
-      (normalize' ?guard ctx map)
+      (normalize' ?guard info map)
       id_expr_list in
     RecordExpr (pos, id, nid_expr_list), gids
   | GroupExpr (pos, kind, expr_list) ->
     let nexpr_list, gids = normalize_list
-      (normalize_expr ?guard ctx map)
+      (normalize_expr ?guard info map)
       expr_list in
     GroupExpr (pos, kind, nexpr_list), gids
   | StructUpdate (pos, expr1, i, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard ctx map expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard info map expr2 in
     StructUpdate (pos, nexpr1, i, nexpr2), union gids1 gids2
   | ArrayConstr (pos, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard ctx map expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard info map expr2 in
     ArrayConstr (pos, nexpr1, nexpr2), union gids1 gids2
   | ArraySlice (pos, expr1, (expr2, expr3)) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard ctx map expr2 in
-    let nexpr3, gids3 = normalize_expr ?guard ctx map expr3 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard info map expr2 in
+    let nexpr3, gids3 = normalize_expr ?guard info map expr3 in
     let gids = union (union gids1 gids2) gids3 in
     ArraySlice (pos, nexpr1, (nexpr2, nexpr3)), gids
   | ArrayIndex (pos, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard ctx map expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard info map expr2 in
     ArrayIndex (pos, nexpr1, nexpr2), union gids1 gids2
   | ArrayConcat (pos, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard ctx map expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard info map expr2 in
     ArrayConcat (pos, nexpr1, nexpr2), union gids1 gids2
   | Quantifier (pos, kind, vars, expr) ->
-    let nexpr, gids = normalize_expr ?guard ctx map expr in
+    let nexpr, gids = normalize_expr ?guard info map expr in
     Quantifier (pos, kind, vars, nexpr), gids
   | When (pos, expr, clock_expr) ->
-    let nexpr, gids = normalize_expr ?guard ctx map expr in
+    let nexpr, gids = normalize_expr ?guard info map expr in
     When (pos, nexpr, clock_expr), gids
   | Current (pos, expr) ->
-    let nexpr, gids = normalize_expr ?guard ctx map expr in
+    let nexpr, gids = normalize_expr ?guard info map expr in
     Current (pos, nexpr), gids
   | Activate (pos, id, expr1, expr2, expr_list) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard ctx map expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard info map expr2 in
     let nexpr_list, gids3 = normalize_list
-      (normalize_expr ?guard ctx map)
+      (normalize_expr ?guard info map)
       expr_list in
     let gids = union (union gids1 gids2) gids3 in
     Activate (pos, id, nexpr1, nexpr2, nexpr_list), gids
   | Merge (pos, id, id_expr_list) ->
-    let normalize' ctx map ?guard (id, expr) =
-    let nexpr, gids = normalize_expr ?guard ctx map expr in
+    let normalize' info map ?guard (id, expr) =
+    let nexpr, gids = normalize_expr ?guard info map expr in
       (id, nexpr), gids
     in 
     let nid_expr_list, gids = normalize_list
-      (normalize' ?guard ctx map)
+      (normalize' ?guard info map)
       id_expr_list in
     Merge (pos, id, nid_expr_list), gids
   | Last _ as expr -> expr, empty
   | Fby (pos, expr1, i, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard ctx map expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard ctx map expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard info map expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard info map expr2 in
     Fby (pos, nexpr1, i, nexpr2), union gids1 gids2
   | CallParam (pos, id, type_list, expr_list) ->
     let nexpr_list, gids = normalize_list
-      (normalize_expr ?guard ctx map)
+      (normalize_expr ?guard info map)
       expr_list in
     CallParam (pos, id, type_list, nexpr_list), gids

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -240,7 +240,8 @@ let normalize_list ctx map f list =
   let over_list (nitems, gids) item =
     let (normal_item, ids) = f ctx map item in
     normal_item :: nitems, union ids gids
-  in List.fold_left over_list ([], empty) list
+  in let list, gids = List.fold_left over_list ([], empty) list in
+  List.rev list, gids
 
 let rec normalize ctx (decls:LustreAst.t) =
   let over_declarations (nitems, node_maps) item =

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -50,9 +50,11 @@
 
   3. Node calls
     e.g.
-      x = node_call(a, b, c)
-      => x = l
-    where l is the node call output
+      x1, ..., xn = ... op node_call(a, b, c) op ...
+      => x1, ..., xn = ... op (l1, ..., ln) op ...
+    where (l1, ..., ln) is a group (list) expression
+      and each li corresponds to an output of the node_call
+      If node_call has only one output, it is instead just an ident expression
     (Note that there is no generated equality here, how the node call is
       referenced at the stage of a LustreNode is by the node_call record where
       the output holds the state variables produced by the node call)
@@ -63,6 +65,7 @@ open Lib
 
 module A = LustreAst
 module AH = LustreAstHelpers
+module Ctx = TypeCheckerContext
 
 module StringMap = struct
   include Map.Make(struct
@@ -75,16 +78,17 @@ end
 type generated_identifiers = {
     locals : LustreAst.expr StringMap.t;
     oracles : (LustreAst.ident * LustreAst.expr) list;
-    calls : (LustreAst.expr
-      * LustreAst.expr
-      * string
-      * (LustreAst.expr list)
-      * (LustreAst.expr list option)) StringMap.t
+    calls : ((string list) (* abstraction variables *)
+      * LustreAst.expr (* condition expression *)
+      * LustreAst.expr (* restart expression *)
+      * string (* node name *)
+      * (LustreAst.expr list) (* node arguments *)
+      * (LustreAst.expr list option)) (* node argument defaults *)
+      list
 }
 
 let pp_print_generated_identifiers ppf gids =
   let locals_list = StringMap.bindings gids.locals |> List.rev in
-  let calls_list = StringMap.bindings gids.calls |> List.rev in
   let pp_print_local = pp_print_pair
     Format.pp_print_string
     A.pp_print_expr
@@ -93,22 +97,20 @@ let pp_print_generated_identifiers ppf gids =
     Format.pp_print_string
     LustreAst.pp_print_expr
     ":"
-  in let pp_print_call = pp_print_pair
-    Format.pp_print_string
-    (fun ppf (cond, restart, ident, args, defaults) ->
-      Format.fprintf ppf 
-      "call(%a,(restart %a every %a)(%a),%a)"
-        A.pp_print_expr cond
-        Format.pp_print_string ident
-        A.pp_print_expr restart
-        (pp_print_list A.pp_print_expr ",@ ") args
-        (pp_print_option
-          (pp_print_list A.pp_print_expr ",@ ")) defaults)
-    ":"
+  in let pp_print_call = (fun ppf (vars, cond, restart, ident, args, defaults) ->
+    Format.fprintf ppf 
+    "%a = call(%a,(restart %a every %a)(%a),%a)"
+    (pp_print_list Format.pp_print_string ",@") vars
+      A.pp_print_expr cond
+      Format.pp_print_string ident
+      A.pp_print_expr restart
+      (pp_print_list A.pp_print_expr ",@ ") args
+      (pp_print_option
+        (pp_print_list A.pp_print_expr ",@ ")) defaults)
   in Format.fprintf ppf "%a\n%a\n%a"
     (pp_print_list pp_print_oracle "\n") gids.oracles
     (pp_print_list pp_print_local "\n") locals_list
-    (pp_print_list pp_print_call "\n") calls_list
+    (pp_print_list pp_print_call "\n") gids.calls
 
 
 (* [i] is module state used to guarantee newly created identifiers are unique *)
@@ -117,7 +119,7 @@ let i = ref 0
 let empty = {
     locals = StringMap.empty;
     oracles = [];
-    calls = StringMap.empty;
+    calls = [];
   }
 
 let union_keys key id1 id2 = match key, id1, id2 with
@@ -130,7 +132,7 @@ let union_keys key id1 id2 = match key, id1, id2 with
 let union ids1 ids2 = {
     locals = StringMap.merge union_keys ids1.locals ids2.locals;
     oracles = ids1.oracles @ ids2.oracles;
-    calls = StringMap.merge union_keys ids1.calls ids2.calls
+    calls = ids1.calls @ ids2.calls
   }
 
 let union_list ids =
@@ -144,7 +146,7 @@ let mk_fresh_local expr =
   let glocal = StringMap.singleton name expr in
   let gids = { locals = glocal;
     oracles = [];
-    calls = StringMap.empty }
+    calls = [] }
   in nexpr, gids
 
 let mk_fresh_oracle ident =
@@ -154,29 +156,41 @@ let mk_fresh_oracle ident =
   let nexpr = A.Ident (Lib.dummy_pos, name) in
   let gids = { locals = StringMap.empty;
     oracles = [name, ident];
-    calls = StringMap.empty }
+    calls = [] }
   in nexpr, gids
 
-let mk_fresh_call cond restart ident args defaults =
-  i := !i + 1;
-  let prefix = string_of_int !i in
-  let name = prefix ^ "_call" in
-  let nexpr = A.Ident (Lib.dummy_pos, name) in
-  let call = StringMap.singleton name (cond, restart, ident, args, defaults) in
+let compute_node_arity ctx ident =
+  let node_type = Ctx.lookup_node_ty ctx ident in
+  match node_type with
+    | Some (A.GroupType ( _, list)) -> List.length list
+    | _ -> assert false (* Nodes must have a group type *)
+
+let mk_fresh_call arity cond restart ident args defaults =
+  let abstractions = List.init arity (fun x ->
+    i := !i + 1;
+    let prefix = string_of_int !i in
+    prefix ^ "_call")
+  in let expr_list = List.map
+    (fun name -> A.Ident (Lib.dummy_pos, name))
+    abstractions
+  in let nexpr = if arity == 1 then 
+    List.hd expr_list
+    else A.GroupExpr (Lib.dummy_pos, A.ExprList, expr_list) in
+  let call = (abstractions, cond, restart, ident, args, defaults) in
   let gids = { locals = StringMap.empty;
     oracles = [];
-    calls = call }
+    calls = [call] }
   in nexpr, gids
 
-let normalize_list f list =
+let normalize_list ctx f list =
   let over_list (nitems, gids) item =
-    let (normal_item, ids) = f item in
+    let (normal_item, ids) = f ctx item in
     normal_item :: nitems, union ids gids
   in List.fold_left over_list ([], empty) list
 
-let rec normalize (decls:LustreAst.t) =
+let rec normalize (ctx:TypeCheckerContext.tc_context) (decls:LustreAst.t) =
   let over_declarations (nitems, node_maps) item =
-    let (normal_item, node_map) = normalize_declaration item in
+    let (normal_item, node_map) = normalize_declaration ctx item in
     normal_item :: nitems, StringMap.merge union_keys node_map node_maps
   in let ast, node_map = List.fold_left over_declarations ([], StringMap.empty) decls in
   
@@ -195,72 +209,72 @@ let rec normalize (decls:LustreAst.t) =
 
   Res.ok (ast, node_map)
 
-and normalize_declaration = function
+and normalize_declaration ctx = function
   | NodeDecl (pos, decl) ->
-    let normal_decl, node_map = normalize_node decl in
+    let normal_decl, node_map = normalize_node ctx decl in
     A.NodeDecl(pos, normal_decl), node_map
   | FuncDecl (pos, decl) ->
-    let normal_decl, node_map = normalize_node decl in
+    let normal_decl, node_map = normalize_node ctx decl in
     A.FuncDecl (pos, normal_decl), node_map
   | decl -> decl, StringMap.empty
 
-and normalize_node
+and normalize_node ctx
     (id, is_func, params, inputs, outputs, locals, items, contracts) =
-  let nitems, gids1 = normalize_list normalize_item items in
+  let nitems, gids1 = normalize_list ctx normalize_item items in
   let ncontracts, gids2 = match contracts with
     | Some contracts ->
-      let ncontracts, gids = normalize_list normalize_contract contracts in
+      let ncontracts, gids = normalize_list ctx normalize_contract contracts in
       (Some ncontracts), gids
     | None -> None, empty
   in let gids = union gids1 gids2 in
   let node_map = StringMap.singleton id gids in
   (id, is_func, params, inputs, outputs, locals, nitems, ncontracts), node_map
 
-and normalize_item = function
+and normalize_item ctx = function
   | Body equation ->
-    let nequation, gids = normalize_equation equation in
+    let nequation, gids = normalize_equation ctx equation in
     Body nequation, gids
   | AnnotMain b -> AnnotMain b, empty
   | AnnotProperty (pos, name, expr) ->
-    let nexpr, gids = normalize_expr expr in
+    let nexpr, gids = normalize_expr ctx expr in
     AnnotProperty (pos, name, nexpr), gids
 
-and normalize_contract = function
+and normalize_contract ctx = function
   | Assume (pos, name, soft, expr) ->
-    let nexpr, gids = normalize_expr expr in
+    let nexpr, gids = normalize_expr ctx expr in
     Assume (pos, name, soft, nexpr), gids
   | Guarantee (pos, name, soft, expr) -> 
-    let nexpr, gids = normalize_expr expr in
+    let nexpr, gids = normalize_expr ctx expr in
     Guarantee (pos, name, soft, nexpr), gids
   | Mode (pos, name, requires, ensures) ->
-    let over_property (pos, name, expr) =
-      let nexpr, gids = normalize_expr expr in
+    let over_property ctx (pos, name, expr) =
+      let nexpr, gids = normalize_expr ctx expr in
       (pos, name, nexpr), gids
     in
-    let nrequires, gids1 = normalize_list over_property requires in
-    let nensures, gids2 = normalize_list over_property ensures in
+    let nrequires, gids1 = normalize_list ctx over_property requires in
+    let nensures, gids2 = normalize_list ctx over_property ensures in
     Mode (pos, name, nrequires, nensures), union gids1 gids2
   | ContractCall (pos, name, inputs, outputs) ->
-    let ninputs, gids = normalize_list normalize_expr inputs in
+    let ninputs, gids = normalize_list ctx normalize_expr inputs in
     ContractCall (pos, name, ninputs, outputs), gids
   | decl -> decl, empty
 
-and normalize_equation = function
+and normalize_equation ctx = function
   | Assert (pos, expr) ->
-    let nexpr, gids = normalize_expr expr in
+    let nexpr, gids = normalize_expr ctx expr in
     Assert (pos, nexpr), gids
   | Equation (pos, lhs, expr) ->
-    let nexpr, gids = normalize_expr expr in
+    let nexpr, gids = normalize_expr ctx expr in
     Equation (pos, lhs, nexpr), gids
   | Automaton (pos, id, states, auto) -> Lib.todo __LOC__
 
-and normalize_expr ?guard =
-  let generate_fresh_ids ?guard expr =
+and normalize_expr ?guard ctx  =
+  let generate_fresh_ids ctx ?guard expr =
     (* If [expr] is already an id or const then we don't create a fresh local *)
     if AH.expr_is_id expr then
       expr, empty
     else
-      let nexpr, gids1 = normalize_expr ?guard expr in
+      let nexpr, gids1 = normalize_expr ctx ?guard expr in
       let iexpr, gids2 = mk_fresh_local nexpr in
       iexpr, union gids1 gids2
   in function
@@ -268,36 +282,39 @@ and normalize_expr ?guard =
   (* Node calls                                                               *)
   (* ************************************************************************ *)
   | Call (pos, id, args) ->
+    let arity = compute_node_arity ctx id in
     let cond = A.Const (Lib.dummy_pos, A.True) in
     let restart =  A.Const (Lib.dummy_pos, A.False) in
-    let nargs, gids1 = normalize_list (generate_fresh_ids ?guard) args in
-    let nexpr, gids2 = mk_fresh_call cond restart id nargs None in
+    let nargs, gids1 = normalize_list ctx (generate_fresh_ids ?guard) args in
+    let nexpr, gids2 = mk_fresh_call arity cond restart id nargs None in
     nexpr, union gids1 gids2
   | Condact (pos, cond, restart, id, args, defaults) ->
-    let ncond, gids1 = normalize_expr ?guard cond in
-    let nrestart, gids2 = normalize_expr ?guard restart in
-    let nargs, gids3 = normalize_list (generate_fresh_ids ?guard) args in
-    let ndefaults, gids4 = normalize_list (normalize_expr ?guard) defaults in
-    let nexpr, gids5 = mk_fresh_call ncond nrestart id nargs (Some ndefaults) in
+    let arity = compute_node_arity ctx id in
+    let ncond, gids1 = normalize_expr ?guard ctx cond in
+    let nrestart, gids2 = normalize_expr ?guard ctx restart in
+    let nargs, gids3 = normalize_list ctx (generate_fresh_ids ?guard) args in
+    let ndefaults, gids4 = normalize_list ctx (normalize_expr ?guard) defaults in
+    let nexpr, gids5 = mk_fresh_call arity ncond nrestart id nargs (Some ndefaults) in
     let gids = union_list [gids1; gids2; gids3; gids4; gids5] in
     nexpr, gids
   | RestartEvery (pos, id, args, restart) ->
+    let arity = compute_node_arity ctx id in
     let cond = A.Const (dummy_pos, A.True) in
-    let nrestart, gids1 = normalize_expr ?guard restart in
-    let nargs, gids2 = normalize_list (generate_fresh_ids ?guard) args in
-    let nexpr, gids3 = mk_fresh_call cond nrestart id nargs None in
+    let nrestart, gids1 = normalize_expr ?guard ctx restart in
+    let nargs, gids2 = normalize_list ctx (generate_fresh_ids ?guard) args in
+    let nexpr, gids3 = mk_fresh_call arity cond nrestart id nargs None in
     let gids = union_list [gids1; gids2; gids3] in
     nexpr, gids
   (* ************************************************************************ *)
   (* Guarding and abstracting pres                                            *)
   (* ************************************************************************ *)
   | Arrow (pos, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard:(Some nexpr1) expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard:(Some nexpr1) ctx expr2 in
     let gids = union gids1 gids2 in
     Arrow (pos, nexpr1, nexpr2), gids
   | Pre (pos, expr) ->
-    let nexpr, gids1 = (generate_fresh_ids ?guard) expr in
+    let nexpr, gids1 = (generate_fresh_ids ctx ?guard) expr in
     let guard, gids2, previously_guarded = match guard with
       | Some guard -> guard, empty, true
       | None -> let guard, gids = mk_fresh_oracle nexpr in
@@ -311,94 +328,94 @@ and normalize_expr ?guard =
   | Ident _ as expr -> expr, empty
   | ModeRef _ as expr -> expr, empty
   | RecordProject (pos, expr, i) ->
-    let nexpr, gids = normalize_expr ?guard expr in
+    let nexpr, gids = normalize_expr ?guard ctx expr in
     RecordProject (pos, nexpr, i), gids
   | TupleProject (pos, expr, i) ->
-    let nexpr, gids = normalize_expr ?guard expr in
+    let nexpr, gids = normalize_expr ?guard ctx expr in
     TupleProject (pos, nexpr, i), gids
   | Const _ as expr -> expr, empty
   | UnaryOp (pos, op, expr) ->
-    let nexpr, gids = normalize_expr ?guard expr in
+    let nexpr, gids = normalize_expr ?guard ctx expr in
     UnaryOp (pos, op, nexpr), gids
   | BinaryOp (pos, op, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard ctx expr2 in
     BinaryOp (pos, op, nexpr1, nexpr2), union gids1 gids2
   | TernaryOp (pos, op, expr1, expr2, expr3) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard expr2 in
-    let nexpr3, gids3 = normalize_expr ?guard expr3 in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard ctx expr2 in
+    let nexpr3, gids3 = normalize_expr ?guard ctx expr3 in
     let gids = union (union gids1 gids2) gids3 in
     TernaryOp (pos, op, nexpr1, nexpr2, nexpr3), gids
   | NArityOp (pos, op, expr_list) ->
-    let nexpr_list, gids = normalize_list (normalize_expr ?guard) expr_list in
+    let nexpr_list, gids = normalize_list ctx (normalize_expr ?guard) expr_list in
     NArityOp (pos, op, nexpr_list), gids
   | ConvOp (pos, op, expr) ->
-    let nexpr, gids = normalize_expr ?guard expr in
+    let nexpr, gids = normalize_expr ?guard ctx expr in
     ConvOp (pos, op, nexpr), gids
   | CompOp (pos, op, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard ctx expr2 in
     CompOp (pos, op, nexpr1, nexpr2), union gids1 gids2
   | RecordExpr (pos, id, id_expr_list) ->
-    let normalize' ?guard (id, expr) =
-      let nexpr, gids = normalize_expr ?guard expr in
+    let normalize' ctx ?guard (id, expr) =
+      let nexpr, gids = normalize_expr ?guard ctx expr in
       (id, nexpr), gids
     in 
-    let nid_expr_list, gids = normalize_list (normalize' ?guard) id_expr_list in
+    let nid_expr_list, gids = normalize_list ctx (normalize' ?guard) id_expr_list in
     RecordExpr (pos, id, nid_expr_list), gids
   | GroupExpr (pos, kind, expr_list) ->
-    let nexpr_list, gids = normalize_list (normalize_expr ?guard) expr_list in
+    let nexpr_list, gids = normalize_list ctx (normalize_expr ?guard) expr_list in
     GroupExpr (pos, kind, nexpr_list), gids
   | StructUpdate (pos, expr1, i, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard ctx expr2 in
     StructUpdate (pos, nexpr1, i, nexpr2), union gids1 gids2
   | ArrayConstr (pos, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard ctx expr2 in
     ArrayConstr (pos, nexpr1, nexpr2), union gids1 gids2
   | ArraySlice (pos, expr1, (expr2, expr3)) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard expr2 in
-    let nexpr3, gids3 = normalize_expr ?guard expr3 in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard ctx expr2 in
+    let nexpr3, gids3 = normalize_expr ?guard ctx expr3 in
     let gids = union (union gids1 gids2) gids3 in
     ArraySlice (pos, nexpr1, (nexpr2, nexpr3)), gids
   | ArrayIndex (pos, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard ctx expr2 in
     ArrayIndex (pos, nexpr1, nexpr2), union gids1 gids2
   | ArrayConcat (pos, expr1, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard ctx expr2 in
     ArrayConcat (pos, nexpr1, nexpr2), union gids1 gids2
   | Quantifier (pos, kind, vars, expr) ->
-    let nexpr, gids = normalize_expr ?guard expr in
+    let nexpr, gids = normalize_expr ?guard ctx expr in
     Quantifier (pos, kind, vars, nexpr), gids
   | When (pos, expr, clock_expr) ->
-    let nexpr, gids = normalize_expr ?guard expr in
+    let nexpr, gids = normalize_expr ?guard ctx expr in
     When (pos, nexpr, clock_expr), gids
   | Current (pos, expr) ->
-    let nexpr, gids = normalize_expr ?guard expr in
+    let nexpr, gids = normalize_expr ?guard ctx expr in
     Current (pos, nexpr), gids
   | Activate (pos, id, expr1, expr2, expr_list) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard expr2 in
-    let nexpr_list, gids3 = normalize_list (normalize_expr ?guard) expr_list in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard ctx expr2 in
+    let nexpr_list, gids3 = normalize_list ctx (normalize_expr ?guard) expr_list in
     let gids = union (union gids1 gids2) gids3 in
     Activate (pos, id, nexpr1, nexpr2, nexpr_list), gids
   | Merge (pos, id, id_expr_list) ->
-    let normalize' ?guard (id, expr) =
-    let nexpr, gids = normalize_expr ?guard expr in
+    let normalize' ctx ?guard (id, expr) =
+    let nexpr, gids = normalize_expr ?guard ctx expr in
       (id, nexpr), gids
     in 
-    let nid_expr_list, gids = normalize_list (normalize' ?guard) id_expr_list in
+    let nid_expr_list, gids = normalize_list ctx (normalize' ?guard) id_expr_list in
     Merge (pos, id, nid_expr_list), gids
   | Last _ as expr -> expr, empty
   | Fby (pos, expr1, i, expr2) ->
-    let nexpr1, gids1 = normalize_expr ?guard expr1 in
-    let nexpr2, gids2 = normalize_expr ?guard expr2 in
+    let nexpr1, gids1 = normalize_expr ?guard ctx expr1 in
+    let nexpr2, gids2 = normalize_expr ?guard ctx expr2 in
     Fby (pos, nexpr1, i, nexpr2), union gids1 gids2
   | CallParam (pos, id, type_list, expr_list) ->
-    let nexpr_list, gids = normalize_list (normalize_expr ?guard) expr_list in
+    let nexpr_list, gids = normalize_list ctx (normalize_expr ?guard) expr_list in
     CallParam (pos, id, type_list, nexpr_list), gids

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -50,17 +50,16 @@
 
      @author Andrew Marmaduke *)
 
-module IMap : sig
-  include (Map.S with type key = LustreAst.ident)
+module StringMap : sig
+  include (Map.S with type key = string)
   val keys: 'a t -> key list
 end
-(** Map for types with identifiers as keys *)
 
 type generated_identifiers = {
-  locals : LustreAst.expr IMap.t;
-  oracles : LustreAst.ident list
+  locals : LustreAst.expr StringMap.t;
+  oracles : (LustreAst.ident * LustreAst.expr) list
 }
 
-val normalize : LustreAst.t -> (LustreAst.t * generated_identifiers, Lib.position * string) result
+val normalize : LustreAst.t -> (LustreAst.t * generated_identifiers StringMap.t, Lib.position * string) result
 
 val pp_print_generated_identifiers : Format.formatter -> generated_identifiers -> unit

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -56,8 +56,8 @@ module StringMap : sig
 end
 
 type generated_identifiers = {
-    node_args : (string * LustreAst.expr) list;
-    locals : LustreAst.expr StringMap.t;
+    node_args : (string * LustreAst.lustre_type * LustreAst.expr) list;
+    locals : (LustreAst.lustre_type * LustreAst.expr) StringMap.t;
     oracles : (string * LustreAst.expr) list;
     propagated_oracles : (string * string) list;
     calls : (Lib.position (* node call position *)

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -56,9 +56,11 @@ module StringMap : sig
 end
 
 type generated_identifiers = {
-    locals : LustreAst.expr StringMap.t;
+    node_args : (string * LustreAst.expr) list;
+    pre_args : (string * LustreAst.expr) list;
     oracles : (LustreAst.ident * LustreAst.expr) list;
-    calls : ((string list) (* abstraction variables *)
+    calls : (Lib.position (* node call position *)
+      * (string list) (* abstraction variables *)
       * LustreAst.expr (* condition expression *)
       * LustreAst.expr (* restart expression *)
       * string (* node name *)

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -57,7 +57,12 @@ end
 
 type generated_identifiers = {
   locals : LustreAst.expr StringMap.t;
-  oracles : (LustreAst.ident * LustreAst.expr) list
+  oracles : (LustreAst.ident * LustreAst.expr) list;
+  calls : (LustreAst.expr
+    * LustreAst.expr
+    * string
+    * (LustreAst.expr list)
+    * (LustreAst.expr list option)) StringMap.t
 }
 
 val normalize : LustreAst.t -> (LustreAst.t * generated_identifiers StringMap.t, Lib.position * string) result

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -57,10 +57,12 @@ end
 
 type generated_identifiers = {
     node_args : (string * LustreAst.expr) list;
-    pre_args : (string * LustreAst.expr) list;
-    oracles : (LustreAst.ident * LustreAst.expr) list;
+    locals : LustreAst.expr StringMap.t;
+    oracles : (string * LustreAst.expr) list;
+    propagated_oracles : (string * string) list;
     calls : (Lib.position (* node call position *)
-      * (string list) (* abstraction variables *)
+      * (string list) (* oracle inputs *)
+      * (string list) (* abstracted inputs *)
       * LustreAst.expr (* condition expression *)
       * LustreAst.expr (* restart expression *)
       * string (* node name *)

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -56,15 +56,19 @@ module StringMap : sig
 end
 
 type generated_identifiers = {
-  locals : LustreAst.expr StringMap.t;
-  oracles : (LustreAst.ident * LustreAst.expr) list;
-  calls : (LustreAst.expr
-    * LustreAst.expr
-    * string
-    * (LustreAst.expr list)
-    * (LustreAst.expr list option)) StringMap.t
+    locals : LustreAst.expr StringMap.t;
+    oracles : (LustreAst.ident * LustreAst.expr) list;
+    calls : ((string list) (* abstraction variables *)
+      * LustreAst.expr (* condition expression *)
+      * LustreAst.expr (* restart expression *)
+      * string (* node name *)
+      * (LustreAst.expr list) (* node arguments *)
+      * (LustreAst.expr list option)) (* node argument defaults *)
+      list
 }
 
-val normalize : LustreAst.t -> (LustreAst.t * generated_identifiers StringMap.t, Lib.position * string) result
+val normalize : TypeCheckerContext.tc_context
+  -> LustreAst.t
+  -> (LustreAst.t * generated_identifiers StringMap.t, Lib.position * string) result
 
 val pp_print_generated_identifiers : Format.formatter -> generated_identifiers -> unit

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1727,7 +1727,7 @@ let add_node_sofar_assumption ctx =
 
          let pre_sofar, _ = (* Context should not be modified *)
            assert (not (guard_flag ctx));
-           E.mk_pre
+           E.mk_pre_with_context
              (* No abstraction should be necessary, see [mk_pre] *)
              (fun _ _ -> assert false) (fun _ -> assert false)
              ctx false (E.mk_var sofar_svar)

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -233,12 +233,6 @@ let pre_offset = Numeral.(pred cur_offset)
 (* Pretty-printing                                                        *)
 (* ********************************************************************** *)
 
-(** Pretty-print a bound or fixed annotation *)
-let pp_print_bound_or_fixed pp ppf = function
-  | Bound x -> pp ppf x
-  | Fixed x -> pp ppf x
-  | Unbound x -> pp ppf x
-
 (* Pretty-print a type as a Lustre type *)
 let rec pp_print_lustre_type safe ppf t = match Type.node_of_type t with
 
@@ -835,7 +829,11 @@ let pp_print_lustre_expr safe ppf = function
       (pp_print_expr ~as_type:expr_type safe) expr_init
       (pp_print_expr ~as_type:expr_type safe) expr_step
 
-
+(** Pretty-print a bound or fixed annotation *)
+let pp_print_bound_or_fixed ppf = function
+  | Bound x -> (pp_print_expr true) ppf x
+  | Fixed x -> (pp_print_expr true) ppf x
+  | Unbound x -> (pp_print_expr true) ppf x
 
 (* ********************************************************************** *)
 (* Predicates                                                             *)
@@ -3286,7 +3284,7 @@ let mk_arrow expr1 expr2 =
 (* Pre expression *)
 (* We don't need to abstract the RHS because the AST normalization pass 
   already has. *)
-let mk_pre mk_lhs_term ({ expr_init; expr_step; expr_type } as expr) =
+let mk_pre ({ expr_init; expr_step; expr_type } as expr) =
   if Term.equal expr_init expr_step then
     match expr_init with
     (* Expression is a constant not part of an unguarded pre expression *)

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -233,6 +233,12 @@ let pre_offset = Numeral.(pred cur_offset)
 (* Pretty-printing                                                        *)
 (* ********************************************************************** *)
 
+(** Pretty-print a bound or fixed annotation *)
+let pp_print_bound_or_fixed pp ppf = function
+  | Bound x -> pp ppf x
+  | Fixed x -> pp ppf x
+  | Unbound x -> pp ppf x
+
 (* Pretty-print a type as a Lustre type *)
 let rec pp_print_lustre_type safe ppf t = match Type.node_of_type t with
 

--- a/src/lustre/lustreExpr.mli
+++ b/src/lustre/lustreExpr.mli
@@ -134,7 +134,7 @@ val type_of_lustre_expr : t -> Type.t
 *)
 
 (** Pretty-print a bound or fixed annotation *)
-val pp_print_bound_or_fixed : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a bound_or_fixed -> unit
+val pp_print_bound_or_fixed : Format.formatter -> expr bound_or_fixed -> unit
 
 (** Pretty-print a Lustre type *)
 val pp_print_lustre_type : bool -> Format.formatter -> Type.t -> unit 
@@ -475,9 +475,9 @@ val mk_gt : t -> t -> t
 (** Apply the followed by operator [->] to the two expressions. *)
 val mk_arrow : t -> t -> t
 
-(** [mk_pre f e] returns the expression [e] if it is a constant, and the
+(** [mk_pre e] returns the expression [e] if it is a constant, and the
     previous state variable if the expression is a current state variable. *)
-val mk_pre : ('a -> Term.t) -> t -> t
+val mk_pre : t -> t
 
 (** Apply the [pre] operator to the expression, abstract the
     expression to a fresh variable if it is not a variable at the

--- a/src/lustre/lustreExpr.mli
+++ b/src/lustre/lustreExpr.mli
@@ -475,11 +475,15 @@ val mk_gt : t -> t -> t
 (** Apply the followed by operator [->] to the two expressions. *)
 val mk_arrow : t -> t -> t
 
+(** [mk_pre f e] returns the expression [e] if it is a constant, and the
+    previous state variable if the expression is a current state variable. *)
+val mk_pre : ('a -> Term.t) -> t -> t
+
 (** Apply the [pre] operator to the expression, abstract the
     expression to a fresh variable if it is not a variable at the
     current state.
 
-    [mk_pre f c b e] returns the expression [e] and context [c] unchanged if it
+    [mk_pre_with_context f c b e] returns the expression [e] and context [c] unchanged if it
     is a constant, and the previous state variable if the expression is a
     current state variable, again together with [c] unchanged.
 
@@ -491,7 +495,7 @@ val mk_arrow : t -> t -> t
 
     [b] is used to denote that we're in a context where there are unguarded
     pres and so we should always introduce fresh intermediate variables. *)
-val mk_pre : ('a -> t -> 'b * 'a) -> ('b -> Term.t) -> 'a -> bool -> t -> t * 'a
+val mk_pre_with_context : ('a -> t -> 'b * 'a) -> ('b -> Term.t) -> 'a -> bool -> t -> t * 'a
 
 (** Select from an array *)
 val mk_select : t -> t -> t

--- a/src/lustre/lustreExpr.mli
+++ b/src/lustre/lustreExpr.mli
@@ -133,6 +133,9 @@ val type_of_lustre_expr : t -> Type.t
     is [true].
 *)
 
+(** Pretty-print a bound or fixed annotation *)
+val pp_print_bound_or_fixed : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a bound_or_fixed -> unit
+
 (** Pretty-print a Lustre type *)
 val pp_print_lustre_type : bool -> Format.formatter -> Type.t -> unit 
 

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -168,7 +168,7 @@ let of_channel in_ch =
           let filtered = List.filter 
             (fun x -> not (LustreIdent.equal x.LustreNode.name ident))
             nodes
-          in filtered @ [n]
+          in n :: filtered
       in nodes, globals
   in
     

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -227,7 +227,8 @@ let of_channel in_ch =
       (pp_print_list LustreNode.pp_print_state_var_instances_debug ";@") nodes
       (pp_print_list LustreNode.pp_print_state_var_defs_debug ";@") nodes
       (pp_print_list StateVar.pp_print_state_var_debug ";@")
-        (nodes |> List.map (fun n -> LustreNode.get_all_state_vars n) |> List.flatten);
+        (nodes |> List.map (fun n -> LustreNode.get_all_state_vars n @ n.oracles)
+          |> List.flatten);
     (if Flags.only_tc () then exit 0);
     (* Return a subsystem tree from the list of nodes *)
     LN.subsystem_of_nodes nodes', globals, declarations

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -212,8 +212,7 @@ let of_channel in_ch =
         (pp_print_pair
           (StateVar.pp_print_state_var)
           (pp_print_list
-            (LustreExpr.pp_print_bound_or_fixed
-              (LustreExpr.pp_print_expr true))
+            (LustreExpr.pp_print_bound_or_fixed)
             ";@ ")
           " = ")
         ";@ ")

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -201,6 +201,9 @@ let of_channel in_ch =
       ^^ "Free Constants: [@[<hv>%a@]];@ \n\n"
       ^^ "State Variable Bounds: [@[<hv>%a@]];@ \n\n"
       ^^ "Nodes: [@[<hv>%a@]];@ \n\n"
+      ^^ "State Var Instances: [@[<hv>%a@]];@ \n\n"
+      ^^ "State Var Definitions: [@[<hv>%a@]];@ \n\n"
+      ^^ "All State Variables: [@[<hv>%a@]];@ \n\n"
       ^^ "===============================================\n")
       (pp_print_list
         (pp_print_pair
@@ -220,7 +223,11 @@ let of_channel in_ch =
           (fun k v acc -> (k, v) :: acc)
           globals.state_var_bounds
           [])
-      (pp_print_list LustreNode.pp_print_node_debug ";@ ") nodes;
+      (pp_print_list LustreNode.pp_print_node_debug ";@ ") nodes
+      (pp_print_list LustreNode.pp_print_state_var_instances_debug ";@") nodes
+      (pp_print_list LustreNode.pp_print_state_var_defs_debug ";@") nodes
+      (pp_print_list StateVar.pp_print_state_var_debug ";@")
+        (nodes |> List.map (fun n -> LustreNode.get_all_state_vars n) |> List.flatten);
     (if Flags.only_tc () then exit 0);
     (* Return a subsystem tree from the list of nodes *)
     LN.subsystem_of_nodes nodes', globals, declarations

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -145,31 +145,33 @@ let of_channel in_ch =
           (* Step 7. Normalize AST: guard pres, abstract to locals where appropriate *)
           LAN.normalize inlined_global_ctx const_inlined_nodes_and_contracts >>= fun (normalized_nodes_and_contracts, generated_ids) ->
           
-          (* The last node in the original ordering should remain the last node after sorting 
-            as the user expects that to be the main node in the case where 
-            no explicit annotations are provided. The reason we do this is because 
-            it is difficut to make the topological sort stable *)
-          
-          (* reverse the list and find the name of the first node declaration from the original list *)
-          let last_node = LH.get_last_node_name (declarations) in
-          (match last_node with
-          | None -> Res.ok (inlined_global_ctx, generated_ids, const_inlined_type_and_consts
-            @ normalized_nodes_and_contracts)
-          | Some ln ->
-              Log.log L_trace "last node is: %a"  LA.pp_print_ident ln 
-            ; Res.ok (inlined_global_ctx, generated_ids, const_inlined_type_and_consts
-                      @ LH.move_node_to_last ln (normalized_nodes_and_contracts))) 
+          Res.ok (inlined_global_ctx,
+            generated_ids,
+            const_inlined_type_and_consts @ normalized_nodes_and_contracts)
         ) in
       let ctx, gids, decls = match tc_res with
       | Ok (c, g, d) ->
         Log.log L_note "Type checking done"
         ; Log.log L_trace "========\n%a\n==========\n" LA.pp_print_program d
         ; (c, g, d)
-      | Error (pos, err) -> fail_at_position pos err in 
+      | Error (pos, err) -> fail_at_position pos err in
       LNG.compile ctx gids decls
   in
+    (* The last node in the original ordering should remain the last node after sorting 
+      as the user expects that to be the main node in the case where 
+      no explicit annotations are provided. The reason we do this is because 
+      it is difficut to make the topological sort stable *)
+    let last_node = LH.get_last_node_name (declarations) in
+    let nodes = match last_node with
+      | None -> nodes
+      | Some ln -> let ident = LustreIdent.mk_string_ident ln in
+        let n = LustreNode.node_of_name ident nodes in
+        let filtered = List.filter 
+          (fun x -> not (LustreIdent.equal x.LustreNode.name ident))
+          nodes
+      in filtered @ [n]
     (* Name of main node *)
-    let main_node = 
+    in let main_node = 
       (* Command-line flag for main node given? *)
       match Flags.lus_main () with 
       (* Use given identifier to choose main node *)

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -26,6 +26,7 @@ module LH = LustreAstHelpers
 module LN = LustreNode
 module LD = LustreDeclarations
 
+module LNG = LustreNodeGen
 module LPI = LustreParser.Incremental
 module LL = LustreLexer          
 module LPMI = LustreParser.MenhirInterpreter
@@ -34,7 +35,7 @@ module TC = LustreTypeChecker
 module TCContext = TypeCheckerContext
 module IC = LustreAstInlineConstants
 module AD = LustreAstDependencies
-(* module LAN = LustreAstNormalizer *)
+module LAN = LustreAstNormalizer
 
 let (>>=) = Res.(>>=)
 let (>>) = Res.(>>)
@@ -113,93 +114,118 @@ let of_channel in_ch =
   (* Get declarations from channel. *)
   let declarations = ast_of_channel in_ch in
 
-  let declarations': LA.t =
-    (* optional type checking and reordering with dependency analysis pass*) 
-    if Flags.no_tc ()
-     then declarations
-     else 
-       let tc_res =  
-         (Log.log L_note "(Experimental) Typechecking enabled."
+  let nodes, globals = if Flags.no_tc () then
+      (* Simplify declarations to a list of nodes *)
+      LD.declarations_to_nodes declarations
+    else 
+      let tc_res =  
+        (Log.log L_note "(Experimental) Typechecking enabled."
 
-         (* Step 0. Split program into top level const and type delcs, and node/contract decls *)
-         ; let (const_type_decls, node_contract_src) = LH.split_program declarations in
+        (* Step 0. Split program into top level const and type delcs, and node/contract decls *)
+        ; let (const_type_decls, node_contract_src) = LH.split_program declarations in
 
-           (* Step 1. Dependency analysis on the top level declarations.  *)
-           AD.sort_globals const_type_decls >>= fun sorted_const_type_decls ->
+          (* Step 1. Dependency analysis on the top level declarations.  *)
+          AD.sort_globals const_type_decls >>= fun sorted_const_type_decls ->
 
-           (* Step 2. Type check top level declarations *)
-           TC.type_check_infer_globals TCContext.empty_tc_context sorted_const_type_decls >>= fun ctx -> 
+          (* Step 2. Type check top level declarations *)
+          TC.type_check_infer_globals TCContext.empty_tc_context sorted_const_type_decls >>= fun ctx -> 
 
-           (* Step 3: Inline type toplevel decls *)
-           IC.inline_constants ctx sorted_const_type_decls >>= fun (inlined_ctx, const_inlined_type_and_consts) -> 
+          (* Step 3: Inline type toplevel decls *)
+          IC.inline_constants ctx sorted_const_type_decls >>= fun (inlined_ctx, const_inlined_type_and_consts) -> 
 
-           (* Step 4. Dependency analysis on nodes and contracts *)
-           AD.sort_and_check_nodes_contracts node_contract_src >>= fun sorted_node_contract_decls ->  
+          (* Step 4. Dependency analysis on nodes and contracts *)
+          AD.sort_and_check_nodes_contracts node_contract_src >>= fun sorted_node_contract_decls ->  
 
-           (* Step 5. type check nodes and contracts *)
-           TC.type_check_infer_nodes_and_contracts inlined_ctx sorted_node_contract_decls >>
-             
-           (* Step 6. Inline constants in node equations *)
-           IC.inline_constants ctx sorted_node_contract_decls >>= fun (_, const_inlined_nodes_and_contracts) ->
+          (* Step 5. type check nodes and contracts *)
+          TC.type_check_infer_nodes_and_contracts inlined_ctx sorted_node_contract_decls >>
+            
+          (* Step 6. Inline constants in node equations *)
+          IC.inline_constants ctx sorted_node_contract_decls >>= fun (ctx, const_inlined_nodes_and_contracts) ->
 
-           (* Step 7. Normalize AST: guard pres, abstract to locals where appropriate *)
-           (* LAN.normalize const_inlined_nodes_and_contracts >>= fun (ctx, ast) -> *)
-           
-           (* The last node in the original ordering should remain the last node after sorting 
-              as the user expects that to be the main node in the case where 
-              no explicit annotations are provided. The reason we do this is because 
-              it is difficut to make the topological sort stable *)
-           
-           (* reverse the list and find the name of the first node declaration from the original list *)
-           let last_node = LH.get_last_node_name (declarations) in
-           (match last_node with
-            | None -> Res.ok (const_inlined_type_and_consts @ const_inlined_nodes_and_contracts)
-            | Some ln ->
-               Log.log L_trace "last node is: %a"  LA.pp_print_ident ln 
-              ; Res.ok (const_inlined_type_and_consts
-                        @ LH.move_node_to_last ln (const_inlined_nodes_and_contracts))) 
-         ) in
-       match tc_res with
-       | Ok d ->
-          Log.log L_note "Type checking done"
-         ; Log.log L_trace "========\n%a\n==========\n" LA.pp_print_program d
-         ; (if Flags.only_tc () then exit 0)
-         ; d  
-       | Error (pos, err) -> fail_at_position pos err in 
-  
-  (* Simplify declarations to a list of nodes *)
-  let nodes, globals = LD.declarations_to_nodes declarations' in
-  (* Name of main node *)
-  let main_node = 
-    (* Command-line flag for main node given? *)
-    match Flags.lus_main () with 
-    (* Use given identifier to choose main node *)
-    | Some s -> LustreIdent.mk_string_ident s
-    (* No main node name given on command-line *)
-    | None -> 
-       (try 
-          (* Find main node by annotation, or take last node as
-              main *)
-          LustreNode.find_main nodes 
-        (* No main node found
-            This only happens when there are no nodes in the input. *)
-        with Not_found -> 
-          raise (NoMainNode "No main node defined in input"))
+          (* Step 7. Normalize AST: guard pres, abstract to locals where appropriate *)
+          LAN.normalize const_inlined_nodes_and_contracts >>= fun (normalized_nodes_and_contracts, generated_ids) ->
+          
+          (* The last node in the original ordering should remain the last node after sorting 
+            as the user expects that to be the main node in the case where 
+            no explicit annotations are provided. The reason we do this is because 
+            it is difficut to make the topological sort stable *)
+          
+          (* reverse the list and find the name of the first node declaration from the original list *)
+          let last_node = LH.get_last_node_name (declarations) in
+          (match last_node with
+          | None -> Res.ok (ctx, generated_ids, const_inlined_type_and_consts
+            @ normalized_nodes_and_contracts)
+          | Some ln ->
+              Log.log L_trace "last node is: %a"  LA.pp_print_ident ln 
+            ; Res.ok (ctx, generated_ids, const_inlined_type_and_consts
+                      @ LH.move_node_to_last ln (normalized_nodes_and_contracts))) 
+        ) in
+      let ctx, gids, decls = match tc_res with
+      | Ok (c, g, d) ->
+        Log.log L_note "Type checking done"
+        ; Log.log L_trace "========\n%a\n==========\n" LA.pp_print_program d
+        ; (c, g, d)
+      | Error (pos, err) -> fail_at_position pos err in 
+      LNG.compile ctx gids decls
   in
-  (* Put main node at the head of the list of nodes *)
-  let nodes' = 
-    try 
-      (* Get main node by name and copy it at the head of the list of
-         nodes *)
-      LN.node_of_name main_node nodes :: nodes
-    with Not_found -> 
-      (* Node with name of main not found 
-         This can only happens when the name is passed as command-line
-         argument *)
-      raise (NoMainNode "Main node not found in input")
-  in
-  (* Return a subsystem tree from the list of nodes *)
-  LN.subsystem_of_nodes nodes', globals, declarations
+    (* Name of main node *)
+    let main_node = 
+      (* Command-line flag for main node given? *)
+      match Flags.lus_main () with 
+      (* Use given identifier to choose main node *)
+      | Some s -> LustreIdent.mk_string_ident s
+      (* No main node name given on command-line *)
+      | None -> 
+        (try 
+            (* Find main node by annotation, or take last node as
+                main *)
+            LustreNode.find_main nodes 
+          (* No main node found
+              This only happens when there are no nodes in the input. *)
+          with Not_found -> 
+            raise (NoMainNode "No main node defined in input"))
+    in
+    (* Put main node at the head of the list of nodes *)
+    let nodes' = 
+      try 
+        (* Get main node by name and copy it at the head of the list of
+          nodes *)
+        LN.node_of_name main_node nodes :: nodes
+      with Not_found -> 
+        (* Node with name of main not found 
+          This can only happens when the name is passed as command-line
+          argument *)
+        raise (NoMainNode "Main node not found in input")
+    in
+    Log.log L_trace ("===============================================\n"
+      ^^ "Free Constants: [@[<hv>%a@]];@ \n\n"
+      ^^ "State Variable Bounds: [@[<hv>%a@]];@ \n\n"
+      ^^ "Nodes: [@[<hv>%a@]];@ \n\n"
+      ^^ "===============================================\n")
+      (pp_print_list
+        (pp_print_pair
+          (LustreIdent.pp_print_ident true)
+          (LustreIndex.pp_print_index_trie true Var.pp_print_var)
+          " = ")
+        ";@ ") globals.free_constants
+      (pp_print_list
+        (pp_print_pair
+          (StateVar.pp_print_state_var)
+          (pp_print_list
+            (LustreExpr.pp_print_bound_or_fixed
+              (LustreExpr.pp_print_expr true))
+            ";@ ")
+          " = ")
+        ";@ ")
+        (StateVar.StateVarHashtbl.fold
+          (fun k v acc -> (k, v) :: acc)
+          globals.state_var_bounds
+          [])
+      (pp_print_list LustreNode.pp_print_node_debug ";@ ") nodes;
+    (if Flags.only_tc () then exit 0);
+    (* Return a subsystem tree from the list of nodes *)
+    LN.subsystem_of_nodes nodes', globals, declarations
+
 
 (* Returns the AST from a file. *)
 let ast_of_file filename =

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -155,23 +155,25 @@ let of_channel in_ch =
         ; Log.log L_trace "========\n%a\n==========\n" LA.pp_print_program d
         ; (c, g, d)
       | Error (pos, err) -> fail_at_position pos err in
-      LNG.compile ctx gids decls
-  in
-    (* The last node in the original ordering should remain the last node after sorting 
+      let nodes, globals = LNG.compile ctx gids decls in
+      (* The last node in the original ordering should remain the last node after sorting 
       as the user expects that to be the main node in the case where 
       no explicit annotations are provided. The reason we do this is because 
       it is difficut to make the topological sort stable *)
-    let last_node = LH.get_last_node_name (declarations) in
-    let nodes = match last_node with
-      | None -> nodes
-      | Some ln -> let ident = LustreIdent.mk_string_ident ln in
-        let n = LustreNode.node_of_name ident nodes in
-        let filtered = List.filter 
-          (fun x -> not (LustreIdent.equal x.LustreNode.name ident))
-          nodes
-      in filtered @ [n]
+      let last_node = LH.get_last_node_name (declarations) in
+      let nodes = match last_node with
+        | None -> nodes
+        | Some ln -> let ident = LustreIdent.mk_string_ident ln in
+          let n = LustreNode.node_of_name ident nodes in
+          let filtered = List.filter 
+            (fun x -> not (LustreIdent.equal x.LustreNode.name ident))
+            nodes
+          in filtered @ [n]
+      in nodes, globals
+  in
+    
     (* Name of main node *)
-    in let main_node = 
+    let main_node = 
       (* Command-line flag for main node given? *)
       match Flags.lus_main () with 
       (* Use given identifier to choose main node *)

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -143,7 +143,7 @@ let of_channel in_ch =
           IC.inline_constants ctx sorted_node_contract_decls >>= fun (ctx, const_inlined_nodes_and_contracts) ->
 
           (* Step 7. Normalize AST: guard pres, abstract to locals where appropriate *)
-          LAN.normalize const_inlined_nodes_and_contracts >>= fun (normalized_nodes_and_contracts, generated_ids) ->
+          LAN.normalize ctx const_inlined_nodes_and_contracts >>= fun (normalized_nodes_and_contracts, generated_ids) ->
           
           (* The last node in the original ordering should remain the last node after sorting 
             as the user expects that to be the main node in the case where 

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -738,9 +738,9 @@ let pp_print_node_debug ppf
          oracle_state_var_map = [@[<hv>%a@]];@ \
          state_var_expr_map = [@[<hv>%a@]]; }@]"
 
+    (I.pp_print_ident false) name
     StateVar.pp_print_state_var instance
     StateVar.pp_print_state_var init_flag
-    (I.pp_print_ident false) name
     pp_print_state_var_trie_debug inputs
     (pp_print_list StateVar.pp_print_state_var ";@ ") oracles
     pp_print_state_var_trie_debug outputs

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -655,9 +655,9 @@ let pp_print_node_call_debug
     pp_print_state_var_trie_debug call_outputs
 
 
-let pp_print_node_debug
-    ppf 
+let pp_print_node_debug ppf 
     { name;
+      is_extern;
       instance;
       init_flag;
       inputs; 
@@ -671,19 +671,20 @@ let pp_print_node_debug
       contract;
       is_main;
       is_function;
-      state_var_source_map } = 
+      state_var_source_map;
+      oracle_state_var_map;
+      state_var_expr_map;
+      silent_contracts } = 
 
   let pp_print_equation = pp_print_node_equation false in
 
   let pp_print_prop ppf (state_var, name, source) = 
-
     Format.fprintf
       ppf
       "%a (%s, %a)"
       StateVar.pp_print_state_var state_var
       name
       Property.pp_print_prop_source source
-
   in
 
   let pp_print_state_var_source ppf = 
@@ -701,7 +702,20 @@ let pp_print_node_debug
         Format.asprintf "al(%a)"
           StateVar.pp_print_state_var sub
       )*)
+  in
 
+  let pp_print_oracle_state_var_map =
+    pp_print_pair
+      StateVar.pp_print_state_var
+      StateVar.pp_print_state_var
+      ":"
+  in
+
+  let pp_print_state_var_expr_map =
+    pp_print_pair
+      StateVar.pp_print_state_var
+      (LustreExpr.pp_print_lustre_expr true)
+      ":"
   in
 
   Format.fprintf 
@@ -720,7 +734,9 @@ let pp_print_node_debug
          contract =   [@[<hv>%a@]];@ \
          is_main =    @[<hv>%B@];@ \
          is_function =    @[<hv>%B@];@ \
-         source_map = [@[<hv>%a@]]; }@]"
+         state_var_source_map = [@[<hv>%a@]];@ \
+         oracle_state_var_map = [@[<hv>%a@]];@ \
+         state_var_expr_map = [@[<hv>%a@]]; }@]"
 
     StateVar.pp_print_state_var instance
     StateVar.pp_print_state_var init_flag
@@ -740,8 +756,12 @@ let pp_print_node_debug
           (C.pp_print_contract false) contract) contract
     is_main
     is_function
-    (pp_print_list pp_print_state_var_source ";@ ") 
-    (SVM.bindings state_var_source_map)
+    (pp_print_list pp_print_state_var_source ";@ ")
+      (SVM.bindings state_var_source_map)
+    (pp_print_list pp_print_oracle_state_var_map ";@")
+      (SVT.fold (fun k v acc -> (k, v) :: acc) oracle_state_var_map [])
+    (pp_print_list pp_print_state_var_expr_map ";@")
+      (SVT.fold (fun k v acc -> (k, v) :: acc) state_var_expr_map [])
 
 
 (* ********************************************************************** *)

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -334,7 +334,7 @@ and compile_ast_expr (cstate:compiler_state) (ctx:C.tc_context) (bounds:E.expr E
     let id = I.mk_string_ident ident in
     let sv = H.find map id |> X.values |> List.hd in
     let ty = C.lookup_ty ctx ident in
-    let is_const = C.lookup_const ctx ident |> Option.is_some in
+    let is_const = C.lookup_const ctx ident |> is_some in
     let is_enum_ctor = match ty with
     | Some (A.EnumType (_, _, ctors)) -> List.exists (fun x -> x == ident) ctors
     | _ -> false

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -127,8 +127,6 @@ let extract_normalized = function
   | A.Ident (pos, ident) -> mk_ident ident
   | _ -> assert false
 
-let mk_state_var_index ident = X.map (fun x -> E.mk_var x) ident
-
 let add_state_var_bounds cstate sv bounds =
   SVT.add cstate.state_var_bounds sv bounds
   
@@ -970,7 +968,7 @@ and compile_node_decl gids is_function cstate ctx pos i ext inputs outputs local
     in List.fold_left over_generated_locals
       (gequations, state_var_expr_map)
       gids.LAN.node_args
-    (* ****************************************************************** *)
+  (* ****************************************************************** *)
   (* Split node items into relevant categories                          *)
   (* ****************************************************************** *)
   in let (node_props, node_eqs, node_asserts, node_automations, is_main) = 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -268,11 +268,8 @@ let expand_tuple pos lhs rhs =
 
 
 let rec compile ctx (gids:LAN.generated_identifiers LAN.StringMap.t) (decls:LustreAst.declaration list) =
-  let over_decls cstate (decl:LustreAst.declaration) =
-    let compiled_decl = compile_declaration cstate gids ctx decl in
-    { nodes = cstate.nodes @ compiled_decl.nodes;
-      free_constants = cstate.free_constants @ compiled_decl.free_constants }
-  in let output = List.fold_left over_decls empty_compiler_state decls in
+  let over_decls cstate decl = compile_declaration cstate gids ctx decl in
+  let output = List.fold_left over_decls empty_compiler_state decls in
   output.nodes,
     { G.free_constants = output.free_constants;
       G.state_var_bounds = SVT.create 7}
@@ -1040,8 +1037,9 @@ and compile_node_decl gids is_function cstate ctx pos i ext inputs outputs local
     oracle_state_var_map;
     state_var_expr_map;
     silent_contracts
-  } in { cstate with
-    nodes = node :: cstate.nodes
+  } in { 
+    nodes = node :: cstate.nodes;
+    free_constants = cstate.free_constants
   }
 
 and compile_const_decl cstate ctx = function

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -862,7 +862,7 @@ and compile_node_decl gids is_function cstate ctx pos i ext inputs outputs local
           "Clocked node local variable not supported for %a"
           A.pp_print_ident i)
       | _ -> None
-    in let locals_and_sources = List.filter_map over_locals locals in
+    in let locals_and_sources = list_filter_map over_locals locals in
     let split = fun (sv_list, svsm') (sv, svsm) ->
       sv :: sv_list, SVM.union (fun _ v _ -> Some v) svsm svsm'
     in List.fold_left split ([], state_var_source_map) locals_and_sources

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -124,8 +124,8 @@ let mk_state_var
   state_var, state_var_source_map'
 
 let mk_ident id = match String.split_on_char '_' id with
-  | i :: id :: [] -> (match int_of_string_opt i with
-    | Some i -> I.push_index (I.mk_string_ident id) i
+  | i :: id' :: [] -> (match int_of_string_opt i with
+    | Some i -> I.push_index (I.mk_string_ident id') i
     | None -> I.mk_string_ident id)
   | list -> I.mk_string_ident id
 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -610,7 +610,6 @@ and compile_node pos ctx cstate map oracles outputs cond restart ident args defa
       | A.Ident(p, i) -> (p, i)
       | _ -> assert false (* enforced by normalization step *))
     |> List.map (fun (p, i) -> p, H.find map (mk_ident i) |> fst)
-    |> List.rev
     |> List.combine input_keys
     |> List.fold_left
       (fun accum ((i, input_sv), (p, sv)) ->

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1,0 +1,1086 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2021 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+(** Translation of type checked AST to intermediate node model
+  
+  @author Andrew Marmaduke *)
+
+open Lib
+open LustreReporting
+
+module A = LustreAst
+module AH = LustreAstHelpers
+module LAN = LustreAstNormalizer
+module G = LustreGlobals
+module N = LustreNode
+module I = LustreIdent
+module X = LustreIndex
+module H = LustreIdent.Hashtbl
+module E = LustreExpr
+
+module SVM = StateVar.StateVarMap
+module SVT = StateVar.StateVarHashtbl
+
+module C = TypeCheckerContext
+
+
+type compiler_state = {
+  nodes : LustreNode.t list;
+  free_constants : (LustreIdent.t * Var.t LustreIndex.t) list;
+}
+
+let empty_compiler_state = { 
+  nodes = [];
+  free_constants = [];
+}
+
+(* Create a state variable for from an indexed state variable in a
+  scope *)
+let mk_state_var
+    ?is_input
+    ?is_const
+    ?for_inv_gen 
+    ?(shadow = false)
+    scope
+    ident 
+    index 
+    state_var_type
+    source
+    state_var_source_map = 
+  (* Concatenate identifier and indexes *)
+  let state_var_name = 
+    Format.asprintf "%a%a"
+      (I.pp_print_ident true) ident
+      (X.pp_print_index true) 
+
+      (* Filter out array indexes *)
+      (List.filter
+        (function 
+          | X.ArrayVarIndex _ 
+          | X.ArrayIntIndex _ -> false
+          | X.RecordIndex _
+          | X.TupleIndex _
+          | X.ListIndex _
+          | X.AbstractTypeIndex _ -> true)
+        index)
+  in
+  (* For each index add a scope to the identifier to distinguish the
+    flattened indexed identifier from unindexed identifiers
+
+    The scopes indicate the positions from the back of the string in
+    the flattened identifier where a new index begins.
+
+    The following indexed identifiers are all flattened to x_y_z, but
+    we can distinguish them by their scopes:
+
+    x_y_z  [] 
+    x.y.z  [2;2]
+    x.y_z  [4]
+    x_y.z  [2]
+  *)
+  let flatten_scopes = X.mk_scope_for_index index in
+  (* Create or retrieve state variable *)
+  let state_var =
+  (* TODO check this *)
+    try
+      StateVar.state_var_of_string
+        (state_var_name,
+        (List.map Ident.to_string (scope @ flatten_scopes)))
+    with Not_found ->
+      StateVar.mk_state_var
+        ?is_input
+        ?is_const
+        ?for_inv_gen 
+        state_var_name
+        (scope @ flatten_scopes)
+        state_var_type 
+  in let state_var_source_map' = match source with
+    | Some s -> SVM.add state_var s state_var_source_map
+    | None -> state_var_source_map
+  in
+  state_var, state_var_source_map'
+
+(* The LustreAstNormalizer is expected to normalize specific expression
+  positions to an identifier (or leave it be if it is a constnat).
+  That assumption is made explicit by calling this function. *)
+let extract_normalized = function
+  | A.Ident (pos, ident) -> ident
+  | A.Const (pos, True) -> "true"
+  | A.Const (pos, False) -> "false"
+  | A.Const (pos, Num x) -> x
+  | A.Const (pos, Dec x) -> x
+  | _ -> assert false
+
+let mk_state_var_index ident = X.map (fun x -> E.mk_var x) ident
+
+(* Match bindings from a trie of state variables and bindings for a
+  trie of expressions and produce a list of equations *)
+let rec expand_tuple' pos accum bounds lhs rhs = match lhs, rhs with 
+  (* No more equations, return in original order *)
+  | [], [] -> accum
+  (* Indexes are not of equal length *)
+  | _, []
+  | [], _ -> fail_at_position pos
+    "Type mismatch in equation: indexes not of equal length"
+    (* All indexes consumed *)
+  | ([], state_var) :: lhs_tl, 
+    ([], expr) :: rhs_tl -> 
+    expand_tuple' pos
+      (((state_var, List.rev bounds), expr) :: accum)
+      [] lhs_tl rhs_tl
+  (* Only array indexes may be left at head of indexes *)
+  | (X.ArrayVarIndex b :: lhs_index_tl, state_var) :: lhs_tl,
+    ([], expr) :: rhs_tl ->
+    expand_tuple' pos accum (E.Bound b :: bounds)
+      ((lhs_index_tl, state_var) :: lhs_tl)
+      (([], expr) :: rhs_tl)
+  (* Array variable on left-hand side, fixed index on right-hand side *)
+  | (X.ArrayVarIndex b :: lhs_index_tl, state_var) :: lhs_tl,
+    (X.ArrayIntIndex i :: rhs_index_tl, expr) :: rhs_tl -> 
+    (* Recurse to produce equations with this index *)
+    let accum' = 
+      expand_tuple' pos accum
+        (E.Fixed (E.mk_int_expr (Numeral.of_int i)) :: bounds)
+        [(lhs_index_tl, state_var)]
+        [(rhs_index_tl, expr)]
+    in
+    (* Return of no fixed indexes on right-hand side left *)
+    if rhs_tl = [] then accum' else
+      (* Continue with next fixed index on right-hand side and
+        variable index on left-hand side *)
+      expand_tuple' pos accum' bounds lhs rhs_tl
+  (* Array index on left-hand and right-hand side *)
+  | (X.ArrayVarIndex b :: lhs_index_tl, state_var) :: lhs_tl,
+    (X.ArrayVarIndex br :: rhs_index_tl, expr) :: rhs_tl -> 
+
+    (* We cannot compare expressions for array bounds syntactically,
+      because that may give too many false negatives. Evaluating both
+      bounds to find if they are equal would be too complicated,
+      therefore accept some false positives here. *)
+
+    (* Take the smaller bound when it is known statically otherwise keep the
+      one from the left-hand side *)
+    let b = if E.is_numeral b && E.is_numeral br
+      && Numeral.(E.(numeral_of_expr b > numeral_of_expr br))
+      then br
+      else b
+    in expand_tuple' pos accum (E.Bound b :: bounds)
+      ((lhs_index_tl, state_var) :: lhs_tl)
+      ((rhs_index_tl, expr) :: rhs_tl)
+  (* Tuple index on left-hand and right-hand side *)
+  | ((X.TupleIndex i :: lhs_index_tl, state_var) :: lhs_tl,
+    (X.TupleIndex j :: rhs_index_tl, expr) :: rhs_tl) 
+  | ((X.ListIndex i :: lhs_index_tl, state_var) :: lhs_tl,
+    (X.ListIndex j :: rhs_index_tl, expr) :: rhs_tl) 
+  | ((X.ArrayIntIndex i :: lhs_index_tl, state_var) :: lhs_tl,
+    (X.ArrayIntIndex j :: rhs_index_tl, expr) :: rhs_tl) -> 
+    (* Indexes are sorted, must match *)
+    if i = j then 
+      expand_tuple' pos accum bounds
+        ((lhs_index_tl, state_var) :: lhs_tl)
+        ((rhs_index_tl, expr) :: rhs_tl)
+    else fail_at_position pos
+      "Type mismatch in equation: indexes do not match"
+  (* Tuple index on left-hand and array index on right-hand side *)
+  | ((X.TupleIndex i :: lhs_index_tl, state_var) :: lhs_tl,
+    (X.ArrayIntIndex j :: rhs_index_tl, expr) :: rhs_tl) ->
+    (* Indexes are sorted, must match *)
+    if i = j then 
+      (* Use tuple index instead of array index on right-hand side *)
+      expand_tuple' pos accum bounds
+        ((lhs_index_tl, state_var) :: lhs_tl)
+        ((lhs_index_tl, expr) :: rhs_tl)
+    else fail_at_position pos
+      "Type mismatch in equation: indexes do not match"
+  (* Record index on left-hand and right-hand side *)
+  | (X.RecordIndex i :: lhs_index_tl, state_var) :: lhs_tl,
+    (X.RecordIndex j :: rhs_index_tl, expr) :: rhs_tl
+  (* Abstract type index works like record except program cannot project field *)
+  | (X.AbstractTypeIndex i :: lhs_index_tl, state_var) :: lhs_tl,
+    (X.AbstractTypeIndex j :: rhs_index_tl, expr) :: rhs_tl -> 
+    (* Indexes are sorted, must match *)
+    if i = j then 
+      expand_tuple' pos accum bounds
+        ((lhs_index_tl, state_var) :: lhs_tl)
+        ((rhs_index_tl, expr) :: rhs_tl)
+    else
+      fail_at_position pos
+        "Type mismatch in equation: record indexes do not match"
+  (* Mismatched indexes on left-hand and right-hand sides *)
+  | (X.RecordIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
+  | (X.RecordIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
+  | (X.RecordIndex _ :: _, _) :: _, (X.ArrayIntIndex _ :: _, _) :: _
+  | (X.RecordIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
+  | (X.RecordIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
+
+  | (X.TupleIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
+  | (X.TupleIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
+  | (X.TupleIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
+  | (X.TupleIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
+
+  | (X.ListIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
+  | (X.ListIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
+  | (X.ListIndex _ :: _, _) :: _, (X.ArrayIntIndex _ :: _, _) :: _
+  | (X.ListIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
+  | (X.ListIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
+
+  | (X.ArrayIntIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
+  | (X.ArrayIntIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
+  | (X.ArrayIntIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
+  | (X.ArrayIntIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
+  | (X.ArrayIntIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
+
+  | (X.ArrayVarIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
+  | (X.ArrayVarIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
+  | (X.ArrayVarIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
+  | (X.ArrayVarIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
+
+  | (X.AbstractTypeIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
+  | (X.AbstractTypeIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
+  | (X.AbstractTypeIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
+  | (X.AbstractTypeIndex _ :: _, _) :: _, (X.ArrayIntIndex _ :: _, _) :: _
+  | (X.AbstractTypeIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
+
+  | (_ :: _, _) :: _, ([], _) :: _ 
+  | ([], _) :: _, (_ :: _, _) :: _ -> fail_at_position pos
+    "Type mismatch in equation: head indexes do not match"
+
+(* Return a list of equations from a trie of state variables and a
+  trie of expressions *)
+let expand_tuple pos lhs rhs = 
+  expand_tuple' pos [] []
+    (List.map (fun (i, e) -> (i, e)) (X.bindings lhs))
+    (List.map (fun (i, e) -> (i, e)) (X.bindings rhs))
+
+
+let rec compile ctx (gids:LAN.generated_identifiers LAN.StringMap.t) (decls:LustreAst.declaration list) =
+  let over_decls cstate (decl:LustreAst.declaration) =
+    let compiled_decl = compile_declaration cstate gids ctx decl in
+    { nodes = cstate.nodes @ compiled_decl.nodes;
+      free_constants = cstate.free_constants @ compiled_decl.free_constants }
+  in let output = List.fold_left over_decls empty_compiler_state decls in
+  output.nodes,
+    { G.free_constants = output.free_constants;
+      G.state_var_bounds = SVT.create 7}
+
+and compile_ast_type (ctx:C.tc_context) = function
+  | A.TVar _ -> Lib.todo __LOC__
+  | A.Bool _ -> X.singleton X.empty_index Type.t_bool
+  | A.Int _ -> X.singleton X.empty_index Type.t_int
+  | A.UInt8 _ -> X.singleton X.empty_index (Type.t_ubv 8)
+  | A.UInt16 _ -> X.singleton X.empty_index (Type.t_ubv 16)
+  | A.UInt32 _ -> X.singleton X.empty_index (Type.t_ubv 32)
+  | A.UInt64 _ -> X.singleton X.empty_index (Type.t_ubv 64)
+  | A.Int8 _ -> X.singleton X.empty_index (Type.t_bv 8)
+  | A.Int16 _ -> X.singleton X.empty_index (Type.t_bv 16)
+  | A.Int32 _ -> X.singleton X.empty_index (Type.t_bv 32)
+  | A.Int64 _ -> X.singleton X.empty_index (Type.t_bv 64)
+  | A.Real _ -> X.singleton X.empty_index Type.t_real
+  | A.IntRange (pos, lbound, ubound) -> 
+    (* TODO: Old code does subtyping here, currently missing *)
+    (* TODO: This type should only be well-formed if bounds are constants 
+      This should be done in the type checker *)
+    Lib.todo __LOC__
+  | A.EnumType (pos, enum_name, enum_elements) ->
+      let ty = Type.mk_enum enum_name enum_elements in
+      X.singleton X.empty_index ty
+  | A.UserType (pos, ident) ->
+    (* Type checker should guarantee a type synonym exists *)
+    let ty = C.lookup_ty_syn ctx ident |> Option.get in
+    compile_ast_type ctx ty
+  | A.AbstractType (pos, ident) ->
+    X.singleton [X.AbstractTypeIndex ident] Type.t_int
+  | A.RecordType (pos, record_fields) ->
+    let over_fields = fun a (_, i, t) ->
+      let over_indices = fun j t a -> X.add (X.RecordIndex i :: j) t a in
+      let compiled_record_field_ty = compile_ast_type ctx t in
+      X.fold over_indices compiled_record_field_ty a
+    in
+    List.fold_left over_fields X.empty record_fields
+  | A.TupleType (pos, tuple_fields) ->
+    let over_fields = fun (i, a) t ->
+      let over_indices = fun j t a -> X.add (X.TupleIndex i :: j) t a in
+      let compiled_tuple_field_ty = compile_ast_type ctx t in
+      succ i, X.fold over_indices compiled_tuple_field_ty a
+    in
+    List.fold_left over_fields (0, X.empty) tuple_fields |> snd
+  | A.GroupType _ -> assert false
+      (* Lib.todo "Trying to flatten group type. Should not happen" *)
+  | A.ArrayType (pos, (type_expr, size_expr)) ->
+    (* TODO: Should we check that array size is constant here or later?
+      If the var_size flag is set, variable sized arrays are allowed
+      otherwise we should fail and make sure they are constant *)
+    Lib.todo __LOC__
+  | A.TArr _ -> assert false
+      (* Lib.todo "Trying to flatten function type. This should not happen" *)
+
+
+and compile_ast_expr (cstate:compiler_state) (ctx:C.tc_context) (bounds:E.expr E.bound_or_fixed list) map = 
+  let rec compile_id_string ident =
+    let id = I.mk_string_ident ident in
+    let sv = H.find map id |> X.values |> List.hd in
+    let ty = C.lookup_ty ctx ident in
+    let is_const = C.lookup_const ctx ident |> Option.is_some in
+    let is_enum_ctor = match ty with
+    | Some (A.EnumType (_, _, ctors)) -> List.exists (fun x -> x == ident) ctors
+    | _ -> false
+    in match (is_const, is_enum_ctor) with
+    | (false, false) -> X.singleton X.empty_index (E.mk_var sv)
+    | (true, false) -> Lib.todo __LOC__
+    | (false, true) -> let ty = Type.enum_of_constr ident in
+      X.singleton X.empty_index (E.mk_constr ident ty)
+    | _ -> assert false
+
+  and compile_mode_reference bounds path' =
+    Lib.todo __LOC__
+
+  and compile_unary bounds mk expr =
+    (* TODO: Old code does a type check here *)
+    X.map mk (compile_ast_expr cstate ctx bounds map expr)
+
+  and compile_binary bounds mk expr1 expr2 =
+    let expr1 = compile_ast_expr cstate ctx bounds map expr1 in
+    let expr2 = compile_ast_expr cstate ctx bounds map expr2 in
+    (* TODO: Old code does three error checks here doublecheck *)
+    X.map2 (fun _ -> mk) expr1 expr2
+
+  and compile_quantifier bounds mk avars expr =
+    let vars_of_quant ctx avars = Lib.todo __LOC__ in
+    let ctx, vars = vars_of_quant ctx avars in
+    let bounds = bounds @
+      List.map (fun v -> E.Unbound (E.unsafe_expr_of_term (Term.mk_var v)))
+        vars in
+    compile_unary bounds (E.mk_forall vars) expr
+
+  and compile_equality bounds polarity expr1 expr2 =
+    let (mk_binary, mk_seq, const_expr) = match polarity with
+      | true -> (E.mk_eq, E.mk_and, E.t_true)
+      | false -> (E.mk_neq, E.mk_or, E.t_false) in
+    let expr = compile_binary bounds mk_binary expr1 expr2 in
+    X.singleton X.empty_index (List.fold_left mk_seq const_expr (X.values expr))
+
+  and compile_ite bounds expr1 expr2 expr3 =
+    (* TODO: Old code checks that expr1 is a non-indexed boolean *)
+    let expr1 = compile_ast_expr cstate ctx bounds map expr1 in
+    let expr1 = match X.bindings expr1 with
+      | [_, expr] -> expr
+      | _ -> assert false
+    in compile_binary bounds (E.mk_ite expr1) expr2 expr3
+
+  and compile_pre bounds expr =
+    let cexpr = compile_ast_expr cstate ctx bounds map expr in
+    let over_indices index expr' accum =
+      let mk_lhs_term (sv, bounds) =
+        let over_bounds (i, t) = function
+          | E.Bound b -> succ i, Term.mk_select t
+            (Term.mk_var @@ E.var_of_expr @@ E.mk_index_var i)
+          | E.Unbound v -> i, Term.mk_select t v
+          | _ -> assert false
+        in let initial = (0, Var.mk_state_var_instance sv E.pre_offset |> Term.mk_var)
+        in List.fold_left over_bounds initial bounds |> snd
+      in let expr' = E.mk_pre mk_lhs_term expr' in
+      X.add index expr' accum
+    in X.fold over_indices cexpr X.empty
+
+  and compile_merge bounds pos clock_ident merge_cases =
+    Lib.todo __LOC__
+
+  and compile_projection bounds expr x =
+    Lib.todo __LOC__
+  
+  and compile_group_expr bounds mk expr_list =
+    let over_exprs = fun (i, accum) expr ->
+      let compiled_expr = compile_ast_expr cstate ctx bounds map expr in
+      let over_expr = fun j e a -> X.add (mk j i) e a in
+      (succ i, X.fold over_expr compiled_expr accum)
+    in List.fold_left over_exprs (0, X.empty) expr_list |> snd
+  
+  and compile_record_expr bounds expr_list =
+    Lib.todo __LOC__
+
+  and compile_struct_update expr1 index expr2 =
+    Lib.todo __LOC__
+
+  and compile_array_ctor bounds expr size_expr =
+    Lib.todo __LOC__
+
+  and compile_array_index bounds expr i =
+    Lib.todo __LOC__
+
+  and compile_node_call bounds map ident cond restart args defaults =
+    let called_node = N.node_of_name ident cstate.nodes in
+    let output_state_vars = X.fold (fun i sv accum ->
+          N.set_state_var_instance sv dummy_pos ident sv ;
+          N.add_state_var_def sv (N.CallOutput (dummy_pos, i)) ;
+          X.add i sv accum
+      ) called_node.outputs X.empty
+    in X.map E.mk_var output_state_vars
+
+  in function
+  (* ****************************************************************** *)
+  (* Identifiers                                                        *)
+  (* ****************************************************************** *)
+  | A.Ident (pos, ident) -> compile_id_string ident
+  | A.ModeRef (pos, path) -> compile_mode_reference bounds path
+  (* ****************************************************************** *)
+  (* Constants                                                          *)
+  (* ****************************************************************** *)
+  | A.Const (pos, A.True) -> X.singleton X.empty_index E.t_true
+  | A.Const (pos, A.False) -> X.singleton X.empty_index E.t_false
+  | A.Const (pos, A.Num d) ->
+    X.singleton X.empty_index (E.mk_int (Numeral.of_string d))
+  | A.Const (pos, A.Dec f) ->
+    X.singleton X.empty_index (E.mk_real (Decimal.of_string f))
+  (* ****************************************************************** *)
+  (* Unary Operators                                                    *)
+  (* ****************************************************************** *)
+  | A.ConvOp (pos, A.ToInt, expr) -> compile_unary bounds E.mk_to_int expr 
+  | A.ConvOp (pos, A.ToUInt8, expr) -> compile_unary bounds E.mk_to_uint8 expr
+  | A.ConvOp (pos, A.ToUInt16, expr) -> compile_unary bounds E.mk_to_uint16 expr
+  | A.ConvOp (pos, A.ToUInt32, expr) -> compile_unary bounds E.mk_to_uint32 expr
+  | A.ConvOp (pos, A.ToUInt64, expr) -> compile_unary bounds E.mk_to_uint64 expr
+  | A.ConvOp (pos, A.ToInt8, expr) -> compile_unary bounds E.mk_to_int8 expr
+  | A.ConvOp (pos, A.ToInt16, expr) -> compile_unary bounds E.mk_to_int16 expr
+  | A.ConvOp (pos, A.ToInt32, expr) -> compile_unary bounds E.mk_to_int32 expr
+  | A.ConvOp (pos, A.ToInt64, expr) -> compile_unary bounds E.mk_to_int64 expr
+  | A.ConvOp (pos, A.ToReal, expr) -> compile_unary bounds E.mk_to_real expr
+  | A.UnaryOp (pos, A.Not, expr) -> compile_unary bounds E.mk_not expr 
+  | A.UnaryOp (pos, A.Uminus, expr) -> compile_unary bounds E.mk_uminus expr 
+  | A.UnaryOp (pos, A.BVNot, expr) -> compile_unary bounds E.mk_bvnot expr
+  (* ****************************************************************** *)
+  (* Binary Operators                                                   *)
+  (* ****************************************************************** *)
+  | A.BinaryOp (pos, A.And, expr1, expr2) ->
+    compile_binary bounds E.mk_and expr1 expr2
+  | A.BinaryOp (pos, A.Or, expr1, expr2) ->
+    compile_binary bounds E.mk_or expr1 expr2 
+  | A.BinaryOp (pos, A.Xor, expr1, expr2) ->
+    compile_binary bounds E.mk_xor expr1 expr2 
+  | A.BinaryOp (pos, A.Impl, expr1, expr2) ->
+    compile_binary bounds E.mk_impl expr1 expr2 
+  | A.BinaryOp (pos, A.Mod, expr1, expr2) ->
+    compile_binary bounds E.mk_mod expr1 expr2 
+  | A.BinaryOp (pos, A.Minus, expr1, expr2) ->
+    compile_binary bounds E.mk_minus expr1 expr2
+  | A.BinaryOp (pos, A.Plus, expr1, expr2) ->
+    compile_binary bounds E.mk_plus expr1 expr2
+  | A.BinaryOp (pos, A.Div, expr1, expr2) ->
+    compile_binary bounds E.mk_div expr1 expr2 
+  | A.BinaryOp (pos, A.Times, expr1, expr2) ->
+    compile_binary bounds E.mk_times expr1 expr2 
+  | A.BinaryOp (pos, A.IntDiv, expr1, expr2) ->
+    compile_binary bounds E.mk_intdiv expr1 expr2 
+  | A.BinaryOp (pos, A.BVAnd, expr1, expr2) ->
+    compile_binary bounds E.mk_bvand expr1 expr2
+  | A.BinaryOp (pos, A.BVOr, expr1, expr2) ->
+    compile_binary bounds E.mk_bvor expr1 expr2
+  | A.BinaryOp (pos, A.BVShiftL, expr1, expr2) ->
+    compile_binary bounds E.mk_bvshl expr1 expr2
+  | A.BinaryOp (pos, A.BVShiftR, expr1, expr2) ->
+    compile_binary bounds E.mk_bvshr expr1 expr2
+  | A.CompOp (pos, A.Lte, expr1, expr2) ->
+    compile_binary bounds E.mk_lte expr1 expr2 
+  | A.CompOp (pos, A.Lt, expr1, expr2) ->
+    compile_binary bounds E.mk_lt expr1 expr2 
+  | A.CompOp (pos, A.Gte, expr1, expr2) ->
+    compile_binary bounds E.mk_gte expr1 expr2 
+  | A.CompOp (pos, A.Gt, expr1, expr2) ->
+    compile_binary bounds E.mk_gt expr1 expr2 
+  | A.Arrow (pos, expr1, expr2) ->
+    compile_binary bounds E.mk_arrow expr1 expr2
+  (* ****************************************************************** *)
+  (* Quantifiers                                                        *)
+  (* ****************************************************************** *)
+  | A.Quantifier (pos, A.Forall, avars, expr) ->
+    compile_quantifier bounds E.mk_forall avars expr
+  | A.Quantifier (pos, A.Exists, avars, expr) ->
+    compile_quantifier bounds E.mk_exists avars expr
+  (* ****************************************************************** *)
+  (* Other Operators                                                    *)
+  (* ****************************************************************** *)
+  | A.CompOp (pos, A.Eq, expr1, expr2) ->
+    compile_equality bounds true expr1 expr2
+  | A.CompOp (pos, A.Neq, expr1, expr2) ->
+    compile_equality bounds false expr1 expr2
+  | A.TernaryOp (pos, A.Ite, expr1, expr2, expr3) ->
+    compile_ite bounds expr1 expr2 expr3
+  | A.Last (pos, i) ->
+    compile_ast_expr cstate ctx bounds map (A.Pre (pos, A.Ident (pos, i)))
+  | A.Pre (pos, expr) -> compile_pre bounds expr
+  | A.Merge (pos, clock_ident, merge_cases) ->
+    compile_merge bounds pos clock_ident merge_cases
+  (* ****************************************************************** *)
+  (* Tuple and Record Operators                                         *)
+  (* ****************************************************************** *)
+  | A.RecordProject (pos, expr, field) ->
+    compile_projection bounds expr (X.RecordIndex field)
+  | A.TupleProject (pos, expr, field) ->
+    compile_projection bounds expr (X.TupleIndex field)
+  | A.GroupExpr (pos, A.ExprList, expr_list) ->
+    let rec flatten_expr_list accum = function
+      | [] -> List.rev accum
+      | A.GroupExpr (pos, A.ExprList, expr_list) :: tl -> 
+        flatten_expr_list accum (expr_list @ tl)
+      | expr :: tl -> flatten_expr_list (expr :: accum) tl
+    in let expr_list = flatten_expr_list [] expr_list in
+    compile_group_expr bounds (fun j i -> X.ListIndex i :: j) expr_list
+  | A.GroupExpr (pos, A.TupleExpr, expr_list) ->
+    compile_group_expr bounds (fun j i -> X.TupleIndex i :: j) expr_list
+  | A.RecordExpr (pos, record_type, expr_list) -> 
+    compile_record_expr bounds expr_list
+  | A.StructUpdate (pos, expr1, index, expr2) ->
+    compile_struct_update expr1 index expr2
+  (* ****************************************************************** *)
+  (* Node Calls                                                         *)
+  (* ****************************************************************** *)
+  | A.Condact (pos, cond, restart, ident, args, defaults) ->
+    let id = I.mk_string_ident ident in
+    compile_node_call bounds map id cond restart args (Some defaults)
+  | A.Call (pos, ident, args)
+  | A.RestartEvery (pos, ident, args, A.Const (_, A.False)) ->
+    let id = I.mk_string_ident ident in
+    let cond = A.Const (dummy_pos, A.True) in
+    let restart = A.Const (dummy_pos, A.False) in
+    compile_node_call bounds map id cond restart args None
+  | A.RestartEvery (pos, ident, args, restart) ->
+    let id = I.mk_string_ident ident in
+    let cond = A.Const (dummy_pos, A.True) in
+    compile_node_call bounds map id cond restart args None
+  (* ****************************************************************** *)
+  (* Array Operators                                                    *)
+  (* ****************************************************************** *)
+  | A.GroupExpr (pos, A.ArrayExpr, expr_list) ->
+    compile_group_expr bounds (fun j i -> j @[X.ArrayIntIndex i]) expr_list
+  | A.ArrayConstr (pos, expr, size_expr) ->
+    compile_array_ctor bounds expr size_expr
+  | A.ArrayIndex (pos, expr, i) -> compile_array_index bounds expr i
+  (* ****************************************************************** *)
+  (* Not Implemented                                                    *)
+  (* ****************************************************************** *)
+  (* TODO below, roughly in order of importance and difficulty *)
+  | A.ArraySlice (pos, _, _) -> fail_at_position pos
+    "Array slices not implemented"
+  (* Concatenation of arrays [A|B] *)
+  | A.ArrayConcat (pos, _, _) -> fail_at_position pos
+    "Array concatenation not implemented"
+  (* Interpolation to base clock *)
+  | A.Current (pos, A.When (_, _, _)) -> fail_at_position pos
+    "Current expression not supported"
+  (* Boolean at-most-one constaint *)
+  | A.NArityOp (pos, A.OneHot, _) -> fail_at_position pos
+    "One-hot expression not supported"
+  (* Followed by operator *)
+  | A.Fby (pos, _, _, _) -> fail_at_position pos
+    "Fby operator not implemented" 
+  (* Projection on clock *)
+  | A.When (pos, _, _) -> fail_at_position pos
+    "When expression must be the argument of a current operator"
+  (* Interpolation to base clock *)
+  | A.Current (pos, _) -> fail_at_position pos
+    "Current operator must have a when expression as argument"
+  | A.Activate (pos, _, _, _, _) -> fail_at_position pos
+    "Activate operator only supported in merge"
+  (* With operator for recursive node calls *)
+  | A.TernaryOp (pos, A.With, _, _, _) -> fail_at_position pos
+    "Recursive nodes not supported"
+  (* Node call to a parametric node *)
+  | A.CallParam (pos, _, _, _) -> fail_at_position pos
+    "Parametric nodes not supported" 
+
+and compile_node_calls cstate ctx map = 
+  let compile_node pos cstate map cond restart ident args defaults =
+    let called_node = N.node_of_name ident cstate.nodes in
+    let node_inputs_of_exprs inputs ast =
+      let cexpr = compile_ast_expr cstate ctx [] map
+        (A.GroupExpr (dummy_pos, A.ExprList, ast)) in
+      X.fold2 (fun i state_var expr accum -> X.add i state_var accum)
+        inputs
+        cexpr
+        X.empty
+    in let node_act_cond_of_expr outputs cond defaults =
+      let cond_test = match cond with
+        | A.Const (pos, A.True) -> true
+        | _ -> false
+      in if cond_test then None, None
+      else
+        let state_var = match cond with
+          | A.Ident (pos, id) ->
+            let ident = I.mk_string_ident id
+            in H.find map ident |> X.values |> List.hd
+          | _ -> assert false
+        in let defaults' = match defaults with
+          | Some [d] -> Some (compile_ast_expr cstate ctx [] map d)
+          | Some d -> Some (compile_ast_expr cstate ctx [] map
+            (A.GroupExpr (dummy_pos, A.ExprList, d)))
+          | None -> None
+        in Some state_var, defaults'
+    in let restart_cond_of_expr restart =
+      let restart_test = match restart with
+        | A.Const (pos, A.False) -> true
+        | _ -> false
+      in if restart_test then None
+      else let state_var = match restart with
+        | A.Ident (pos, id) ->
+          let ident = I.mk_string_ident id
+          in H.find map ident |> X.values |> List.hd
+        | _ -> assert false
+      in Some state_var
+    in let input_state_vars = node_inputs_of_exprs called_node.inputs args in
+    let act_state_var, defaults = node_act_cond_of_expr called_node.outputs cond defaults in
+    let restart_state_var = restart_cond_of_expr restart in
+    let cond_state_var = match act_state_var, restart_state_var with
+      | None, None -> []
+      | Some c, None -> [N.CActivate c]
+      | None, Some r -> [N.CRestart r]
+      | Some c, Some r -> [N.CActivate c; N.CRestart r]
+    in let node_call = {
+      N.call_pos = pos;
+      N.call_node_name = ident;
+      N.call_cond = cond_state_var;
+      N.call_inputs = input_state_vars;
+      N.call_oracles = called_node.oracles;
+      N.call_outputs = called_node.outputs;
+      N.call_defaults = defaults
+    }
+    in [node_call]
+
+  in function
+  | A.Ident (pos, ident) -> []
+  | A.ModeRef (pos, path) -> []
+  | A.Const (pos, x) -> []
+  | A.ConvOp (pos, conv, expr) -> compile_node_calls cstate ctx map expr
+  | A.UnaryOp (pos, op, expr) -> compile_node_calls cstate ctx map expr
+  | A.BinaryOp (pos, op, expr1, expr2) ->
+    let calls1 = compile_node_calls cstate ctx map expr1 in
+    let calls2 = compile_node_calls cstate ctx map expr2 in
+    calls1 @ calls2
+  | A.CompOp (pos, op, expr1, expr2) ->
+    let calls1 = compile_node_calls cstate ctx map expr1 in
+    let calls2 = compile_node_calls cstate ctx map expr2 in
+    calls1 @ calls2
+  | A.Arrow (pos, expr1, expr2) ->
+    let calls1 = compile_node_calls cstate ctx map expr1 in
+    let calls2 = compile_node_calls cstate ctx map expr2 in
+    calls1 @ calls2
+  | A.Quantifier (pos, quantifier, avars, expr) ->
+    compile_node_calls cstate ctx map expr
+  | A.TernaryOp (pos, A.Ite, expr1, expr2, expr3) ->
+    let calls1 = compile_node_calls cstate ctx map expr1 in
+    let calls2 = compile_node_calls cstate ctx map expr2 in
+    let calls3 = compile_node_calls cstate ctx map expr3 in
+    calls1 @ calls2 @ calls3
+  | A.Last (pos, i) -> []
+  | A.Pre (pos, expr) -> compile_node_calls cstate ctx map expr
+  | A.Merge (pos, clock_ident, merge_cases) ->
+    List.fold_left (fun x (i, expr) -> x @ compile_node_calls cstate ctx map expr)
+      [] merge_cases
+  | A.RecordProject (pos, expr, field) -> compile_node_calls cstate ctx map expr
+  | A.TupleProject (pos, expr, field) -> compile_node_calls cstate ctx map expr
+  | A.GroupExpr (pos, kind, expr_list) ->
+    List.fold_left (fun x expr -> x @ compile_node_calls cstate ctx map expr)
+      [] expr_list
+  | A.RecordExpr (pos, record_type, expr_list) -> 
+    List.fold_left (fun x (i, expr) -> x @ compile_node_calls cstate ctx map expr)
+      [] expr_list
+  | A.StructUpdate (pos, expr1, index, expr2) ->
+    let calls1 = compile_node_calls cstate ctx map expr1 in
+    let calls2 = compile_node_calls cstate ctx map expr2 in
+    calls1 @ calls2
+  | A.ArrayConstr (pos, expr, size_expr) ->
+    let calls1 = compile_node_calls cstate ctx map expr in
+    let calls2 = compile_node_calls cstate ctx map size_expr in
+    calls1 @ calls2
+  | A.ArrayIndex (pos, expr, i) ->
+    let calls1 = compile_node_calls cstate ctx map expr in
+    let calls2 = compile_node_calls cstate ctx map i in
+    calls1 @ calls2
+  (* ****************************************************************** *)
+  (* Node Calls                                                         *)
+  (* ****************************************************************** *)
+  | A.Condact (pos, cond, restart, ident, args, defaults) ->
+    let id = I.mk_string_ident ident in
+    compile_node pos cstate map cond restart id args (Some defaults)
+  | A.Call (pos, ident, args)
+  | A.RestartEvery (pos, ident, args, A.Const (_, A.False)) ->
+    let id = I.mk_string_ident ident in
+    let cond = A.Const (dummy_pos, A.True) in
+    let restart = A.Const (dummy_pos, A.False) in
+    compile_node pos cstate map cond restart id args None
+  | A.RestartEvery (pos, ident, args, restart) ->
+    let id = I.mk_string_ident ident in
+    let cond = A.Const (dummy_pos, A.True) in
+    compile_node pos cstate map cond restart id args None
+  (* ****************************************************************** *)
+  (* Not Implemented                                                    *)
+  (* ****************************************************************** *)
+  (* TODO below, roughly in order of importance and difficulty *)
+  | A.ArraySlice (pos, _, _) -> fail_at_position pos
+    "Array slices not implemented"
+  (* Concatenation of arrays [A|B] *)
+  | A.ArrayConcat (pos, _, _) -> fail_at_position pos
+    "Array concatenation not implemented"
+  (* Interpolation to base clock *)
+  | A.Current (pos, A.When (_, _, _)) -> fail_at_position pos
+    "Current expression not supported"
+  (* Boolean at-most-one constaint *)
+  | A.NArityOp (pos, A.OneHot, _) -> fail_at_position pos
+    "One-hot expression not supported"
+  (* Followed by operator *)
+  | A.Fby (pos, _, _, _) -> fail_at_position pos
+    "Fby operator not implemented" 
+  (* Projection on clock *)
+  | A.When (pos, _, _) -> fail_at_position pos
+    "When expression must be the argument of a current operator"
+  (* Interpolation to base clock *)
+  | A.Current (pos, _) -> fail_at_position pos
+    "Current operator must have a when expression as argument"
+  | A.Activate (pos, _, _, _, _) -> fail_at_position pos
+    "Activate operator only supported in merge"
+  (* With operator for recursive node calls *)
+  | A.TernaryOp (pos, A.With, _, _, _) -> fail_at_position pos
+    "Recursive nodes not supported"
+  (* Node call to a parametric node *)
+  | A.CallParam (pos, _, _, _) -> fail_at_position pos
+    "Parametric nodes not supported" 
+
+  
+and compile_node_decl gids is_function cstate ctx pos i ext inputs outputs locals items contracts =
+  let name = I.mk_string_ident i in
+  let node_scope = name |> I.to_scope in
+  let state_var_source_map = SVM.empty in
+  let is_extern = ext in
+  let instance =
+    StateVar.mk_state_var
+      ~is_const:true
+      (I.instance_ident |> I.string_of_ident false)
+      (I.to_scope name @ I.reserved_scope)
+      Type.t_int
+  in let init_flag = 
+    StateVar.mk_state_var
+      (I.init_flag_ident |> I.string_of_ident false)
+      (I.to_scope name @ I.reserved_scope)
+      Type.t_bool
+  in let ident_map = H.create 7
+  (* ****************************************************************** *)
+  (* Node Inputs                                                        *)
+  (* ****************************************************************** *)
+  in let (inputs, state_var_source_map) =
+    (* TODO: The documentation on lustreNode says that a single argument
+      node should have a non-list index (a singleton index), but the old
+      node generation code does not seem to honor that *)
+    let over_inputs = fun (compiled_input, svsm) (pos, i, ast_type, clock, is_const) ->
+      match clock with
+      | A.ClockTrue ->
+        let n = X.top_max_index compiled_input |> succ in
+        let ident = I.mk_string_ident i in
+        let index_types = compile_ast_type ctx ast_type in
+        let over_indices = fun index index_type (accum, svsm) ->
+          let state_var, svsm = mk_state_var
+            ~is_input:true
+            ~is_const
+            (node_scope @ I.user_scope)
+            ident
+            index
+            index_type
+            (Some N.Input)
+            svsm
+          in let result = X.add (X.ListIndex n :: index) state_var accum
+          in H.add ident_map ident result;
+          result, svsm
+        in X.fold over_indices index_types (compiled_input, svsm)
+      | _ -> fail_at_position pos "Clocked node inputs not supported"
+    in List.fold_left over_inputs (X.empty, state_var_source_map) inputs
+  (* ****************************************************************** *)
+  (* Node Outputs                                                       *)
+  (* ****************************************************************** *)
+  in let (outputs, state_var_source_map) =
+    (* TODO: The documentation on lustreNode does not state anything about
+      the requirements for indices of outputs, yet the old code makes it
+      a singleton index in the event there is only one index *)
+    let over_outputs = fun (is_single) (compiled_output, svsm) (pos, i, ast_type, clock) ->
+      match clock with
+      | A.ClockTrue ->
+        let n = X.top_max_index compiled_output |> succ in
+        let ident = I.mk_string_ident i in
+        let index_types = compile_ast_type ctx ast_type in
+        let over_indices = fun index index_type (accum, svsm) ->
+          let state_var, svsm = mk_state_var
+            ~is_input:false
+            (node_scope @ I.user_scope)
+            ident
+            index
+            index_type
+            (Some N.Output)
+            svsm
+          and index' = if is_single then index
+            else X.ListIndex n :: index
+          in let result = X.add index' state_var accum
+          in H.add ident_map ident result;
+          result, svsm
+        in X.fold over_indices index_types (compiled_output, svsm)
+      | _ -> fail_at_position pos "Clocked node outputs not supported"
+    and is_single = List.length outputs = 1
+    in List.fold_left (over_outputs is_single) (X.empty, state_var_source_map) outputs
+  (* ****************************************************************** *)
+  (* User Locals                                                        *)
+  (* ****************************************************************** *)
+  in let (locals, state_var_source_map) =
+    let over_locals = fun local ->
+      match local with
+      | A.NodeVarDecl (_, (pos, i, ast_type, A.ClockTrue)) ->
+        let ident = I.mk_string_ident i
+        and index_types = compile_ast_type ctx ast_type in
+        let over_indices = fun index index_type (accum, svsm) ->
+          let state_var, svsm = mk_state_var
+            ~is_input:false
+            (node_scope @ "impl" :: I.user_scope)
+            ident
+            index
+            index_type
+            (Some N.Local)
+            svsm
+          in let result = X.add index state_var accum
+          in H.add ident_map ident result;
+          result, svsm
+        in Some (X.fold over_indices index_types (X.empty, state_var_source_map))
+      | A.NodeVarDecl (_, (pos, i, _, _)) -> fail_at_position pos
+        (Format.asprintf
+          "Clocked node local variable not supported for %a"
+          A.pp_print_ident i)
+      | _ -> None
+    in let locals_and_sources = List.filter_map over_locals locals in
+    let split = fun (sv_list, svsm') (sv, svsm) ->
+      sv :: sv_list, SVM.union (fun _ v _ -> Some v) svsm svsm'
+    in List.fold_left split ([], state_var_source_map) locals_and_sources
+  (* ****************************************************************** *)
+  (* Generated Locals                                                   *)
+  (* ****************************************************************** *)
+  in let (glocals, gequations, state_var_source_map, state_var_expr_map) =
+    let generated_locals = LAN.StringMap.bindings gids.LAN.locals in
+    let over_generated_locals (glocals, geqns, svsm, svem) (id, expr) =
+      let ident = I.mk_string_ident id in
+      let nexpr = compile_ast_expr cstate ctx [] ident_map expr in
+      let nexpr' = nexpr |> X.values |> List.hd in
+      let state_var, svsm = mk_state_var
+        (node_scope @ I.reserved_scope)
+        ident
+        X.empty_index
+        (E.type_of_lustre_expr nexpr')
+        None
+        svsm
+      in let result = X.singleton X.empty_index state_var in
+      let equation = expand_tuple pos result nexpr in
+      H.add ident_map ident result;
+      SVT.add svem state_var nexpr';
+      result :: glocals, equation @ geqns, svsm, svem
+    in List.fold_left over_generated_locals
+      ([], [], state_var_source_map, SVT.create 7)
+      generated_locals
+  (* ****************************************************************** *)
+  (* Oracles                                                            *)
+  (* ****************************************************************** *)
+  in let (oracles, state_var_source_map, oracle_state_var_map) =
+    let over_oracles (oracles, svsm, osvm) (id, expr) =
+      let oracle_ident = I.mk_string_ident id in
+      let (closed_sv, state_var_type) = match expr with
+        | A.Ident (pos, id') ->
+          let ident = I.mk_string_ident id' in
+          let closed_sv = H.find ident_map ident |> X.values |> List.hd in
+          (Some closed_sv), StateVar.type_of_state_var closed_sv
+        | A.Const (pos, v) -> None, (match v with
+          | A.True | A.False -> Type.mk_bool ()
+          | A.Dec _ -> Type.mk_real ()
+          | A.Num _ -> Type.mk_int ())
+        | _ -> assert false
+      in let state_var, svsm = mk_state_var
+        (node_scope @ I.reserved_scope)
+        oracle_ident
+        X.empty_index
+        state_var_type
+        (Some N.Oracle)
+        svsm
+      in let result = X.singleton X.empty_index state_var in 
+      H.add ident_map oracle_ident result;
+      (match closed_sv with
+        | Some sv -> SVT.add osvm state_var sv
+        | None -> ());
+      state_var :: oracles, svsm, osvm
+    in List.fold_left over_oracles
+      ([], state_var_source_map, SVT.create 7)
+      gids.LAN.oracles
+  (* ****************************************************************** *)
+  (* Split node items into relevant categories                          *)
+  (* ****************************************************************** *)
+  in let (node_props, node_eqs, node_asserts, node_automations, is_main) = 
+    let over_items = fun (props, eqs, asserts, autos, is_main) (item) ->
+      match item with
+      | A.Body e -> (match e with
+        | A.Assert (p, e) -> (props, eqs, (p, e) :: asserts, autos, is_main)
+        | A.Equation (p, l, e) -> (props, (p, l, e) :: eqs, asserts, autos, is_main)
+        | A.Automaton (p, s, i, r) -> (props, eqs, asserts, (p, s, i, r) :: autos, is_main))
+      | A.AnnotMain flag -> (props, eqs, asserts, autos, flag || is_main)
+      | A.AnnotProperty (p, n, e) -> ((p, n, e) :: props, eqs, asserts, autos, is_main) 
+    in List.fold_left over_items ([], [], [], [], false) items
+  (* ****************************************************************** *)
+  (* Properties and Assertions                                          *)
+  (* ****************************************************************** *)
+  in let props =
+    let op (pos, name_opt, expr) =
+      let id = extract_normalized expr |> I.mk_string_ident in
+      let sv_index = H.find ident_map id in
+      let sv = sv_index |> X.values |> List.hd in
+      let name = match name_opt with
+        | Some n -> n
+        | None -> Format.asprintf "@[<h>%a@]" A.pp_print_expr expr
+      in sv, name, (Property.PropAnnot pos)
+    in List.map op node_props
+
+  in let asserts =
+    let op (pos, expr) =
+      let id = extract_normalized expr |> I.mk_string_ident in
+      let sv_index = H.find ident_map id in
+      let sv = sv_index |> X.values |> List.hd in
+      (pos, sv)
+    in List.map op node_asserts
+  (* ****************************************************************** *)
+  (* Compile Equations and Node Calls                                   *)
+  (* ****************************************************************** *)
+  in let (equations, calls) =
+    let compile_struct_item = fun struct_item -> match struct_item with
+      | A.SingleIdent (pos, i) ->
+        let ident = I.mk_string_ident i in
+        H.find ident_map ident, 0
+      | A.ArrayDef (pos, i, l) ->
+        let ident = I.mk_string_ident i in
+        let result = H.find ident_map ident in
+        (* TODO: Old code checks that array lengths between l and result match *)
+        (* TODO: Old code checks that result must have at least one element *)
+        (* TODO: Old code suggets that shadowing can occur here *)
+        let indexes = List.length l in
+        result, indexes
+      | A.TupleStructItem (pos, _)
+      | A.TupleSelection (pos, _, _)
+      | A.FieldSelection (pos, _, _)
+      | A.ArraySliceStructItem (pos, _, _) ->
+        fail_at_position pos "Assignment not supported"
+
+    in let over_equations = fun (eqns, calls) (pos, lhs, ast_expr) ->
+      let eq_lhs, indexes = match lhs with
+        | A.StructDef (pos, []) -> (X.empty, 0)
+        | A.StructDef (pos, [e]) -> compile_struct_item e
+        | A.StructDef (pos, l) ->
+          let construct_index = fun i j e a -> X.add (X.ListIndex i :: j) e a in
+          let over_items = fun (i, accum) e -> 
+            let t, _ = compile_struct_item e in
+              i + 1, X.fold (construct_index i) t accum
+          in let i, res = List.fold_left over_items (0, X.empty) l
+          in res, 0
+
+      in let rm_array_var_index lst =
+        List.filter (function
+        | X.ArrayVarIndex _ -> false
+        | _ -> true
+        ) lst
+
+      in let lhs_bounds = List.fold_left (fun acc (i, sv) ->
+        N.add_state_var_def sv (N.ProperEq (AH.pos_of_expr ast_expr, rm_array_var_index i)) ;
+        List.fold_left (fun (acc, cpt) -> function
+            | X.ArrayVarIndex b -> if cpt < indexes
+              then E.Bound b :: acc, succ cpt
+              else acc, cpt
+            | _ -> acc, cpt
+          ) (acc, 0) i
+        |> fst
+      ) [] (X.bindings eq_lhs)
+
+      in let eq_rhs = compile_ast_expr cstate ctx lhs_bounds ident_map ast_expr
+      in let equations = expand_tuple pos eq_lhs eq_rhs in
+      let node_calls = compile_node_calls cstate ctx ident_map ast_expr in
+      (* TODO: Old code tries to infer a more strict type here
+        lustreContext 2040+ *)
+      (equations @ eqns, node_calls @ calls)
+    in List.fold_left over_equations ([], []) node_eqs
+  in let locals = locals @ glocals in
+  let equations = equations @ gequations
+  
+  (* TODO: Not currently handling contracts *)
+  in let contract = None
+  in let silent_contracts = []
+
+  in let (node:N.t) = { name;
+    is_extern;
+    instance;
+    init_flag;
+    inputs;
+    oracles;
+    outputs;
+    locals;
+    equations;
+    calls;
+    asserts;
+    props;
+    contract;
+    is_main;
+    is_function;
+    state_var_source_map;
+    oracle_state_var_map;
+    state_var_expr_map;
+    silent_contracts
+  } in { cstate with
+    nodes = node :: cstate.nodes
+  }
+
+and compile_const_decl cstate ctx = function
+  | A.FreeConst (pos, i, ty) ->
+    let ident = I.mk_string_ident i in
+    let cty = compile_ast_type ctx ty in
+    let over_index = fun i ty vt ->
+      let state_var, _ = mk_state_var
+        ?is_input:(Some false)
+        ?is_const:(Some true)
+        ?for_inv_gen:(Some true)
+        I.user_scope
+        ident
+        i
+        ty
+        None
+        SVM.empty
+      in let v = Var.mk_const_state_var state_var in
+      X.add i v vt
+    in let vt = X.fold over_index cty X.empty in
+    { cstate with free_constants = (ident, vt) :: cstate.free_constants }
+  (* TODO: Old code does some subtyping checks for Typed constants
+    Otherwise these other constants are used only for constant propagation *)
+  | _ -> cstate
+
+and compile_declaration cstate gids ctx = function
+  | A.TypeDecl (pos, type_rhs) -> cstate
+  | A.ConstDecl (pos, const_decl) -> compile_const_decl cstate ctx const_decl
+  | A.FuncDecl (span, (i, ext, [], inputs, outputs, locals, items, contracts)) ->
+    let pos = span.start_pos in
+    let gids = LAN.StringMap.find i gids in
+    compile_node_decl gids true cstate ctx pos i ext inputs outputs locals items contracts
+  | A.NodeDecl (span, (i, ext, [], inputs, outputs, locals, items, contracts)) ->
+    let pos = span.start_pos in
+    let gids = LAN.StringMap.find i gids in
+    compile_node_decl gids false cstate ctx pos i ext inputs outputs locals items contracts
+  | A.ContractNodeDecl (pos, node_decl) -> Lib.todo __LOC__
+  | A.NodeParamInst (pos, _)
+  | A.NodeDecl (pos, _) ->
+    fail_at_position pos.start_pos "Parametric nodes are not supported"
+  | A.FuncDecl (pos, _) ->
+    fail_at_position pos.start_pos "Parametric functions are not supported"

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -300,7 +300,7 @@ and compile_ast_type (ctx:C.tc_context) = function
       X.singleton X.empty_index ty
   | A.UserType (pos, ident) ->
     (* Type checker should guarantee a type synonym exists *)
-    let ty = C.lookup_ty_syn ctx ident |> Option.get in
+    let ty = C.lookup_ty_syn ctx ident |> get in
     compile_ast_type ctx ty
   | A.AbstractType (pos, ident) ->
     X.singleton [X.AbstractTypeIndex ident] Type.t_int

--- a/src/lustre/lustreNodeGen.mli
+++ b/src/lustre/lustreNodeGen.mli
@@ -1,0 +1,26 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2021 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+ *)
+(** Translation of type checked AST to intermediate node model
+  
+  @author Andrew Marmaduke *)
+
+val compile : TypeCheckerContext.tc_context
+-> LustreAstNormalizer.generated_identifiers LustreAstNormalizer.StringMap.t
+-> LustreAst.declaration list
+-> LustreNode.t list * LustreGlobals.t
+ 

--- a/src/lustre/lustreSimplify.ml
+++ b/src/lustre/lustreSimplify.ml
@@ -447,7 +447,7 @@ let rec eval_ast_expr bounds ctx =
             res
            in
            let expr', ctx =
-             E.mk_pre
+             E.mk_pre_with_context
               mk_local
               mk_lhs_term
               ctx

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1523,7 +1523,7 @@ let type_check_infer_nodes_and_contracts: tc_context -> LA.t -> tc_context tc_re
           (Log.log L_trace ("===============================================\n"
                             ^^ "Type checking declaration Groups Done\n"
                             ^^"===============================================\n")
-          ;  R.ok ctx))
+          ; R.ok global_ctx))
 
 (* 
    Local Variables:

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -39,6 +39,11 @@ val type_check_infer_nodes_and_contracts: tc_context -> LA.t -> tc_context tc_re
 val report_tc_result: unit tc_result list -> unit tc_result
 (** Report whether everything is [Ok] or if there are any [Error]s *)
 
+val local_var_binding: tc_context -> LA.node_local_decl -> tc_context tc_result
+
+val infer_type_expr: tc_context -> LA.expr -> tc_type tc_result
+(** Infer type of Lustre expression given a typing context *)
+
 (* 
    Local Variables:
    compile-command: "make -k -C .."

--- a/src/terms/stateVar.ml
+++ b/src/terms/stateVar.ml
@@ -165,6 +165,15 @@ let uf_symbols_map = UfSymbol.UfSymbolHashtbl.create 41
 (* Pretty-printing                                                       *)
 (* ********************************************************************* *)
 
+(* Pretty-print the property of a state variable *)
+let pp_print_state_var_prop ppf prop =
+  Format.fprintf ppf
+    "{var_type:%a; uf_symbol:%a; is_input:%b; is_const:%b; for_inv_gen:%b"
+    Type.pp_print_type prop.var_type
+    UfSymbol.pp_print_uf_symbol prop.uf_symbol
+    prop.is_input
+    prop.is_const
+    prop.for_inv_gen
 
 (* Pretty-print a scoped name of a state variable *)
 let pp_print_state_var_name ppf (n, s) =
@@ -186,6 +195,11 @@ let pp_print_state_var_node ppf (n, s) =
 (* Pretty-print a hashconsed state variable *)
 let pp_print_state_var ppf { Hashcons.node = (n, s) } =
   pp_print_state_var_node ppf (n, s)
+
+let pp_print_state_var_debug ppf state_var =
+  Format.fprintf ppf "node %a;prop %a\n"
+    (pp_print_state_var_name) state_var.Hashcons.node
+    (pp_print_state_var_prop) state_var.Hashcons.prop
 
 (* Return a string representation of a hashconsed state variable *)
 let string_of_state_var s = string_of_t pp_print_state_var s

--- a/src/terms/stateVar.mli
+++ b/src/terms/stateVar.mli
@@ -158,6 +158,8 @@ val get_select_ufs : unit -> UfSymbol.t list
 (** Pretty-print a state variable *)
 val pp_print_state_var : Format.formatter -> t -> unit
 
+val pp_print_state_var_debug : Format.formatter -> t -> unit
+
 (** Return a string representation of a symbol *)
 val string_of_state_var : t -> string
 

--- a/src/utils/Res.mli
+++ b/src/utils/Res.mli
@@ -74,15 +74,10 @@ val  safe_unwrap: 'a -> ('a, 'e) result -> 'a
 val unwrap : 'a res -> 'a
 
 (** Maps functions to [Ok] or [Err]. *)
-val map_res: ('a -> 'b) -> (
-  (Format.formatter -> unit) -> Format.formatter -> unit
-) -> 'a res -> 'b res
+val map_res: ('a -> 'b) -> ('c -> 'd) -> ('a, 'c) result -> ('b, 'd) result
 
-  
 (** Maps a function to a result if it's [Err]. *)
-val map_err: (
-  (Format.formatter -> unit) -> Format.formatter -> unit
-) -> 'a res -> 'a res
+val map_err: ('a -> 'b) -> ('c, 'a) result -> ('c, 'b) result
 
 (** Feeds a result to a function returning a result, propagates if argument's
 an error. *)

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -405,14 +405,8 @@ let list_join equal l1 l2 =
     | _ -> list_join' equal [] l1 l2
 
 let list_filter_map f =
-  let rec rev_append l1 l2 =
-    match l1 with
-      [] -> l2
-    | a :: l -> rev_append l (a :: l2)
-  in
-  let rev l = rev_append l [] in
   let rec aux accu = function
-    | [] -> rev accu
+    | [] -> List.rev accu
     | x :: l ->
         match f x with
         | None -> aux accu l

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -617,6 +617,11 @@ let escape_xml_string s =
    if the option value is [None] *)
 let get = function None -> raise (Invalid_argument "get") | Some x -> x
 
+(** Check if an option has some content *)
+let is_some = function
+  | Some _ -> true
+  | None -> false
+
 let min_option f1 f2 = match f1, f2 with
   | None, None -> None
   | Some f, None | None, Some f -> Some f

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -404,6 +404,22 @@ let list_join equal l1 l2 =
     (* Call recursive function with initial accumulator *)
     | _ -> list_join' equal [] l1 l2
 
+let list_filter_map f =
+  let rec rev_append l1 l2 =
+    match l1 with
+      [] -> l2
+    | a :: l -> rev_append l (a :: l2)
+  in
+  let rev l = rev_append l [] in
+  let rec aux accu = function
+    | [] -> rev accu
+    | x :: l ->
+        match f x with
+        | None -> aux accu l
+        | Some v -> aux (v :: accu) l
+  in
+  aux []
+
 let rec list_apply: ('a -> 'b) list -> 'a -> 'b list = fun fs arg ->
   match fs with
   | [] -> []

--- a/src/utils/lib.mli
+++ b/src/utils/lib.mli
@@ -159,6 +159,11 @@ val list_subset_uniq :  ('a -> 'a -> int) -> 'a list -> 'a list -> bool
     at each element are equal. *)
 val list_join : ('a -> 'a -> bool) -> ('a * 'b) list -> ('a * 'b list) list -> ('a * 'b list) list
 
+(** Apply a map over a list where if the output is None then the element
+    is dropped from the resulting list and if the output is Some value
+    then that value is added to the resulting list *)
+val list_filter_map : ('a -> 'b option) -> 'a list -> 'b list
+
 (** Lexicographic comparison of pairs *)
 val compare_pairs : ('a -> 'a -> int) -> ('b -> 'b -> int) -> 'a * 'b -> 'a * 'b -> int 
 

--- a/src/utils/lib.mli
+++ b/src/utils/lib.mli
@@ -60,6 +60,9 @@ val flip: ('a -> 'b -> 'c) -> ('b -> 'a -> 'c)
     if the option value is [None] *)
 val get : 'a option -> 'a
 
+(** Check if an option has some content *)
+val is_some : 'a option -> bool
+
 (** Return the min between two optional floats. Return None if both floats are None. *)
 val min_option : float option -> float option -> float option
 


### PR DESCRIPTION
This node generation pass does not include structured data or Daniel's new properties generated for subranges or contracts. The structured data code is already written but I wasn't able to test it yet and having a smaller surface to review seemed like a good idea anyway.

Normalization needed to change slightly to record the node where the ids where generated. It may make sense to annotate the generated ids with additional information (such as whether it should be constant).

~~One thing I am unsure about: Node Calls in the old code will abstract new state variables for outputs and oracles and create equations to the effect of `abs_0 = o1` (where `abs_0` is the new abstraction and `o1` is the old state variable for the node output). It is not clear to me why this is the case or needed and in the current code I do not do this abstraction.~~