### PR TITLE
Update computation of deadlocking trace and conflict

### DIFF
--- a/src/flags.ml
+++ b/src/flags.ml
@@ -1133,10 +1133,43 @@ module Contracts = struct
     )
   let refinement () = !refinement
 
+
+  let print_deadlock_default = true
+  let print_deadlock = ref print_deadlock_default
+  let _ = add_spec
+    "--print_deadlock"
+    (bool_arg print_deadlock)
+    (fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        Print a deadlocking trace and a conflict when@ \
+        a contract is proven unrealizable@ \
+        Default: %a\
+      @]"
+      fmt_bool print_deadlock_default
+    )
+  let print_deadlock () = !print_deadlock
+
+
+  let check_contract_is_sat_default = true
+  let check_contract_is_sat = ref check_contract_is_sat_default
+let _ = add_spec
+    "--check_contract_is_sat"
+    (bool_arg check_contract_is_sat)
+    (fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        Check whether a contract proven unrealizable is satisfiable@ \
+        Default: %a\
+      @]"
+      fmt_bool print_deadlock_default
+    )
+  let check_contract_is_sat () = !check_contract_is_sat
+
 end
 
 
-(* Contracts flags. *)
+(* Certificates and proofs flags. *)
 module Certif = struct
 
   include Make_Spec (struct end)

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -461,6 +461,12 @@ module Contracts : sig
 
   (** Activate refinement. *)
   val refinement : unit -> bool
+
+  (** Print deadlocking trace and a conflict *)
+  val print_deadlock : unit -> bool
+
+  (** Check whether a unrealizable contract is satisfiable *)
+  val check_contract_is_sat : unit -> bool
 end
 
 

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -716,14 +716,17 @@ let run in_sys =
           Stat.start_timer Stat.analysis_time ;
           match result with
           | Unrealizable _ -> (
-            let result =
-              ContractChecker.check_contract_satisfiability sys
-            in
-            Log.log_result
-              (ContractChecker.pp_print_satisfiability_result_pt param)
-              ContractChecker.pp_print_satisfiability_result_xml
-              ContractChecker.pp_print_satisfiability_result_json
-              result ;
+            if Flags.Contracts.check_contract_is_sat () then (
+              KEvent.log L_note "Checking satisfiability of contract..." ;
+              let result =
+                ContractChecker.check_contract_satisfiability sys
+              in
+              Log.log_result
+                (ContractChecker.pp_print_satisfiability_result_pt param)
+                ContractChecker.pp_print_satisfiability_result_xml
+                ContractChecker.pp_print_satisfiability_result_json
+                result ;
+            )
           )
           | _ -> () ;
 

--- a/src/lustre/contractChecker.ml
+++ b/src/lustre/contractChecker.ml
@@ -204,8 +204,18 @@ let check_contract_realizability in_sys sys =
 
 
 let compute_unviable_trace_and_core analyze in_sys param sys u_result =
+
+  let vars_at_1 =
+    TSys.vars_of_bounds ~with_init_flag:true sys Numeral.one Numeral.one
+    |> List.filter (fun v -> not (Var.is_const_state_var v))
+  in
+
+  let controllable_vars_at_0, controllable_vars_at_1 =
+    compute_controllable_vars in_sys sys vars_at_1
+  in
+
   Realizability.compute_deadlocking_trace_and_conflict
-    analyze in_sys param sys u_result
+    analyze in_sys param sys controllable_vars_at_0 controllable_vars_at_1 u_result
     
 
 let core_desc = "conflicting constraints"

--- a/src/realizability.mli
+++ b/src/realizability.mli
@@ -60,6 +60,8 @@ val compute_deadlocking_trace_and_conflict :
   'a InputSystem.t ->
   Analysis.param ->
   TransSys.t ->
+  Var.t list ->
+  Var.t list ->
   unrealizable_result ->
   ((StateVar.t * Model.value list) list * ModelElement.loc_core)
 


### PR DESCRIPTION
Partially revert changes of PR #852: conflicts _dependent_ on last trace input values again. It also adds a flag to disable computation of a deadlock when a contract is proven unrealizable and a flag to disable contract satisfiability check.