### PR TITLE
Enable new array dependency check

### DIFF
--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -39,7 +39,7 @@ module AD = LustreAstDependencies
 module LAN = LustreAstNormalizer
 module LS = LustreSyntaxChecks
 module LIA = LustreAbstractInterpretation
-(* module LAD = LustreArrayDependencies *)
+module LAD = LustreArrayDependencies
 
 type error = [
   | `LustreArrayDependencies of Lib.position * LustreArrayDependencies.error_kind
@@ -147,7 +147,7 @@ let type_check declarations =
     let* (inlined_ctx, const_inlined_type_and_consts) = IC.inline_constants ctx sorted_const_type_decls in
 
     (* Step 6. Dependency analysis on nodes and contracts *)
-    let* (sorted_node_contract_decls, toplevel_nodes, _node_summary) = AD.sort_and_check_nodes_contracts node_contract_src in
+    let* (sorted_node_contract_decls, toplevel_nodes, node_summary) = AD.sort_and_check_nodes_contracts node_contract_src in
 
     (* Step 7. type check nodes and contracts *)
     let* global_ctx = TC.type_check_infer_nodes_and_contracts inlined_ctx sorted_node_contract_decls in
@@ -158,7 +158,7 @@ let type_check declarations =
     in
 
     (* Step 9. Check that inductive array equations are well-founded *)
-    (* let* _ = LAD.check_inductive_array_dependencies inlined_global_ctx node_summary const_inlined_nodes_and_contracts in *)
+    let* _ = LAD.check_inductive_array_dependencies inlined_global_ctx node_summary const_inlined_nodes_and_contracts in
 
     (* Step 10. Infer tighter subrange constraints with abstract interpretation *)
     let abstract_interp_ctx = LIA.interpret_program inlined_global_ctx const_inlined_nodes_and_contracts in

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -127,7 +127,7 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
 (* *************************************************************************** *)
 (*                   Lustre Ast Array Dependencies Checks                      *)
 (* *************************************************************************** *)
-(*let _ = run_test_tt_main ("frontend lustreArrayDependencies error tests" >::: [
+let _ = run_test_tt_main ("frontend lustreArrayDependencies error tests" >::: [
   mk_test "test invalid inductive array def 1" (fun () ->
     match load_file "./lustreArrayDependencies/inductive_array1.lus" with
     | Error (`LustreArrayDependencies  (_, Cycle _)) -> true
@@ -172,7 +172,7 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
     match load_file "./lustreArrayDependencies/inductive_array11.lus" with
     | Error (`LustreArrayDependencies  (_, Cycle _)) -> true
     | _ -> false);
-])*)
+])
 
 (* *************************************************************************** *)
 (*                      Lustre Ast Dependencies Checks                         *)

--- a/tests/regression/success/array-index-check.lus
+++ b/tests/regression/success/array-index-check.lus
@@ -1,0 +1,6 @@
+node test() returns(y: int^3);
+let
+  y[i] = 0 -> (if i=0 then pre y[i]+1 else y[(i - 1)]);
+
+  check y[1]=0 -> y[1]>0;
+tel;


### PR DESCRIPTION
The old dependency check fails on model with arrays (see included regression test). This PR performs old dependency check only when `old_frontend` is true.