### PR TITLE
Use bitvector constant extension in MathSAT

### DIFF
--- a/src/terms/bitvector.ml
+++ b/src/terms/bitvector.ml
@@ -628,8 +628,10 @@ let pp_yices_print_bitvector_d ppf i s =
     fprintf ppf "0b%a" pp_print_bitvector_b' b
 
 (* Pretty-print a bitvector in SMTLIB extended decimal format *)
-let pp_smtlib_print_bitvector_d ppf n size = 
-  fprintf ppf "(_ bv%s %s)" (Numeral.string_of_numeral n) (Numeral.string_of_numeral size)
+let pp_smtlib_print_bitvector_d ppf b =
+  let len = length_of_bitvector b in
+  let num = ubv_to_num b in
+  fprintf ppf "(_ bv%a %d)" Numeral.pp_print_numeral num len
 
 (* Pretty-print an unsigned Lustre machine integer *)
 let pp_print_unsigned_machine_integer ppf b =

--- a/src/terms/bitvector.mli
+++ b/src/terms/bitvector.mli
@@ -276,7 +276,7 @@ val bv_arsh : t -> t -> t
 val pp_smtlib_print_bitvector_b : Format.formatter -> t -> unit
 
 (** Pretty-print a bitvector in SMTLIB extended decimal format *)
-val pp_smtlib_print_bitvector_d : Format.formatter -> Numeral.t -> Numeral.t -> unit
+val pp_smtlib_print_bitvector_d : Format.formatter -> t -> unit
 
 (** Pretty-print a constant bitvector in Yices' binary format *)
 val pp_yices_print_bitvector_b : Format.formatter -> t -> unit


### PR DESCRIPTION
Workaround for a bug in MathSAT:
`(get-value (= x #b0000))` throws "syntax error, unexpected BINCONSTANT"
`(get-value (= x (_ bv0 4)))` works fine