### PR TITLE
Mismatches between init and trans elements do not fail

### DIFF
--- a/src/modelElement.mli
+++ b/src/modelElement.mli
@@ -100,7 +100,6 @@ type category = [ `NODE_CALL | `CONTRACT_ITEM | `EQUATION | `ASSERTION | `ANNOTA
 val is_model_element_in_categories :
   model_element -> bool (* is_main_node *) -> category list -> bool
 
-exception InitTransMismatch of int * int
 val full_loc_core_for_sys :
   'a InputSystem.t -> TransSys.t -> only_top_level:bool -> loc_core
 val filter_loc_core_by_categories :


### PR DESCRIPTION
Given enumeration type `t = enum { A=0, B=1, C=2 `}, and equation `x = A -> if y then t1 else t2`, Kind 2 currently generates constraint `0 <= V(A) <=2` for init, and constraint `0 <= (ite y t1 t2) <= 2` for trans, where `t1` and `t2` are integer variables at the SMT level. However, it discards the first constraint since it is trivially satisfied. This causes a mismatch between the number of init and trans elements. This PR accommodates situations like above.