### PR TITLE
Tweak cvc5 options

### DIFF
--- a/src/smt/CVC5Driver.ml
+++ b/src/smt/CVC5Driver.ml
@@ -35,9 +35,10 @@ let cmd_line
   let common_flags =
     [|
       "--incremental";
-      "--decision=internal";
       "--ext-rew-prep=agg";
-      "--dag-thresh=0";
+      "--mbqi";                (* Use model-based quantifier instantiation (best for sat) *)
+      "--full-saturate-quant"; (* Resort to full effort techniques instead of answering
+                                  unknown due to limited quantifier reasoning (best for unsat) *)
     |]
   in
 


### PR DESCRIPTION
Remove `--decision=internal` (it is already the default value)
Remove `--dag-thresh=0` (added for proofs, but not required anymore)
Add `--mbqi` (good for disproving invalid properties with quantifiers)
Add `--full-saturate-quant` (avoid unknown answers)
Keep `--ext-rew-prep=agg` (helps to solve more benchmarks, in general)