### PR TITLE
Revert a few changes applied in PR #890

### DIFF
--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -308,9 +308,11 @@ and simplify_expr ?(is_guarded = false) ctx =
     | _ -> e')
   | LA.Pre (pos, e) ->
     let e' = simplify_expr ~is_guarded:false ctx e in
-    if Flags.lus_push_pre () then 
-      push_pre is_guarded pos e'
-    else Pre (pos, e')
+    if is_guarded && LH.expr_is_const e' then e'
+    else
+      if Flags.lus_push_pre ()
+      then push_pre is_guarded pos e'
+      else Pre (pos, e')
   | Arrow (pos, e1, e2) ->
     let e1' = simplify_expr ~is_guarded ctx e1 in
     let e2' = simplify_expr ~is_guarded:true ctx e2 in

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1212,9 +1212,9 @@ and normalize_expr ?guard info map =
     let nexpr2, gids2 = normalize_expr ?guard:(Some nexpr1) info map expr2 in
     let gids = union gids1 gids2 in
     Arrow (pos, nexpr1, nexpr2), gids
-  (* | Pre (pos1, ArrayIndex (pos2, expr1, expr2)) ->
+   | Pre (pos1, ArrayIndex (pos2, expr1, expr2)) ->
     let expr = A.ArrayIndex (pos2, Pre (pos1, expr1), expr2) in
-    normalize_expr ?guard info map expr *)
+    normalize_expr ?guard info map expr
   | Pre (pos, expr) as p ->
     let ivars = info.inductive_variables in
     let ty = if expr_has_inductive_var ivars expr |> is_some then

--- a/tests/regression/falsifiable/forall-pre-array.lus
+++ b/tests/regression/falsifiable/forall-pre-array.lus
@@ -1,0 +1,21 @@
+node count( const n : int ; B : bool^n ) returns ( C : int ) ;
+  var A : int^n ;
+let
+  A[i] = if i = 0 then if B[i] then 1 else 0
+         else A[i-1] + (if B[i] then 1 else 0);
+  C = A[n-1] ;
+tel
+
+node Buffer( const n : int; Init : int ; Request: bool^n; Turn : bool^n; Value : int^n )
+returns ( Accepted : bool^n ) ;
+(*@contract
+  assume n > 0 ;
+  assume n <= 4 ;
+  
+  guarantee "fair" true -> 
+   forall (i:int) 0 <= i and i < n =>
+    pre Request[i] and not pre Accepted[i] => Accepted[i] ;
+*)
+let
+  Accepted[i] = Request[i] and (Turn[i] or count(n, Request) = 1) ;
+tel


### PR DESCRIPTION
They were introduced under the assumption that pre pushing was always performed.
Currently pre pushing is optional (--lus_push_pre).