### PR TITLE
Change new frontend logging to debug output

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -532,7 +532,7 @@ let rec normalize ctx (decls:LustreAst.t) =
     ([], StringMap.empty) decls
   in let ast = List.rev ast in
   
-  Log.log L_trace ("===============================================\n"
+  Debug.parse ("===============================================\n"
     ^^ "Generated Identifiers:\n%a\n\n"
     ^^ "Normalized lustre AST:\n%a\n"
     ^^ "===============================================\n")
@@ -631,7 +631,7 @@ and normalize_node info map
   in
   let ctx = List.fold_left
     (fun ctx local -> Chk.local_var_binding ctx local
-      |> Res.map_err (fun (_, s) -> fun ppf -> Format.pp_print_string ppf s)
+      |> Res.map_err (fun (_, s) -> fun _ -> Debug.parse "%s" s)
       |> Res.unwrap)
     ctx
     locals
@@ -689,7 +689,7 @@ and normalize_node info map
   let ncontracts, gids5 = match contracts with
     | Some contracts ->
       let ctx = Chk.tc_ctx_of_contract info.context contracts
-        |> Res.map_err (fun (_, s) -> fun ppf -> Format.pp_print_string ppf s)
+        |> Res.map_err (fun (_, s) -> fun _ -> Debug.parse "%s" s)
         |> Res.unwrap in
       let contract_ref = new_contract_reference () in
       let info = { info with context = ctx; contract_ref } in
@@ -865,7 +865,7 @@ and abstract_expr ?guard force info map is_ghost expr =
     let ty = if expr_has_inductive_var ivars expr |> is_some then
       (StringMap.choose_opt info.inductive_variables) |> get |> snd
     else Chk.infer_type_expr info.context expr
-      |> Res.map_err (fun (_, s) -> fun ppf -> Format.pp_print_string ppf s)
+      |> Res.map_err (fun (_, s) -> fun _ -> Debug.parse "%s" s)
       |> Res.unwrap in
     let nexpr, gids1 = normalize_expr ?guard info map expr in
     let iexpr, gids2 = mk_fresh_local info pos is_ghost ivars ty nexpr expr in
@@ -906,7 +906,7 @@ and normalize_expr ?guard info map =
       let ty = if expr_has_inductive_var ivars expr |> is_some then
         (StringMap.choose_opt info.inductive_variables) |> get |> snd
       else Chk.infer_type_expr info.context expr
-        |> Res.map_err (fun (_, s) -> fun ppf -> Format.pp_print_string ppf s)
+        |> Res.map_err (fun (_, s) -> fun _ -> Debug.parse "%s" s)
         |> Res.unwrap in
       let nexpr, gids1 = normalize_expr ?guard info map expr in
       let iexpr, gids2 = mk_fresh_node_arg_local info pos is_const ivars ty nexpr in
@@ -1031,7 +1031,7 @@ and normalize_expr ?guard info map =
     let ty = if expr_has_inductive_var ivars expr |> is_some then
         (StringMap.choose_opt info.inductive_variables) |> get |> snd
       else Chk.infer_type_expr info.context expr
-        |> Res.map_err (fun (_, s) -> fun ppf -> Format.pp_print_string ppf s)
+        |> Res.map_err (fun (_, s) -> fun _ -> Debug.parse "%s" s)
         |> Res.unwrap in
     let nexpr, gids1 = abstract_expr ?guard:None false info map false expr in
     let guard, gids2, previously_guarded = match guard with
@@ -1055,7 +1055,7 @@ and normalize_expr ?guard info map =
     let ty = if expr_has_inductive_var ivars expr |> is_some then
       (StringMap.choose_opt info.inductive_variables) |> get |> snd
     else Chk.infer_type_expr info.context expr
-      |> Res.map_err (fun (_, s) -> fun ppf -> Format.pp_print_string ppf s)
+      |> Res.map_err (fun (_, s) -> fun _ -> Debug.parse "%s" s)
       |> Res.unwrap in
     let nexpr, gids1 = normalize_expr ?guard info map expr in
     let ivars = info.inductive_variables in

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -158,7 +158,7 @@ let type_check declarations =
         LA.pp_print_expr e))
       unguarded_pre_warnings;
     Debug.parse "Type checking done"
