### PR TITLE
Rename misleading SMT option parameter

### DIFF
--- a/src/c2i/C2I.ml
+++ b/src/c2i/C2I.ml
@@ -155,19 +155,19 @@ let mk_solvers sys =
   (* Destroy all existing solvers. *)
   let solver1 =
     SMTSolver.create_instance
-      ~produce_assignments:true
+      ~produce_models:true
       (TransSys.get_logic sys) (Flags.Smt.solver ())
   in
 
   let solver2 =
     SMTSolver.create_instance
-      ~produce_assignments:true
+      ~produce_models:true
       (TransSys.get_logic sys) (Flags.Smt.solver ())
   in
 
   let solver3 =
     SMTSolver.create_instance
-      ~produce_assignments:true
+      ~produce_models:true
       (TransSys.get_logic sys) (Flags.Smt.solver ())
   in
 

--- a/src/c2i/C2Icnf.ml
+++ b/src/c2i/C2Icnf.ml
@@ -97,7 +97,7 @@ type contex = {
     1, and a transition between 0 and 1 is asserted. *)
 let mk_solver sys init =
   let solver = Solver.create_instance
-    ~produce_assignments:true
+    ~produce_models:true
     (Sys.get_logic sys)
     (Flags.Smt.solver ())
   in

--- a/src/certif/certifChecker.ml
+++ b/src/certif/certifChecker.ml
@@ -476,7 +476,7 @@ let under_approx sys k invs prop =
   in
   
   let solver =
-    SMTSolver.create_instance ~produce_assignments:true
+    SMTSolver.create_instance ~produce_models:true
       logic (Flags.Smt.solver ())
   in
 
@@ -1154,7 +1154,7 @@ let minimize_invariants sys props invs_predicate =
 
     (* Creating solver that will be used to replay and minimize inductive step *)
     let solver =
-      SMTSolver.create_instance ~produce_unsat_assumptions:true ~produce_assignments:true
+      SMTSolver.create_instance ~produce_unsat_assumptions:true ~produce_models:true
         logic (Flags.Smt.solver ())
     in
     

--- a/src/dead_code/lustreChecker.ml
+++ b/src/dead_code/lustreChecker.ml
@@ -145,7 +145,7 @@ let main () =
     (* Create solver instance *)
     let solver = 
       SMTSolver.new_solver
