### PR TITLE
Add new IC3 engine (IC3IA) that uses Implicit Abstraction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ external tools, Kind 2 can output its results in JSON and XML formats
 
 By default Kind 2 runs a process for bounded model checking (BMC), two processes
 for k-induction (one for a fixed value of k=2, and other for increasing values of k),
-several processes for invariant generation, and a process for IC3
+several processes for invariant generation, a process for IC3QE, and several processes for IC3IA
 in parallel on all properties simultaneously. It incrementally outputs
 counterexamples to properties as well as properties proved invariant.
 
@@ -43,11 +43,11 @@ The following command-line options control its operation
 See `Techniques <https://kind.cs.uiowa.edu/kind2_user_doc/1_techniques/1_techniques.html>`_ for configuration examples and
 more details on each technique.
 
-``--enable {BMC|IND|IND2|IC3|INVGEN|INVGENOS|...}`` Select model checking engines
+``--enable {BMC|IND|IND2|IC3QE|IC3IA|INVGEN|INVGENOS|...}`` Select model checking engines
 
-By default, all four model checking engines are run in parallel.
-Give any combination of ``--enable BMC``\ , ``--enable IND``, ``--enable IND2`` and
-``--enable IC3`` to select which engines to run. The option ``--enable BMC`` alone
+By default, all five model checking engines are run in parallel.
+Give any combination of ``--enable BMC``, ``--enable IND``, ``--enable IND2``,
+``--enable IC3QE`` and ``--enable IC3IA`` to select which engines to run. The option ``--enable BMC`` alone
 will not be able to prove properties valid, choosing ``--enable IND`` and
 ``--enable IND2`` only (or either of the two alone) will not produce any results.
 Any other combination is sound

--- a/doc/usr/source/1_techniques/4_ic3.rst
+++ b/doc/usr/source/1_techniques/4_ic3.rst
@@ -3,28 +3,55 @@
 IC3
 ---
 
-`IC3/PDR <http://link.springer.com/chapter/10.1007%2F978-3-642-18275-4_7>`_ is a recent technique by Aaron Bradley. IC3 alone can falsify and prove properties. To enable nothing but IC3, run
+Kind 2 supports two SMT-based extensions of the SAT-based verification technique `IC3 <http://link.springer.com/chapter/10.1007%2F978-3-642-18275-4_7>`_.
+The challenge when lifting IC3 to infinite state systems is the computation of pre-images of the system's transition relation.
+The first extension, IC3QE, uses quantifier elimination to compute the pre-image.
+If the input problem is in linear integer arithmetic, Kind 2 uses a built-in method that performs
+a fast approximate quantifier elimination. Otherwise,
+the quantifier elimination is delegated to an SMT solver, which is at this time possible with Z3 and cvc5.
+
+The second extension, IC3IA, implements a version of IC3 that relies on implicit (predicate) abstraction by 
+`Cimatti et al <https://link.springer.com/chapter/10.1007/978-3-642-54862-8_4>`_.
+The main idea of the method is to work on an abstraction of the state space induced by a set of predicates
+so that the computation of pre-images of the system's transition relation does not require the use
+of quantifier elimination. As with most abstraction methods, this introduces the problem of having
+to handle spurious abstract counterexamples for the property to be proven, that is, traces that
+falsify the property in the abstracted system but are not actual executions of the original system.
+The method addresses this problem by using an abstraction refinement technique based on logical
+interpolants. 
+Kind 2 currently supports two proof-based interpolating SMT solvers for the generation of interpolants:
+MathSAT and SMTInterpol. In addition, Kind 2 also implements a built-in method for producing
+interpolants based on quantifier elimination that can be used with Z3 and cvc5.
+When the IC3IA engine is enabled, each property is handled separately by a
+different process; two when the built-in method for producing interpolants is used,
+one generating backward interpolants and another one generating forward interpolants.
+
+To enable nothing but the IC3 engines (IC3QE and IC3IA), run
 
 .. code-block:: none
 
    kind2 --enable IC3 <file>
 
-The challenge when lifting IC3 to infinite state systems is the pre-image computation. If the input problem is in linear integer arithmetic, Kind 2 performs a fast approximate quantifier elimination. Otherwise, the quantifier elimination is delegated to an SMT solver, which is at this time only possible with Z3 or cvc5.
+If you only want to enable of the engines, e.g. IC3QE, run
 
-Options
-^^^^^^^
+.. code-block:: none
 
-``--qe_method {precise|impl|cooper}`` (default ``cooper``\ ) -- select the quantifier elimination strategy: ``cooper`` (default) for the built-in approximate method, ``precise`` or ``impl`` to delegate to the SMT solver.
+   kind2 --enable IC3QE <file>
+
+
+IC3-IA Options
+^^^^^^^^^^^^^^
+
+``--smt_itp_solver {MathSAT | SMTInterpol | Z3qe | cvc5qe}`` -- set the SMT solver used for interpolation.
+
+IC3-QE Options
+^^^^^^^^^^^^^^
+
+``--qe_method {precise|impl|cooper}`` (default ``cooper``) -- select the quantifier elimination strategy: ``cooper`` for the built-in approximate method, ``precise`` or ``impl`` to delegate to the SMT solver.
 The ``precise`` strategy computes the exact pre-image, which is an expensive operation.
-The ``impl`` strategy under-approximates the result by computing an conjunctive implicant first.
+The ``impl`` strategy under-approximates the result by computing a conjunctive implicant first.
 If the problem is not in linear integer arithmetic, ``cooper`` falls back to ``impl``.
 
-``--ic3_check_inductive <bool>`` (default ``true``\ ) -- Check if a blocking clause is inductive and communicate it as an invariant to concurrent verification engines. 
+``--smt_qe_solver {Z3 | cvc5}`` (default ``detect``) -- set the SMT solver used for quantifier elimination
 
-``--ic3_block_in_future  <bool>`` (default ``true``\ ) -- Block each clause not only in the frame it was discovered, but also in all higher frames.
-
-``--ic3_fwd_prop_non_gen <bool>`` (default ``true``\ ) -- Attempt forward propagation of clauses before inductive generalization.
-
-``--ic3_fwd_prop_ind_gen <bool>`` (default ``true``\ ) -- Inductively generalize clauses after forward propagation.
-
-``--ic3_fwd_prop_subsume <bool>`` (default ``true``\ ) -- Check syntactic subsumption of forward propagated clauses
+To see other advanced options run ``--help_of ic3qe``.

--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -838,7 +838,8 @@ with the same input values provide different output values.
 To prevent this kind of counterexamples from happening, Kind 2 offers an option
 called ``--enforce_func_congruence`` which enforces
 abstract functions to behave as mathematical functions.
-The downside of using this option is that the IC3 engine is forced to
+The downside of using this option is that the IC3QE engine and
+IC3IA engine with the Z3qe or cvc5qe options are forced to
 shut down because its current implementation cannot reason about
 the resulting system.
 

--- a/doc/usr/source/2_input/3_machine_ints.rst
+++ b/doc/usr/source/2_input/3_machine_ints.rst
@@ -151,8 +151,9 @@ the usage of integers and machine integers together. To use any of
 the other supported SMT solvers, the Lustre input must contain only
 machine integers.
 
-Moreover, :ref:`IC3 <1_techniques/4_ic3>` requires either cvc5 or Z3
+Moreover, the IC3QE engine requires either cvc5 or Z3,
+and the IC3IA engine requires MathSAT, cvc5, or Z3,
 to run on models with machine integers.
-If none of them is available,
-Kind 2 runs with the IC3 model checking engine disabled.
+If these requirements are not satisfied,
+Kind 2 runs with the corresponding IC3 model checking engine disabled.
 

--- a/doc/usr/source/home.rst
+++ b/doc/usr/source/home.rst
@@ -14,7 +14,7 @@ external tools, Kind 2 can output its results in JSON and XML formats
 
 By default Kind 2 runs a process for bounded model checking (BMC), two processes
 for k-induction (one for a fixed value of k=2, and other for increasing values of k),
-several processes for invariant generation, and a process for IC3
+several processes for invariant generation, a process for IC3QE, and several processes for IC3IA
 in parallel on all properties simultaneously. It incrementally outputs
 counterexamples to properties as well as properties proved invariant.
 
@@ -23,11 +23,11 @@ The following command-line options control its operation
 See :ref:`Techniques <1_techniques/1_techniques>` for configuration examples and
 more details on each technique.
 
-``--enable {BMC|IND|IND2|IC3|INVGEN|INVGENOS|...}`` Select model checking engines
+``--enable {BMC|IND|IND2|IC3QE|IC3IA|INVGEN|INVGENOS|...}`` Select model checking engines
 
-By default, all four model checking engines are run in parallel.
-Give any combination of ``--enable BMC``\ , ``--enable IND``, ``--enable IND2`` and
-``--enable IC3`` to select which engines to run. The option ``--enable BMC`` alone
+By default, all five model checking engines are run in parallel.
+Give any combination of ``--enable BMC``, ``--enable IND``, ``--enable IND2``,
+``--enable IC3QE`` and ``--enable IC3IA`` to select which engines to run. The option ``--enable BMC`` alone
 will not be able to prove properties valid, choosing ``--enable IND`` and
 ``--enable IND2`` only (or either of the two alone) will not produce any results.
 Any other combination is sound

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -3078,6 +3078,7 @@ module Global = struct
   type enable = kind_module list
   let kind_module_of_string = function
     | "IC3" -> `IC3
+    | "IC3IA" -> `IC3IA
     | "BMC" -> `BMC
     | "BMCSKIP" -> `BMCSKIP
     | "IND" -> `IND
@@ -3100,6 +3101,7 @@ module Global = struct
 
   let string_of_kind_module = function
     | `IC3 -> "IC3"
+    | `IC3IA -> "IC3IA"
     | `BMC -> "BMC"
     | `BMCSKIP -> "BMCSKIP"
     | `IND -> "IND"
