### PR TITLE
Rework node call expansion in inductive equations

### DIFF
--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -37,6 +37,9 @@ val expr_is_false : expr -> bool
 val pos_of_expr : expr -> Lib.position
 (** Returns the position of an expression *)
 
+val expr_contains_call : expr -> bool
+(** Checks if the expression contains a call to a node *)
+
 val type_contains_subrange : lustre_type -> bool
 (** Returns true if the lustre type expression contains an IntRange or if it is an IntRange *)
 

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -73,6 +73,10 @@ module StringMap : sig
   val keys: 'a t -> key list
 end
 
+module StringSet : sig
+  include (Set.S with type elt = string)
+end
+
 type source = Local | Input | Output | Ghost
 
 type generated_identifiers = {
@@ -114,6 +118,7 @@ type generated_identifiers = {
     * string (* Generated name for Range Expression *)
     * string) (* Original name that is constrained *)
     list;
+  expanded_variables : StringSet.t;
   equations :
     (LustreAst.typed_ident list (* quantified variables *)
     * string list (* contract scope  *)

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -831,9 +831,9 @@ let pp_print_lustre_expr safe ppf = function
 
 (** Pretty-print a bound or fixed annotation *)
 let pp_print_bound_or_fixed ppf = function
-  | Bound x -> (pp_print_expr true) ppf x
-  | Fixed x -> (pp_print_expr true) ppf x
-  | Unbound x -> (pp_print_expr true) ppf x
+  | Bound x -> Format.fprintf ppf "@[<hv 1>(Bound %a)@]" (pp_print_expr true) x
+  | Fixed x -> Format.fprintf ppf "@[<hv 1>(Fixed %a)@]" (pp_print_expr true) x
+  | Unbound x -> Format.fprintf ppf "@[<hv 1>(Unbound %a)@]" (pp_print_expr true) x
 
 (* ********************************************************************** *)
 (* Predicates                                                             *)

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1502,9 +1502,14 @@ and eq_type_array: tc_context -> (LA.lustre_type * LA.expr) -> (LA.lustre_type *
   = fun ctx (ty1, e1) (ty2, e2) ->
   (* eq_lustre_type ctx ty1 ty2 *)
   R.ifM (eq_lustre_type ctx ty1 ty2)
+    (* Are the array sizes equal numerals? *)
     ( match IC.eval_int_expr ctx e1, IC.eval_int_expr ctx e2 with
-      | Ok l1,  Ok l2  -> if l1 = l2 then R.ok true else R.ok false
-      | Error _ , _ | _, Error _ -> R.ok true ) (* This fails if we have free constants *)
+      | Ok l1,  Ok l2  -> R.ok (l1 = l2)
+      | Error _ , _ | _, Error _ ->
+        (* Are the array sizes syntactically identical? *)
+        match LH.syn_expr_equal None e1 e2 with
+        | Ok b -> R.ok b
+        | Error _ -> R.ok false) 
     (R.ok false)
 (** Compute equality for [LA.ArrayType].
    If there are free constants in the size, the eval function will fail,


### PR DESCRIPTION
- Fix issue with state vars being added too many times when static arrays are used.
- Add in static array type indexes when the size is numeral and the expansion flag is explicitly set. 
- Fix type checker claiming too many symbolic arrays are equal.

I think we should ideally work towards a world where (the types of) numeral sized arrays are _always_ expanded. The problem at the moment is that the way we handle matching together symbolic arrays and static arrays is a mess. Perhaps we should reject the situation entirely (i.e. a static array is never well-typed in an expression with a symbolic array).

That would help things, but there is still a lot of annoying edge cases and plumbing that would need to happen to guarantee a static sized array is _known_ static.