### PR TITLE
Allow checking multiple top-levels in modular mode

### DIFF
--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -186,11 +186,11 @@ let of_channel in_ch =
   in
     
     (* Name of main node *)
-    let main_node = 
+    let main_nodes =
       (* Command-line flag for main node given? *)
       match Flags.lus_main () with 
       (* Use given identifier to choose main node *)
-      | Some s -> LustreIdent.mk_string_ident s
+      | Some s -> [LustreIdent.mk_string_ident s]
       (* No main node name given on command-line *)
       | None -> 
         (try 
@@ -202,17 +202,20 @@ let of_channel in_ch =
           with Not_found -> 
             raise (NoMainNode "No main node defined in input"))
     in
-    (* Put main node at the head of the list of nodes *)
-    let nodes' = 
+    (* Check that main nodes all exist *)
+    let _ =
       try 
-        (* Get main node by name and copy it at the head of the list of
-          nodes *)
-        LN.node_of_name main_node nodes :: nodes
+        List.map (fun mn -> LN.node_of_name mn nodes) main_nodes
       with Not_found -> 
         (* Node with name of main not found 
-          This can only happens when the name is passed as command-line
+          This can only happen when the name is passed as command-line
           argument *)
         raise (NoMainNode "Main node not found in input")
+    in
+    (* Check whether it's OK to have multiple main nodes *)
+    let _ =
+      if List.length main_nodes > 1 && not (Flags.modular ()) then
+        raise (Failure "multiple --%MAIN annotations is only supported in modular mode")
     in
     Log.log L_trace ("===============================================\n"
       ^^ "Free Constants: [@[<hv>%a@]];@ \n\n"
@@ -248,7 +251,7 @@ let of_channel in_ch =
           |> List.flatten);
     (if Flags.only_tc () then exit 0);
     (* Return a subsystem tree from the list of nodes *)
-    LN.subsystem_of_nodes nodes', globals, declarations
+    LN.subsystem_of_nodes main_nodes nodes, globals, declarations
 
 
 (* Returns the AST from a file. *)

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -283,11 +283,13 @@ val node_of_name : LustreIdent.t -> t list -> t
 (** Return true if a node of the given name exists in the a list of nodes *)
 val exists_node_of_name : LustreIdent.t -> t list -> bool 
 
-(** Return name of the first node annotated with --%MAIN.  Raise
-    [Not_found] if no node has a --%MAIN annotation or [Failure
-    "find_main"] if more than one node has a --%MAIN annotation.
+(** Return name of all nodes annotated with --%MAIN.  Raise
+    [Not_found] if no node has a --%MAIN annotation.
+    If the processing mode does not support multiple main nodes,
+    then it is the caller's responsibility to ensure there is
+    only a single main node.
 *)
-val find_main : t list -> LustreIdent.t
+val find_main : t list -> LustreIdent.t list
 
 (** Return the identifier of the top node
 
@@ -300,7 +302,7 @@ val has_effective_contract : t -> bool
 
 (** Return a tree-like subsystem hierarchy from a flat list of nodes,
     where the top node is at the head of the list. *)
-val subsystem_of_nodes : t list -> t SubSystem.t
+val subsystem_of_nodes : LustreIdent.t list -> t list -> t SubSystem.t
 
 (** Return list of topologically ordered list of nodes from subsystem.
     The top node is the head of the list. *)

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -1212,7 +1212,7 @@ let slice_to_abstraction'
   in
   
   (* Create subsystem from list of nodes *)
-  N.subsystem_of_nodes nodes'
+  N.subsystem_of_nodes [] nodes'
 
 
 let no_slice {N.outputs ; N.locals ; N.contract; N.props } is_impl =


### PR DESCRIPTION
Hi Daniel,

We have a use-case where we have multiple top-level nodes that are
called by different pieces of C code. These top-level nodes share
some common utility functions, so re-checking them separately adds
some extra time.

This PR adds the ability to annotate multiple nodes with `--%MAIN;`
and check all of the transitively reachable nodes just once.
I've restricted this to only work in modular mode, because
non-modular mode will re-check the properties multiple times anyway.

If you think this restriction to only work in modular mode is too severe, I can probably figure out how to make non-modular mode work. I think it's a little more effort as I'd need to synthesise a definition that uses all of the top-level nodes.