@@ -3125,7 +3127,7 @@ module Global = struct
       ) ^ "]"
     | [] -> "[]"
   let enable_values = [
-    `IC3 ; `BMC ; `IND ; `IND2 ;
+    `IC3 ; `IC3IA ; `BMC ; `IND ; `IND2 ;
     `INVGEN ; `INVGENOS ;
     `INVGENINT ; `INVGENINTOS ;
     `INVGENMACH ; `INVGENMACHOS ;
@@ -3137,7 +3139,7 @@ module Global = struct
   let disable_default_init = []
 
   let enable_default_after = [
-    `BMC ; `IND ; `IND2 ; `IC3 ;
+    `BMC ; `IND ; `IND2 ; `IC3 ; `IC3IA ;
     `INVGEN ; `INVGENOS ;
     (* `INVGENINT ; *) `INVGENINTOS ; `INVGENMACHOS ;
     (* `INVGENREAL ; *) `INVGENREALOS ;

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -754,28 +754,27 @@ end
 
 
 
-(* IC3 flags. *)
-module IC3 = struct
+(* IC3QE flags. *)
+module IC3QE = struct
 
   include Make_Spec (struct end)
 
   (* Identifier of the module. *)
-  let id = "ic3"
+  let id = "ic3qe"
   (* Short description of the module. *)
-  let desc = "IC3 flags"
+  let desc = "IC3-QE flags"
   (* Explanation of the module. *)
   let fmt_explain fmt =
     Format.fprintf fmt "@[<v>\
-      IC3 (a.k.a. PDR) is a relatively recent technique that tries to prove@ \
-      a property by contructing an inductive invariant that implies it.@ \
-      The IC3 engine in Kind 2 performs quantifier elimination which has its@ \
-      own flags (see module \"qe\").\
+      The IC3-QE engine is an SMT-based extension of IC3 (a.k.a. PDR) that@ \
+      uses quantifier elimination (QE) to generalize counterexamples.@ \
+      The QE procedure has its own flags (see module \"qe\").
     @]"
 
   let check_inductive_default = true
   let check_inductive = ref check_inductive_default
   let _ = add_spec
-    "--ic3_check_inductive"
+    "--ic3qe_check_inductive"
     (bool_arg check_inductive)
     (fun fmt ->
     Format.fprintf fmt
@@ -787,7 +786,7 @@ module IC3 = struct
   let print_to_file_default = None
   let print_to_file = ref print_to_file_default
   let _ = add_spec
-    "--ic3_print_to_file"
+    "--ic3qe_print_to_file"
     (Arg.String (fun str -> print_to_file := Some str))
     (fun fmt ->
       Format.fprintf fmt
@@ -802,7 +801,7 @@ module IC3 = struct
   let inductively_generalize_default = 1
   let inductively_generalize = ref inductively_generalize_default
   let _ = add_spec
-    "--ic3_inductively_generalize"
+    "--ic3qe_inductively_generalize"
     (Arg.Set_int inductively_generalize)
     (fun fmt ->
       Format.fprintf fmt
@@ -820,7 +819,7 @@ module IC3 = struct
   let block_in_future_default = true
   let block_in_future = ref block_in_future_default
   let _ = add_spec
-    "--ic3_block_in_future"
+    "--ic3qe_block_in_future"
     (bool_arg block_in_future)
     (fun fmt ->
       Format.fprintf fmt
@@ -832,7 +831,7 @@ module IC3 = struct
   let block_in_future_first_default = true
   let block_in_future_first = ref block_in_future_first_default
   let _ = add_spec
-    "--ic3_block_in_future_first"
+    "--ic3qe_block_in_future_first"
     (bool_arg block_in_future_first)
     (fun fmt ->
       Format.fprintf fmt
@@ -848,7 +847,7 @@ module IC3 = struct
   let fwd_prop_non_gen_default = true
   let fwd_prop_non_gen = ref fwd_prop_non_gen_default
   let _ = add_spec
-    "--ic3_fwd_prop_non_gen"
+    "--ic3qe_fwd_prop_non_gen"
     (bool_arg fwd_prop_non_gen)
     (fun fmt ->
       Format.fprintf fmt
@@ -860,7 +859,7 @@ module IC3 = struct
   let fwd_prop_ind_gen_default = true
   let fwd_prop_ind_gen = ref fwd_prop_ind_gen_default
   let _ = add_spec
-    "--ic3_fwd_prop_ind_gen"
+    "--ic3qe_fwd_prop_ind_gen"
     (bool_arg fwd_prop_ind_gen)
     (fun fmt ->
       Format.fprintf fmt
@@ -875,7 +874,7 @@ module IC3 = struct
   let fwd_prop_subsume_default = true
   let fwd_prop_subsume = ref fwd_prop_subsume_default
   let _ = add_spec
-    "--ic3_fwd_prop_subsume"
+    "--ic3qe_fwd_prop_subsume"
     (bool_arg fwd_prop_subsume)
     (fun fmt ->
       Format.fprintf fmt
@@ -887,7 +886,7 @@ module IC3 = struct
   let use_invgen_default = true
   let use_invgen = ref use_invgen_default
   let _ = add_spec
-    "--ic3_use_invgen"
+    "--ic3qe_use_invgen"
     (bool_arg use_invgen)
     (fun fmt ->
       Format.fprintf fmt
@@ -897,7 +896,7 @@ module IC3 = struct
   let use_invgen () = !use_invgen
 
   type abstr = [ `None | `IA ]
-  let abstr_of_string = function
+  (*let abstr_of_string = function
     | "None" -> `None
     | "IA" -> `IA
     | _ -> raise (Arg.Bad "Bad value for --ic3_abstr")
@@ -906,10 +905,10 @@ module IC3 = struct
     | `None -> "None"
   let abstr_values = [
     `None ; `IA
-  ] |> List.map string_of_abstr |> String.concat ", "
+  ] |> List.map string_of_abstr |> String.concat ", "*)
   let abstr_default = `None
   let abstr = ref abstr_default
-  let _ = add_spec
+  (*let _ = add_spec
     "--ic3_abstr"
     (Arg.String (fun str -> abstr := abstr_of_string str))
     (fun fmt ->
@@ -920,7 +919,7 @@ module IC3 = struct
           Default: %s\
         @]"
         abstr_values (string_of_abstr abstr_default)
-    )
+    )*)
   let abstr () = !abstr
 
 end
@@ -1379,7 +1378,7 @@ module Certif = struct
     (bool_arg smaller_holes)
     (fun fmt ->
       Format.fprintf fmt
-        "@[<v>Generate proofs with smaller trust holes. Substantially \
+        "@[<v>Generate proofs with smaller trust holes.@ Substantially \
          increases the size of the proof.@ Default: %a@]"
         fmt_bool smaller_holes_default
     )
@@ -1393,7 +1392,7 @@ module Certif = struct
     (fun fmt ->
         Format.fprintf fmt
           "@[<v>Breakdown proofs into smaller steps, where each step is checked \
-          independently. Substantially reduces LFSC memory footprint. @ \
+          independently.@ Substantially reduces LFSC memory footprint. @ \
           Default:%a@]"
           fmt_bool smaller_holes_default)
   let flatten_proof () = !flatten_proof
@@ -2568,8 +2567,8 @@ let module_map = [
   (BmcKind.id,
     (module BmcKind: FlagModule)
   ) ;
-  (IC3.id,
-    (module IC3: FlagModule)
+  (IC3QE.id,
+    (module IC3QE: FlagModule)
   ) ;
   (Invgen.id,
     (module Invgen: FlagModule)
@@ -3108,6 +3107,7 @@ module Global = struct
   type enable = kind_module list
   let kind_module_of_string = function
     | "IC3" -> `IC3
+    | "IC3QE" -> `IC3QE
     | "IC3IA" -> `IC3IA
     | "BMC" -> `BMC
     | "BMCSKIP" -> `BMCSKIP
@@ -3131,6 +3131,7 @@ module Global = struct
 
   let string_of_kind_module = function
     | `IC3 -> "IC3"
+    | `IC3QE -> "IC3QE"
     | `IC3IA -> "IC3IA"
     | `BMC -> "BMC"
     | `BMCSKIP -> "BMCSKIP"
@@ -3157,19 +3158,19 @@ module Global = struct
       ) ^ "]"
     | [] -> "[]"
   let enable_values = [
-    `IC3 ; `IC3IA ; `BMC ; `IND ; `IND2 ;
+    `IC3 ; `IC3QE; `IC3IA ; `BMC ; `IND ; `IND2 ;
     `INVGEN ; `INVGENOS ;
     `INVGENINT ; `INVGENINTOS ;
     `INVGENMACH ; `INVGENMACHOS ;
     `INVGENREAL ; `INVGENREALOS ;
     `C2I ; `Interpreter ; `MCS ; `CONTRACTCK
-  ] |> List.map string_of_kind_module |> String.concat ", "
+  ] |> List.map string_of_kind_module
 
   let enable_default_init = []
   let disable_default_init = []
 
   let enable_default_after = [
-    `BMC ; `IND ; `IND2 ; `IC3 ; `IC3IA ;
+    `BMC ; `IND ; `IND2 ; `IC3QE ; `IC3IA ;
     `INVGEN ; `INVGENOS ;
     (* `INVGENINT ; *) `INVGENINTOS ; `INVGENMACHOS ;
     (* `INVGENREAL ; *) `INVGENREALOS ;
@@ -3202,11 +3203,12 @@ module Global = struct
     (fun fmt ->
       Format.fprintf fmt
         "\
-          where <string> can be %s@ \
-          Enable Kind module, repeat option to enable several modules@ \
+          @[<hov>where <string> can be %a@]@ \
+          Enable Kind module, repeat option to enable several modules.@ \
+          IC3 is a virtual module that enables both IC3QE and IC3IA.@ \
           Default: %s\
         "
-        enable_values
+        (pp_print_list Format.pp_print_string ",@ ") enable_values
         (string_of_enable enable_default_after)
     )
     
@@ -3240,10 +3242,10 @@ module Global = struct
     (fun fmt ->
       Format.fprintf fmt
       "\
-        where <string> can be %s@ \
+        @[<hov>where <string> can be %a@]@ \
         Disable a Kind module\
       "
-      enable_values
+      (pp_print_list Format.pp_print_string ",@ ") enable_values
     )
   (* let disabled () = !disabled *)
 

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -289,6 +289,7 @@ module Smt : sig
   val qe_solver : unit -> qe_solver
 
   type itp_solver = [
+    | `MathSAT_SMTLIB
     | `SMTInterpol_SMTLIB
     | `detect
   ]

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -282,11 +282,24 @@ module Smt : sig
     | `detect
   ]
 
-  (** Set SMT solver for QE and executable *)
+  (** Set SMT solver for QE *)
   val set_qe_solver : qe_solver -> unit
 
   (** Which SMT solver for QE to use. *)
   val qe_solver : unit -> qe_solver
+
+  type itp_solver = [
+    | `SMTInterpol_SMTLIB
+    | `detect
+  ]
+
+  (** Set SMT solver for interpolation *)
+  val set_itp_solver : itp_solver -> unit
+
+  (** Which SMT solver for interpolation to use. *)
+  val itp_solver : unit -> itp_solver
+
+  val get_itp_solver : unit -> solver
 
   (** Use check-sat with assumptions, or simulate with push/pop *)
   val check_sat_assume : unit -> bool

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -395,8 +395,8 @@ module BmcKind : sig
 end
 
 
-(** {2 IC3 flags} *)
-module IC3 : sig
+(** {2 IC3QE flags} *)
+module IC3QE : sig
 
   (** Check inductiveness of blocking clauses. *)
   val check_inductive : unit -> bool
@@ -425,10 +425,10 @@ module IC3 : sig
   (** Use invariants from invariant generators. *)
   val use_invgen : unit -> bool
 
-  (** Legal abstraction mechanisms for in IC3. *)
+  (** DEPRECATED: Legal abstraction mechanisms for in IC3. *)
   type abstr = [ `None | `IA ]
 
-  (** Abstraction mechanism IC3 should use. *)
+  (** DEPRECATED: Abstraction mechanism IC3 should use. *)
   val abstr : unit -> abstr
 end
 

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -289,8 +289,10 @@ module Smt : sig
   val qe_solver : unit -> qe_solver
 
   type itp_solver = [
+    | `cvc5_QE
     | `MathSAT_SMTLIB
     | `SMTInterpol_SMTLIB