-        ~produce_assignments:true 
+        ~produce_models:true 
         `QF_UFLIA
         (Flags.smtsolver ())
     in

--- a/src/dead_code/testgen/testgen.ml
+++ b/src/dead_code/testgen/testgen.ml
@@ -176,7 +176,7 @@ let run_strategy out_dir sys strategy =
   (* Creating a new solver for this run. *)
   let solver =
     S.create_instance
-      ~produce_assignments:true
+      ~produce_models:true
       (TransSys.get_scope sys)
       (TransSys.get_logic sys)
       (TransSys.get_abstraction sys)

--- a/src/ic3/IC3.ml
+++ b/src/ic3/IC3.ml
@@ -3046,7 +3046,7 @@ let main_ic3 input_sys aparam trans_sys =
   (* Create new solver instance *)
   let solver =
     SMTSolver.create_instance
-      ~produce_assignments:true
+      ~produce_models:true
       ~produce_unsat_assumptions:true
       logic
       (Flags.Smt.solver ())

--- a/src/induction/base.ml
+++ b/src/induction/base.ml
@@ -309,7 +309,7 @@ let init input_sys aparam trans =
 
   (* Creating solver. *)
   let solver =
-    SMTSolver.create_instance ~produce_assignments:true
+    SMTSolver.create_instance ~produce_models:true
       (TransSys.get_logic trans) (Flags.Smt.solver ())
   in
 

--- a/src/induction/step.ml
+++ b/src/induction/step.ml
@@ -662,7 +662,7 @@ let launch input_sys aparam trans =
 
   (* Creating solver. *)
   let solver =
-    SMTSolver.create_instance ~produce_assignments:true
+    SMTSolver.create_instance ~produce_models:true
       logic (Flags.Smt.solver ())
   in
 

--- a/src/induction/step2.ml
+++ b/src/induction/step2.ml
@@ -97,7 +97,7 @@ type 'a ctx = {
 let mk_ctx in_sys param sys =
   let solver =
     Smt.create_instance
-      ~produce_assignments:true
+      ~produce_models:true
       (Sys.get_logic sys)
       (Flags.Smt.solver())
   in

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -164,7 +164,7 @@ let main input_file input_sys _ trans_sys =
   (* Create solver instance *)
   let solver = 
     Flags.Smt.solver ()
-    |> SMTSolver.create_instance ~produce_assignments:true logic
+    |> SMTSolver.create_instance ~produce_models:true logic
   in
 
   (* Create a reference for the solver. Only used in on_exit. *)

--- a/src/invgen/lockStepDriver.ml
+++ b/src/invgen/lockStepDriver.ml
@@ -98,7 +98,7 @@ let kill_base { solver } = Smt.delete_instance solver
 (** Creates a solver for the base case. *)
 let mk_base_checker_solver sys k =
   let solver = (* Creating solver. *)
-    Smt.create_instance ~produce_assignments: true
+    Smt.create_instance ~produce_models: true
       (Sys.get_logic sys) (Flags.Smt.solver ())
   in
 
@@ -522,7 +522,7 @@ let kill_pruning { solver } = Smt.delete_instance solver
 (** Creates a new pruning solver. *)
 let mk_pruning_checker_solver sys two_state =
   let solver = (* Creating solver. *)
-    Smt.create_instance ~produce_assignments:true
+    Smt.create_instance ~produce_models:true
       (Sys.get_logic sys) (Flags.Smt.solver ())
   in
 

--- a/src/ivcMcs.ml
+++ b/src/ivcMcs.ml
@@ -1062,7 +1062,7 @@ let get_logic ?(pathcomp=false) sys =
 let create_solver ?(pathcomp=false) ?(approximate=false) sys actlits bmin bmax =
   let solver =
     SMTSolver.create_instance ~timeout:(Flags.IVC.ivc_uc_timeout ())
-    ~produce_assignments:pathcomp ~produce_unsat_assumptions:true
+    ~produce_models:pathcomp ~produce_unsat_assumptions:true
     ~minimize_cores:(not approximate) (get_logic ~pathcomp sys) (Flags.Smt.solver ()) in
   List.iter (SMTSolver.declare_fun solver) actlits ;
   TS.declare_sorts_ufs_const sys (SMTSolver.declare_fun solver) (SMTSolver.declare_sort solver) ;
@@ -1620,7 +1620,7 @@ let umivc_ ?(os_invs=[]) make_ts_analyzer sys props k enter_nodes
     let sys_cs = List.fold_left (fun acc sv -> TS.add_global_constant acc (Var.mk_const_state_var sv)) sys_cs actsvs in
 
     (* Initialize the seed map *)
-    let map = SMTSolver.create_instance ~produce_assignments:true
+    let map = SMTSolver.create_instance ~produce_models:true
       (`Inferred (TermLib.FeatureSet.of_list [IA; LA])) (Flags.Smt.solver ()) in
     actsvs
     |> List.map Var.mk_const_state_var

--- a/src/qe/QE.ml
+++ b/src/qe/QE.ml
@@ -53,7 +53,7 @@ let get_solver_instance trans_sys =
  
       (* Create solver instance *)
       let solver = SMTSolver.create_instance
-          ~produce_assignments:true
+          ~produce_models:true
           (TermLib.add_quantifiers (TransSys.get_logic trans_sys))
           (get_qe_solver ())
       in
@@ -119,7 +119,7 @@ let get_checking_solver_instance trans_sys =
       (* Create solver instance with support for quantifiers *)
       let solver =     
         SMTSolver.create_instance 
-          ~produce_assignments:true
+          ~produce_models:true
           (* add quantifiers to system logic *)
           (TermLib.add_quantifiers (TransSys.get_logic trans_sys))
           (Flags.Smt.solver ())
@@ -714,7 +714,7 @@ let ae_val_gen trans_sys premise elim conclusion =
   (* Create new solver instance *)
   let solver =
     SMTSolver.create_instance
-      ~produce_assignments:true
+      ~produce_models:true
       (TransSys.get_logic trans_sys)
       (Flags.Smt.solver ())
   in

--- a/src/realizability.ml
+++ b/src/realizability.ml
@@ -93,7 +93,7 @@ let compute_unsat_core sys context requirements ex_var_lst =
   let solver =
     SMTSolver.create_instance
       ~produce_unsat_assumptions:true
-      ~produce_assignments:true
+      ~produce_models:true
       ~minimize_cores:true
       (TSys.get_logic sys)
       (Flags.Smt.solver ())
@@ -719,7 +719,7 @@ let compute_deadlocking_trace_and_conflict
   let solver =
     SMTSolver.create_instance
       ~produce_unsat_assumptions:true
