### PR TITLE
Add options: --print_cex, --print_witness, and --dump_deadlock

### DIFF
--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -142,8 +142,9 @@ The second example demonstrates reachability properties using a single ``counter
    tel
 
 Kind 2 produces output reporting that the first four expressions are reachable, while the last is not.
-For each reachable expression, Kind 2 prints a witness into a file.
-To print the witness in the terminal instead, you can pass ``--dump_witness false`` to Kind 2.
+If you want to print a witness in the standard output for each proven reachability property,
+pass ``--print_witness true`` to Kind 2. To dump the witness to a file instead,
+pass ``--dump_witness true`` to Kind 2.
 
 Conditional Properties
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -536,17 +536,17 @@ module BmcKind = struct
     )
   let check_unroll () = !check_unroll
 
-  let print_cex_default = false
-  let print_cex = ref print_cex_default
+  let ind_print_cex_default = false
+  let ind_print_cex = ref ind_print_cex_default
   let _ = add_spec
     "--ind_print_cex"
-    (bool_arg print_cex)
+    (bool_arg ind_print_cex)
     (fun fmt ->
       Format.fprintf fmt
         "@[<v>Print counterexamples to induction@ Default: %a@]"
-        fmt_bool print_cex_default
+        fmt_bool ind_print_cex_default
     )
-  let print_cex () = !print_cex
+  let ind_print_cex () = !ind_print_cex
 
   let compress_default = true
   let compress = ref compress_default
@@ -1156,13 +1156,25 @@ module Contracts = struct
       Format.fprintf fmt
       "@[<v>\
         Print a deadlocking trace and a conflict when@ \
-        a contract is proven unrealizable@ \
+        a contract is proven unrealizable.@ \
         Default: %a\
       @]"
       fmt_bool print_deadlock_default
     )
   let print_deadlock () = !print_deadlock
 
+  let dump_deadlock_default = false
+  let dump_deadlock = ref dump_deadlock_default
+  let _ = add_spec
+    "--dump_deadlock"
+    (bool_arg dump_deadlock)
+    (fun fmt ->
+      Format.fprintf fmt
+        "Dump deadlocking trace to a file. Only in plain text output.@ \
+        Default: %b"
+        dump_deadlock_default
+    )
+  let dump_deadlock () = ! dump_deadlock
 
   let check_contract_is_sat_default = true
   let check_contract_is_sat = ref check_contract_is_sat_default
@@ -1175,7 +1187,7 @@ let _ = add_spec
         Check whether a contract proven unrealizable is satisfiable@ \
         Default: %a\
       @]"
-      fmt_bool print_deadlock_default
+      fmt_bool check_contract_is_sat_default
     )
   let check_contract_is_sat () = !check_contract_is_sat
 
@@ -1662,8 +1674,8 @@ module IVC = struct
     (fun fmt ->
       Format.fprintf fmt
         "\
-          Disable the must-set optimisation.@ \
-          This setting is ignored if --ivc_must_set is true.@ \
+          Disable the must-set optimization.@ \
+          Ignored if --ivc_must_set is true.@ \
           Default: %a\
         "
         fmt_bool ivc_disable_must_opt_default
@@ -1866,21 +1878,21 @@ module MCS = struct
   let print_mcs_legacy () = !print_mcs_legacy
 
 
-  let print_mcs_counterexample_default = false
-  let print_mcs_counterexample = ref print_mcs_counterexample_default
+  let print_mcs_cex_default = false
+  let print_mcs_cex = ref print_mcs_cex_default
   let _ = add_spec
-    "--print_mcs_counterexample"
-    (bool_arg print_mcs_counterexample)
+    "--print_mcs_cex"
+    (bool_arg print_mcs_cex)
     (fun fmt ->
       Format.fprintf fmt
         "\
-          Print a counterexample for each MCS found@ \
-          (ignored if --print_mcs_legacy is true)@ \
+          Print a counterexample for each MCS found.@ \
+          Ignored if --print_mcs_legacy is true@ \
           Default: %a\
         "
-        fmt_bool print_mcs_counterexample_default
+        fmt_bool print_mcs_cex_default
     )
-  let print_mcs_counterexample () = !print_mcs_counterexample
+  let print_mcs_cex () = !print_mcs_cex
 
 
   let mcs_per_property_default = true
@@ -2782,7 +2794,36 @@ module Global = struct
         print_invs_default
     )
   let print_invs () = ! print_invs
+  
+  let print_cex_default = true
+  let print_cex = ref print_cex_default
+  let _ = add_spec
+    "--print_cex"
+    (bool_arg print_cex)
+    (fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        Print counterexamples to (disproven) invariant properties.@ \
+        Only in plain text output. Default: %a\
+      @]"
+      fmt_bool print_cex_default
+    )
+  let print_cex () = !print_cex
 
+  let print_witness_default = false
+  let print_witness = ref print_witness_default
+  let _ = add_spec
+    "--print_witness"
+    (bool_arg print_witness)
+    (fun fmt ->
+      Format.fprintf fmt
+      "@[<v>\
+        Print witnesses of proven reachability properties.@ \
+        Only in plain text output. Default: %a\
+      @]"
+      fmt_bool print_witness_default
+    )
+  let print_witness () = !print_witness
 
   (* Dump counterexample to a file. *)
   let dump_cex_default = false
@@ -2792,23 +2833,24 @@ module Global = struct
     (bool_arg dump_cex)
     (fun fmt ->
       Format.fprintf fmt
-        "Dump counterexample of invariant property / deadlocking trace to a file.@ \
-        Only in plain text output.@ \
+        "Dump counterexamples to a file instead of printing them in stdout.@ \
+        Only in plain text output. Implies --print_cex true.@ \
         Default: %b"
         dump_cex_default
     )
