### PR TITLE
Memoize graph reachability

### DIFF
--- a/src/utils/graph.mli
+++ b/src/utils/graph.mli
@@ -124,7 +124,11 @@ module type S = sig
    *  or throws an [CyclicGraphException] if the graph is cyclic.
    *  Implimentation is of this function is based on Kahn's algorithm *)    
 
-  val reachable: t -> vertex -> vertices
+  module VMap : sig
+    include (Map.S with type key = vertex)
+  end
+
+  val memoized_reachable: vertices VMap.t ref -> t -> vertex -> vertices
   (** Finds all the [vertices] that are rechable from the given [vertex] in a graph *)
 
 

--- a/tests/ounit/utils/testGraph.ml
+++ b/tests/ounit/utils/testGraph.ml
@@ -54,13 +54,16 @@ let basic_tests =
 let rechability_tests =
   [
     "reachable singleton" >:: (fun _ ->
-      assert_equal [v0] (G.to_vertex_list (G.reachable singleton_g v0))
+      let memo = ref G.VMap.empty in
+      assert_equal [v0] (G.to_vertex_list (G.memoized_reachable memo singleton_g v0))
         ~printer:(Lib.string_of_t (Format.pp_print_list HString.pp_print_hstring) ))
   ; "reachable cycle graph" >:: (fun _ ->
-    assert_equal [v0;v1] (G.to_vertex_list (G.reachable dos_cycle_g v0))
+    let memo = ref G.VMap.empty in
+    assert_equal [v0;v1] (G.to_vertex_list (G.memoized_reachable memo dos_cycle_g v0))
       ~printer:(Lib.string_of_t (Format.pp_print_list HString.pp_print_hstring) ))
   ; "reachable cycle graph2" >:: (fun _ ->
-    assert_equal [v0;v1;v2] (G.to_vertex_list (G.reachable cycle_and_one_more v0))
+    let memo = ref G.VMap.empty in
+    assert_equal [v0;v1;v2] (G.to_vertex_list (G.memoized_reachable memo cycle_and_one_more v0))
       ~printer:(Lib.string_of_t (Format.pp_print_list HString.pp_print_hstring)))
   ]
   


### PR DESCRIPTION
After thinking about this for entirely too long. I realized that what I would have done would have ended up being a dynamic programming approach to what should already be possible with the graph setup. Thus, I decided to just try memoizing the output of the `reachable` function. And it works great. I diffed the output of the original `reachable` and the `memoized_reachable` for the `cruise_controller` example and they are identical (as one would hope!)

With this change the new front-end takes ~.04s to parse the `cruise_controller` example on my machine. 

The final incarnation memoizes with a supplied memo table (as opposed to including the table inside the `reachable` function and only having recursive calls memoized). Surprisingly this didn't turn out to be a huge win (about ~.30 seconds), but it should future proof a bit better with larger files and the cost is low to do.