### PR TITLE
Replace Boolector with Bitwuzla

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+New features:
+
+- Support for SMT solver Bitwuzla.
+  - Its predecessor, Boolector, is no longer supported.
+
 # Kind 2 v1.7.0
 
 New features:

--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,9 @@ given enough time and resources).
 
 ``--timeout <int>`` (default ``0`` = none) -- Run for the given number of seconds of wall clock time
 
-``--smt_solver {Boolector|cvc5|MathSAT|Yices|Yices2|Z3}`` (default ``Z3``\ ) -- Select SMT solver
+``--smt_solver {Bitwuzla|cvc5|MathSAT|Yices|Yices2|Z3}`` (default ``Z3``\ ) -- Select SMT solver
 
-``--boolector_bin <file>`` -- Executable for Boolector
+``--bitwuzla_bin <file>`` -- Executable for Bitwuzla
 
 ``--cvc5_bin <file>`` -- Executable for cvc5
 
@@ -98,7 +98,7 @@ To run Kind 2 the following software must be installed on your computer:
 * Linux or macOS, and
 * a supported SMT solver
 
-  * `Boolector <https://boolector.github.io/>`_ (for inputs with only machine integers),
+  * `Bitwuzla <https://bitwuzla.github.io/>`_ (for inputs with only machine integers),
   * `cvc5 <https://cvc5.github.io/>`_\ ,
   * `MathSAT 5 <http://mathsat.fbk.eu/index.html>`_\ ,
   * `Yices 2 <http://yices.csl.sri.com/>`_\ ,
@@ -106,8 +106,8 @@ To run Kind 2 the following software must be installed on your computer:
   * `Z3 <https://github.com/Z3Prover/z3>`_
 
 Z3 is the presently recommended SMT solver and the default option. For problems with
-only machine integers we recommend to use Boolector in combination with Z3:
-select Boolector as the main solver (``--smt_solver Boolector``) but
+only machine integers we recommend to use Bitwuzla in combination with Z3:
+select Bitwuzla as the main solver (``--smt_solver Bitwuzla``) but
 make sure the Z3 binary is also accessible to Kind 2.
 
 

--- a/doc/usr/source/home.rst
+++ b/doc/usr/source/home.rst
@@ -37,9 +37,9 @@ given enough time and resources).
 
 ``--timeout <int>`` (default ``0`` = none) -- Run for the given number of seconds of wall clock time
 
-``--smt_solver {Boolector|cvc5|MathSAT|Yices|Yices2|Z3}`` (default ``Z3``\ ) -- Select SMT solver
+``--smt_solver {Bitwuzla|cvc5|MathSAT|Yices|Yices2|Z3}`` (default ``Z3``\ ) -- Select SMT solver
 
-``--boolector_bin <file>`` -- Executable for Boolector
+``--bitwuzla_bin <file>`` -- Executable for Bitwuzla
 
 ``--cvc5_bin <file>`` -- Executable for cvc5
 
@@ -78,7 +78,7 @@ To run Kind 2 the following software must be installed on your computer:
 * Linux or macOS, and
 * a supported SMT solver
 
-  * `Boolector <https://boolector.github.io/>`_ (for inputs with only machine integers),
+  * `Bitwuzla <https://bitwuzla.github.io/>`_ (for inputs with only machine integers),
   * `cvc5 <https://cvc5.github.io/>`_\ ,
   * `MathSAT 5 <http://mathsat.fbk.eu/index.html>`_\ ,
   * `Yices 2 <http://yices.csl.sri.com/>`_\ ,
@@ -86,8 +86,8 @@ To run Kind 2 the following software must be installed on your computer:
   * `Z3 <https://github.com/Z3Prover/z3>`_
 
 Z3 is the presently recommended SMT solver and the default option. For problems with
-only machine integers we recommend to use Boolector in combination with Z3:
-select Boolector as the main solver (``--smt_solver Boolector``) but
+only machine integers we recommend to use Bitwuzla in combination with Z3:
+select Bitwuzla as the main solver (``--smt_solver Bitwuzla``) but
 make sure the Z3 binary is also accessible to Kind 2.
 
 