-    ; Log.log L_trace "========\n%a\n==========\n" LA.pp_print_program d
+    ; Debug.parse "========\n%a\n==========\n" LA.pp_print_program d
     ; (c, g, d)
   | Error (pos, err) -> fail_at_position pos err
 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -685,13 +685,12 @@ and compile_ast_expr
     let cexpr2 = compile_ast_expr cstate ctx bounds map expr2 in
     let rec aux accum = function
       | [] -> List.rev accum
-      | A.Label (pos, index) :: tl ->
+      | A.Label (_, index) :: tl ->
         let accum' = X.RecordIndex index :: accum in
         if X.mem_prefix (List.rev accum') cexpr1 then
           aux accum' tl
-        else fail_at_position pos
-          (Format.asprintf "Invalid index %s for expression" index)
-      | A.Index (pos, index_expr) :: tl ->
+        else assert false (* guaranteed by type checker *)
+      | A.Index (_, index_expr) :: tl ->
         let index_cexpr = compile_ast_expr cstate ctx bounds map index_expr in
         let index = (index_cexpr |> X.values |> List.hd).expr_init in
         let cexpr_sub = X.find_prefix accum cexpr1 in
@@ -702,10 +701,10 @@ and compile_ast_expr
               | X.ArrayVarIndex _ :: _, _
               | X.ArrayIntIndex _ :: _, _ -> X.ArrayIntIndex value
               | X.TupleIndex _ :: _,_ -> X.TupleIndex value
-              | _ -> fail_at_position pos "Invalid index for expression")
+              | _ -> assert false (* guaranteed by type checker *))
           else (match X.choose cexpr_sub with
             | X.ArrayVarIndex _ :: _, _ -> X.ArrayVarIndex index
-            | _ -> fail_at_position pos "Invalid index for expression" )
+            | _ -> assert false (* guaranteed by type checker *) )
         in aux (i :: accum) tl
     in
     let rec mk_cond_indexes (acc, cpt) li ri =

--- a/src/utils/graph.ml
+++ b/src/utils/graph.ml
@@ -329,7 +329,7 @@ module Make (Ord: OrderedType) = struct
       = fun ((vs, _) as g) sorted_vs ->
       let no_outgoing_vs = non_source_vertices g in
 
-      Log.log L_trace
+      Debug.parse
         "-----------\nGraph state:\n %a\nSorted vertices: %a\n new non source vertices: %a\n-------------"	
         pp_print_graph g	
         (Lib.pp_print_list pp_print_vertex ",") sorted_vs	
@@ -354,7 +354,7 @@ module Make (Ord: OrderedType) = struct
 
     let rec reachable_from_aux: vertices -> vertex -> t -> vertices
       = fun acc sv ((_, es)  as g) ->
-      Log.log L_trace
+      Debug.parse
         "-----------\nGraph state:\n %a\naccumulated vertices: %a\n current vertex vertices: %a\n-------------"	
         pp_print_graph g	
         (Lib.pp_print_list pp_print_vertex ",") (VSet.elements acc)	
@@ -374,7 +374,7 @@ module Make (Ord: OrderedType) = struct
                                           (remove_edges g new_edgs))) (VSet.elements new_vs)) in  
     if (VSet.mem origin_v vs) then
       let vs' = VSet.add origin_v (reachable_from_aux VSet.empty origin_v g) in
-      Log.log L_trace "cumulative reachable from %a are %a"
+      Debug.parse "cumulative reachable from %a are %a"
         pp_print_vertex origin_v
         pp_print_vertices vs'
       ; vs'


### PR DESCRIPTION
I took a more aggressive tact with this because I believe most of this logging to really be debug output and because it is easy now to pick and choose which lines probably should have been logged (given that they're all neatly enumerated now).

Some logging lines I completely deleted, because I didn't believe they added anything (even in a debug scenario).