### PR TITLE
Fix leaking of internal name in property id

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -805,8 +805,19 @@ and normalize_item info map = function
     Body nequation, gids
   | AnnotMain b -> AnnotMain b, empty ()
   | AnnotProperty (pos, name, expr) ->
+    let name' =
+      match name with
+      | None -> (
+        let hs_expr =
+          Format.asprintf "@[<h>%a@]" A.pp_print_expr expr
+          |> HString.mk_hstring
+        in
+        Some hs_expr
+      )
+      | Some _ as n -> n
+    in
     let nexpr, gids = abstract_expr false info map false expr in
-    AnnotProperty (pos, name, nexpr), gids
+    AnnotProperty (pos, name', nexpr), gids
 
 and rename_ghost_variables info node_id contract =
   let sep = HString.mk_hstring "_contract_" in

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -224,9 +224,9 @@ let print_nodes_and_globals nodes globals =
       globals.LG.state_var_bounds
       [])
   (pp_print_list LustreNode.pp_print_node_debug ";@ ") nodes
-  (pp_print_list LustreNode.pp_print_state_var_instances_debug ";@") nodes
-  (pp_print_list LustreNode.pp_print_state_var_defs_debug ";@") nodes
-  (pp_print_list StateVar.pp_print_state_var_debug ";@")
+  (pp_print_list LustreNode.pp_print_state_var_instances_debug ";@ ") nodes
+  (pp_print_list LustreNode.pp_print_state_var_defs_debug ";@ ") nodes
+  (pp_print_list StateVar.pp_print_state_var_debug ";@ ")
     (nodes |> List.map (fun n -> LustreNode.get_all_state_vars n @ n.oracles)
       |> List.flatten)
 

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -759,9 +759,9 @@ let pp_print_node_debug ppf
     is_function
     (pp_print_list pp_print_state_var_source ";@ ")
       (SVM.bindings state_var_source_map)
-    (pp_print_list pp_print_oracle_state_var_map ";@")
+    (pp_print_list pp_print_oracle_state_var_map ";@ ")
       (SVT.fold (fun k v acc -> (k, v) :: acc) oracle_state_var_map [])
-    (pp_print_list pp_print_state_var_expr_map ";@")
+    (pp_print_list pp_print_state_var_expr_map ";@ ")
       (SVT.fold (fun k v acc -> (k, v) :: acc) state_var_expr_map [])
 
 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1760,21 +1760,16 @@ and compile_node_decl gids is_function cstate ctx i ext inputs outputs locals it
   (* ****************************************************************** *)
   in let props =
     let op (pos, name_opt, expr) =
-      let name_opt = match name_opt with
-        | Some name -> Some (HString.string_of_hstring name)
-        | None -> None
-      in
       let id_str = match expr with
         | A.Ident (_, id_str) -> id_str
         | A.ArrayIndex (_, A.Ident (_, id_str), _) -> id_str
         | _ -> assert false (* must be abstracted *)
       in let id = mk_ident id_str in
       let sv = H.find !map.state_var id in
-      let name = match name_opt with
-        | Some n -> n
-        | None -> let abs = LAN.StringMap.find_opt id_str gids.LAN.locals in
-          let name = match abs with | Some (_, _, _, e) -> e | None -> expr in
-            Format.asprintf "@[<h>%a@]" A.pp_print_expr name
+      let name =
+        match name_opt with
+        | Some n -> HString.string_of_hstring n
+        | None -> assert false (* Prop named in LustreAstNormalizer *)
       in sv, name, (Property.PropAnnot pos)
     in List.map op node_props
 
@@ -2039,8 +2034,6 @@ and compile_node_decl gids is_function cstate ctx i ext inputs outputs locals it
   (* Finalize and build intermediate LustreNode                         *)
   (* ****************************************************************** *)
   in let locals = sofar_local @ ghost_locals @ glocals @ locals in
-  let calls = calls in
-  let props = props in
   let equations = sofar_equation @ equations @ gequations in
   let asserts = List.sort (fun (p1, _) (p2, _) -> compare_pos p1 p2) asserts in
   let state_var_source_map = SVT.fold

--- a/src/terms/stateVar.ml
+++ b/src/terms/stateVar.ml
@@ -197,7 +197,7 @@ let pp_print_state_var ppf { Hashcons.node = (n, s) } =
   pp_print_state_var_node ppf (n, s)
 
 let pp_print_state_var_debug ppf state_var =
-  Format.fprintf ppf "node %a;prop %a\n"
+  Format.fprintf ppf "node %a; prop %a"
     (pp_print_state_var_name) state_var.Hashcons.node
     (pp_print_state_var_prop) state_var.Hashcons.prop
 


### PR DESCRIPTION
If a model includes an unnamed property that consists of just a call to a node that returns a bool, Kind 2 uses the call output as the associated state variable. Before this change, the internal name was leaked in the property id. For an example, see the analysis output for: `tests/regression/success/const_in_contract.lus`. The issue started to show up after commit c6add74.

This PR also handles a case of expression abstraction missed in c6add74