### PR TITLE
Improve performance by switching to HStrings immediately (at parsing time)

### DIFF
--- a/src/ivcMcs.ml
+++ b/src/ivcMcs.ml
@@ -181,7 +181,8 @@ let undef_expr pos_sv_map const_expr typ expr =
         let n = (List.length typ) in
         if n > !max_nb_args then max_nb_args := n ;
         A.Call(*Param*)
-          (pos, rand_function_name_for n typ, (*typ,*) [Const (dpos, Num (string_of_int i))])
+          (pos, HString.mk_hstring (rand_function_name_for n typ),
+            (*typ,*) [Const (dpos, Num (HString.mk_hstring (string_of_int i)))])
       end else begin
         try Hashtbl.find previous_rands svs
         with Not_found ->
@@ -189,7 +190,8 @@ let undef_expr pos_sv_map const_expr typ expr =
           let n = (List.length typ) in
           if n > !max_nb_args then max_nb_args := n ;
           let res = A.Call(*Param*)
-            (pos, rand_function_name_for n typ, (*typ,*) [Const (dpos, Num (string_of_int i))])
+            (pos, HString.mk_hstring (rand_function_name_for n typ),
+              (*typ,*) [Const (dpos, Num (HString.mk_hstring (string_of_int i)))])
           in Hashtbl.replace previous_rands svs res ; res
       end
 
@@ -219,10 +221,10 @@ let rand_node name ts =
     | n -> aux prefix ((prefix^(string_of_int (counter ())))::acc) (n-1)
   in
   let outs = aux "out" [] (List.length ts)
