### PR TITLE
Add --exit_code_mode option

### DIFF
--- a/doc/usr/source/3_output/3_exit_codes.rst
+++ b/doc/usr/source/3_output/3_exit_codes.rst
@@ -5,7 +5,9 @@ Exit codes
 
 Since version 1.9.0, Kind 2 returns the standard exit code ``0`` for success,
 and a non-zero exit code to indicate an error, or an unsuccessful
-analysis result. The precise meaning of the exit codes are described
+analysis result. To force Kind 2 to use only non-zero exit codes for errors,
+pass the option ``--exit_code_mode only_errors``.
+The precise meaning of the exit codes are described
 in section :ref:`Code Convention<Current Exit Codes>`.
 For information on the old convention, see section
 :ref:`Former Convention<Former Exit Codes>`.

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -3314,6 +3314,39 @@ let check_nonvacuity_default = true
     )
   let debug_log () = ! debug_log
 
+  
+  type exit_code_convention = [
+    `RESULTS_AND_ERRORS | `ONLY_ERRORS
+  ]
+  let exit_code_convention_of_string = function
+    | "results_and_errors" -> `RESULTS_AND_ERRORS
+    | "only_errors" -> `ONLY_ERRORS
+    | unexpected -> Arg.Bad (
+      Format.sprintf "Unexpected value \"%s\" for flag --exit_code" unexpected
+    ) |> raise
+  let string_of_exit_code_convention = function
+    | `RESULTS_AND_ERRORS -> "results_and_errors"
+    | `ONLY_ERRORS -> "only_errors"
+  let exit_code_mode_default = `RESULTS_AND_ERRORS
+  let exit_code_mode = ref exit_code_mode_default
+  let _ = add_spec
+    "--exit_code_mode"
+    (Arg.String
+      (fun str -> exit_code_mode := exit_code_convention_of_string str)
+    )
+    (fun fmt ->
+      Format.fprintf fmt
+        "\
+          where <string> can be results_and_errors, only_errors@ \
+          Select the exit code convention that Kind 2 should follow@ \
+          results_and_errors = use exit code to report analysis results and errors@ \
+          only_errors = only use a non-zero exit code for errors@ \
+          See user documentation for a description of the exit code conventions@ \
+          Default: %s\
+        "
+        (string_of_exit_code_convention exit_code_mode_default)
+    )
+  let exit_code_mode () = !exit_code_mode
 
   (* Log level. *)
   let _ = set_log_level default_log_level
@@ -3420,6 +3453,7 @@ end
 type enable = Global.enable
 type input_format = Global.input_format
 type real_precision = Global.real_precision
+type exit_code_convention = Global.exit_code_convention
 
 
 (* ********************************************************************** *)
@@ -3452,6 +3486,7 @@ let check_subproperties = Global.check_subproperties
 let lus_main = Global.lus_main
 let debug = Global.debug
 let debug_log = Global.debug_log
+let exit_code_mode = Global.exit_code_mode
 let log_level = Global.log_level
 let log_format_xml = Global.log_format_xml
 let log_format_json = Global.log_format_json

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -186,6 +186,9 @@ val debug : unit -> string list
 (** Logfile for debug output  *)
 val debug_log : unit -> string option
 
+type exit_code_convention = [`RESULTS_AND_ERRORS | `ONLY_ERRORS]
+val exit_code_mode : unit -> exit_code_convention
+
 (** Verbosity level *)
 val log_level : unit -> Lib.log_level
 

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -147,17 +147,21 @@ let status_of_safety_results in_sys =
       "Incomplete analysis result: Not all properties could be proven invariant" ;
     ExitCodes.incomplete_analysis
   in
-  match Anal.results_is_safe !all_results with
-  | None -> report_incomplete_analysis ()
-  | Some false -> ExitCodes.unsafe_result
-  | Some true -> (
-    let l1 = List.length (ISys.analyzable_subsystems in_sys) in
-    let l2 = Anal.results_size !all_results in
-    if l1 = l2 then
-      ExitCodes.success
-    else
-      report_incomplete_analysis ()
+  match Flags.exit_code_mode () with
+  | `RESULTS_AND_ERRORS -> (
+    match Anal.results_is_safe !all_results with
+    | None -> report_incomplete_analysis ()
+    | Some false -> ExitCodes.unsafe_result
+    | Some true -> (
+      let l1 = List.length (ISys.analyzable_subsystems in_sys) in
+      let l2 = Anal.results_size !all_results in
+      if l1 = l2 then
+        ExitCodes.success
+      else
+        report_incomplete_analysis ()
+    )
   )
+  | `ONLY_ERRORS -> ExitCodes.success
 
 let status_of_realiz_results in_sys =
   let analyze_results results =
@@ -181,17 +185,21 @@ let status_of_realiz_results in_sys =
       "Incomplete analysis result: Not all imported nodes could be proven realizable" ;
     ExitCodes.incomplete_analysis
   in
-  match analyze_results !realizability_results with
-  | None -> report_incomplete_analysis ()
-  | Some false -> ExitCodes.unsafe_result
-  | Some true -> (
-    let l1 = List.length (ISys.contract_check_params in_sys) in
-    let l2 = List.length !realizability_results in
-    if l1 = l2 then
-      ExitCodes.success
-    else
-      report_incomplete_analysis ()
+  match Flags.exit_code_mode () with
+  | `RESULTS_AND_ERRORS -> (
+    match analyze_results !realizability_results with
+    | None -> report_incomplete_analysis ()
+    | Some false -> ExitCodes.unsafe_result
+    | Some true -> (
+      let l1 = List.length (ISys.contract_check_params in_sys) in
+      let l2 = List.length !realizability_results in
+      if l1 = l2 then
+        ExitCodes.success
+      else
+        report_incomplete_analysis ()
+    )
   )
+  | `ONLY_ERRORS -> ExitCodes.success
 
 (* Return the status code from an exception *)
 let status_of_exn process status = function


### PR DESCRIPTION
This option allows the user to select the exit code convention that Kind 2 should follow:
- results_and_errors = use exit code to report analysis results and errors (default)
- only_errors = only use a non-zero exit code for errors