-      ~produce_assignments:true
+      ~produce_models:true
       ~minimize_cores:true
       (TSys.get_logic sys)
       (Flags.Smt.solver ())

--- a/src/smt/BoolectorDriver.ml
+++ b/src/smt/BoolectorDriver.ml
@@ -22,7 +22,7 @@ include GenericSMTLIBDriver
 let cmd_line
     _ (* logic *)
     timeout
-    _ (* produce_assignments *) 
+    _ (* produce_models *) 
     _ (* produce_proofs *)
     _ (* produce_unsat_cores *)
     _ (* produce_unsat_assumptions *)

--- a/src/smt/CVC5Driver.ml
+++ b/src/smt/CVC5Driver.ml
@@ -22,7 +22,7 @@ include GenericSMTLIBDriver
 let cmd_line
     logic
     timeout
-    _ (* produce_assignments *) 
+    _ (* produce_models *) 
     _ (* produce_proofs *)
     _ (* produce_unsat_cores *)
     _ (* produce_unsat_assumptions *)

--- a/src/smt/MathSATDriver.ml
+++ b/src/smt/MathSATDriver.ml
@@ -21,7 +21,7 @@ include GenericSMTLIBDriver
 (* Configuration for MathSAT *)
 let cmd_line 
     logic timeout 
-    _ (* produce_assignments *)
+    _ (* produce_models *)
     _ (* produce_proofs *)
     _ (* produce_unsat_cores *)
     _ (* produce_unsat_assumptions *)

--- a/src/smt/SMTLIBSolver.ml
+++ b/src/smt/SMTLIBSolver.ml
@@ -900,7 +900,7 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
   (* Create an instance of the solver *)
   let create_instance
       ?(timeout=0)
-      ?(produce_assignments=false)
+      ?(produce_models=false)
       ?(produce_proofs=false)
       ?(produce_unsat_cores=false)
       ?(produce_unsat_assumptions=false)
@@ -914,7 +914,7 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
       Driver.cmd_line
         logic
         timeout
-        produce_assignments
+        produce_models
         produce_proofs
         produce_unsat_cores
         produce_unsat_assumptions
@@ -1005,10 +1005,7 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
     let headers =
       "(set-option :print-success true)" ::
       (headers minimize_cores) @
-      (if produce_assignments then
-        (*["(set-option :produce-assignments true)"] else []) @*)
-        (* The command get-model is used instead of get-assignment,
-          thus we should use the option produce-models instead of produce-assignments *)
+      (if produce_models then
         ["(set-option :produce-models true)"] else []) @
       (if produce_unsat_cores ||
           (produce_unsat_assumptions && not (Flags.Smt.check_sat_assume ()))
@@ -1156,7 +1153,7 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
     
     let solver = create_instance
         ~timeout:P.timeout
-        ~produce_assignments:P.produce_assignments
+        ~produce_models:P.produce_models
         ~produce_unsat_cores:P.produce_unsat_cores
         ~produce_unsat_assumptions:P.produce_unsat_assumptions
         ~minimize_cores:P.minimize_cores

--- a/src/smt/SMTSolver.ml
+++ b/src/smt/SMTSolver.ml
@@ -129,7 +129,7 @@ let bool_of_int_option = function
    uninterpreted function symbols *)
 let create_instance
     ?timeout
-    ?produce_assignments
+    ?produce_models
     ?produce_proofs
     ?produce_unsat_cores
     ?produce_unsat_assumptions
@@ -145,7 +145,7 @@ let create_instance
   let module Params = 
   struct
     let timeout = bool_of_int_option timeout
-    let produce_assignments = bool_of_bool_option produce_assignments
+    let produce_models = bool_of_bool_option produce_models
     let produce_proofs = bool_of_bool_option produce_proofs
     let produce_unsat_cores = bool_of_bool_option produce_unsat_cores
     let produce_unsat_assumptions = bool_of_bool_option produce_unsat_assumptions

--- a/src/smt/SMTSolver.mli
+++ b/src/smt/SMTSolver.mli
@@ -34,7 +34,7 @@ exception Timeout
     the given flags *)
 val create_instance :
   ?timeout: int ->
-  ?produce_assignments:bool ->
+  ?produce_models:bool ->
   ?produce_proofs:bool ->
   ?produce_unsat_cores:bool ->
   ?produce_unsat_assumptions:bool ->

