### PR TITLE
Switch to full relative path in the fname field for the position record

### DIFF
--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -423,7 +423,7 @@ rule token = parse
 
       (* Starting position in new file *)
       let zero_pos =
-        { Lexing.pos_fname = p ;
+        { Lexing.pos_fname = fname ;
           Lexing.pos_lnum = 1  ;
           Lexing.pos_bol = 0   ;
           Lexing.pos_cnum = 0  }


### PR DESCRIPTION
We already have to compute this path in the lexer in order to open the file, so just return it.