### PR TITLE
Term module accepts empty sum and empty product

### DIFF
--- a/src/terms/term.ml
+++ b/src/terms/term.ml
@@ -1345,14 +1345,14 @@ let mk_bvsge = function
 
 (* Hashcons an addition *)
 let mk_plus = function
-  | [] -> invalid_arg "Term.mk_plus"
+  | [] -> mk_num_of_int 0
   | [a] -> a
   | a -> mk_app_of_symbol_node `PLUS a
 
 
 (* Hashcons a multiplication *)
 let mk_times = function
-  | [] -> invalid_arg "Term.mk_times"
+  | [] -> mk_num_of_int 1
   | [a] -> a
   | a -> mk_app_of_symbol_node `TIMES a
 


### PR DESCRIPTION
It is assumed in the ivcMcs module. Fix corner case.