### PR TITLE
Use only weak hash-consing implementation

### DIFF
--- a/src/flags.ml
+++ b/src/flags.ml
@@ -3206,23 +3206,7 @@ module Global = struct
     )
   let color () = !color
 
-  
-  (* Use weak hash-consing. *)
-  let weakhcons_default = false
-  let weakhcons = ref weakhcons_default
-  let _ = add_spec
-    "--weakhcons"
-    (bool_arg weakhcons)
-    (fun fmt ->
-      Format.fprintf fmt
-        "\
-          Use weak hash-consing.@ \
-          Default: %a\
-        "
-        fmt_bool weakhcons_default
-    )
-  let weakhcons () = !weakhcons
-  
+
   (* Version flag. *)
   let _ = add_spec
     "--version"
@@ -3288,7 +3272,6 @@ let clear_input_files = Global.clear_input_files
 let add_input_file = Global.add_input_file
 let lus_compile = Global.lus_compile
 let color = Global.color
-let weakhcons = Global.weakhcons
 
 (* Path to subdirectory for a system (in the output directory). *)
 let subdir_for scope =

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -225,8 +225,6 @@ val lus_compile : unit -> bool
 (** Colored output. *)
 val color : unit -> bool
 
-(** Use weak hash-consing. *)
-val weakhcons : unit -> bool
 
 (** {2 SMT solver flags} *)
 module Smt : sig

--- a/src/utils/hashcons.ml
+++ b/src/utils/hashcons.ml
@@ -53,16 +53,7 @@ module type HSig = sig
   module Make(H : HashedType) : (S with type key = H.t and type prop = H.prop)
 end
 
-
-
-let selected =
-  if Flags.weakhcons () then
-    (module HashconsWeak : HSig)
-  else
-    (module HashconsStrong : HSig)
-
-
-include (val (selected))
+include (val (module HashconsWeak : HSig))
 
   
 (* 

--- a/src/utils/hashconsWeak.ml
+++ b/src/utils/hashconsWeak.ml
@@ -118,7 +118,7 @@ and add t d =
   loop 0
 
 let hashcons t d p =
-  let hkey = Hashtbl.hash d in
+  let hkey = Hashtbl.hash d land max_int in
   let index = hkey mod (Array.length t.table) in
   let bucket = t.table.(index) in
   let sz = Weak.length bucket in
@@ -266,7 +266,7 @@ struct
     loop 0
 
   let hashcons t d p =
-    let hkey = H.hash d in
+    let hkey = H.hash d land max_int in
     let index = hkey mod (Array.length t.table) in
     let bucket = t.table.(index) in
     let sz = Weak.length bucket in
@@ -290,7 +290,7 @@ struct
   (* A version of hashcons that returns existing values, but does not
      insert the value into the table *)
   let find t d =
-    let hkey = H.hash d in
+    let hkey = H.hash d land max_int in
     let index = hkey mod (Array.length t.table) in
     let bucket = t.table.(index) in
     let sz = Weak.length bucket in


### PR DESCRIPTION
We found a hard-to-reproduce issue where a term that is still alive disappears from the hash-consing table that uses normal pointers (`hashconsStrong`), which should never happen! Since the problem has not been reproduced so far when the hash-consing table with weak pointers is used instead (`hashconsWeak`), this PR switches to the implementation that uses weak pointers.