+  let set_dump_cex b = dump_cex := b
   let dump_cex () = ! dump_cex
 
   (* Dump witness to a file. *)
-  let dump_witness_default = true
+  let dump_witness_default = false
   let dump_witness = ref dump_witness_default
   let _ = add_spec
     "--dump_witness"
     (bool_arg dump_witness)
     (fun fmt ->
       Format.fprintf fmt
-        "Dump witness of reachability property to a file.@ \
-        Only in plain text output.@ \
+        "Dump witnesses to a file instead of printing them in stdout.@ \
+        Only in plain text output. Implies --print_witness true.@ \
         Default: %b"
         dump_witness_default
     )
@@ -3310,7 +3352,10 @@ let output_dir = Global.output_dir
 let include_dirs = Global.include_dirs
 let log_invs = Global.log_invs
 let print_invs = Global.print_invs
+let print_cex = Global.print_cex
+let print_witness = Global.print_witness
 let dump_cex = Global.dump_cex
+let set_dump_cex = Global.set_dump_cex
 let dump_witness = Global.dump_witness
 let only_parse = Global.only_parse
 let lsp = Global.lsp

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -162,10 +162,19 @@ val log_invs : unit -> bool
 (** Prints invariants **)
 val print_invs : unit -> bool
 
-(** Dump counterexample / deadlocking trace to a file **)
+(** Print counterexamples **)
+val print_cex : unit -> bool
+
+(** Print witnesses **)
+val print_witness : unit -> bool
+
+(** Dump counterexample to disproven invariant property to a file **)
 val dump_cex : unit -> bool
 
-(** Dump witness of reachability property to a file **)
+(** Set whether dumping counterexamples *)
+val set_dump_cex : bool -> unit
+
+(** Dump witness of proven reachability property to a file **)
 val dump_witness : unit -> bool
 
 (** Debug sections to enable *)
@@ -342,7 +351,7 @@ module BmcKind : sig
   val check_unroll : unit -> bool
 
   (** Print counterexamples to induction. *)
-  val print_cex : unit -> bool
+  val ind_print_cex : unit -> bool
 
   (** Compress inductive counterexample. *)
   val compress : unit -> bool
@@ -470,6 +479,9 @@ module Contracts : sig
 
   (** Print deadlocking trace and a conflict *)
   val print_deadlock : unit -> bool
+
+  (** Dump deadlocking trace to a file **)
+  val dump_deadlock : unit -> bool
 
   (** Check whether a unrealizable contract is satisfiable *)
   val check_contract_is_sat : unit -> bool
@@ -601,7 +613,7 @@ module MCS : sig
   val print_mcs_legacy : unit -> bool
 
   (** Print the counterexample found for each MCS *)
-  val print_mcs_counterexample : unit -> bool
+  val print_mcs_cex : unit -> bool
 
   (** If true, compute MCS over elements of the main node only *)
   val mcs_only_main_node : unit -> bool

--- a/src/induction/step.ml
+++ b/src/induction/step.ml
@@ -266,7 +266,7 @@ let split (input_sys, analysis, trans) solver k to_split actlits =
       if
         (Flags.BmcKind.compress ()) ||
         (Flags.BmcKind.lazy_invariants ()) ||
-        (Flags.BmcKind.print_cex ())
+        (Flags.BmcKind.ind_print_cex ())
       then 
 
         (* Get model for all variables *)
@@ -285,7 +285,7 @@ let split (input_sys, analysis, trans) solver k to_split actlits =
 
   in
 
-  let print_cex = Flags.BmcKind.print_cex () in
+  let print_cex = Flags.BmcKind.ind_print_cex () in
 
   (* Function to run if unsat. *)
   let if_unsat _ = None in

--- a/src/lustre/contractChecker.ml
+++ b/src/lustre/contractChecker.ml
@@ -253,7 +253,7 @@ let pp_print_realizability_result_pt
   | Unrealizable u_res ->
     print_not_unknown_result Pretty.failure_tag ;
 
-    if Flags.Contracts.print_deadlock () then (
+    if Flags.Contracts.print_deadlock () || Flags.Contracts.dump_deadlock () then (
       KEvent.log L_note "Computing deadlocking trace and conflict..." ;
       let trace, core =
         compute_unviable_trace_and_core
@@ -262,6 +262,10 @@ let pp_print_realizability_result_pt
       let cpd =
         ME.loc_core_to_print_data in_sys sys core_desc None core
       in
+      (* Store dump_cex value *)
+      let dump_cex = Flags.dump_cex () in 
+      (* dump_deadlock uses same infrastructure as dump_cex*)
+      Flags.set_dump_cex (Flags.Contracts.dump_deadlock ()) ; 
       Format.fprintf
         fmt
         "@[<v>%a@]@."
@@ -269,6 +273,8 @@ let pp_print_realizability_result_pt
           ~title:"Deadlocking trace" ~color:"red" (Flags.dump_cex ())
           L_warn in_sys param sys None true)
         trace ;
+      (* Restore dump_cex value *)
+      Flags.set_dump_cex dump_cex ;
 
       Format.fprintf
         fmt

--- a/src/modelElement.ml
+++ b/src/modelElement.ml
@@ -207,7 +207,7 @@ let attach_approx_to_print_data data approx =
 
 let print_mcs_counterexample in_sys param sys typ fmt (prop, cex) =
   try
-    if Flags.MCS.print_mcs_counterexample ()
+    if Flags.MCS.print_mcs_cex () || Flags.dump_cex ()
     then
       match typ with
       | `PT ->


### PR DESCRIPTION
It also changes the default value for `--dump_witness` to `false`.