### PR TITLE
Add support for bit-vector SMT extensions 

### DIFF
--- a/src/ic3/IC3.ml
+++ b/src/ic3/IC3.ml
@@ -706,9 +706,6 @@ let extrapolate trans_sys state f g =
     | QE.QuantifiedTermFound _ ->
         let err = "Disabling IC3: Cannot generalize quantified terms." in
         raise (UnsupportedFeature err)
-    | GenericSMTLIBDriver.UnsupportedZ3Symbol s ->
-        let err = ("Disabling IC3: Special non-SMTLIB symbol " ^ s ^ " detected in QE.") in
-        raise (UnsupportedFeature err)
   in
 
   Stat.record_time Stat.ic3_generalize_time;

--- a/src/smt/genericSMTLIBDriver.ml
+++ b/src/smt/genericSMTLIBDriver.ml
@@ -18,8 +18,6 @@
 
 open Lib
 
-exception UnsupportedZ3Symbol of string
-
 (* ********************************************************************** *)
 (* Dummy and default values                                               *)
 (* ********************************************************************** *)
@@ -364,41 +362,35 @@ let gen_expr_of_string_sexpr'
         (* Symbol from string *)
         let s = 
 
-          if ((HString.string_of_hstring h = "bvudiv_i") || 
-              (HString.string_of_hstring h = "bvsdiv_i") ||
-              (HString.string_of_hstring h = "bvurem_i") || 
-              (HString.string_of_hstring h = "bvsrem_i")) then
-            (raise (UnsupportedZ3Symbol (HString.string_of_hstring h)))
-          else
-            try 
+          try
 
-              (* Map the string to an interpreted function symbol *)
-              symbol_of_atom h 
+            (* Map the string to an interpreted function symbol *)
+            symbol_of_atom h
 
-            with 
+          with
 
-              (* Function symbol is uninterpreted *)
-              | Not_found -> 
+            (* Function symbol is uninterpreted *)
+            | Not_found ->
 
-                (* Uninterpreted symbol from string *)
-                let u = 
+              (* Uninterpreted symbol from string *)
+              let u =
 
-                  try 
+                try
 
-                    UfSymbol.uf_symbol_of_string (HString.string_of_hstring h)
+                  UfSymbol.uf_symbol_of_string (HString.string_of_hstring h)
 
-                  with Not_found -> 
-  
-                    (* Cannot convert to an expression *)
-                    failwith 
-                      (Format.sprintf 
-                        "Undeclared uninterpreted function symbol %s in \
-                          S-expression"
-                        (HString.string_of_hstring h))
-                in
+                with Not_found ->
 
-                (* Get the uninterpreted symbol of the string *)
-                Symbol.mk_symbol (`UF u)
+                  (* Cannot convert to an expression *)
+                  failwith
+                    (Format.sprintf
+                      "Undeclared uninterpreted function symbol %s in \
+                        S-expression"
+                      (HString.string_of_hstring h))
+              in
+
+              (* Get the uninterpreted symbol of the string *)
+              Symbol.mk_symbol (`UF u)
 
 
           in
@@ -644,6 +636,10 @@ let smtlib_string_symbol_list =
    ("bvsdiv", Symbol.mk_symbol `BVSDIV);
    ("bvurem", Symbol.mk_symbol `BVUREM);
    ("bvsrem", Symbol.mk_symbol `BVSREM);
+   ("bvudiv_i", Symbol.mk_symbol `BVUDIV);
+   ("bvsdiv_i", Symbol.mk_symbol `BVSDIV);
+   ("bvurem_i", Symbol.mk_symbol `BVUREM);
+   ("bvsrem_i", Symbol.mk_symbol `BVSREM);
    ("bvshl", Symbol.mk_symbol `BVSHL);
    ("bvlshr", Symbol.mk_symbol `BVLSHR);
    ("bvashr", Symbol.mk_symbol `BVASHR);

--- a/src/smt/genericSMTLIBDriver.ml
+++ b/src/smt/genericSMTLIBDriver.ml
@@ -335,6 +335,27 @@ let gen_expr_of_string_sexpr'
 
       expr_of_string_sexpr conv bound_vars e |> Term.bump_state Numeral.one
 
+    (* Bit-vector constant of the form (_ bvX n) where X and n are numerals, i.e. (_ bv13 32) *)
+    | HStringSExpr.List [HStringSExpr.Atom s1; HStringSExpr.Atom s2; HStringSExpr.Atom n]
+      when s1 == s_index && HString.sub s2 0 2 = "bv" -> (
+
+      let size =
+        try Numeral.of_string (HString.string_of_hstring n)
+        with _ -> failwith ("Invalid bit-vector constant (size)")
+      in
+
+      let num =
+        try
+          HString.sub s2 2 (HString.length s2 - 2)
+          |> Numeral.of_string
+        with _ -> failwith ("Invalid bit-vector constant (value)")
+      in
+
+      let bv = Bitvector.num_to_ubv size num in
+
+      Term.mk_bv bv
+
+    )
     (*  A list with more than one element *)
     | HStringSExpr.List ((HStringSExpr.Atom h) :: tl) -> 
 

--- a/src/terms/bitvector.mli
+++ b/src/terms/bitvector.mli
@@ -52,6 +52,9 @@ val bvconcat : t -> t -> t
 (** {1 Numeral to Unsigned Bitvector}
 @author Arjun Viswanathan *)
 
+(** [num_to_ubv s n] returns size [s] unsigned bitvector converted from numeral [n] *)
+val num_to_ubv : Numeral.t -> Numeral.t -> t
+
 (** Return size 8 unsigned bitvector converted from a numeral *)
 val num_to_ubv8 : Numeral.t -> t
 


### PR DESCRIPTION
MathSAT `(get-value)` command returns bit-vector constants of the form `(_ bvX n)`. Kind 2 was ignoring constants in this format leading to an assertion failure. For instance, an assertion failure was triggered when running Kind 2 with `--smt_solver MathSAT --enable IC3` on [rtp_vt.lus](https://github.com/kind2-mc/kind2-benchmarks/blob/master/FMCAD08/Int32/protocol/rtp_vt.lus). This PR adds support for bit-vector constants of the form `(_ bvX n)`.

In addition, this PR makes Kind 2 replace non-standard symbols `bvudiv_i`, `bvsdiv_i`, `bvurem_i`, and `bvsrem_i` returned by some commands of z3 with SMTLIB standard symbols. See this [issue](https://github.com/Z3Prover/z3/issues/1133) for more details.