-  |> List.map2 (fun t out -> dpos,out,t,A.ClockTrue) ts
+  |> List.map2 (fun t out -> dpos,HString.mk_hstring out,t,A.ClockTrue) ts
   in
   A.NodeDecl (dspan,
-    (name, true, [], [dpos,"id",A.Int dpos,A.ClockTrue, false],
+    (name, true, [], [dpos,HString.mk_hstring "id",A.Int dpos,A.ClockTrue, false],
     outs, [], [], None)
   )
 
@@ -404,6 +406,7 @@ let minimize_contract_node_eq ue lst cne =
 let minimize_node_decl ue loc_core
   ((id, extern, tparams, inputs, outputs, locals, items, spec) as ndecl) =
 
+  let id' = HString.string_of_hstring id in
   let id_typ_map = build_id_typ_map inputs outputs locals in
 
   let minimize_with_lst lst =
@@ -419,7 +422,7 @@ let minimize_node_decl ue loc_core
     (id, extern, tparams, inputs, outputs, locals, items, spec)
   in
   
-  let scope = (Scope.mk_scope [id]) in
+  let scope = (Scope.mk_scope [id']) in
   if List.exists (fun sc -> Scope.equal sc scope) (scopes_of_loc_core loc_core)
   then (
     get_model_elements_of_scope loc_core scope
@@ -501,7 +504,7 @@ let minimize_lustre_ast ?(valid_lustre=false) in_sys (_,loc_core,_) ast =
   in
   aux minimized (!max_nb_args)*)
   Hashtbl.fold (fun ts n acc ->
-    (rand_node n ts)::acc
+    (rand_node (HString.mk_hstring n) ts)::acc
   )
   rand_functions
   minimized

--- a/src/ivcMcs.ml
+++ b/src/ivcMcs.ml
@@ -170,7 +170,7 @@ let rand_function_name_for _ ts =
 let undef_expr pos_sv_map const_expr typ expr =
   let pos = H.pos_of_expr expr in
   match pos_sv_map with
-  | None -> A.Ident (pos, "_")
+  | None -> A.Ident (pos, HString.mk_hstring "_")
   | Some pos_sv_map ->
     if const_expr then expr (* a call to __rand is not a valid constant expression *)
     else

--- a/src/lustre/contractsToProps.ml
+++ b/src/lustre/contractsToProps.ml
@@ -26,7 +26,7 @@ let blah_opt txt name pos =
     txt
     (fun fmt -> match name with
       | None -> ()
-      | Some name -> Format.fprintf fmt " (%s)" name
+      | Some name -> Format.fprintf fmt " (%s)" (HString.string_of_hstring name)
     )
     pp_print_position pos
 
@@ -78,7 +78,7 @@ let rec collect_contracts (locals, asserts, props) = function
               blah
                 (Format.sprintf "%s from mode %s"
                   (blah_opt "Ensure" e_name e_pos)
-                  name
+                  (HString.string_of_hstring name)
                 )
                 pos,
               reqs,

--- a/src/lustre/lspInfo.ml
+++ b/src/lustre/lspInfo.ml
@@ -31,11 +31,14 @@ let lsp_type_decl_json ppf { Ast.start_pos = spos; Ast.end_pos = epos } =
          \"objectType\" : \"lsp\",@,\
          \"source\" : \"lsp\",@,\
          \"kind\" : \"typeDecl\",@,\
-         \"name\" : \"%s\",@,\
+         \"name\" : \"%a\",@,\
          %a\"startLine\" : %d,@,\
          \"startColumn\" : %d,@,\
          \"endLine\" : %d,@,\
-         \"endColumn\" : %d@]@.}@." id pp_print_fname_json file slnum scnum
+         \"endColumn\" : %d@]@.}@."
+        HString.pp_print_hstring id
+        pp_print_fname_json file
+        slnum scnum
         elnum ecnum
 
 let lsp_const_decl_json ppf { Ast.start_pos = spos; Ast.end_pos = epos } =
@@ -50,11 +53,14 @@ let lsp_const_decl_json ppf { Ast.start_pos = spos; Ast.end_pos = epos } =
          \"objectType\" : \"lsp\",@,\
          \"source\" : \"lsp\",@,\
          \"kind\" : \"constDecl\",@,\
-         \"name\" : \"%s\",@,\
+         \"name\" : \"%a\",@,\
          %a\"startLine\" : %d,@,\
          \"startColumn\" : %d,@,\
          \"endLine\" : %d,@,\
-         \"endColumn\" : %d@]@.}@." id pp_print_fname_json file slnum scnum
+         \"endColumn\" : %d@]@.}@."
+        HString.pp_print_hstring id
+        pp_print_fname_json file
+        slnum scnum
         elnum ecnum
 
 let lsp_node_json ppf { Ast.start_pos = spos; Ast.end_pos = epos }
@@ -66,12 +72,14 @@ let lsp_node_json ppf { Ast.start_pos = spos; Ast.end_pos = epos }
      \"objectType\" : \"lsp\",@,\
      \"source\" : \"lsp\",@,\
      \"kind\" : \"node\",@,\
-     \"name\" : \"%s\",@,\
+     \"name\" : \"%a\",@,\
      \"imported\" : \"%b\",@,\
      %a\"startLine\" : %d,@,\
      \"startColumn\" : %d,@,\
      \"endLine\" : %d,@,\
-     \"endColumn\" : %d@]@.}@." id imported pp_print_fname_json file slnum scnum
+     \"endColumn\" : %d@]@.}@."
+    HString.pp_print_hstring id
+    imported pp_print_fname_json file slnum scnum
     elnum ecnum
 
 let lsp_function_json ppf { Ast.start_pos = spos; Ast.end_pos = epos }
@@ -83,12 +91,14 @@ let lsp_function_json ppf { Ast.start_pos = spos; Ast.end_pos = epos }
      \"objectType\" : \"lsp\",@,\
      \"source\" : \"lsp\",@,\
      \"kind\" : \"function\",@,\
-     \"name\" : \"%s\",@,\
+     \"name\" : \"%a\",@,\
      \"imported\" : \"%b\",@,\
      %a\"startLine\" : %d,@,\
      \"startColumn\" : %d,@,\
      \"endLine\" : %d,@,\
-     \"endColumn\" : %d@]@.}@." id imported pp_print_fname_json file slnum scnum
+     \"endColumn\" : %d@]@.}@."
+    HString.pp_print_hstring id
+    imported pp_print_fname_json file slnum scnum
     elnum ecnum
 
 let lsp_contract_json ppf { Ast.start_pos = spos; Ast.end_pos = epos }
@@ -100,11 +110,13 @@ let lsp_contract_json ppf { Ast.start_pos = spos; Ast.end_pos = epos }
      \"objectType\" : \"lsp\",@,\
      \"source\" : \"lsp\",@,\
      \"kind\" : \"contract\",@,\
-     \"name\" : \"%s\",@,\
+     \"name\" : \"%a\",@,\
      %a\"startLine\" : %d,@,\
      \"startColumn\" : %d,@,\
      \"endLine\" : %d,@,\
-     \"endColumn\" : %d@]@.}@." id pp_print_fname_json file slnum scnum elnum
+     \"endColumn\" : %d@]@.}@."
+    HString.pp_print_hstring id
+    pp_print_fname_json file slnum scnum elnum
     ecnum
 
 let print_ast_info declarations =

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -17,7 +17,6 @@
 *)
 
 open Lib
-open HString
 
 exception Parser_error
 

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -32,7 +32,7 @@ type ident = HString.t
 module SI = struct
   include (Set.Make (struct
                type t = ident
-               let compare = Stdlib.compare
+               let compare = HString.compare
              end))
   let flatten: t list -> t = fun sets ->
     List.fold_left union empty sets

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -46,7 +46,7 @@ exception Parser_error
 (** {1 Types} *)
 
 (** An identifier *)
-type ident = string
+type ident = HString.t
 
 module SI: sig
   include (Set.S with type elt = ident)
@@ -54,7 +54,7 @@ module SI: sig
 end
 
 (** A single index *)
-type index = string
+type index = HString.t
 
 (** A clock expression *)
 type clock_expr =
@@ -90,8 +90,8 @@ type comparison_operator =
 
 type constant =
   | True | False
-  | Num of string
-  | Dec of string
+  | Num of HString.t
+  | Dec of HString.t
 
 type quantifier =
   | Forall | Exists
@@ -251,7 +251,7 @@ and state =
 type node_item =
   | Body of node_equation
   | AnnotMain of bool
-  | AnnotProperty of position * string option * expr
+  | AnnotProperty of position * HString.t option * expr
 
 (* A contract ghost constant. *)
 type contract_ghost_const = const_decl
@@ -260,16 +260,16 @@ type contract_ghost_const = const_decl
 type contract_ghost_var = const_decl
 
 (* A contract assume. *)
-type contract_assume = position * string option * bool (* soft *) * expr
+type contract_assume = position * HString.t option * bool (* soft *) * expr
 
 (* A contract guarantee. *)
-type contract_guarantee = position * string option * bool (* soft *) * expr
+type contract_guarantee = position * HString.t option * bool (* soft *) * expr
 
 (* A contract requirement. *)
-type contract_require = position * string option * expr
+type contract_require = position * HString.t option * expr
 
 (* A contract ensure. *)
-type contract_ensure = position * string option * expr
+type contract_ensure = position * HString.t option * expr
 
 (* A contract mode. *)
 type contract_mode =

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -1064,7 +1064,7 @@ let rec remove_node_in_declarations:
   function
   | [] -> None
   | (NodeDecl (_, (n', _, _, _, _, _, _, _)) as mn) :: rest ->
-     if Stdlib.compare n' n = 0
+     if HString.compare n' n = 0
      then Some (mn, pres @ rest)
      else remove_node_in_declarations n (pres @ [mn]) rest 
   | d :: rest -> remove_node_in_declarations n (pres @ [d]) rest 
@@ -1078,11 +1078,11 @@ let move_node_to_last: ident -> declaration list -> declaration list =
 
 
 let sort_typed_ident: typed_ident list -> typed_ident list = fun ty_idents ->
-  List.sort (fun (_,i1,_) (_,i2,_) -> Stdlib.compare i1 i2) ty_idents
+  List.sort (fun (_,i1,_) (_,i2,_) -> HString.compare i1 i2) ty_idents
 (** Sort identifiers  *)
 
 let sort_idents: ident list -> ident list = fun ids ->
-  List.sort (fun i1 i2 -> Stdlib.compare i1 i2) ids
+  List.sort (fun i1 i2 -> HString.compare i1 i2) ids
 (** sort typed identifiers *)
 
 let rec syn_expr_equal depth_limit x y : (bool, unit) result =

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -43,7 +43,7 @@ val expr_contains_call : expr -> bool
 val type_contains_subrange : lustre_type -> bool
 (** Returns true if the lustre type expression contains an IntRange or if it is an IntRange *)
 
-val substitute : string -> expr -> expr -> expr
+val substitute : HString.t -> expr -> expr -> expr
 (** Subsitute the supplied identifier and expression into the last expression *)
 
 val has_unguarded_pre : expr -> bool
@@ -63,7 +63,7 @@ val node_local_decl_has_pre_or_arrow : node_local_decl -> Lib.position option
 val node_item_has_pre_or_arrow : node_item -> Lib.position option
 (** Checks whether a node equation has a `pre` or a `->`. *)
 
-val replace_lasts : string list -> string -> SI.t -> expr -> expr * SI.t
+val replace_lasts : LustreAst.index list -> string -> SI.t -> expr -> expr * SI.t
 (** [replace_lasts allowed prefix acc e] replaces [last x] expressions in AST
     [e] by abstract identifiers prefixed with [prefix]. Only identifiers that
     appear in the list [allowed] are allowed to appear under a last. It returns

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -69,18 +69,18 @@
      @author Andrew Marmaduke *)
 
 module StringMap : sig
-  include (Map.S with type key = string)
+  include (Map.S with type key = HString.t)
   val keys: 'a t -> key list
 end
 
 module StringSet : sig
-  include (Set.S with type elt = string)
+  include (Set.S with type elt = HString.t)
 end
 
 type source = Local | Input | Output | Ghost
 
 type generated_identifiers = {
-  node_args : (string (* abstracted variable name *)
+  node_args : (HString.t (* abstracted variable name *)
     * bool (* whether the variable is constant *)
     * LustreAst.lustre_type
     * LustreAst.expr)
@@ -91,37 +91,37 @@ type generated_identifiers = {
     * LustreAst.expr)
     StringMap.t;
   locals : (bool (* whether the variable is ghost *)
-    * string list (* scope *)
+    * HString.t list (* scope *)
     * LustreAst.lustre_type
     * LustreAst.expr (* abstracted expression *)
     * LustreAst.expr) (* original expression *)
     StringMap.t;
   contract_calls :
     (Lib.position
-    * string list (* contract scope *)
+    * HString.t list (* contract scope *)
     * LustreAst.contract_node_equation list)
     StringMap.t;
   warnings : (Lib.position * LustreAst.expr) list;
-  oracles : (string * LustreAst.lustre_type * LustreAst.expr) list;
-  propagated_oracles : (string * string) list;
+  oracles : (HString.t * LustreAst.lustre_type * LustreAst.expr) list;
+  propagated_oracles : (HString.t * HString.t) list;
   calls : (Lib.position (* node call position *)
-    * (string list) (* oracle inputs *)
-    * string (* abstracted output *)
+    * (HString.t list) (* oracle inputs *)
+    * HString.t (* abstracted output *)
     * LustreAst.expr (* condition expression *)
     * LustreAst.expr (* restart expression *)
-    * string (* node name *)
+    * HString.t (* node name *)
     * (LustreAst.expr list) (* node arguments *)
     * (LustreAst.expr list option)) (* node argument defaults *)
     list;
   subrange_constraints : (source
     * Lib.position
-    * string (* Generated name for Range Expression *)
-    * string) (* Original name that is constrained *)
+    * HString.t (* Generated name for Range Expression *)
+    * HString.t) (* Original name that is constrained *)
     list;
   expanded_variables : StringSet.t;
   equations :
     (LustreAst.typed_ident list (* quantified variables *)
-    * string list (* contract scope  *)
+    * HString.t list (* contract scope  *)
     * LustreAst.eq_lhs
     * LustreAst.expr)
     list;

--- a/src/lustre/lustreContext.mli
+++ b/src/lustre/lustreContext.mli
@@ -178,7 +178,7 @@ val add_contract_node_decl_to_context :
 
 (** Return a contract node by its identifier *)
 val contract_node_decl_of_ident :
-  t -> string -> Lib.position * LustreAst.contract_node_decl
+  t -> HString.t -> Lib.position * LustreAst.contract_node_decl
 
 (** Return a context that raises an error when defining an
     expression.

--- a/src/lustre/lustreDependencies.ml
+++ b/src/lustre/lustreDependencies.ml
@@ -114,24 +114,24 @@ let mem deps (key_type, key_ident) (val_type, val_ident) =
 (** Identifier corresponding to a declaration. *)
 let info_of_decl = function
 | A.TypeDecl ({A.start_pos=pos}, A.AliasType (_, ident, _)) ->
-  pos, ident |> I.mk_string_ident, Type
+  pos, ident |> HString.string_of_hstring |> I.mk_string_ident, Type
 | A.TypeDecl ({A.start_pos=pos}, A.FreeType (_, ident)) ->
-  pos, ident |> I.mk_string_ident, Type
+  pos, ident |> HString.string_of_hstring |> I.mk_string_ident, Type
 
 | A.ConstDecl ({A.start_pos=pos}, A.FreeConst(_, ident, _)) ->
-  pos, ident |> I.mk_string_ident, Const
+  pos, ident |> HString.string_of_hstring |> I.mk_string_ident, Const
 | A.ConstDecl ({A.start_pos=pos}, A.UntypedConst(_, ident, _)) ->
-  pos, ident |> I.mk_string_ident, Const
+  pos, ident |> HString.string_of_hstring |> I.mk_string_ident, Const
 | A.ConstDecl ({A.start_pos=pos}, A.TypedConst(_, ident, _, _)) ->
-  pos, ident |> I.mk_string_ident, Const
+  pos, ident |> HString.string_of_hstring |> I.mk_string_ident, Const
 
 | A.NodeDecl ({A.start_pos=pos}, (ident, _, _, _, _, _, _, _)) ->
-  pos, ident |> I.mk_string_ident, NodeOrFun
+  pos, ident |> HString.string_of_hstring |> I.mk_string_ident, NodeOrFun
 | A.FuncDecl ({A.start_pos=pos}, (ident, _, _, _, _, _, _, _)) ->
-  pos, ident |> I.mk_string_ident, NodeOrFun
+  pos, ident |> HString.string_of_hstring |> I.mk_string_ident, NodeOrFun
 
 | A.ContractNodeDecl ({A.start_pos=pos}, (ident, _, _, _, _)) ->
-  pos, ident |> I.mk_string_ident, Contract
+  pos, ident |> HString.string_of_hstring |> I.mk_string_ident, Contract
 
 | decl ->
   Format.asprintf
@@ -142,7 +142,7 @@ let info_of_decl = function
 (** Inserts a declaration in a list of declarations, after the one with name
 [f_ident]. *)
 let insert_decl decl (f_type, f_ident) decls =
-  let ident = I.string_of_ident false f_ident in
+  let ident = HString.mk_hstring (I.string_of_ident false f_ident) in
   let has_ident = match f_type with
     | NodeOrFun -> (
       function

--- a/src/lustre/lustreIdent.ml
+++ b/src/lustre/lustreIdent.ml
@@ -42,7 +42,7 @@ module LustreIdent = struct
   let compare (i1, l1) (i2, l2) =
     let c = Ident.compare i1 i2 in
     if c <> 0 then c
-    else Lib.compare_lists Stdlib.compare l1 l2
+    else Lib.compare_lists Int.compare l1 l2
       
 
 end

--- a/src/lustre/lustreIndex.ml
+++ b/src/lustre/lustreIndex.ml
@@ -112,10 +112,10 @@ let compare_one_index a b = match a, b with
 
   (* Use polymorphic comparison on strings and integers *)
   | RecordIndex a, RecordIndex b
-  | AbstractTypeIndex a, AbstractTypeIndex b -> Stdlib.compare a b
+  | AbstractTypeIndex a, AbstractTypeIndex b -> String.compare a b
   | TupleIndex a, TupleIndex b
   | ListIndex a, ListIndex b
-  | ArrayIntIndex a, ArrayIntIndex b -> Stdlib.compare a b
+  | ArrayIntIndex a, ArrayIntIndex b -> Int.compare a b
 
   (* Variable indexes are equal regardless of the bound expression *)
   | ArrayVarIndex _, ArrayVarIndex _ -> 0

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -228,7 +228,7 @@ let of_channel only_parse in_ch =
         let last_node = LH.get_last_node_name (declarations) in
         let nodes = match last_node with
         | None -> nodes
-        | Some ln -> let ident = LustreIdent.mk_string_ident ln in
+        | Some ln -> let ident = LustreIdent.mk_string_ident (HString.string_of_hstring ln) in
           let n = LustreNode.node_of_name ident nodes in
           let filtered =
             List.filter

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -476,21 +476,21 @@ rule token = parse
   | "rsh" { RSH }
 
   (* Decimal or numeral *)
-  | decimal as p { DECIMAL p }
-  | exponent_decimal as p { DECIMAL p }
-  | numeral as p { NUMERAL p }
+  | decimal as p { DECIMAL (HString.mk_hstring p) }
+  | exponent_decimal as p { DECIMAL (HString.mk_hstring p) }
+  | numeral as p { NUMERAL (HString.mk_hstring p) }
 
-  | hex_num as p { NUMERAL p }
-  | hex_dec1 as p { DECIMAL p }
-  | hex_dec2 as p { DECIMAL p }
+  | hex_num as p { NUMERAL (HString.mk_hstring p) }
+  | hex_dec1 as p { DECIMAL (HString.mk_hstring p) }
+  | hex_dec2 as p { DECIMAL (HString.mk_hstring p) }
 
   (* Keyword *)
   | id as p {
-    try Hashtbl.find keyword_table p with Not_found -> (SYM p)
+    try Hashtbl.find keyword_table p with Not_found -> (SYM (HString.mk_hstring p))
   }
 
   (* Identifier with quote, throw quote away *)
-  | '\'' (id as p) { QUOTSYM p }
+  | '\'' (id as p) { QUOTSYM (HString.mk_hstring p) }
 
   (* Whitespace *)
   | whitespace { token lexbuf }
@@ -570,7 +570,7 @@ and return_at_eol t = parse
 
 and string = parse
   | "\""
-      { STRING (Buffer.contents string_buf) }
+      { STRING (HString.mk_hstring (Buffer.contents string_buf)) }
   | "\\" (_ as c)
       { Buffer.add_char string_buf (char_for_backslash c); string lexbuf }
   | newline

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -69,14 +69,14 @@ let merge_branches transitions =
 %token RCURLYBRACKET 
 
 (* Tokens for decimals and numerals *)
-%token <string>DECIMAL
-%token <string>NUMERAL
+%token <HString.t>DECIMAL
+%token <HString.t>NUMERAL
 
-%token <string>STRING
+%token <HString.t>STRING
 
 (* Identifier token *)
-%token <string>SYM 
-%token <string>QUOTSYM 
+%token <HString.t>SYM 
+%token <HString.t>QUOTSYM 
       
 (* Tokens for types *)
 %token TYPE
@@ -836,7 +836,7 @@ pexpr(Q):
 
   (* Tuple projection (not quantified) *)
   | e = pexpr(Q); DOTPERCENT; i = NUMERAL 
-  { let idx = try (int_of_string i) with
+  { let idx = try (int_of_string (HString.string_of_hstring i)) with
               | _ -> fail_at_position (mk_pos $startpos(i)) "Tuple projection index exceeds int range" in
     A.TupleProject (mk_pos $startpos, e, idx) }
 
@@ -1057,7 +1057,7 @@ pexpr(Q):
     c = ident; SEMICOLON;
     pos = pexpr(Q); SEMICOLON;
     neg = pexpr(Q); RPAREN 
-    { A.Merge (mk_pos $startpos, c, ["true", pos; "false", neg]) }
+    { A.Merge (mk_pos $startpos, c, [HString.mk_hstring "true", pos; HString.mk_hstring "false", neg]) }
 
   (* N-way merge operator *)
   | MERGE; 
@@ -1068,7 +1068,7 @@ pexpr(Q):
   (* A temporal operation *)
   | PRE; e = pexpr(Q) { A.Pre (mk_pos $startpos, e) }
   | FBY LPAREN; e1 = pexpr(Q) COMMA; s = NUMERAL; COMMA; e2 = pexpr(Q) RPAREN
-    { let idx = try (int_of_string s) with
+    { let idx = try (int_of_string (HString.string_of_hstring s)) with
                 | _ -> fail_at_position (mk_pos $startpos(s)) "Fby argument exceeds int range" in
       A.Fby (mk_pos $startpos, e1, idx, e2) }
 
@@ -1133,8 +1133,8 @@ clock_expr:
   | TRUE { A.ClockTrue }
 
 merge_case_id:
-  | TRUE { "true" }
-  | FALSE { "false" }
+  | TRUE { HString.mk_hstring "true" }
+  | FALSE { HString.mk_hstring "false" }
   | c = ident { c }
 
 merge_case :
@@ -1143,16 +1143,15 @@ merge_case :
     
 (* ********************************************************************** *)
 
-
 (* An identifier *)
 ident:
   (* Contract tokens are not keywords. *)
-  | MODE { "mode" }
-  | ASSUME { "assume" }
-  | GUARANTEE { "guarantee" }
-  | REQUIRE { "require" }
-  | ENSURE { "ensure" }
-  | WEAKLY { "weakly" }
+  | MODE { HString.mk_hstring "mode" }
+  | ASSUME { HString.mk_hstring "assume" }
+  | GUARANTEE { HString.mk_hstring "guarantee" }
+  | REQUIRE { HString.mk_hstring "require" }
+  | ENSURE { HString.mk_hstring "ensure" }
+  | WEAKLY { HString.mk_hstring "weakly" }
   | s = SYM { s }
 
 ident_or_quotident:

--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -31,7 +31,7 @@ module IMap = struct
   (* everything that [Stdlib.Map] gives us  *)
   include Map.Make(struct
               type t = LA.ident
-              let compare i1 i2 = Stdlib.compare i1 i2
+              let compare i1 i2 = HString.compare i1 i2
             end)
   let keys: 'a t -> key list = fun m -> List.map fst (bindings m)
 end

--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -322,7 +322,7 @@ let pp_print_enum_variants: Format.formatter -> enum_variants -> unit
     (fun ppf (i, exm) ->
       Format.fprintf ppf "(enum %a -> [%a])"
         LA.pp_print_ident i
-        (Lib.pp_print_list Format.pp_print_string ",") exm)
+        (Lib.pp_print_list HString.pp_print_hstring ",") exm)
           ", " ppf (IMap.bindings m)
 (** Pretty print enumeration types and their variants *)
 

--- a/src/utils/hString.ml
+++ b/src/utils/hString.ml
@@ -198,6 +198,8 @@ let concat { Hashcons.node = n } l =
 
   mk_hstring (String.concat n (List.map string_of_hstring l))
 
+let concat2 a b = concat (mk_hstring "") [a;b]
+
 let iter f { Hashcons.node = n } = String.iter f n
 
 let iteri f { Hashcons.node = n } = String.iteri f n

--- a/src/utils/hString.mli
+++ b/src/utils/hString.mli
@@ -76,6 +76,7 @@ val sub : t -> int -> int -> string
 val fill : t -> int -> int -> char -> t
 val blit : t -> int -> t -> int -> int -> t
 val concat : t -> t list -> t
+val concat2 : t -> t -> t
 val iter : (char -> unit) -> t -> unit
 val iteri : (int -> char -> unit) -> t -> unit
 val map : (char -> char) -> t -> t

--- a/src/utils/hashconsStrong.ml
+++ b/src/utils/hashconsStrong.ml
@@ -36,7 +36,7 @@ type ('a, 'b) hash_consed =  {
   prop : 'b }
 
 (* Comparison based on tags *)
-let compare { tag = t1 } { tag = t2 } = Stdlib.compare t1 t2
+let compare { tag = t1 } { tag = t2 } = Int.compare t1 t2
 
 (* Equality based on tags *)
 let equal { tag = t1 } { tag = t2 } = t1 = t2
@@ -299,7 +299,7 @@ let stats t =
   let lens = Array.map (fun (_, b) -> Array.length b) t.table in
 
   (* Sort to find longest bucket *)
-  Array.sort Stdlib.compare lens;
+  Array.sort Int.compare lens;
 
   (* Sum up lengths of all buckets *)
   let totlen = Array.fold_left ( + ) 0 lens in
@@ -659,7 +659,7 @@ struct
     let lens = Array.map (fun (_, b) -> Array.length b) t.table in
     
     (* Sort to find longest bucket *)
-    Array.sort Stdlib.compare lens;
+    Array.sort Int.compare lens;
     
     (* Sum up lengths of all buckets *)
     let totlen = Array.fold_left ( + ) 0 lens in

--- a/src/utils/hashconsWeak.ml
+++ b/src/utils/hashconsWeak.ml
@@ -23,7 +23,7 @@ type ('a, 'b) hash_consed =  {
   prop : 'b }
 
 (* Comparison based on tags *)
-let compare { tag = t1 } { tag = t2 } = Stdlib.compare t1 t2
+let compare { tag = t1 } { tag = t2 } = Int.compare t1 t2
 
 (* Equality based on tags *)
 let equal { tag = t1 } { tag = t2 } = t1 = t2
@@ -142,7 +142,7 @@ let hashcons t d p =
 let stats t =
   let len = Array.length t.table in
   let lens = Array.map Weak.length t.table in
-  Array.sort Stdlib.compare lens;
+  Array.sort Int.compare lens;
   let totlen = Array.fold_left ( + ) 0 lens in
   (len, count t, totlen, lens.(0), lens.(len/2), lens.(len-1))
 
@@ -314,7 +314,7 @@ struct
   let stats t =
     let len = Array.length t.table in
     let lens = Array.map Weak.length t.table in
-    Array.sort Stdlib.compare lens;
+    Array.sort Int.compare lens;
     let totlen = Array.fold_left ( + ) 0 lens in
     (len, count t, totlen, lens.(0), lens.(len/2), lens.(len-1))
       

--- a/tests/ounit/lustre/testAstDependencies.ml
+++ b/tests/ounit/lustre/testAstDependencies.ml
@@ -20,7 +20,6 @@
    
    @author Apoorv Ingle *)
 
-module LI = LustreInput
 module LA = LustreAst
 open OUnit2
 
@@ -31,10 +30,11 @@ let dspan = { LA.start_pos = dp; LA.end_pos = dp }
 let (>>=) = Res.(>>=)
           
 let linear_decls = [
-    LA.TypeDecl (dspan, LA.AliasType(dp, "t0", LA.UserType (dp, "t1")))
-  ; LA.TypeDecl (dspan, LA.AliasType(dp, "t1", LA.UserType (dp, "t2")))
-  ; LA.TypeDecl (dspan, LA.AliasType(dp, "t2", LA.Int dp))
-  ; LA.ConstDecl (dspan, LA.TypedConst (dp, "c", LA.Const (dp, Num "1"), LA.UserType (dp, "t0")))
+    LA.TypeDecl (dspan, LA.AliasType(dp, HString.mk_hstring "t0", LA.UserType (dp, HString.mk_hstring "t1")))
+  ; LA.TypeDecl (dspan, LA.AliasType(dp, HString.mk_hstring "t1", LA.UserType (dp, HString.mk_hstring "t2")))
+  ; LA.TypeDecl (dspan, LA.AliasType(dp, HString.mk_hstring "t2", LA.Int dp))
+  ; LA.ConstDecl (dspan, LA.TypedConst (dp, HString.mk_hstring "c",
+    LA.Const (dp, Num (HString.mk_hstring "1")), LA.UserType (dp, HString.mk_hstring "t0")))
   ]
   
 let sorted_linear_decls = fun _ -> AD.sort_globals linear_decls
@@ -50,10 +50,11 @@ let tests_should_pass = [
 
 
 let circular_decls = [
-    LA.TypeDecl (dspan, LA.AliasType(dp, "t0", LA.UserType (dp, "t1")))
-  ; LA.TypeDecl (dspan, LA.AliasType(dp, "t1", LA.UserType (dp, "t2")))
-  ; LA.TypeDecl (dspan, LA.AliasType(dp, "t2", LA.UserType (dp, "t0")))
-  ; LA.ConstDecl (dspan, LA.TypedConst (dp, "c", LA.Const (dp, Num "1"), LA.UserType (dp, "t0")))  ]
+    LA.TypeDecl (dspan, LA.AliasType(dp, HString.mk_hstring "t0", LA.UserType (dp, HString.mk_hstring "t1")))
+  ; LA.TypeDecl (dspan, LA.AliasType(dp, HString.mk_hstring "t1", LA.UserType (dp, HString.mk_hstring "t2")))
+  ; LA.TypeDecl (dspan, LA.AliasType(dp, HString.mk_hstring "t2", LA.UserType (dp, HString.mk_hstring "t0")))
+  ; LA.ConstDecl (dspan, LA.TypedConst (dp, HString.mk_hstring "c",
+    LA.Const (dp, Num (HString.mk_hstring "1")), LA.UserType (dp, HString.mk_hstring "t0")))  ]
 
 
 let failure_circular_decls = fun _ ->  AD.sort_globals circular_decls

--- a/tests/ounit/utils/testGraph.ml
+++ b/tests/ounit/utils/testGraph.ml
@@ -23,13 +23,13 @@ open OUnit2
 
 module G = Graph.Make(struct
                type t = LustreAst.ident
-               let compare = Stdlib.compare
+               let compare = HString.compare
                let pp_print_t = LustreAst.pp_print_ident 
              end)
 
-let v0 = "v0"
-let v1 = "v1"
-let v2 = "v2"
+let v0 = HString.mk_hstring "v0"
+let v1 = HString.mk_hstring "v1"
+let v2 = HString.mk_hstring "v2"
                          
 let singleton_g = G.add_vertex G.empty v0
 let dos_g = G.add_vertex singleton_g v1
@@ -46,7 +46,8 @@ let basic_tests =
   
   ; "sorted dos" >:: (fun _ -> assert_equal [v0;v1] (G.topological_sort dos_connected_g))
   ; "cyclic dos" >:: (fun _ -> assert_raises
-                                 (Graph.CyclicGraphException [v0; v1])
+                                 (Graph.CyclicGraphException
+                                  [HString.string_of_hstring v0; HString.string_of_hstring v1])
                                  (fun _ -> G.topological_sort dos_cycle_g))
   ]
 
@@ -54,13 +55,13 @@ let rechability_tests =
   [
     "reachable singleton" >:: (fun _ ->
       assert_equal [v0] (G.to_vertex_list (G.reachable singleton_g v0))
-        ~printer:(Lib.string_of_t (Format.pp_print_list Format.pp_print_string) ))
+        ~printer:(Lib.string_of_t (Format.pp_print_list HString.pp_print_hstring) ))
   ; "reachable cycle graph" >:: (fun _ ->
     assert_equal [v0;v1] (G.to_vertex_list (G.reachable dos_cycle_g v0))
-      ~printer:(Lib.string_of_t (Format.pp_print_list Format.pp_print_string) ))
+      ~printer:(Lib.string_of_t (Format.pp_print_list HString.pp_print_hstring) ))
   ; "reachable cycle graph2" >:: (fun _ ->
     assert_equal [v0;v1;v2] (G.to_vertex_list (G.reachable cycle_and_one_more v0))
-      ~printer:(Lib.string_of_t (Format.pp_print_list Format.pp_print_string)))
+      ~printer:(Lib.string_of_t (Format.pp_print_list HString.pp_print_hstring)))
   ]
   
 let _ = run_test_tt_main ("test suite for graphs" >::: basic_tests @ rechability_tests) 


### PR DESCRIPTION
The bad news:

This change only shaves off about 2 seconds, leaving the old front-end at 0.02s and the new front-end at ~2s for the `cruise_controller` example

The good news:

After some experimentation and profiling, I decided to try commenting out the dependency sorting passes (there are only two). If no dependency sorting is done at all, the new front-end is **as fast as the old front end** (for parsing). This means that all of the remaining slow down is in the dependency sorting code.

Also, there are places in the code base where `Stdlib.compare` is used that have nothing to do with either front-end. I did not change these, should they be changed?