### PR TITLE
Fix consts in contract

### DIFF
--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -472,15 +472,23 @@ let substitute: TC.tc_context -> LA.declaration -> (TC.tc_context * LA.declarati
   | (LA.NodeDecl (span, (i, imported, params, ips, ops, ldecls, items, contract))) ->
     let ips' = inline_constants_of_const_clocked_type_decl ctx ips in
     let ops' = inline_constants_of_clocked_type_decl ctx ops in
+    let contract' = match contract with
+      | Some contract -> Some (inline_constants_of_contract ctx contract)
+      | None -> None
+    in
     let ctx', ldecls' = inline_constants_of_node_locals ctx ldecls in
     let items' = inline_constants_of_node_items ctx' items in
-     ctx, (LA.NodeDecl (span, (i, imported, params, ips', ops', ldecls', items', contract)))
+     ctx, (LA.NodeDecl (span, (i, imported, params, ips', ops', ldecls', items', contract')))
   | (LA.FuncDecl (span, (i, imported, params, ips, ops, ldecls, items, contract))) ->
     let ips' = inline_constants_of_const_clocked_type_decl ctx ips in
     let ops' = inline_constants_of_clocked_type_decl ctx ops in
+    let contract' = match contract with
+      | Some contract -> Some (inline_constants_of_contract ctx contract)
+      | None -> None
+    in
     let ctx', ldecls' = inline_constants_of_node_locals ctx ldecls in
     let items' = inline_constants_of_node_items ctx' items in
-     ctx, (LA.FuncDecl (span, (i, imported, params, ips', ops', ldecls', items', contract)))
+     ctx, (LA.FuncDecl (span, (i, imported, params, ips', ops', ldecls', items', contract')))
   | (LA.ContractNodeDecl (span, (i, params, ips, ops, contract))) ->
      ctx, (LA.ContractNodeDecl (span, (i, params, ips, ops, inline_constants_of_contract ctx contract)))
   | e -> (ctx, e)

--- a/tests/regression/success/const_in_contract.lus
+++ b/tests/regression/success/const_in_contract.lus
@@ -1,0 +1,14 @@
+node id_bool(x: bool) returns (out: bool)
+let
+  out = x;
+tel
+
+const ok: bool = true;
+node x(in: bool) returns (out: bool);
+(*@contract
+  guarantee id_bool(ok);
+*)
+let
+  out = in;
+  --%PROPERTY id_bool(ok);
+tel


### PR DESCRIPTION
Fixes #878, also adds constant inlining for node/fn contracts, I assume this was accidentally missed?