### PR TITLE
Fixes in invariant pruning

### DIFF
--- a/doc/usr/source/1_techniques/3_invgen.rst
+++ b/doc/usr/source/1_techniques/3_invgen.rst
@@ -20,7 +20,8 @@ Options
 
 Invariant generation can be tweaked using the following options. Note that this will affect both the one state and two state process if both are running.
 
-``--invgen_prune_trivial <bool>`` (default ``true``\ ) -- when invariants are discovered, do not communicate the ones that are direct consequences of the transition relation.
+``--invgen_prune_trivial <bool>`` (default ``true``\ ) -- when invariants are discovered, do not communicate one-state invariants implied by previous one-state invariants,
+and two-state invariants implied by previous two-state invariants or the transition relation.
 
 ``--invgen_max_succ <int>`` (default ``1``\ ) -- the number of unrolling to perform on subsystems before moving on to the next one in the hierarchy.
 

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -2080,8 +2080,9 @@ module Invgen = struct
     (fun fmt ->
       Format.fprintf fmt
         "@[<v>\
-          Invariant generation will only communicate invariants not implied@ \
-          by the transition relation@ \
+          Invariant generation will only communicate one-state invariants not implied by@ \
+          previous one-state invariants, and two-state invariants not implied by@ \
+          previous two-state invariants or the transition relation@ \
           Default: %a\
         @]"
         fmt_bool prune_trivial_default

--- a/src/invgen/invGen.ml
+++ b/src/invgen/invGen.ml
@@ -352,7 +352,7 @@ module Make (Graph : GraphSig) : Out = struct
     (* Format.printf "  pruning@.@." ; *)
     let (non_trivial, trivial) =
       if Flags.Invgen.prune_trivial () then
-        Lsd.query_pruning pruner invs
+        Lsd.query_pruning pruner two_state invs
       else (invs, [])
     in
 

--- a/src/invgen/invGen.ml
+++ b/src/invgen/invGen.ml
@@ -306,7 +306,7 @@ module Make (Graph : GraphSig) : Out = struct
   pruning solver map [sys_map].
 
   Returns the new invariants for the system [sys]. *)
-  let recv_and_update input_sys aparam top_sys sys_map sys =
+  let recv_and_update two_state input_sys aparam top_sys sys_map sys =
 
     let update_pruning_checkers map =
       Scope.Map.fold (
@@ -318,7 +318,8 @@ module Make (Graph : GraphSig) : Out = struct
             try (
               let pruning_checker = SysMap.find sys_map this_sys in
               Lsd.pruning_add_invariants pruning_checker false os ;
-              Lsd.pruning_add_invariants pruning_checker true ts
+              if two_state then
+                Lsd.pruning_add_invariants pruning_checker true ts
             ) with Not_found -> (
               (* System is abstract or was discarded, skipping it. *)
             )
@@ -434,7 +435,7 @@ module Make (Graph : GraphSig) : Out = struct
 
     (* Receiving messages, don't care about new invariants for now as we
     haven't create the base/step checker yet. *)
-    let _ = recv_and_update input_sys param top_sys sys_map sys in
+    let _ = recv_and_update two_state input_sys param top_sys sys_map sys in
 
     (* Retrieving pruning checker for this system. *)
     let pruning_checker =
@@ -506,7 +507,7 @@ module Make (Graph : GraphSig) : Out = struct
 
     (* Receiving messages. *)
     let new_os, new_ts =
-      recv_and_update input_sys param top_sys sys_map sys
+      recv_and_update two_state input_sys param top_sys sys_map sys
     in
     Lsd.step_add_invariants lsd false new_os ;
     Lsd.step_add_invariants lsd true new_ts ;
@@ -711,7 +712,7 @@ module Make (Graph : GraphSig) : Out = struct
       invariants. *)
       Graph.mine top_only two_state aparam sys (
         fun sys ->
-          let pruning_checker = Lsd.mk_pruning_checker sys in
+          let pruning_checker = Lsd.mk_pruning_checker sys two_state in
           prune_ref := pruning_checker :: (! prune_ref) ;
           SysMap.replace sys_map sys pruning_checker
       )

--- a/src/invgen/invGen.ml
+++ b/src/invgen/invGen.ml
@@ -308,7 +308,7 @@ module Make (Graph : GraphSig) : Out = struct
   Returns the new invariants for the system [sys]. *)
   let recv_and_update input_sys aparam top_sys sys_map sys =
 
