### PR TITLE
Bump ocaml version to 4.14.1 in GitHub Actions

### DIFF
--- a/.github/workflows/kind2-nightly.yml
+++ b/.github/workflows/kind2-nightly.yml
@@ -52,7 +52,7 @@ jobs:
     if: github.repository == 'kind2-mc/kind2'
     strategy:
       matrix: # Single configuration
-        ocaml-version: [ 4.14.0 ]
+        ocaml-version: [ 4.14.1 ]
         # Only matrix variables can be used at runs-on
         os: [ macos-11 ]
 

--- a/.github/workflows/kind2-release.yml
+++ b/.github/workflows/kind2-release.yml
@@ -52,7 +52,7 @@ jobs:
     if: github.repository == 'kind2-mc/kind2'
     strategy:
       matrix: # Single configuration
-        ocaml-version: [ 4.14.0 ]
+        ocaml-version: [ 4.14.1 ]
         # Only matrix variables can be used at runs-on
         os: [ macos-11 ]
 


### PR DESCRIPTION
It bumps the OCaml version for `kind2-nightly.yml` and `kind2-release.yml`