### PR TITLE
fix subranges with type syns and orig types

### DIFF
--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -138,7 +138,8 @@ let expand_type_syn: tc_context -> tc_type -> tc_type
 
 let rec expand_nested_type_syn: tc_context -> tc_type -> tc_type
   = fun ctx -> function
-  | UserType _ as ty -> expand_type_syn ctx ty
+  | UserType _ as ty -> 
+    expand_nested_type_syn ctx (expand_type_syn ctx ty)
   | TupleType (p, tys) ->
     let tys = List.map (expand_nested_type_syn ctx) tys in
     TupleType (p, tys)

--- a/tests/regression/success/infer_tight_subrange.lus
+++ b/tests/regression/success/infer_tight_subrange.lus
@@ -46,3 +46,27 @@ let
    --%PROPERTY 0 <= o[2] and o[2] <= 1 ;
    --%MAIN ;
 tel;
+
+type S = subrange [1,2] of int;
+type tr1 = struct { s: S};
+type tr2 = struct { r: tr1; x: S};
+type ta = tr2^3;
+type tt = [tr2,int];
+
+node N6(e: tr2) returns (z: tt);
+let
+  z = {e, e.x};
+   --%MAIN ;
+tel
+
+node N7(e: tr2) returns (z: ta);
+let
+  z = [e, e, e];
+   --%MAIN ;
+tel
+
+node N8(e: tr2) returns (z: tr2);
+let
+  z = e;
+   --%MAIN ;
+tel


### PR DESCRIPTION
Expanding type synonyms in structured types was not correctly
recursing in strucutred types when reaching a type synonym.

Comparing to original types was not fine-grained enough