### PR TITLE
Use generated identifiers for desugaring multiple assignment

### DIFF
--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -48,12 +48,8 @@ type t = {
     * LustreAst.expr)
     StringMap.t;
   locals : (bool (* whether the variable is ghost *)
-    * LustreAst.lustre_type
-    * LustreAst.expr (* abstracted expression *)
-    * LustreAst.expr (* original expression *)
-    * int) (* index *)
+    * LustreAst.lustre_type)
     StringMap.t;
-  generated_locals : LustreAst.expr StringMap.t; (* maps generated local to corresponding user-defined variable *)
   contract_calls :
     (Lib.position
     * (Lib.position * HString.t) list (* contract scope *)
@@ -104,7 +100,6 @@ let union_keys key id1 id2 = match key, id1, id2 with
   | _, (Some _), (Some _) -> assert false
 let union ids1 ids2 = {
     locals = StringMap.merge union_keys ids1.locals ids2.locals;
-    generated_locals = StringMap.merge union_keys ids1.generated_locals ids2.generated_locals;
     array_constructors = StringMap.merge union_keys
       ids1.array_constructors ids2.array_constructors;
     node_args = ids1.node_args @ ids2.node_args;
@@ -127,7 +122,6 @@ let union_keys2 key id1 id2 = match key, id1, id2 with
   
   let empty () = {
     locals = StringMap.empty;
-    generated_locals = StringMap.empty;
     array_constructors = StringMap.empty;
     node_args = [];
     oracles = [];

--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -50,7 +50,8 @@ type t = {
   locals : (bool (* whether the variable is ghost *)
     * LustreAst.lustre_type
     * LustreAst.expr (* abstracted expression *)
-    * LustreAst.expr) (* original expression *)
+    * LustreAst.expr (* original expression *)
+    * int) (* index *)
     StringMap.t;
   generated_locals : LustreAst.expr StringMap.t; (* maps generated local to corresponding user-defined variable *)
   contract_calls :

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -45,7 +45,8 @@ type t = {
   locals : (bool (* whether the variable is ghost *)
     * LustreAst.lustre_type
     * LustreAst.expr (* abstracted expression *)
-    * LustreAst.expr) (* original expression *)
+    * LustreAst.expr (* original expression *)
+    * int) (* index *)
     StringMap.t;
   generated_locals : LustreAst.expr StringMap.t; (* maps generated local to corresponding user-defined variable *)
   contract_calls :

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -43,12 +43,8 @@ type t = {
     * LustreAst.expr)
     StringMap.t;
   locals : (bool (* whether the variable is ghost *)
-    * LustreAst.lustre_type
-    * LustreAst.expr (* abstracted expression *)
-    * LustreAst.expr (* original expression *)
-    * int) (* index *)
+    * LustreAst.lustre_type)
     StringMap.t;
-  generated_locals : LustreAst.expr StringMap.t; (* maps generated local to corresponding user-defined variable *)
   contract_calls :
     (Lib.position
     * (Lib.position * HString.t) list (* contract scope *)

--- a/src/lustre/lustreAbstractInterpretation.ml
+++ b/src/lustre/lustreAbstractInterpretation.ml
@@ -246,7 +246,7 @@ and interpret_node ty_ctx gids (id, _, _, ins, outs, locals, items, contract) =
   in
   let gids_node = GeneratedIdentifiers.StringMap.find id gids in
   let ty_ctx = GeneratedIdentifiers.StringMap.fold
-    (fun id (_, ty, _, _, _) ctx -> Ctx.add_ty ctx id ty) (gids_node.GeneratedIdentifiers.locals) ty_ctx
+    (fun id (_, ty) ctx -> Ctx.add_ty ctx id ty) (gids_node.GeneratedIdentifiers.locals) ty_ctx
   in
   let eqns = List.fold_left (fun acc -> function
     | LA.Body eqn -> (match eqn with

--- a/src/lustre/lustreAbstractInterpretation.mli
+++ b/src/lustre/lustreAbstractInterpretation.mli
@@ -33,4 +33,4 @@ val get_type: context -> LustreAst.ident -> LustreAst.ident -> LustreAst.lustre_
 
 val union: context -> context -> context
 
-val interpret_program: TypeCheckerContext.tc_context -> LustreAst.t -> context
+val interpret_program: TypeCheckerContext.tc_context -> GeneratedIdentifiers.t GeneratedIdentifiers.StringMap.t -> LustreAst.t -> context

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -176,7 +176,7 @@ let type_check declarations =
     let* _ = LAD.check_inductive_array_dependencies inlined_global_ctx node_summary const_inlined_nodes_and_contracts in
 
     (* Step 13. Infer tighter subrange constraints with abstract interpretation *)
-    let abstract_interp_ctx = LIA.interpret_program inlined_global_ctx const_inlined_nodes_and_contracts in
+    let abstract_interp_ctx = LIA.interpret_program inlined_global_ctx gids const_inlined_nodes_and_contracts in
 
     (* Step 14. Normalize AST: guard pres, abstract to locals where appropriate *)
     let* (normalized_nodes_and_contracts, gids, warnings2) = 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1504,7 +1504,7 @@ and compile_node_decl gids is_function cstate ctx i ext inputs outputs locals it
   (* ****************************************************************** *)
   in let glocals =
     let locals_list = GI.StringMap.bindings gids.GI.locals in
-    let over_generated_locals glocals (id, (is_ghost, expr_type, _, _)) =
+    let over_generated_locals glocals (id, (is_ghost, expr_type, _, _, _)) =
       let ident = mk_ident id in
       let index_types = compile_ast_type cstate ctx map expr_type in
       let over_indices = fun index index_type accum ->

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1504,7 +1504,7 @@ and compile_node_decl gids is_function cstate ctx i ext inputs outputs locals it
   (* ****************************************************************** *)
   in let glocals =
     let locals_list = GI.StringMap.bindings gids.GI.locals in
-    let over_generated_locals glocals (id, (is_ghost, expr_type, _, _, _)) =
+    let over_generated_locals glocals (id, (is_ghost, expr_type)) =
       let ident = mk_ident id in
       let index_types = compile_ast_type cstate ctx map expr_type in
       let over_indices = fun index index_type accum ->
@@ -1857,10 +1857,8 @@ and compile_node_decl gids is_function cstate ctx i ext inputs outputs locals it
         | _ -> acc, cpt)
         (acc, 0) i |> fst
       in
-      let id = HString.mk_hstring (StateVar.name_of_state_var sv) in
-      let is_dep = GI.StringMap.mem id (gids.generated_locals) in
       if not is_generated then
-        N.add_state_var_def sv ~is_dep:is_dep
+        N.add_state_var_def sv ~is_dep:false
           (N.ProperEq (AH.pos_of_expr expr, rm_array_var_index i));
       result
     ) [] (X.bindings eq_lhs)

--- a/src/lustre/lustreRemoveMultAssign.ml
+++ b/src/lustre/lustreRemoveMultAssign.ml
@@ -42,7 +42,7 @@ let split_and_flatten5 xs =
 let mk_fresh_temp_name id =
   i := !i + 1;
   let prefix = HString.mk_hstring (string_of_int !i) in
-  let name = HString.concat2 prefix (HString.mk_hstring "temp")in
+  let name = HString.concat2 prefix (HString.mk_hstring "temp") in
   let gids = { (GI.empty ()) with generated_locals = GI.StringMap.singleton name (A.Ident(Lib.dummy_pos, id)); } in
   name, gids
   

--- a/src/lustre/lustreRemoveMultAssign.ml
+++ b/src/lustre/lustreRemoveMultAssign.ml
@@ -40,7 +40,7 @@ let split_and_flatten3 xs =
 let mk_fresh_temp_var ty =
   i := !i + 1;
   let prefix = HString.mk_hstring (string_of_int !i) in
-  let name = HString.concat2 prefix (HString.mk_hstring "temp") in
+  let name = HString.concat2 prefix (HString.mk_hstring "_proj") in
   let gids2 = { (GI.empty ()) with 
     locals = GI.StringMap.singleton name (false, ty);
   } in


### PR DESCRIPTION
Use generated identifiers for desugaring multiple assignment, rather than modifying the input AST. Prevents internal (generated) variables from being leaked to the user.