+    | `Z3_QE
     | `detect
   ]
 

--- a/src/ic3/IC3.ml
+++ b/src/ic3/IC3.ml
@@ -46,7 +46,7 @@ let print_stats () =
 
   KEvent.stat
     ([Stat.misc_stats_title, Stat.misc_stats] @
-     (if Flags.IC3.abstr () = `IA then 
+     (if Flags.IC3QE.abstr () = `IA then 
         [Stat.ic3_stats_title, Stat.ic3_stats;
          Stat.ic3ia_stats_title, Stat.ic3ia_stats]
       else 
@@ -980,7 +980,7 @@ let rec block solver input_sys aparam trans_sys prop_set term_tbl predicates =
                 let cti_gen = 
 
                   (* Abstraction used? *)
-                  match Flags.IC3.abstr () with
+                  match Flags.IC3QE.abstr () with
 
                     (* No abstraction *)
                     | `None ->
@@ -1407,7 +1407,7 @@ let rec block solver input_sys aparam trans_sys prop_set term_tbl predicates =
                frames,
 
                (* Add cube to block to next higher frame if flag is set *)
-               if Flags.IC3.block_in_future () then
+               if Flags.IC3QE.block_in_future () then
 
                  add_to_block_tl
                    solver
@@ -1508,7 +1508,7 @@ let rec block solver input_sys aparam trans_sys prop_set term_tbl predicates =
                    raise (Counterexample (block_clause :: block_trace))
                  in
 
-                 (match Flags.IC3.abstr () with
+                 (match Flags.IC3QE.abstr () with
                    | `None ->
                      raise_cex ()
 
@@ -1569,7 +1569,7 @@ let rec block solver input_sys aparam trans_sys prop_set term_tbl predicates =
 
                     R_i-1[x] & C[x] & T[x,x'] & ~C[x'] is sat *)
                  let cti_gen =
-                   match Flags.IC3.abstr () with
+                   match Flags.IC3QE.abstr () with
                      | `None ->
 
                        extrapolate 
@@ -1859,7 +1859,7 @@ let fwd_propagate solver input_sys aparam trans_sys prop_set frames =
       if 
 
         (* Inductive generalization after forward propagation? *)
-        Flags.IC3.fwd_prop_ind_gen () ||
+        Flags.IC3QE.fwd_prop_ind_gen () ||
 
         (* Inductively generalize forward propagated clause that was
            not generalized *)
@@ -1890,7 +1890,7 @@ let fwd_propagate solver input_sys aparam trans_sys prop_set frames =
     let l = C.literals_of_clause c' in
 
     (* Subsumption after forward propagation? *)
-    if Flags.IC3.fwd_prop_subsume () then
+    if Flags.IC3QE.fwd_prop_subsume () then
 
       (* Is clause subsumed in frame? *)
       if F.is_subsumed a l then
@@ -1978,7 +1978,7 @@ let fwd_propagate solver input_sys aparam trans_sys prop_set frames =
           (C.props_of_prop_set prop_set);
 
         (* Check inductiveness of blocking clauses? *)
-        if Flags.IC3.check_inductive () && prop <> [] then 
+        if Flags.IC3QE.check_inductive () && prop <> [] then 
 
           (
 
@@ -2224,7 +2224,7 @@ let fwd_propagate solver input_sys aparam trans_sys prop_set frames =
             let fwd' = 
 
               (* Try propagating clauses before generalization? *)
-              if Flags.IC3.fwd_prop_non_gen () then
+              if Flags.IC3QE.fwd_prop_non_gen () then
 
                 (
                   
@@ -3079,7 +3079,7 @@ let main_ic3 input_sys aparam trans_sys =
 
 
   let bound =
-    match Flags.IC3.abstr () with
+    match Flags.IC3QE.abstr () with
       | `None -> 1
       | `IA -> 3
   in
@@ -3139,7 +3139,7 @@ let main_ic3 input_sys aparam trans_sys =
            trans_sys Numeral.zero)]);
 
   (* Print inductive assertions to file? *)
-  (match Flags.IC3.print_to_file () with
+  (match Flags.IC3QE.print_to_file () with
 
     (* Keep default formatter *)
     | None -> ()
@@ -3163,7 +3163,7 @@ let main_ic3 input_sys aparam trans_sys =
   in
   let predicates =
 
-    match Flags.IC3.abstr () with
+    match Flags.IC3QE.abstr () with
 
       | `IA ->
 
@@ -3269,7 +3269,7 @@ let main input_sys aparam trans_sys =
   )
   | _ -> () );
 
