### PR TITLE
Fix path compression BV encoding in minimize_invariants

### DIFF
--- a/src/certif/certifChecker.ml
+++ b/src/certif/certifChecker.ml
@@ -1145,10 +1145,15 @@ let minimize_invariants sys props invs_predicate =
     Debug.certif "Trying to simplify up to k = %d\n" k_orig;
 
     let logic =
+      let open TermLib in
+      let open TermLib.FeatureSet in
       match TransSys.get_logic sys with
-      | `Inferred fs when Flags.BmcKind.compress () ->
-        `Inferred (TermLib.sup_logics [fs; TermLib.FeatureSet.of_list [IA; LA; UF]])
-      | `Inferred l -> `Inferred (TermLib.FeatureSet.add UF l)
+      | `Inferred fs when Flags.BmcKind.compress () -> (
+        if Compress.only_bv sys
+        then `Inferred (sup_logics [ fs; of_list [ BV; UF ] ])
+        else `Inferred (sup_logics [ fs; of_list [ IA; LA; UF ] ])
+      )
+      | `Inferred l -> `Inferred (add UF l)
       | l -> l
     in
 

--- a/src/induction/compress.ml
+++ b/src/induction/compress.ml
@@ -193,7 +193,12 @@ let only_bv trans_sys =
   | `SMTLogic "QF_AUFBV" -> true
   | `SMTLogic _
   | `None -> false
-  | `Inferred l -> TermLib.FeatureSet.(subset l (of_list [ Q; UF; A; BV ]))
+  | `Inferred l when TermLib.FeatureSet.(subset l (of_list [Q; UF; A])) -> (
+    match Flags.Smt.solver () with
+    | `Boolector_SMTLIB -> true
+    | _ -> false
+  )
+  | `Inferred l -> TermLib.FeatureSet.(mem BV l && not(mem IA l))
 
 
 (* Declare uninterpreted function symbol *)

--- a/src/induction/compress.mli
+++ b/src/induction/compress.mli
@@ -37,6 +37,7 @@ val incr_k : unit -> unit
     some simulation relations. *)
 val check_and_block : (UfSymbol.t -> unit) -> TransSys.t -> Model.path -> Term.t list
 
+val only_bv : TransSys.t -> bool
 
 (* 
    Local Variables:

--- a/src/induction/step.ml
+++ b/src/induction/step.ml
@@ -653,10 +653,10 @@ let launch input_sys aparam trans =
   let logic =
     match TransSys.get_logic trans with
     | `Inferred fs when Flags.BmcKind.compress () ->
-        let open TermLib.FeatureSet in
-        if subset fs (of_list [ Q; UF; A; BV ]) then
-          `Inferred (sup_logics [ fs; of_list [ BV; UF ] ])
-        else `Inferred (sup_logics [ fs; of_list [ IA; LA; UF ] ])
+      let open TermLib.FeatureSet in
+      if Compress.only_bv trans
+      then `Inferred (sup_logics [ fs; of_list [ BV; UF ] ])
+      else `Inferred (sup_logics [ fs; of_list [ IA; LA; UF ] ])
     | l -> l
   in
 


### PR DESCRIPTION
It also tweaks encoding so that bit-vectors are only introduced in Boolean/Array problems when Boolector is used.