### PR TITLE
Add warnings/errors for unguarded pre

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -116,6 +116,7 @@ let get_warnings map = map
   |> StringMap.bindings
   |> List.map (fun (_, { warnings }) -> warnings)
   |> List.flatten
+  |> List.sort (fun (p1, _) (p2, _) -> compare_pos p1 p2)
 
 let pp_print_generated_identifiers ppf gids =
   let locals_list = StringMap.bindings gids.locals 

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -74,26 +74,27 @@ module StringMap : sig
 end
 
 type generated_identifiers = {
-    node_args : (string (* abstracted variable name *)
-      * bool (* whether the variable is constant *)
-      * LustreAst.lustre_type
-      * LustreAst.expr)
-      list;
-    locals : (bool (* whether the variable is ghost *)
-      * LustreAst.lustre_type
-      * LustreAst.expr)
-      StringMap.t;
-    oracles : (string * LustreAst.expr) list;
-    propagated_oracles : (string * string) list;
-    calls : (Lib.position (* node call position *)
-      * (string list) (* oracle inputs *)
-      * (string list) (* abstracted inputs *)
-      * LustreAst.expr (* condition expression *)
-      * LustreAst.expr (* restart expression *)
-      * string (* node name *)
-      * (LustreAst.expr list) (* node arguments *)
-      * (LustreAst.expr list option)) (* node argument defaults *)
-      list
+  node_args : (string (* abstracted variable name *)
+    * bool (* whether the variable is constant *)
+    * LustreAst.lustre_type
+    * LustreAst.expr)
+    list;
+  locals : (bool (* whether the variable is ghost *)
+    * LustreAst.lustre_type
+    * LustreAst.expr)
+    StringMap.t;
+  warnings : (Lib.position * LustreAst.expr) list;
+  oracles : (string * LustreAst.expr) list;
+  propagated_oracles : (string * string) list;
+  calls : (Lib.position (* node call position *)
+    * (string list) (* oracle inputs *)
+    * (string list) (* abstracted inputs *)
+    * LustreAst.expr (* condition expression *)
+    * LustreAst.expr (* restart expression *)
+    * string (* node name *)
+    * (LustreAst.expr list) (* node arguments *)
+    * (LustreAst.expr list option)) (* node argument defaults *)
+    list
 }
 
 val normalize : TypeCheckerContext.tc_context
@@ -101,3 +102,5 @@ val normalize : TypeCheckerContext.tc_context
   -> (LustreAst.t * generated_identifiers StringMap.t, Lib.position * string) result
 
 val pp_print_generated_identifiers : Format.formatter -> generated_identifiers -> unit
+
+val get_warnings : generated_identifiers StringMap.t -> (Lib.position * LustreAst.expr) list

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -151,6 +151,15 @@ let of_channel in_ch =
         ) in
       let ctx, gids, decls = match tc_res with
       | Ok (c, g, d) ->
+        let unguarded_pre_warnings = LAN.get_warnings g in
+        let error_or_warn = if Flags.lus_strict ()
+          then fail_at_position
+          else warn_at_position
+        in List.iter (fun (p, e) -> error_or_warn p
+          (Format.asprintf
+            "@[<hov 2>Unguarded pre in expression@ %a@]"
+            LA.pp_print_expr e))
+          unguarded_pre_warnings;
         Log.log L_note "Type checking done"
         ; Log.log L_trace "========\n%a\n==========\n" LA.pp_print_program d
         ; (c, g, d)


### PR DESCRIPTION
This adds warnings (or errors if the strict flag is set) for unguarded pres.

This does not include unguarded pres in contracts yet, but it sets up the pipeline for adding them. When contracts are added in a future PR the requisite warnings will be added also at that time.