-  match Flags.IC3.abstr () with
+  match Flags.IC3QE.abstr () with
   | `IA -> main_ic3 input_sys aparam trans_sys
   | `None -> (
     TransSys.iter_subsystems

--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -1,0 +1,861 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+open Lib
+
+module TS = Term.TermSet
+module CS = Cube.CubeSet
+module CM = Cube.CubeMap
+
+let base_offset = Numeral.zero
+let base_abstr_offset = Numeral.one
+let prime_abstr_offset = Numeral.succ base_abstr_offset
+let prime_offset = Numeral.of_int 3
+let max_offset = prime_abstr_offset
+
+(* Interpolation instance if created *)
+let ref_interpolator = ref None
+
+let max_unrolling = ref 0 
+
+let init_svar () =
+  StateVar.mk_state_var
+    ~is_input:false
+    ~is_const:false
+    ~for_inv_gen:false
+    "%init"
+    []
+    Type.t_bool
+
+let get_init offset =
+  Var.mk_state_var_instance (init_svar ()) offset
+  |> Term.mk_var
+
+let rec declare_init_var declare lbound ubound =
+  if Numeral.(lbound <= ubound) then
+    let var = Var.mk_state_var_instance (init_svar ()) lbound in
+    declare (Var.unrolled_uf_of_state_var_instance var) ;
+    declare_init_var declare (Numeral.succ lbound) ubound
+
+let on_exit _ =
+  max_unrolling := 0 ;
+  match !ref_interpolator with
+  | None -> ()
+  | Some s -> SMTSolver.delete_instance s
+
+(* Counterexample trace for some property *)
+exception Counterexample of Model.path
+
+type solving_options =
+  | Default
+  | ExtractModel
+  | NoInd
+
+exception Terminate
+
+let handle_events in_sys param sys prop_name =
+  (* Receive queued messages 
+     Side effect: Terminate when ControlMessage TERM is received.*)
+  let messages = KEvent.recv () in
+
+  (* Update transition system from messages *)
+  let _ = 
+    KEvent.update_trans_sys in_sys param sys messages 
+  in
+
+  match TransSys.get_prop_status sys prop_name with
+  | Property.PropFalse _
+  | Property.PropInvariant _ -> raise Terminate
+  | _ -> ()
+
+let sys_def solver sys offset =
+  let init_term_curr =
+    get_init offset
+  in
+  let init_term_prev =
+    get_init (Numeral.pred offset)
+  in
+  let init =
+    Term.mk_and
+      [TransSys.init_of_bound
+        (Some (SMTSolver.declare_fun solver))
+        sys
+        offset;
+        Term.mk_not init_term_curr;
+        init_term_prev
+      ]
+   in
+   let trans =
+    Term.mk_and
+      [TransSys.trans_of_bound
+        (Some (SMTSolver.declare_fun solver))
+        sys
+        offset;
+        Term.mk_not init_term_curr;
+        Term.mk_not init_term_prev
+      ]
+   in
+   Term.mk_or [init; trans]
+
+
+let get_logic sys =
+  match Flags.Smt.itp_solver () with
+  | `MathSAT_SMTLIB -> (
+    let open TermLib in
+    let open TermLib.FeatureSet in
+    match TransSys.get_logic sys with
+    | `Inferred l when mem IA l ->
+      (* The interpolants MathSAT computes in QF_LIA can use the floor function
+         (implemented using to_real/to_int in SMT-LIB 2)
+      *)
+      `Inferred (FeatureSet.add RA l)
+    | l -> l
+  )
+  | _ -> TransSys.get_logic sys
+
+let mk_solver sys =
+   let solver =
+     SMTSolver.create_instance
+       ~produce_models:true
+       ~produce_unsat_cores:true
+       (get_logic sys)
+       (Flags.Smt.solver ())
+   in
+
+   TransSys.define_and_declare_of_bounds
+     sys
+     (SMTSolver.define_fun solver)
+     (SMTSolver.declare_fun solver)
+     (SMTSolver.declare_sort solver)
+     (Numeral.zero)
+     (Numeral.succ max_offset) ;
+
+   declare_init_var
+     (SMTSolver.declare_fun solver)
+     (Numeral.zero)
+     (Numeral.succ max_offset) ;
+
+   SMTSolver.assert_term solver 
+     (sys_def solver sys prime_abstr_offset) ;
+
+   solver
+
+
+let depth frames = List.length frames - 2
+
+let get_R frames k =
+  list_suffix frames k
+  |> List.map (fun f -> Frame.to_term f)
+  |> Term.mk_and
+  
+let check_sat solver predicates term =
+  SMTSolver.push solver ;
+  SMTSolver.assert_term solver term ;
+  let res =
+    SMTSolver.check_sat_and_get_term_values
+      solver
+      (fun _ predicate_evaluations -> (* If sat. *)
+        Some predicate_evaluations
+      )
+      (fun _ -> None) (* If unsat. *)
+      (TS.elements predicates)
+  in
+  SMTSolver.pop solver ; res
+
+let extract_cube predicates predicate_evaluations =
+  let eval p =
+    let is_true =
+      match List.assoc_opt p predicate_evaluations with
+      | Some v -> assert (Term.is_bool v); v = Term.t_true
+      | None -> assert false
+    in
+    if is_true then p else Term.negate p
+  in
+  let cube =
+    List.fold_left
+      (fun c p -> Cube.add (eval p) c)
+      Cube.empty
+      (TS.elements predicates)
+  in
+  cube
+
+
+let get_bad_cube solver predicates frames prop =
+  let r_and_not_p =
+    Term.mk_and [get_R frames (depth frames); Term.mk_not prop]
+  in
+  match check_sat solver predicates r_and_not_p with
+  | Some predicate_evaluations -> (
+    Some (extract_cube predicates predicate_evaluations)
+  )
+  | None -> None
+
+
+let get_cubes next_cube init_c =
+  let rec loop acc c =
+    match CM.find_opt c next_cube with
+    | None -> acc
+    | Some n -> loop (n :: acc) n
+  in
+  loop [init_c] init_c |> List.rev
+
+
+let add_predicates solver old_predicates new_predicates =
+  let new_predicates =
+    TS.diff new_predicates old_predicates
+  in
+  TS.iter
+  (fun p ->
+     SMTSolver.trace_comment solver
+       (Format.asprintf "New predicate: %a" Term.pp_print_term p) ;
+
+     SMTSolver.assert_term
+       solver
+       (Term.mk_eq
+          [Term.bump_state base_offset p;
+           Term.bump_state base_abstr_offset p]);
+
+     SMTSolver.assert_term
+       solver
+       (Term.mk_eq
+          [Term.bump_state prime_abstr_offset p;
+           Term.bump_state prime_offset p]);
+  )
+  new_predicates ;
+  TS.union old_predicates new_predicates
+
+(* Interpolation Group ids for MathSAT *)
+let ig_newid =
+  let r = ref 0 in
+  fun () -> incr r; Format.sprintf "g%d" !r
+
+let refine solver sys predicates cubes =
+
+  let len = List.length cubes in
+
+  let intrpo =
+    match !ref_interpolator with
+      | Some s ->
+        
+        if len > !max_unrolling then (
+          
+          TransSys.declare_vars_of_bounds
+            sys
+            (SMTSolver.declare_fun s)
+            (Numeral.of_int (!max_unrolling + 1))
+            (Numeral.of_int len);
+
+          declare_init_var
+            (SMTSolver.declare_fun s)
+            (Numeral.of_int (!max_unrolling + 1))
+            (Numeral.of_int len);
+
+          max_unrolling := len;
+        );
+        s
+
+      | None ->
+
+        let solver = 
+          SMTSolver.create_instance
+            ~produce_models:true
+            ~produce_interpolants:true
+            (get_logic sys)
+            (Flags.Smt.get_itp_solver ())
+        in
+
+        TransSys.define_and_declare_of_bounds
+          sys
+          (SMTSolver.define_fun solver)
+          (SMTSolver.declare_fun solver)
+          (SMTSolver.declare_sort solver)
+          (Numeral.(pred zero))
+          (Numeral.of_int len);
+
+        declare_init_var
+          (SMTSolver.declare_fun solver)
+          (Numeral.(pred zero))
+          (Numeral.of_int len);
+
+        ref_interpolator := Some solver;
+        max_unrolling := len;
+        solver
+
+  in
+
+  let interpolizers =
+    cubes
+    |> List.mapi (fun i c ->
+      let cube = Cube.to_term c |> Term.bump_state (Numeral.of_int (i - 1)) in
+      if i < (len - 1) then
+        Term.mk_and
+          [ cube; sys_def intrpo sys (Numeral.of_int i) ]
+      else
+        cube
+      (* If prop is not in the set of initial predicates: *)
+      (*Term.mk_and
+        [ Cube.to_term c |> Term.bump_state (Numeral.of_int (i - 1));
+          if i < (len - 1) then
+            sys_def intrpo sys (Numeral.of_int i)
+          else
+            Term.mk_not (prop |> Term.bump_state (Numeral.of_int (i - 1)))
+        ]*)
+    )
+  in
+
+  SMTSolver.push intrpo;  
+
+  (* Compute the interpolants *)
+  let names =
+    match Flags.Smt.itp_solver () with
+    | `MathSAT_SMTLIB -> (
+      List.map
+        (fun t ->
+          let id = ig_newid () in
+          SMTSolver.assert_term intrpo (Term.set_inter_group t id) ;
+          SMTExpr.ArgString id
+        )
+        interpolizers
+    )
+    | `SMTInterpol_SMTLIB -> (
+      List.map
+        (fun t ->
+        SMTExpr.ArgString
+          (SMTSolver.assert_named_term_wr
+              intrpo
+              t))
+      interpolizers
+    )
+    | _ -> failwith ("Interpolating solver not found or unsupported")
+  in
+
+  if SMTSolver.check_sat 
+      intrpo
+  then (
+    let cex_path =
+      Model.path_from_model
+        (TransSys.state_vars sys)
+        (SMTSolver.get_model intrpo)
+        (Numeral.of_int (len - 2))
+    in
+
+    raise (Counterexample cex_path)
+  )
+  else (
+    let interpolants = 
+      SMTSolver.get_interpolants
+        intrpo
+        names
+    in
+
+    SMTSolver.pop
+      intrpo;
+
+    (*interpolants
+    |> List.iteri (fun i t -> Format.printf "INTERPOLANT%d: %a@." i Term.pp_print_term t);*)
+
+    let atoms =
+      List.mapi
+        (fun i t -> Term.bump_state (Numeral.of_int (~-(i))) t)
+        interpolants
+      |>
+      List.filter
+        (fun t -> not (t == Term.t_false || t == Term.t_true))
+      |>
+      List.fold_left
+        (fun acc interp -> Term.TermSet.union (Term.get_atoms interp) acc)
+        Term.TermSet.empty
+    in
+
+    (*atoms
+    |> Term.TermSet.elements
+    |> List.iteri (fun i t -> Format.printf "ATOM%d: %a@." i Term.pp_print_term t);*)
+
+    add_predicates solver predicates atoms
+  )
+
+
+let is_blocked solver frames s =
+  (* Check syntactic subsumption (faster than SAT): *) 
+  let blocked =
+    list_suffix frames (TCube.frame_index s)
+    |> List.exists (fun f ->
+      Frame.cubes f
+      |> CS.elements
+      |> List.exists (fun c -> Cube.subsumes c (TCube.cube s))
+    )
+  in
+  if blocked then
+    true
+  else (
+    (* Semantic subsumption thru SAT: *)
+    let query =
+      Term.mk_and
+        [TCube.cube s |> Cube.to_term;
+         get_R frames (TCube.frame_index s)]
+    in
+    match check_sat solver TS.empty query with
+    | None -> true
+    | _ -> false
+  )
+
+let is_initial init c =
+  not (Cube.contains (Term.mk_not init) c)
+
+
+let get_minimum_f f_names unsat_core =
+  match List.find_opt (fun (_, f) -> TS.mem f unsat_core) f_names with
+  | None -> TCube.FrameInf
+  | Some (i, _) -> TCube.Frame i
+
+
+let get_minimal_non_initial_cube init p_names unsat_core =
+  let cube =
+    List.fold_left
+      (fun c (l, l') ->
+        if TS.mem l' unsat_core then Cube.add l c else c
+      )
+      Cube.empty
+      p_names
+  in
+  if is_initial init cube then
+    Cube.add (Term.mk_not init) cube
+  else
+    cube
+
+let solve_relative solver predicates frames s option =
+
+  let cube = TCube.cube s in
+
+  SMTSolver.push solver ;
+
+  if option <> NoInd then (
+    let not_cube = Term.negate (Cube.to_term cube) in
+    SMTSolver.assert_term solver not_cube
+  ) ;
+
+  let k = 
+    match TCube.frame s with
+    | TCube.Frame i -> i - 1
+    | TCube.FrameInf -> (List.length frames) - 1
+    | TCube.FrameNull -> assert false
+  in
+
+  let named_frames, last_frame  =
+    let named_frames = list_suffix frames k in
+    named_frames,
+    List.rev named_frames |> List.hd
+  in
+
+  let f_names =
+    List.mapi
+      (fun i f ->
+        let t = Frame.to_term f in
+        SMTSolver.assert_named_term_wr solver t |> ignore ;
+        (k+i, t)
+      )
+      named_frames
+  in
+  SMTSolver.assert_term solver (Frame.to_term last_frame) ;
+
+  let p_literals = Cube.literals cube in
+
+  let p_names =
+    List.map
+      (fun l ->
+        let l' =
+          Term.bump_state Numeral.(prime_offset - base_offset) l
+        in
+        SMTSolver.assert_named_term_wr solver l' |> ignore ;
+        l, l'
+      )
+      p_literals
+  in
+
+  let res =
+    SMTSolver.check_sat_and_get_term_values
+      solver
+      (fun _ predicate_evaluations ->
+        Some predicate_evaluations
+      )
+      (fun _ -> None )
+      (TS.elements predicates)
+  in
+
+  match res with
+  | Some predicate_evaluations -> (
+    let c =
+      match option with
+      | ExtractModel ->
+         extract_cube predicates predicate_evaluations
+      | _ -> Cube.empty
+    in
+    SMTSolver.pop solver ;
+    TCube.mk c TCube.FrameNull
+  )
+  | None -> (
+    let unsat_core =
+      SMTSolver.get_unsat_core_of_names solver |> TS.of_list
+    in
+    SMTSolver.pop solver ;
+
+    let min_frame = get_minimum_f f_names unsat_core in
+    let min_cube =
+      let init = get_init base_offset in
+      get_minimal_non_initial_cube init p_names unsat_core
+    in
+    let frame =
+      match min_frame with
+      | TCube.FrameInf -> min_frame
+      | TCube.Frame i when i = depth frames -> min_frame
+      | TCube.Frame i -> TCube.Frame (i+1)
+      | TCube.FrameNull -> assert false
+    in
+    TCube.mk min_cube frame
+  )
+
+let generalize solver init predicates frames s =
+  let c = TCube.cube s in
+  let f = TCube.frame s in
+
+  let c' =
+    List.fold_left
+      (fun c l ->
+        let c' = Cube.remove l c in
+
+        if (is_initial init c') then
+          c
+        else (
+          let s' = TCube.mk c' f in
+          let z =
+            solve_relative solver predicates frames s' Default
+          in
+          match TCube.frame z with
+          | TCube.FrameNull -> c
+          | _ -> c'
+        )
+      )
+      c
+      (Cube.literals c)
+  in
+  TCube.mk c' f
+
+
+let get_invariant init c =
+  List.fold_left
+    (fun disj l ->
+      if not (l == (Term.mk_not init)) then
+        Term.negate l :: disj
+      else
+        disj
+    )
+    []
+    (Cube.literals c)
+  |> Term.mk_or
+
+
+let add_blocked_cube solver sys init frames s =
+  let k =
+    match TCube.frame s with
+    | Frame f -> min f (depth frames + 1)
+    | FrameInf -> depth frames + 1
+    | _ -> assert false
+  in
+
+  let s_cube = TCube.cube s in
+
+  let frames1, frames2 = list_split (k+1) frames in
+
+  let frames1' =
+    List.hd frames1
+    ::
+    (List.tl frames1
+    |> List.map (fun f ->
+      match f with
+      | Frame.Fi cubes -> (
+        let cubes' =
+          CS.elements cubes
+          |> List.fold_left
+              (fun acc c ->
+                if (Cube.subsumes s_cube c)
+                then CS.remove c acc
+                else acc
+              )
+              cubes
+        in
+        Frame.Fi cubes'
+      )
+      | _ -> assert false
+    ))
+  in
+
+  (* Store clause *)
+  let frames =
+    (list_apply_at
+      (function
+        | Frame.Fi cubes -> Frame.Fi (CS.add s_cube cubes)
+        | _ -> assert false
+      )
+      k
+      frames1')
+    @ frames2
+  in
+
+  SMTSolver.trace_comment solver
+    (Format.asprintf "Blocked [%d] : %a" k Cube.pp_print_cube s_cube) ;
+
+  (* Report if invariant *)
+  if TCube.frame s = TCube.FrameInf then (
+    let inv = get_invariant init (TCube.cube s) in
+    let cert = (1, inv) in
+    KEvent.invariant
+      (TransSys.scope_of_trans_sys sys) inv cert false
+  ) ;
+  
+  frames
+
+
+let block_cube solver in_sys param sys prop_name predicates next_cube frames s0 =
+
+  let init = get_init base_offset in
+
+  let insert q c =
+    PriorityQueue.(insert q (TCube.frame_index c) c)
+  in
+
+  let rec loop predicates next_cube frames q =
+    match PriorityQueue.extract q with
+    | None -> predicates, next_cube, frames
+    | Some (_, s, q) -> (
+
+      handle_events in_sys param sys prop_name ;
+
+      match TCube.frame s with
+      | Frame 0 -> (
+        let predicates =
+          get_cubes next_cube (TCube.cube s)
+          |> refine solver sys predicates
+        in
+        SMTSolver.trace_comment solver "Refined abstraction" ;
+        predicates, next_cube, frames
+      )
+      | _ -> (
+        let next_cube, frames, q =
+          if not (is_blocked solver frames s) then (
+            assert (not (is_initial init (TCube.cube s))) ;
+            let z =
+              solve_relative solver predicates frames s ExtractModel
+            in
+
+            match TCube.frame z with
+            | TCube.FrameNull -> (
+              (* Cube 's' was not blocked by image of predecessor *)
+              let frame =
+                match TCube.frame s with
+                | Frame i -> TCube.Frame (i-1)
+                | _ -> assert false
+              in
+              let c = TCube.cube z in
+              let z = TCube.mk c frame in
+              let next_cube = CM.add c (TCube.cube s) next_cube in
+              let q = insert (insert q z) s in
+              next_cube, frames, q
+            )
+            | _ -> (
+              (* Cube 's' was blocked by image of predecessor *)
+              let z =
+                generalize solver init predicates frames z
+              in
+              (* Push z as far forward as possible *)
+              let rec push_forward z' =
+                match TCube.frame z' with
+                | Frame f when f < (depth frames) - 1 -> (
+                  let nz =
+                    let nxt = TCube.next z' in
+                    solve_relative solver predicates frames nxt Default
+                  in
+                  match TCube.frame nz with
+                  | FrameNull -> z'
+                  | _ -> push_forward nz
+                )
+                | _ -> z'
+              in
+              let z = push_forward z in
+              let frames = add_blocked_cube solver sys init frames z in
+              let q =
+                if (TCube.frame_index s < (depth frames) &&
+                    TCube.frame z <> TCube.FrameInf)
+                then (
+                  insert q (TCube.next s)
+                )
+                else q
+              in
+              next_cube, frames, q
+            )
+          )
+          else (
+            next_cube, frames, q
+          )
+        in
+        loop predicates next_cube frames q
+      )
+    )
+  in
+
+  let q = insert PriorityQueue.empty s0 in
+
+  loop predicates next_cube frames q
+
+
+let add_frame f frames =
+  Lib.list_insert_at f (List.length frames - 1) frames
+
+
+let get_invariants init frames k =
+  List.fold_left
+    (fun invs f ->
+      CS.fold
+        (fun c invs -> get_invariant init c :: invs)
+        (Frame.cubes f)
+        invs
+    )
+    []
+    (list_suffix frames k)
+
+let propogate_blocked_cubes solver in_sys param sys prop_name predicates frames =
+  let init = get_init base_offset in
+  let rec loop frames k =
+    if k < depth frames then (
+      let frames =
+        CS.fold
+          (fun c frames' ->
+            handle_events in_sys param sys prop_name ;
+            let s =
+              let tc = TCube.mk c (Frame (k+1)) in
+              solve_relative solver predicates frames' tc NoInd
+            in
+            if TCube.frame s <> TCube.FrameNull then
+              add_blocked_cube solver sys init frames s
+            else
+              frames'
+          )
+          (List.nth frames k |> Frame.cubes)
+          frames
+      in
+      if List.nth frames k |> Frame.is_empty then (
+        Some (get_invariants init frames (k+1)), frames
+      )
+      else (
+        loop frames (k+1)
+      )
+    )
+    else (
+      None, frames
+    )
+  in
+  loop frames 1
+
+
+let main prop in_sys param sys =
+   
+   let solver = mk_solver sys in
+
+   let prop_name = prop.Property.prop_name in
+
+   let init = get_init base_offset in
+
+   let prop = Term.mk_or [prop.Property.prop_term; init] in
+
+   let predicates =
+     add_predicates solver TS.empty
+       (Term.get_atoms prop |> TS.add init)
+   in
+
+   SMTSolver.trace_comment solver
+     (Format.sprintf "Checking property: %s" prop_name);
+
+   let frames =
+     Frame.mk_frame init :: [Frame.empty]
+   in
+
+   let next_cube = CM.empty in
+
+   try (
+
+    let rec loop predicates next_cube frames =
+      match get_bad_cube solver predicates frames prop with
+      | Some cube -> (
+        let s =
+          TCube.mk cube (TCube.Frame (depth frames))
+        in
+        let predicates, next_cube, frames =
+          block_cube solver in_sys param sys prop_name predicates next_cube frames s
+        in
+        loop predicates next_cube frames
+      )
+      | None -> (
+        let frames = add_frame Frame.empty frames in
+
+        Debug.ic3 "Number of frames: %d" (List.length frames);
+        
+        SMTSolver.trace_comment solver
+          (Format.sprintf "Number of frames: %d" (List.length frames)) ;
+
+        match propogate_blocked_cubes solver in_sys param sys prop_name predicates frames with
+        | None, frames -> loop predicates next_cube frames
+        | Some invariants, _ -> invariants
+      )
+    in
+
+    let invariants = loop predicates next_cube frames in
+    
+    invariants
+    |> List.iter (fun i ->
+      let cert = (1, i) in
+      KEvent.invariant
+        (TransSys.scope_of_trans_sys sys) i cert false
+    ) ;
+
+    let cert = 1, Term.mk_and invariants in
+
+    KEvent.prop_status
+      (Property.PropInvariant cert)
+      in_sys
+      param
+      sys
+      prop_name
+   )
+   with
+   | Counterexample cex_path -> (
+
+    KEvent.prop_status 
+      (Property.PropFalse (Model.path_to_list cex_path))
+      in_sys
+      param 
+      sys 
+      prop_name;
+
+    KEvent.log
+      L_info 
+      "Property %s disproved by IC3IA"
+      prop_name
+   ) 
+   
+  | Terminate -> ();
+
+   SMTSolver.delete_instance solver

--- a/src/ic3ia/IC3IA.mli
+++ b/src/ic3ia/IC3IA.mli
@@ -1,0 +1,34 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+(** Property-directed reachability (aka IC3) with Implicit Abstraction 
+
+    Adaptation of the PDR algorithm implemented by JKind, based on
+    "Efficient implementation of property directed reachability"
+    by Niklas Een, Alan Mishchenko, and Robert Brayton.
+
+    SMT extension based on "IC3 Modulo Theories via Implicit Predicate Abstraction"
+    by Alessandro Cimatti, Alberto Griggio, Sergio Mover, and Stefano Tonetta
+
+    @author Daniel Larraz *)
+
+(** Entry point *)
+val main : Property.t -> 'a InputSystem.t -> Analysis.param -> TransSys.t -> unit
+    
+(** Cleanup before exit *)
+val on_exit : TransSys.t option -> unit

--- a/src/ic3ia/IC3IA.mli
+++ b/src/ic3ia/IC3IA.mli
@@ -28,7 +28,7 @@
     @author Daniel Larraz *)
 
 (** Entry point *)
-val main : Property.t -> 'a InputSystem.t -> Analysis.param -> TransSys.t -> unit
+val main : bool -> Property.t -> 'a InputSystem.t -> Analysis.param -> TransSys.t -> unit
     
 (** Cleanup before exit *)
 val on_exit : TransSys.t option -> unit

--- a/src/ic3ia/cube.ml
+++ b/src/ic3ia/cube.ml
@@ -1,0 +1,42 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+module TS = Term.TermSet
+
+type t = TS.t
+
+module CubeSet = Set.Make(TS)
+
+module CubeMap = Map.Make(TS)
+
+let empty = TS.empty
+
+let add = TS.add
+
+let remove = TS.remove
+
+let literals = TS.elements
+
+let subsumes = TS.subset
+
+let contains = TS.mem
+
+let to_term c = literals c |> Term.mk_and
+
+let pp_print_cube fmt c =
+   Format.fprintf fmt "%a" Term.pp_print_term (to_term c)

--- a/src/ic3ia/cube.mli
+++ b/src/ic3ia/cube.mli
@@ -1,0 +1,39 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+type t
+
+module CubeSet : Set.S with type elt = t
+
+module CubeMap : Map.S with type key = t
+
+val empty : t
+
+val add : Term.t -> t -> t
+
+val remove : Term.t -> t -> t
+
+val literals : t -> Term.t list
+
+val subsumes : t -> t -> bool
+
+val contains : Term.t -> t -> bool
+
+val to_term : t -> Term.t
+
+val pp_print_cube : Format.formatter -> t -> unit

--- a/src/ic3ia/frame.ml
+++ b/src/ic3ia/frame.ml
@@ -1,0 +1,43 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+module CS = Cube.CubeSet
+
+type t =
+  | Ft of Term.t
+  | Fi of CS.t
+
+let empty = Fi CS.empty
+
+let is_empty = function
+  | Fi cubes -> CS.is_empty cubes
+  | _ -> false
+
+let mk_frame t = Ft t
+
+let cubes = function
+  | Fi cubes -> cubes
+  | _ -> assert false
+
+let to_term = function
+  | Ft t -> t
+  | Fi cubes -> (
+    CS.elements cubes
+    |> List.map (fun c -> Cube.to_term c |> Term.mk_not)
+    |> Term.mk_and
+  )

--- a/src/ic3ia/frame.mli
+++ b/src/ic3ia/frame.mli
@@ -1,0 +1,31 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+type t =
+  | Ft of Term.t
+  | Fi of Cube.CubeSet.t
+
+val empty : t
+
+val is_empty : t -> bool
+
+val mk_frame : Term.t -> t
+
+val cubes : t -> Cube.CubeSet.t
+
+val to_term : t -> Term.t

--- a/src/ic3ia/tCube.ml
+++ b/src/ic3ia/tCube.ml
@@ -1,0 +1,44 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+type frame_ref =
+  | FrameNull
+  | FrameInf
+  | Frame of int 
+
+type t = {
+  cube : Cube.t;
+  frame: frame_ref;
+}
+
+let mk cube frame = { cube; frame }
+
+let cube { cube } = cube
+
+let frame { frame } = frame
+
+let frame_index { frame } =
+  match frame with
+  | Frame i -> i
+  | FrameNull -> assert false
+  | FrameInf  -> assert false
+
+let next {cube; frame} =
+  match frame with
+  | Frame i -> {cube; frame=Frame (i+1)}
+  | _ -> assert false

--- a/src/ic3ia/tCube.mli
+++ b/src/ic3ia/tCube.mli
@@ -1,0 +1,37 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+type frame_ref =
+  | FrameNull
+  | FrameInf
+  | Frame of int 
+
+type t = {
+  cube : Cube.t;
+  frame: frame_ref;
+}
+
+val mk : Cube.t -> frame_ref -> t
+
+val cube : t -> Cube.t
+
+val frame : t -> frame_ref
+
+val frame_index : t -> int
+
+val next : t -> t

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -64,45 +64,61 @@ let renice () =
     let nice' = Unix.nice nice in
     KEvent.log L_info "[renice] renicing to %d" nice'
 
+
+type process =
+  | GenericCall of Lib.kind_module
+  | IC3IA_Call of Property.t
+
+let get_kind_module = function
+  | GenericCall m -> m
+  | IC3IA_Call _ -> `IC3IA
+
+
 (** Main function of the process *)
 let main_of_process = function
-  | `IC3 -> IC3.main
-  | `BMC -> BMC.main false
-  | `BMCSKIP -> BMC.main true
-  | `IND -> IND.main
-  | `IND2 -> IND2.main
-  | `INVGEN -> renice () ; InvGen.main_bool true
-  | `INVGENOS -> renice () ; InvGen.main_bool false
-  | `INVGENINT -> renice () ; InvGen.main_int true
-  | `INVGENINTOS -> renice () ; InvGen.main_int false
-  | `INVGENINT8 -> renice () ; InvGen.main_int8 true
-  | `INVGENINT8OS -> renice () ; InvGen.main_int8 false
-  | `INVGENINT16 -> renice () ; InvGen.main_int16 true
-  | `INVGENINT16OS -> renice () ; InvGen.main_int16 false
-  | `INVGENINT32 -> renice () ; InvGen.main_int32 true
-  | `INVGENINT32OS -> renice () ; InvGen.main_int32 false
-  | `INVGENINT64 -> renice () ; InvGen.main_int64 true
-  | `INVGENINT64OS -> renice () ; InvGen.main_int64 false
-  | `INVGENUINT8 -> renice () ; InvGen.main_uint8 true
-  | `INVGENUINT8OS -> renice () ; InvGen.main_uint8 false
-  | `INVGENUINT16 -> renice () ; InvGen.main_uint16 true
-  | `INVGENUINT16OS -> renice () ; InvGen.main_uint16 false
-  | `INVGENUINT32 -> renice () ; InvGen.main_uint32 true
-  | `INVGENUINT32OS -> renice () ; InvGen.main_uint32 false
-  | `INVGENUINT64 -> renice () ; InvGen.main_uint64 true
-  | `INVGENUINT64OS -> renice () ; InvGen.main_uint64 false
-  | `INVGENREAL -> renice () ; InvGen.main_real true
-  | `INVGENREALOS -> renice () ; InvGen.main_real false
-  | `C2I -> renice () ; C2I.main
-  | `Interpreter -> Flags.Interpreter.input_file () |> Interpreter.main
-  | `Supervisor -> InvarManager.main false false child_pids
-  | `INVGENMACH | `INVGENMACHOS | `MCS | `CONTRACTCK
-  | `Parser | `Certif -> ( fun _ _ _ -> () )
+  | GenericCall m -> (
+    match m with
+    | `IC3 -> IC3.main
+    | `IC3IA -> assert false
+    | `BMC -> BMC.main false
+    | `BMCSKIP -> BMC.main true
+    | `IND -> IND.main
+    | `IND2 -> IND2.main
+    | `INVGEN -> renice () ; InvGen.main_bool true
+    | `INVGENOS -> renice () ; InvGen.main_bool false
+    | `INVGENINT -> renice () ; InvGen.main_int true
+    | `INVGENINTOS -> renice () ; InvGen.main_int false
+    | `INVGENINT8 -> renice () ; InvGen.main_int8 true
+    | `INVGENINT8OS -> renice () ; InvGen.main_int8 false
+    | `INVGENINT16 -> renice () ; InvGen.main_int16 true
+    | `INVGENINT16OS -> renice () ; InvGen.main_int16 false
+    | `INVGENINT32 -> renice () ; InvGen.main_int32 true
+    | `INVGENINT32OS -> renice () ; InvGen.main_int32 false
+    | `INVGENINT64 -> renice () ; InvGen.main_int64 true
+    | `INVGENINT64OS -> renice () ; InvGen.main_int64 false
+    | `INVGENUINT8 -> renice () ; InvGen.main_uint8 true
+    | `INVGENUINT8OS -> renice () ; InvGen.main_uint8 false
+    | `INVGENUINT16 -> renice () ; InvGen.main_uint16 true
+    | `INVGENUINT16OS -> renice () ; InvGen.main_uint16 false
+    | `INVGENUINT32 -> renice () ; InvGen.main_uint32 true
+    | `INVGENUINT32OS -> renice () ; InvGen.main_uint32 false
+    | `INVGENUINT64 -> renice () ; InvGen.main_uint64 true
+    | `INVGENUINT64OS -> renice () ; InvGen.main_uint64 false
+    | `INVGENREAL -> renice () ; InvGen.main_real true
+    | `INVGENREALOS -> renice () ; InvGen.main_real false
+    | `C2I -> renice () ; C2I.main
+    | `Interpreter -> Flags.Interpreter.input_file () |> Interpreter.main
+    | `Supervisor -> InvarManager.main false false child_pids
+    | `INVGENMACH | `INVGENMACHOS | `MCS | `CONTRACTCK
+    | `Parser | `Certif -> ( fun _ _ _ -> () )
+  )
+  | IC3IA_Call prop -> IC3IA.main prop
 
 (** Cleanup function of the process *)
 let on_exit_of_process mdl =
   ( match mdl with
     | `IC3 -> IC3.on_exit None
+    | `IC3IA -> IC3IA.on_exit None
     | `BMCSKIP
     | `BMC -> BMC.on_exit None
     | `IND -> IND.on_exit None
@@ -398,6 +414,7 @@ let on_exit_child ?(_alone=false) messaging_thread process exn =
 
 (** Forks and runs a child process. *)
 let run_process in_sys param sys messaging_setup process =
+  let kind_module = get_kind_module process in
   (* Fork a new process. *)
   let pid = Unix.fork () in
   match pid with
@@ -412,8 +429,8 @@ let run_process in_sys param sys messaging_setup process =
     SMTSolver.delete_instance_entries () ;
     (* Initialize messaging system for process. *)
     let messaging_thread =
-      on_exit_child None process
-      |> KEvent.run_process process messaging_setup
+      on_exit_child None kind_module
+      |> KEvent.run_process kind_module messaging_setup
     in
 
     try 
@@ -422,7 +439,7 @@ let run_process in_sys param sys messaging_setup process =
       KEvent.set_relay_log ();
 
       (* Set module currently running. *)
-      KEvent.set_module process;
+      KEvent.set_module kind_module;
 
       (* Record backtraces on log levels debug and higher. *)
       if output_on_level L_debug then
@@ -430,7 +447,7 @@ let run_process in_sys param sys messaging_setup process =
 
       KEvent.log L_debug
         "Starting new process %a with PID %d" 
-        pp_print_kind_module process
+        pp_print_kind_module kind_module
         pid;
 
       ( (* Change debug output to per process file. *)
@@ -443,7 +460,7 @@ let run_process in_sys param sys messaging_setup process =
           try (* Output to [f.PROCESS-PID]. *)
             let f' = 
               Format.sprintf "%s.%s-%d" 
-                f (debug_ext_of_process process) pid
+                f (debug_ext_of_process kind_module) pid
             in
 
             (* Open output channel to file. *)
@@ -462,12 +479,12 @@ let run_process in_sys param sys messaging_setup process =
       (* Run main function of process *)
       main_of_process process in_sys param sys ;
       (* Cleanup and exit *)
-      on_exit_child (Some messaging_thread) process Exit
+      on_exit_child (Some messaging_thread) kind_module Exit
 
     with
     (* Termination message received. *)
     | KEvent.Terminate as e ->
-      on_exit_child (Some messaging_thread) process e
+      on_exit_child (Some messaging_thread) kind_module e
     (* Catch all other exceptions. *)
     | e ->
       (* Get backtrace now, Printf changes it. *)
@@ -476,18 +493,35 @@ let run_process in_sys param sys messaging_setup process =
         KEvent.log L_fatal
           "Caught %s in %a.@ Backtrace:@ %a"
           (Printexc.to_string e)
-          pp_print_kind_module process
+          pp_print_kind_module kind_module
           print_backtrace backtrace
       ) ;
       (* Cleanup and exit. *)
-      on_exit_child (Some messaging_thread) process e
+      on_exit_child (Some messaging_thread) kind_module e
 
   )
 
   (* We are the parent process. *)
   | _ ->
     (* Keep PID of child process and return. *)
-    child_pids := (pid, process) :: !child_pids
+    child_pids := (pid, kind_module) :: !child_pids
+
+
+let create_processes modules sys =
+  let ic3ia_module, other_modules = modules |> List.partition (
+    function `IC3IA -> true | _ -> false)
+  in
+  let processes = List.map (fun m -> GenericCall m) other_modules in
+  match ic3ia_module with
+  | [] -> processes
+  | _ -> (
+    List.fold_left
+      (fun acc p ->
+        IC3IA_Call p :: acc
+      )
+      processes
+      (TSys.get_real_properties sys)
+  )
 
 let process_invgen_mach_modules sys (modules: Lib.kind_module list) : Lib.kind_module list =
   let invgenmach_modules, other_modules = modules |> List.partition (
@@ -556,8 +590,10 @@ let analyze msg_setup save_results ignore_props stop_if_falsified modules in_sys
         query with a lower bound *)
       let modules = reachability_query_modules sys modules in
 
+      let processes = create_processes modules sys in
+
       (* Start all child processes. *)
-      modules |> List.iter (
+      processes |> List.iter (
         fun p -> run_process in_sys param sys msg_setup p
       ) ;
 

--- a/src/simplify.mli
+++ b/src/simplify.mli
@@ -49,7 +49,11 @@
 val has_division_by_zero_happened: unit -> bool
 
 (** Simplify a term *)
-val simplify_term : (UfSymbol.t * (Var.t list * Term.t)) list -> Term.t -> Term.t
+val simplify_term :
+  ?split_eq:bool ->
+  (UfSymbol.t * (Var.t list * Term.t)) list ->
+  Term.t ->
+  Term.t
 
 (** Simplify a term given an assignment to variables
 
@@ -57,7 +61,13 @@ val simplify_term : (UfSymbol.t * (Var.t list * Term.t)) list -> Term.t -> Term.
     assigns a default value per variable, for example, to smooth a
     partially defined model. The defaults for variables must not be
     circular, otherwise the simplification will cycle. *)
-val simplify_term_model : ?default_of_var:(Var.t -> Term.t) -> (UfSymbol.t * (Var.t list * Term.t)) list -> Model.t -> Term.t -> Term.t
+val simplify_term_model :
+  ?split_eq:bool ->
+  ?default_of_var:(Var.t -> Term.t) ->
+  (UfSymbol.t * (Var.t list * Term.t)) list ->
+  Model.t ->
+  Term.t ->
+  Term.t
 
 (** Remove some ITE applications without introducing new symbols *)
 val remove_ite : Term.t -> Term.t

--- a/src/smt/MathSATDriver.ml
+++ b/src/smt/MathSATDriver.ml
@@ -66,7 +66,15 @@ let cmd_line
     theory.bv.eager=true
    *)
 
-  let cmd = [| mathsat_bin |] in
+  let cmd =
+    [|
+      mathsat_bin;
+      (* Workaround for problem in MathSAT 5.6.9 and below *)
+      "-preprocessor.interpolation_ite_elimination=true";
+      (* Required for interpolation *)
+      "-theory.bv.eager=false"
+    |]
+  in
     match timeout with
     | None -> cmd
     | Some timeout ->

--- a/src/smt/SMTExpr.ml
+++ b/src/smt/SMTExpr.ml
@@ -28,6 +28,7 @@ type var = Var.t
 type custom_arg = 
   | ArgString of string
   | ArgExpr of t
+  | ArgList of custom_arg list
 
 
 
@@ -269,9 +270,12 @@ struct
     quantified_smtexpr_of_term false [] term
 
   (* Pretty-print a custom argument *)
-  let pp_print_custom_arg ppf = function 
+  let rec pp_print_custom_arg ppf = function
     | ArgString s -> Format.pp_print_string ppf s
     | ArgExpr e -> pp_print_expr ppf e
+    | ArgList l ->
+      Format.fprintf ppf "(%a)"
+        (Lib.pp_print_list pp_print_custom_arg " ") l
 
 
   (* Return a string representation of a custom argument *)

--- a/src/smt/SMTExpr.mli
+++ b/src/smt/SMTExpr.mli
@@ -36,6 +36,7 @@ type var = Var.t
 type custom_arg = 
   | ArgString of string  (** String argument *)
   | ArgExpr of t      (** Expression argument *)
+  | ArgList of custom_arg list
 
 
 (** {1 Pretty-printing and String Conversions} *)

--- a/src/smt/SMTSolver.ml
+++ b/src/smt/SMTSolver.ml
@@ -1055,14 +1055,18 @@ let kind s = s.solver_kind
 let get_interpolants solver args =
   let module S = (val solver.solver_inst) in
   
-  match execute_custom_command solver "compute-interpolant" args (List.length args) with
-  | `Custom i ->
-     List.map
-       (fun sexpr ->
-        (S.Conv.term_of_smtexpr
-           (GenericSMTLIBDriver.expr_of_string_sexpr sexpr)))
-       (List.tl i)
-
+  match execute_custom_command solver "get-interpolants" args 1 with
+  | `Custom i -> (
+    match (List.hd i) with
+    | HStringSExpr.List sexpr_lst -> (
+      List.map
+        (fun sexpr ->
+          (S.Conv.term_of_smtexpr
+            (GenericSMTLIBDriver.expr_of_string_sexpr sexpr)))
+        sexpr_lst
+    )
+    | _ -> assert false
+  )
   | _ (* error_response *) -> []
 
 

--- a/src/smt/SMTSolver.mli
+++ b/src/smt/SMTSolver.mli
@@ -238,6 +238,8 @@ val trace_comment : t -> string -> unit
 
 val get_interpolants : t -> SMTExpr.custom_arg list -> SMTExpr.t list
 
+val get_qe_interpolants : bool -> t -> Term.t list -> Term.t list
+
 (** Apply quantifier elimination to a SMTExpr *)
 val get_qe_expr : t -> SMTExpr.t -> Term.t list
 

--- a/src/terms/term.ml
+++ b/src/terms/term.ml
@@ -191,11 +191,18 @@ let is_named t =  match node_of_term t with
   | T.Annot (_, a) when TermAttr.is_named a -> true
   | _ -> false
 
+let is_interp_group t =  match node_of_term t with
+  | T.Annot (_, a) when TermAttr.is_interp_group a -> true
+  | _ -> false
 
 (* Return the term of a named term *)
 let term_of_named t =  match node_of_term t with
   | T.Annot (t, a) when TermAttr.is_named a -> t
   | _ -> invalid_arg "term_of_named"
+
+let term_of_interp_group t =  match node_of_term t with
+  | T.Annot (t, a) when TermAttr.is_interp_group a -> t
+  | _ -> invalid_arg "term_of_interp_group"
 
 
 (* Return the name of a named term *)
@@ -206,9 +213,17 @@ let name_of_named t =  match node_of_term t with
     let (s, n) = TermAttr.named_of_attr a in
 
     (* Fail if not in term namespace, otherwise return integer *)
-    if s <> "t" then invalid_arg "term_of_named" else n
+    if s <> "t" then invalid_arg "name_of_named" else n
       
-  | _ -> invalid_arg "term_of_named"
+  | _ -> invalid_arg "name_of_named"
+
+
+let name_of_interp_group t =  match node_of_term t with
+  | T.Annot (_, a) when TermAttr.is_interp_group a ->
+
+    TermAttr.interp_group_of_attr a
+
+  | _ -> invalid_arg "name_of_interp_group"
 
 
 (* Return true if the term is an integer constant *)
@@ -1544,6 +1559,10 @@ let mk_named t =
 
      Order pair in this way to put it an association list *)
   (n, T.mk_annot t (TermAttr.mk_named "t" n))
+
+
+let set_inter_group t g =
+  T.mk_annot t (TermAttr.mk_interp_group g)
 
 
 (* Hashcons a named term *)

--- a/src/terms/term.ml
+++ b/src/terms/term.ml
@@ -1005,6 +1005,40 @@ let is_lambda_identity l =
   with Invalid_argument _ -> false
 
 
+let get_atoms t =
+  let rec loop acc t =
+    match T.destruct t with
+    | T.Const _ -> (
+      if type_of_term t == Type.mk_bool () then
+        TermSet.add t acc
+      else
+        acc
+    )
+    | T.Var v -> (
+      if Var.type_of_var v == Type.mk_bool () then
+        TermSet.add t acc
+      else
+        acc
+    )
+    | T.App (_, l) -> (
+      if type_of_term t == Type.mk_bool () then
+        let atoms =
+          List.fold_left
+            (fun acc t -> loop acc t)
+            TermSet.empty
+            l
+        in
+        if TermSet.is_empty atoms then
+          TermSet.add t acc
+        else
+          TermSet.union acc atoms
+      else
+        TermSet.empty
+    )
+  in
+  loop TermSet.empty t
+
+
 (* Is the term a Boolean atom? *)
 let is_atom t = match T.destruct t with 
 

--- a/src/terms/term.mli
+++ b/src/terms/term.mli
@@ -476,6 +476,8 @@ val has_quantifier : t -> bool
 (** Convert a flat term to a term *)
 val construct : T.flat -> t
 
+val get_atoms : t -> TermSet.t
+
 (** Return true if the term is a simple Boolean atom, that is, has
     type Boolean and does not contain subterms of type Boolean *)
 val is_atom : t -> bool

--- a/src/terms/term.mli
+++ b/src/terms/term.mli
@@ -333,6 +333,11 @@ val mk_store : t -> t -> t -> t
     its name *)
 val mk_named : t -> int * t
 
+(** [set_inter_group t g] associates term [t] with
+    interpolation group [g] and return the corresponing
+    interpolation group term *)
+val set_inter_group : t -> string -> t
+
 (** Name term with the given integer in a given namespace
 
     This is a basic function, the caller has to generate the name, and
@@ -526,6 +531,16 @@ val term_of_named : t -> t
 
 (** Return the name of a named term *)
 val name_of_named : t -> int
+
+(** Return true if the term is an interpolation group term *)
+val is_interp_group : t -> bool
+
+(** Return the term of an interpolation group term *)
+val term_of_interp_group : t -> t
+
+(** Return the name of an interpolation group term *)
+val name_of_interp_group : t -> string
+
 
 (** Return true if the term is an integer constant *)
 val is_numeral : t -> bool

--- a/src/terms/termAttr.mli
+++ b/src/terms/termAttr.mli
@@ -54,6 +54,9 @@ module AttrMap : Map.S with type key = t
 (** Return a name attribute *)
 val mk_named : string -> int -> t
 
+(** Return an interpolation group attribute *)
+val mk_interp_group : string -> t
+
 (** Return a fun-def attribute *)
 val fundef : t
 
@@ -62,12 +65,19 @@ val fundef : t
 (** Return true if the attribute is a name *)
 val is_named : t -> bool
 
-(** Return true if the attribute is a name *)
+(** Return true if the attribute is fundef *)
 val is_fundef : t -> bool
+
+(** Return true if the attribute is an interpolation group *)
+val is_interp_group : t -> bool
 
 (** Return the name in a name attribute, raises [Invalid_argument] for
     other attributes *)
 val named_of_attr : t -> string * int
+
+(** Return the name in an interpolation group attribute,
+    raises [Invalid_argument] for other attributes *)
+val interp_group_of_attr : t -> string
 
 (** {1 Pretty-printing} *)
 

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -826,6 +826,7 @@ let pp_print_version ppf = pp_print_banner ppf ()
 (* Kind modules *)
 type kind_module = 
   [ `IC3
+  | `IC3QE
   | `IC3IA
   | `BMC
   | `BMCSKIP
@@ -866,8 +867,9 @@ type kind_module =
 
 (* Pretty-print the type of the process *)
 let pp_print_kind_module ppf = function
-  | `IC3 -> fprintf ppf "property directed reachability"
-  | `IC3IA -> fprintf ppf "property directed reachability (implicit abstraction)"
+  | `IC3 -> fprintf ppf "property directed reachability (QE and IA)"
+  | `IC3QE -> fprintf ppf "property directed reachability (QE)"
+  | `IC3IA -> fprintf ppf "property directed reachability (IA)"
   | `BMC -> fprintf ppf "bounded model checking"
   | `BMCSKIP -> fprintf ppf "bounded model checking (skip)"
   | `IND -> fprintf ppf "inductive step"
@@ -911,6 +913,7 @@ let string_of_kind_module = string_of_t pp_print_kind_module
 (* Return a short representation of kind module *)
 let short_name_of_kind_module = function
  | `IC3 -> "ic3"
+ | `IC3QE -> "ic3qe"
  | `IC3IA -> "ic3ia"
  | `BMC -> "bmc"
  | `BMCSKIP -> "bmcskip"
@@ -952,6 +955,7 @@ let short_name_of_kind_module = function
 (* Process type of a string *)
 let kind_module_of_string = function 
   | "IC3" -> `IC3
+  | "IC3QE" -> `IC3QE
   | "IC3IA" -> `IC3IA
   | "BMC" -> `BMC
   | "BMCSKIP" -> `BMCSKIP
@@ -1023,6 +1027,7 @@ let int_of_kind_module = function
   | `INVGENMACH -> 28
   | `INVGENMACHOS -> 29
   | `IC3IA -> 31
+  | `IC3QE -> 32
 
 
 (* Timeouts *)

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -825,7 +825,8 @@ let pp_print_version ppf = pp_print_banner ppf ()
 
 (* Kind modules *)
 type kind_module = 
-  [ `IC3 
+  [ `IC3
+  | `IC3IA
   | `BMC
   | `BMCSKIP
   | `IND
@@ -866,6 +867,7 @@ type kind_module =
 (* Pretty-print the type of the process *)
 let pp_print_kind_module ppf = function
   | `IC3 -> fprintf ppf "property directed reachability"
+  | `IC3IA -> fprintf ppf "property directed reachability (implicit abstraction)"
   | `BMC -> fprintf ppf "bounded model checking"
   | `BMCSKIP -> fprintf ppf "bounded model checking (skip)"
   | `IND -> fprintf ppf "inductive step"
@@ -909,6 +911,7 @@ let string_of_kind_module = string_of_t pp_print_kind_module
 (* Return a short representation of kind module *)
 let short_name_of_kind_module = function
  | `IC3 -> "ic3"
+ | `IC3IA -> "ic3ia"
  | `BMC -> "bmc"
  | `BMCSKIP -> "bmcskip"
  | `IND -> "ind"
@@ -949,6 +952,7 @@ let short_name_of_kind_module = function
 (* Process type of a string *)
 let kind_module_of_string = function 
   | "IC3" -> `IC3
+  | "IC3IA" -> `IC3IA
   | "BMC" -> `BMC
   | "BMCSKIP" -> `BMCSKIP
   | "IND" -> `IND
@@ -1018,6 +1022,7 @@ let int_of_kind_module = function
   | `INVGENUINT64OS -> 27
   | `INVGENMACH -> 28
   | `INVGENMACHOS -> 29
+  | `IC3IA -> 31
 
 
 (* Timeouts *)

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -196,15 +196,26 @@ let rec fold_until f acc n = function
   | h :: t as l -> if n = 0 then (acc, l)
                    else fold_until f (f acc h) (n - 1) t
 
-let list_slice list i k =
-  let _, list = (* drop n elements *)
-    fold_until (fun _ _ -> []) [] i list
+let list_split k l =
+  let l1, l2 =
+    fold_until (fun acc h -> h :: acc) [] k l
+  in
+  List.rev l1, l2
+
+let list_slice l i k =
+  let _, l = (* drop n elements *)
+    fold_until (fun _ _ -> []) [] i l
   in
   let taken, _ = (* take (k - i + 1) elements *)
-    fold_until (fun acc h -> h :: acc) [] (k - i + 1) list
+    fold_until (fun acc h -> h :: acc) [] (k - i + 1) l
   in
   List.rev taken
 
+let list_suffix l i =
+  let _, l = (* drop n elements *)
+    fold_until (fun _ _ -> []) [] i l
+  in
+  l
 
 (* [chain_list \[e1; e2; ...\]] is \[\[e1; e2\]; \[e2; e3\]; ... \]]*)
 let chain_list = function 

--- a/src/utils/lib.mli
+++ b/src/utils/lib.mli
@@ -132,9 +132,18 @@ val list_insert_at : 'a -> int -> 'a list -> 'a list
 (** Apply a function to the nth element of a list *)
 val list_apply_at : ('a -> 'a) -> int -> 'a list -> 'a list
 
-(* [list_slice l i k] returns a list containing the elements between
+(** [list_slice l i k] returns a list containing the elements between
    the [i]th and [k]th element of [l]*)
 val list_slice : 'a list -> int -> int -> 'a list
+
+(** [list_suffix l i] returns a list containing the elements between
+   the [i]th and the last element of [l] *)
+val list_suffix : 'a list -> int -> 'a list
+
+(** [list_split n l] divides list [l] into two at index [n]
+    The first will contain all indices from [0,n) and
+    the second will contain all indices from [n,len) *)
+val list_split : int -> 'a list -> ('a list * 'a list)
 
 (** [chain_list \[e1; e2; ...\]] is [\[\[e1; e2\]; \[e2; e3\]; ... \]] *)
 val chain_list : 'a list -> 'a list list 

--- a/src/utils/lib.mli
+++ b/src/utils/lib.mli
@@ -386,6 +386,7 @@ val pp_print_version : Format.formatter -> unit
 (** Kind modules *)
 type kind_module =
   [ `IC3
+  | `IC3IA
   | `BMC
   | `BMCSKIP
   | `IND

--- a/src/utils/lib.mli
+++ b/src/utils/lib.mli
@@ -386,6 +386,7 @@ val pp_print_version : Format.formatter -> unit
 (** Kind modules *)
 type kind_module =
   [ `IC3
+  | `IC3QE
   | `IC3IA
   | `BMC
   | `BMCSKIP

--- a/src/utils/priorityQueue.ml
+++ b/src/utils/priorityQueue.ml
@@ -1,0 +1,50 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+ *)
+
+type priority = int
+
+type 'a t = Empty | Node of priority * 'a * 'a t * 'a t
+
+let empty = Empty
+
+let is_empty = function
+  | Empty -> true
+  | _ -> false
+
+let rec insert queue prio elt =
+  match queue with
+  | Empty -> Node(prio, elt, Empty, Empty)
+  | Node(p, e, left, right) ->
+    if prio <= p
+    then Node(prio, elt, insert right p e, left)
+    else Node(p, e, insert right prio elt, left)
+   
+let rec remove_top = function
+  | Empty -> Empty
+  | Node(_, _, left, Empty) -> left
+  | Node(_, _, Empty, right) -> right
+  | Node(_, _, (Node(lprio, lelt, _, _) as left),
+               (Node(rprio, relt, _, _) as right)) ->
+    if lprio <= rprio
+    then Node(lprio, lelt, remove_top left, right)
+    else Node(rprio, relt, left, remove_top right)
+
+let extract = function
+  | Empty -> None
+  | Node(prio, elt, _, _) as queue ->
+    Some (prio, elt, remove_top queue)

--- a/src/utils/priorityQueue.mli
+++ b/src/utils/priorityQueue.mli
@@ -1,0 +1,29 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+ *)
+
+type priority = int
+
+type 'a t
+
+val empty : 'a t
+
+val is_empty : 'a t -> bool
+
+val insert : 'a t -> priority -> 'a -> 'a t
+
+val extract : 'a t -> (priority * 'a * 'a t) option


### PR DESCRIPTION
The old IC3 engine that uses quantifier elimination has been renamed to IC3QE. Now IC3 is a virtual module that enables both IC3QE and IC3IA.