--- a/src/smt/Yices2SMT2Driver.ml
+++ b/src/smt/Yices2SMT2Driver.ml
@@ -23,7 +23,7 @@ include GenericSMTLIBDriver
 let cmd_line
     logic
     timeout
-    _ (* produce_assignments *) 
+    _ (* produce_models *) 
     _ (* produce_proofs *)
     _ (* produce_unsat_cores *)
     _ (* produce_unsat_assumptions *)

--- a/src/smt/Z3Driver.ml
+++ b/src/smt/Z3Driver.ml
@@ -22,7 +22,7 @@ include GenericSMTLIBDriver
 let cmd_line
     _ (* logic *)
     timeout
-    _ (* produce_assignments *) 
+    _ (* produce_models *) 
     _ (* produce_proofs *)
     _ (* produce_unsat_cores *)
     _ (* produce_unsat_assumptions *)

--- a/src/smt/Z3Driver.ml
+++ b/src/smt/Z3Driver.ml
@@ -62,7 +62,6 @@ let check_sat_limited_cmd ms =
 
 
 let headers minimize_cores =
-  ["(set-option :interactive-mode true)"] @
   (* Core minimization only supported by Z3 for now *)
   (if minimize_cores then ["(set-option :smt.core.minimize true)"] else [])
 

--- a/src/smt/solverSig.mli
+++ b/src/smt/solverSig.mli
@@ -23,7 +23,7 @@ module type Params = sig
 
   val timeout : int
 
-  val produce_assignments : bool
+  val produce_models : bool
 
   val produce_unsat_cores : bool
 
@@ -126,7 +126,7 @@ module type S = sig
   (** The functor [Create] creates a new instance of the SMT solver with
       paramters passed as its arguments. The parameter argument [P] conataints
       a unique identifier [id], initialized to the logic [l] and produces
-      assignments if the optional labelled argument [produce_assignments] is
+      models if the optional labelled argument [produce_models] is
       [true], proofs if [produce_proofs] is true, unsatisfiable cores if
       [produce_unsat_cores] is true, and unsatisfiable sets of assumptions if
       [produce_unsat_assumptions] is true *)

--- a/src/smt/yicesDriver.ml
+++ b/src/smt/yicesDriver.ml
@@ -23,7 +23,7 @@ open Lib
 let cmd_line
     _ (* logic *)
     timeout
-    _ (* produce_assignments *)
+    _ (* produce_models *)
     _ (* produce_proofs *)
     _ (* produce_unsat_cores *)
     _ (* produce_unsat_assumptions *)

--- a/src/smt/yicesNative.ml
+++ b/src/smt/yicesNative.ml
@@ -1170,7 +1170,7 @@ let trace_coms solver_ppf com = match solver_ppf with
 
 (* Create an instance of the solver *)
 let create_instance
-    ?produce_assignments
+    ?produce_models
     ?produce_proofs
     ?produce_unsat_cores
     ?produce_unsat_assumptions
@@ -1193,7 +1193,7 @@ let create_instance
     YicesDriver.cmd_line
       logic
       0
-      produce_assignments
+      produce_models
       produce_proofs
       produce_unsat_cores
       produce_unsat_assumptions
@@ -1270,12 +1270,12 @@ let create_instance
     }
   in
 
-  (* Produce assignments to be queried with get-values, default is
+  (* Produce models to be queried with get-values, default is
      false per SMTLIB specification *)
   
   let evidence =
     (match produce_unsat_assumptions with Some o -> o | None -> false) ||
-    (match produce_assignments with Some o -> o | None -> false)
+    (match produce_models with Some o -> o | None -> false)
   in
 
   let header_logic solver =
@@ -1381,7 +1381,7 @@ module Create (P : SolverSig.Params) : SolverSig.Inst = struct
   module Conv = Conv
 
   let solver = create_instance
-      ~produce_assignments:P.produce_assignments
+      ~produce_models:P.produce_models
       ~produce_unsat_cores:P.produce_unsat_cores
       ~produce_unsat_assumptions:P.produce_unsat_assumptions
       ~produce_proofs:P.produce_proofs

--- a/src/testgen/testgenSolver.ml
+++ b/src/testgen/testgenSolver.ml
@@ -60,7 +60,7 @@ let mk sys =
   (* Creating solver. *)
   let solver =
     S.create_instance
-      ~produce_assignments:true
+      ~produce_models:true
       (Sys.get_logic sys)
       (Flags.Smt.solver ())
   in


### PR DESCRIPTION
It also removes deprecated and unused SMT option (`:interactive-mode`)