-    let [@ocaml.warning "-27"] update_pruning_checkers sys_invs map =
+    let update_pruning_checkers map =
       Scope.Map.fold (
         fun scope (os, ts) acc ->
           let this_sys = Sys.find_subsystem_of_scope top_sys scope in
@@ -333,7 +333,7 @@ module Make (Graph : GraphSig) : Out = struct
     |> KEvent.update_trans_sys_sub input_sys aparam top_sys
     |> fst
     (* Update everything. *)
-    |> update_pruning_checkers []
+    |> update_pruning_checkers
 
 
   (** Queries step to identify invariants, prunes trivial ones away,

--- a/src/invgen/lockStepDriver.ml
+++ b/src/invgen/lockStepDriver.ml
@@ -587,7 +587,7 @@ let pruning_add_invariants t ts invs =
 
 
 (** Separates the trivial invariants from a list of candidates. *)
-let query_pruning pruning_checker =
+let query_pruning pruning_checker two_state =
 
   let { solver } = pruning_checker in
   
@@ -608,7 +608,7 @@ let query_pruning pruning_checker =
       Actlit.term_of_actlit actlit
     in
 
-    let k = Num.one in
+    let k = if two_state then Num.one else Num.zero in
 
     (* Bumping everyone for query and get values. *)
     let cands = candidates |> List.map (Term.bump_state k) in

--- a/src/invgen/lockStepDriver.ml
+++ b/src/invgen/lockStepDriver.ml
@@ -17,9 +17,6 @@
 *)
 
 
-open Lib
-
-
 (** Lock Step Driver for graph-based invariant generation.
 
 Provides structures to abstract SMT-solvers for the base / step case, as well
@@ -648,12 +645,15 @@ let query_pruning pruning_checker =
     | None ->
       Smt.trace_comment solver "|===| Done." ;
       (non_trivial, candidates)
-    | Some (non_triv :: non_trivs, rest) ->
+    | Some (non_triv, rest) ->
+      loop (List.rev_append non_triv non_trivial) rest
+    (*| Some (non_triv :: non_trivs, rest) ->
+      (* pruning_add_invariants pruning_checker two_state [non_triv]; *)
       loop (non_triv :: non_trivial) (List.rev_append non_trivs rest)
     | Some ([], _) ->
       KEvent.log L_fatal
         "[pruning] satisfiable instance but no falsifiable candidate" ;
-      exit 2
+      exit 2*)
   in
 
   loop []

--- a/src/invgen/lockStepDriver.mli
+++ b/src/invgen/lockStepDriver.mli
@@ -111,7 +111,7 @@ val pruning_sys : pruning -> TransSys.t
 val kill_pruning : pruning -> unit
 
 (** Creates a pruning checker for a system. *)
-val mk_pruning_checker : TransSys.t -> pruning
+val mk_pruning_checker : TransSys.t -> bool -> pruning
 
 (** Adds invariants to a pruning checker.
 Second argument is the one-state invariants, third is the two-state ones. *)

--- a/src/invgen/lockStepDriver.mli
+++ b/src/invgen/lockStepDriver.mli
@@ -120,7 +120,7 @@ val pruning_add_invariants : pruning -> bool -> Term.t list -> unit
 (** Checks if some terms are trivially implied by the transition relation.
 
 Returns a pair of the trivial and the non-trivial invariants. *)
-val query_pruning : pruning -> Term.t list -> ( Term.t list * Term.t list )
+val query_pruning : pruning -> bool -> Term.t list -> ( Term.t list * Term.t list )
 
 (* 
    Local Variables:


### PR DESCRIPTION
In commit https://github.com/kind2-mc/kind2/commit/6954967d3e550e1e3e223088d78cc6b9de4c0008 non-trivial invariants are processed individually so that they are taken into account to prune next candidates. However, commit https://github.com/kind2-mc/kind2/commit/79fea6412802c2e1e2df2ca3c95097f5c650b2b9 stopped adding discovered invariants to pruner so that no information is learnt and each non-trivial invariant is discovered multiple times. Adding a call to `pruning_add_invariants` like in the [original code](https://github.com/kind2-mc/kind2/commit/6954967d3e550e1e3e223088d78cc6b9de4c0008#diff-1d69aae45111266ee95fae8a104bb4a79e61422f881ecade0dd6bcd870f0e2b2R645) would restore the intended behavior, but it has some downsides:
 - Non-trivial invariants are added to the pruner twice: during the loop and after pruning is done.
 - If `conditional_pruning_solver_reset` restarts the solver, the discovered non-trivial invariants until that point will be ignored like in the current behavior.
 - Multiple candidates are checked at the same time, but only one non-trivial invariant is learnt in each iteration.
 
Input to reproduce the issue fixed in commit [4fbb341](https://github.com/kind2-mc/kind2/pull/903/commits/4fbb3418337f63a867975460457a23544bf0f798) using z3 4.8.9: [relatedCounters_small_bounds.lus](https://github.com/kind2-mc/kind2-benchmarks/blob/master/FunctionalChain/relatedCounters/relatedCounters_small_bounds.lus)
Running `kind2 --certif true relatedCounters_small_bounds.lus` triggered the following error: 
`<Error> Caught CertifChecker.CouldNotProve(_) in post-analysis treatment.`