### PR TITLE
Fix simulation of systems with imported subnodes

### DIFF
--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1695,7 +1695,7 @@ let add_node_sofar_assumption ctx =
 
     | { node = None } -> raise (Invalid_argument "add_node_sofar_assumption")
 
-    | { node = Some ({ N.equations ; N.contract } as n) } ->
+    | { node = Some ({ N.locals ; N.equations; N.contract } as n) } ->
 
       match contract with
 
@@ -1723,8 +1723,13 @@ let add_node_sofar_assumption ctx =
 
          let equations' = ((sofar_svar, []), expr) :: equations in
 
-         (* Return node with equation added *)
-         { ctx with node = Some { n with N.equations = equations' } }
+         (* Return node with equation and local variable added *)
+         { ctx with
+             node = Some { n with
+               N.equations = equations' ;
+               N.locals = D.singleton D.empty_index sofar_svar :: locals
+             }
+         }
 
        )
 

--- a/src/lustre/lustreContract.ml
+++ b/src/lustre/lustreContract.ml
@@ -115,9 +115,9 @@ let svars_of_modes modes set = modes |> List.fold_left (
 ) set
 
 
-let svars_of { assumes ; sofar_assump ; guarantees ; modes } =
+let svars_of ?(with_sofar_var=true) { assumes ; sofar_assump ; guarantees ; modes } =
   let initial_set =
-    if assumes <> [] then
+    if with_sofar_var then
       SVarSet.singleton sofar_assump
     else
       SVarSet.empty

--- a/src/lustre/lustreContract.mli
+++ b/src/lustre/lustreContract.mli
@@ -104,7 +104,7 @@ val add_gua: t -> (svar * bool) list -> t
 (** Adds modes to a contract. *)
 val add_modes: t -> mode list -> t
 
-val svars_of: t -> StateVar.StateVarSet.t
+val svars_of: ?with_sofar_var:bool -> t -> StateVar.StateVarSet.t
 
 (** Pretty prints a svar wrapper. *)
 val pp_print_svar: Format.formatter -> svar -> unit

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -1358,10 +1358,15 @@ let stateful_vars_of_node
       (List.map (fun (sv, _, _, _) -> sv) props) 
   in
 
-  (* Add stateful variables from global and mode contracts *)
+  (* Add stateful variables from contracts *)
   let stateful_vars = match contract with
     | None -> stateful_vars
-    | Some contract -> C.svars_of contract |> SVS.union stateful_vars 
+    | Some contract ->
+      (* Sofar variable should only be added if the corresponding equation is present,
+         which is detected below since its definition refers to itself:
+         sofar = [...] and pre sofar
+      *)
+      C.svars_of ~with_sofar_var:false contract |> SVS.union stateful_vars
   in
 
   (* Add stateful variables from equations *)

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -1327,8 +1327,6 @@ let stateful_vars_of_expr { E.expr_step } =
     (expr_step :> Term.t)
 
 
-let stateful_vars_of_prop (state_var, _, _, _) = SVS.singleton state_var
-
 (* Return all stateful variables from expressions in a node *)
 let stateful_vars_of_node
     { inputs; 
@@ -1354,11 +1352,10 @@ let stateful_vars_of_node
   in
 
   (* Add stateful variables from properties *)
-  let stateful_vars =
-    List.fold_left
-      (fun accum p -> SVS.union accum (stateful_vars_of_prop p))
+  let stateful_vars = 
+    add_to_svs
       stateful_vars
-      props
+      (List.map (fun (sv, _, _, _) -> sv) props) 
   in
 
   (* Add stateful variables from global and mode contracts *)
@@ -1399,13 +1396,6 @@ let stateful_vars_of_node
            a)
       stateful_vars
       locals
-  in
-  
-  (* Add property variables *)
-  let stateful_vars = 
-    add_to_svs
-      stateful_vars
-      (List.map (fun (sv, _, _, _) -> sv) props) 
   in
 
   (* Add stateful variables from assertions *)

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -1144,11 +1144,9 @@ let [@ocaml.warning "-27"] root_and_leaves_of_contracts
     
   (* Slice starting with contracts *)
   let node_roots =
-    (* Always include at least roots of contract *)
-    roots_of_contract contract |> SVS.elements
-    (*match roots node false with
-      | None -> roots_of_contract contract
-      | Some r -> SVS.elements r*)
+    match roots node false with
+    | None -> roots_of_contract contract |> SVS.elements
+    | Some r -> SVS.elements r
   in
 
   (* Do not consider anything below outputs *)
@@ -1243,7 +1241,13 @@ let slice_to_abstraction
 let slice_to_abstraction_and_property
   ?(preserve_sig = false) analysis vars subsystem
 =
-  let roots = (fun _ _ -> Some vars) in
+  let roots { N.contract } is_impl =
+    if is_impl then
+      Some vars
+    else
+      (* Always include at least roots of contract *)
+      Some (roots_of_contract contract) 
+  in
   slice_to_abstraction'
     ~preserve_sig:preserve_sig analysis roots subsystem
 


### PR DESCRIPTION
Kind 2 triggered a `Not_found` exception when simulating systems with imported subnodes using the new front-end. When `map_top_reconstruct_and_add` tried to map local variable 'sofar' of an imported subnode without assumptions, the code did not find the variable in the corresponding transition system. This was not an issue in the old front-end because the 'sofar' variable was not being added to locals, and the mapping was not triggered. This commit solves the issue by preventing no-slicing step from removing the 'sofar' variable when the contract has no assumptions.

To reproduce the issue, simulate the following system model with the interpreter for a couple of steps:
```
node imported N(x: int) returns (y:int);
(*@contract
  guarantee y>x;
*)

node M(x: int) returns (y:int);
let
   y = N(x);
   check y>x;
tel
```