### PR TITLE
Fix misc bugs

### DIFF
--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -162,3 +162,8 @@ val syn_type_equal : int option -> lustre_type -> lustre_type -> (bool, unit) re
 (** Check syntactic equality of Lustre types (ignoring positions) up to a certain optional depth.
     If the depth is reached, then [Error ()] is returned, otherwise [Ok false] if the
     two expressions are unequal and [Ok true] if they are equal.*)
+
+val hash : int option -> expr -> int
+(** Compute the hash of an AST expression to the given depth. After the depth limit is reached
+    the same hash value is assigned to every sub expression. This function does not include position
+    information in the hash. *)

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -826,22 +826,6 @@ and normalize_contract info map node_id items =
       | AssumptionVars decl ->
         AssumptionVars decl, empty (), StringMap.empty
     in
-(*     Format.eprintf "accum interp: %a\n\n"
-      (pp_print_list
-        (pp_print_pair
-          Format.pp_print_string
-          Format.pp_print_string
-          ":")
-        "\n")
-      (StringMap.bindings !interpretation);
-    Format.eprintf "new interp: %a\n\n"
-      (pp_print_list
-        (pp_print_pair
-          Format.pp_print_string
-          Format.pp_print_string
-          ":")
-        "\n")
-      (StringMap.bindings interpretation'); *)
     interpretation := StringMap.merge union_keys !interpretation interpretation';
     result := nitem :: !result;
     gids := union !gids gids';

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -91,14 +91,13 @@ type generated_identifiers = {
     * LustreAst.expr)
     StringMap.t;
   locals : (bool (* whether the variable is ghost *)
-    * HString.t list (* scope *)
     * LustreAst.lustre_type
     * LustreAst.expr (* abstracted expression *)
     * LustreAst.expr) (* original expression *)
     StringMap.t;
   contract_calls :
     (Lib.position
-    * HString.t list (* contract scope *)
+    * (Lib.position * HString.t) list (* contract scope *)
     * LustreAst.contract_node_equation list)
     StringMap.t;
   warnings : (Lib.position * LustreAst.expr) list;
@@ -122,7 +121,7 @@ type generated_identifiers = {
   expanded_variables : StringSet.t;
   equations :
     (LustreAst.typed_ident list (* quantified variables *)
-    * HString.t list (* contract scope  *)
+    * (Lib.position * HString.t) list (* contract scope  *)
     * LustreAst.eq_lhs
     * LustreAst.expr)
     list;

--- a/src/lustre/lustreContract.ml
+++ b/src/lustre/lustreContract.ml
@@ -35,6 +35,9 @@ let mk_svar pos num name svar scope = {
   pos ; num ; name ; svar ; scope
 }
 
+(** Returns the position of the svar *)
+let pos_of_svar { pos } = pos
+
 let prop_name_of_svar { pos ; name = s; scope } kind name =
   match s with
   | Some n ->
@@ -128,7 +131,7 @@ let pp_print_svar fmt { pos ; num ; svar } =
     num pp_print_position pos SVar.pp_print_state_var svar
 
 let pp_print_svar_debug fmt { pos; num; name; svar; scope } =
-  Format.fprintf fmt "[%d] [%a] (name:%a) (scope:%a) (%a)"
+  Format.fprintf fmt "[%d] [%a] (name:%a) (sv:%a) (scope:%a)"
     num
     pp_print_position pos
     (pp_print_option Format.pp_print_string) name

--- a/src/lustre/lustreContract.mli
+++ b/src/lustre/lustreContract.mli
@@ -46,6 +46,9 @@ val mk_svar :
   Lib.position -> int -> string option ->
   StateVar.t -> (Lib.position * string) list -> svar
 
+(** Returns the position of the svar *)
+val pos_of_svar : svar -> Lib.position
+
 (** Generates a property name.
 
 [prop_name_of_svar svar kind name] generates a property name with the trace

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -624,9 +624,10 @@ and compile_ast_expr
   and compile_mode_reference path' =
     let path' = List.map HString.string_of_hstring path' in
     let rpath = List.rev path' in
-    let path' = (rpath |> List.tl |> List.rev)
-      @ (List.map HString.string_of_hstring !map.contract_scope)
-      @ [(rpath |> List.hd)] in
+    let path1 = (rpath |> List.tl |> List.rev) in
+    let path2 = List.map HString.string_of_hstring !map.contract_scope in
+    let path3 = [(rpath |> List.hd)] in
+    let path' = path2 @ path1 @ path3 in
     let rec find_mode = function
       | { C.path ; C.requires } :: tail ->
         if path = path' then
@@ -1269,16 +1270,6 @@ and compile_contract cstate gids ctx map contract_scope node_scope contract =
         LAN.StringMap.find id gids.LAN.contract_calls
       in
       let svar_scope = (call_pos, List.hd scope) :: contract_scope in
-(*       let subst expr id =
-        let expr = compile_ast_expr cstate ctx [] map expr in
-        let ident = mk_ident id in
-        H.replace !map.expr ident expr;
-      in
-      let in_formals = List.map (fun (_, i, _, _, _) -> i) in_formals in
-      let out_formals = List.map (fun (_, i, _, _) -> i) out_formals in
-      let out_params = List.map (fun i -> A.Ident (pos, i)) out_params in
-      List.iter2 subst in_params in_formals;
-      List.iter2 subst out_params out_formals; *)
       let contract_scope = List.map (fun (_, i) -> i) svar_scope in
       map := { !map with contract_scope };
       let (a, g) = compile_contract cstate gids ctx map svar_scope node_scope contract_eqns

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1907,8 +1907,9 @@ and compile_node_decl gids is_function cstate ctx i ext inputs outputs locals it
   (* ****************************************************************** *)
   (* Finalize and build intermediate LustreNode                         *)
   (* ****************************************************************** *)
-  in let locals = sofar_local @ ghost_locals @ locals @ glocals in
-  let equations = sofar_equation @ equations @ gequations in
+  in let locals = sofar_local @ ghost_locals @ glocals @ locals in
+  let calls = List.rev calls in
+  let equations = List.rev (sofar_equation @ equations @ gequations) in
   let state_var_source_map = SVT.fold
     (fun k v a -> SVM.add k v a)
     !map.source SVM.empty in

--- a/tests/experimental/success/contract_import_indirection.lus
+++ b/tests/experimental/success/contract_import_indirection.lus
@@ -1,0 +1,46 @@
+
+node H (u:bool) returns (v:bool);
+let
+   v = not u;
+tel;
+
+contract A (a:bool) returns (b:bool) ;
+let
+  assume a;
+  assume H(a);
+  guarantee not b;
+  mode Am (
+      require a;
+      ensure not b;
+  );
+tel
+
+contract B (x:bool) returns (y:bool) ;
+let
+  var v: bool = not (not x);
+
+  assume H(x);
+  import A (x) returns (y);
+  mode Bm (
+      require x;
+      require v;
+      require v;
+      ensure ::A::Am;
+  );
+tel
+
+contract C (n:bool) returns (m:bool);
+let
+    import B (n) returns (m);
+    import A (n) returns (m);
+tel
+
+node N (u:bool) returns (v:bool);
+(*@contract
+  var h1: bool = not u;
+  import C (h1) returns (v);
+  guarantee ::C::B::A::Am;
+*)
+let
+   v = u;
+tel;


### PR DESCRIPTION
- Fixed a bug where mode paths were computed incorrectly in a special case with contract node import indirection
- Fixed a bug where contract node outputs weren't substituted for their arguments
- Changed ordering of Lustre intermediate representation to more closely match the old frontend
- Fixed a bug with abstraction variable caches not respecting the invariants needed to be a `Map` key, put them inside a `Hashtbl` instead.
- Fixed scope of mode ensures/requires