### PR TITLE
Fix printing of bitvector sort in LFSC proofs

### DIFF
--- a/src/certif/proof.ml
+++ b/src/certif/proof.ml
@@ -568,6 +568,7 @@ let rec pp_print_sort ppf t =
     else
       Format.fprintf ppf "(cvc.FArray %a %a)" pp_print_sort ti pp_print_sort te
   | Abstr s -> Format.pp_print_string ppf ("cvc." ^ s)
+  | UBV i | BV i -> Format.fprintf ppf "(BitVec %d)" i
   | _ -> Type.pp_print_type ppf t
 
 (* Return a string representation of a sort *)


### PR DESCRIPTION
Issue introduced in commit dfc1a99