--- a/src/doc/index.mld
+++ b/src/doc/index.mld
@@ -171,7 +171,7 @@ Source files live in subdirectory [SMTSolver]
 {!modules:
   GenericSMTLIBDriver
   CVC5Driver
-  BoolectorDriver
+  BitwuzlaDriver
   MathSATDriver
   Yices2SMT2Driver
   Z3Driver

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -117,7 +117,7 @@ module Smt = struct
 
   (* Active SMT solver. *)
   type solver = [
-    | `Boolector_SMTLIB
+    | `Bitwuzla_SMTLIB
     | `cvc5_SMTLIB
     | `MathSAT_SMTLIB
     | `Yices2_SMTLIB
@@ -126,7 +126,7 @@ module Smt = struct
     | `detect
   ]
   let solver_of_string = function
-    | "Boolector" -> `Boolector_SMTLIB
+    | "Bitwuzla" -> `Bitwuzla_SMTLIB
     | "cvc5" -> `cvc5_SMTLIB
     | "MathSAT" ->  `MathSAT_SMTLIB
     | "Yices2" -> `Yices2_SMTLIB
@@ -134,7 +134,7 @@ module Smt = struct
     | "Z3" -> `Z3_SMTLIB
     | _ -> Arg.Bad "Bad value for --smt_solver" |> raise
   let string_of_solver = function
-    | `Boolector_SMTLIB -> "Boolector"
+    | `Bitwuzla_SMTLIB -> "Bitwuzla"
     | `cvc5_SMTLIB -> "cvc5"
     | `MathSAT_SMTLIB -> "MathSAT"
     | `Yices2_SMTLIB -> "Yices2"
@@ -143,7 +143,7 @@ module Smt = struct
     | `detect -> "detect"
 
   (* Suggested order of use (more capabilities, more theories, better performance) *)
-  let solver_values = "Z3, cvc5, Yices2, MathSAT, Boolector, Yices"
+  let solver_values = "Z3, cvc5, Yices2, MathSAT, Bitwuzla, Yices"
   let solver_default = `detect
   let solver = ref solver_default
   let _ = add_spec
@@ -281,19 +281,19 @@ module Smt = struct
   let set_mathsat_bin str = mathsat_bin := str
   let mathsat_bin () = !mathsat_bin
 
-  (* Boolector binary. *)
-  let boolector_bin_default = "boolector"
-  let boolector_bin = ref boolector_bin_default
+  (* Bitwuzla binary. *)
+  let bitwuzla_bin_default = "bitwuzla"
+  let bitwuzla_bin = ref bitwuzla_bin_default
   let _ = add_spec
-    "--boolector_bin"
-    (Arg.Set_string boolector_bin)
+    "--bitwuzla_bin"
+    (Arg.Set_string bitwuzla_bin)
     (fun fmt ->
       Format.fprintf fmt
-        "@[<v>Executable of Boolector solver@ Default: \"%s\"@]"
-        boolector_bin_default
+        "@[<v>Executable of Bitwuzla solver@ Default: \"%s\"@]"
+        bitwuzla_bin_default
     )
-  let set_boolector_bin str = boolector_bin := str
-  let boolector_bin () = !boolector_bin
+  let set_bitwuzla_bin str = bitwuzla_bin := str
+  let bitwuzla_bin () = !bitwuzla_bin
 
   (* Z3 binary. *)
   let z3_bin_default = "z3"
@@ -394,9 +394,9 @@ module Smt = struct
   
   (* Check which SMT solver is available *)
   let check_smtsolver () = match solver () with
-    (* User chose Boolector *)
-    | `Boolector_SMTLIB ->
-      find_solver ~fail:true "Boolector" (boolector_bin ()) |> ignore
+    (* User chose Bitwuzla *)
+    | `Bitwuzla_SMTLIB ->
+      find_solver ~fail:true "Bitwuzla" (bitwuzla_bin ()) |> ignore
     (* User chose cvc5 *)
     | `cvc5_SMTLIB ->
       find_solver ~fail:true "cvc5" (cvc5_bin ()) |> ignore
@@ -435,9 +435,9 @@ module Smt = struct
         set_mathsat_bin exec;
       with Not_found ->
       try
-        let exec = find_solver ~fail:false "Boolector" (boolector_bin ()) in
-        set_solver `Boolector_SMTLIB;
-        set_boolector_bin exec;
+        let exec = find_solver ~fail:false "Bitwuzla" (bitwuzla_bin ()) in
+        set_solver `Bitwuzla_SMTLIB;
+        set_bitwuzla_bin exec;
       with Not_found ->
       try
         let exec = find_solver ~fail:false "Yices" (yices_bin ()) in
@@ -3483,17 +3483,6 @@ let solver_dependant_actions solver =
   in
 
   match solver with
-  | `Boolector_SMTLIB -> (
-    let cmd = Format.asprintf "%s --version" (Smt.boolector_bin ()) in
-    match get_version true cmd with
-    | Some (major_rev, minor_rev, patch_rev) ->
-      if major_rev < 3 || (major_rev = 3 && (minor_rev < 2 || (minor_rev = 2 && patch_rev < 2))) then (
-        Log.log L_error "Kind 2 requires Boolector 3.2.2 or later. Found version: %d.%d.%d"
-          major_rev minor_rev patch_rev ;
-        raise Error
-      )
-    | None -> Log.log L_warn "Couldn't determine Boolector version"
-  )
   | `MathSAT_SMTLIB -> (
     let cmd = Format.asprintf "%s -version" (Smt.mathsat_bin ()) in
     match get_version true cmd with

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -242,7 +242,7 @@ module Smt : sig
 
   (** Legal SMT solvers. *)
   type solver = [
-    | `Boolector_SMTLIB
+    | `Bitwuzla_SMTLIB
     | `cvc5_SMTLIB
     | `MathSAT_SMTLIB
     | `Yices2_SMTLIB
@@ -280,8 +280,8 @@ module Smt : sig
   (** Change sending of short names to SMT solver *)
   val set_short_names : bool -> unit
 
-  (** Executable of Boolector solver *)
-  val boolector_bin : unit -> string
+  (** Executable of Bitwuzla solver *)
+  val bitwuzla_bin : unit -> string
 
   (** Executable of cvc5 solver *)
   val cvc5_bin : unit -> string

--- a/src/induction/compress.ml
+++ b/src/induction/compress.ml
@@ -195,7 +195,7 @@ let only_bv trans_sys =
   | `None -> false
   | `Inferred l when TermLib.FeatureSet.(subset l (of_list [Q; UF; A])) -> (
     match Flags.Smt.solver () with
-    | `Boolector_SMTLIB -> true
+    | `Bitwuzla_SMTLIB -> true
     | _ -> false
   )
   | `Inferred l -> TermLib.FeatureSet.(mem BV l && not(mem IA l))

--- a/src/smt/BitwuzlaDriver.ml
+++ b/src/smt/BitwuzlaDriver.ml
@@ -18,7 +18,7 @@
 
 include GenericSMTLIBDriver
 
-(* Configuration for Boolector *)
+(* Configuration for Bitwuzla *)
 let cmd_line
     _ (* logic *)
     timeout
@@ -28,8 +28,8 @@ let cmd_line
     _ (* produce_unsat_assumptions *)
     _ (* minimize_cores *) 
     _ (* produce_interpolants *) =
-  (* Path and name of Boolector executable *)
-  let boolector_bin = Flags.Smt.boolector_bin () in
+  (* Path and name of Bitwuzla executable *)
+  let bitwuzla_bin = Flags.Smt.bitwuzla_bin () in
 
   (* Timeout based on Flags.timeout_wall has been disabled because
      it seems to cause performance regressions on some models... *)
@@ -44,17 +44,15 @@ let cmd_line
   in
   let timeout = Lib.min_option timeout_global timeout_local in
 
-  let base_cmd = [| boolector_bin; "--smt2"; "--incremental" |] in
+  let base_cmd = [| bitwuzla_bin; "--smt2"; "--incremental" |] in
   match timeout with
   | None -> base_cmd
   | Some timeout ->
       let timeout = Format.sprintf "--time=%.0f" (timeout |> ceil) in
       Array.append base_cmd [| timeout |]
 
-(* Command to limit check-sat in Z3 to run for the given numer of ms
-   at most *)
 let check_sat_limited_cmd _ =
-  failwith "check-sat with timeout not implemented for Boolector"
+  failwith "check-sat with timeout not implemented for Bitwuzla"
 
 let string_of_logic l =
   let open TermLib in
@@ -62,17 +60,13 @@ let string_of_logic l =
   match l with
   | `Inferred fs ->
       if mem IA fs || mem RA fs then
-        failwith "Boolector only supports BV logics"
+        failwith "Bitwuzla only supports BV logics"
       else
-        (* We add BV because Boolector does not support QF_UF logic *)
-        GenericSMTLIBDriver.string_of_logic (`Inferred (add BV fs))
+        GenericSMTLIBDriver.string_of_logic l
   | `None -> "ALL"
   | `SMTLogic s ->
       if String.contains s 'I' || String.contains s 'R' then
-        failwith "Boolector only supports BV logics"
-      else if not (String.contains s 'B') then
-        (* We add BV because Boolector does not support QF_UF logic *)
-        String.concat "" [ s; "BV" ]
+        failwith "Bitwuzla only supports BV logics"
       else s
 
 let pp_print_logic fmt l = Format.pp_print_string fmt (string_of_logic l)

--- a/src/smt/SMTSolver.ml
+++ b/src/smt/SMTSolver.ml
@@ -35,7 +35,7 @@ let gentag =
 
 
 (* Instantiate module for SMTLIB2 solvers with drivers *)
-module BoolectorSMTLIB : SolverSig.S = SMTLIBSolver.Make (BoolectorDriver)
+module BitwuzlaSMTLIB : SolverSig.S = SMTLIBSolver.Make (BitwuzlaDriver)
 module Z3SMTLIB : SolverSig.S = SMTLIBSolver.Make (Z3Driver)
 module CVC5SMTLIB : SolverSig.S = SMTLIBSolver.Make (CVC5Driver)
 module Yices2SMTLIB : SolverSig.S = SMTLIBSolver.Make (Yices2SMT2Driver)
@@ -159,7 +159,7 @@ let create_instance
   (* Module for solver from options *)
   let fomodule =
     match kind with
-    | `Boolector_SMTLIB -> (module BoolectorSMTLIB.Create(Params) : SolverSig.Inst)
+    | `Bitwuzla_SMTLIB -> (module BitwuzlaSMTLIB.Create(Params) : SolverSig.Inst)
     | `cvc5_SMTLIB -> (module CVC5SMTLIB.Create(Params) : SolverSig.Inst)
     | `MathSAT_SMTLIB -> (module MathSATSMTLIB.Create(Params) : SolverSig.Inst)
     | `Yices_native -> (module YicesNative.Create(Params) : SolverSig.Inst)


### PR DESCRIPTION
In our experiments, Bitwuzla outperforms Boolector. Moreover, Bitwuzla has support for unsat cores which will be handy in the near future.