### PR TITLE
Use Lustre variable for node calls whenever possible

### DIFF
--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -968,6 +968,15 @@ let node_call_of_svar { calls } svar =
   in
   loop calls
 
+let node_call_svars { calls } =
+  List.fold_left
+    (fun acc { call_outputs } ->
+      D.bindings call_outputs
+      |> List.map snd
+      |> SVS.of_list |> SVS.union acc)
+    SVS.empty
+    calls
+
 (* Return the scope of the name of the node *)
 let scope_of_node { name } = name |> I.to_scope
 

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -335,11 +335,14 @@ val equation_of_svar : t -> StateVar.t -> equation option
     there is an output without an equational definition *)
 val partially_defined : t -> bool
 
-(** Returns the equation for a state variable if any. *)
+(** Returns the source of a state variable if any. *)
 val source_of_svar : t -> StateVar.t -> state_var_source option
 
 (** Returns the node call the svar is (one of) the output(s) of, if any. *)
 val node_call_of_svar : t -> StateVar.t -> node_call option
+
+(** Returns a set of state variables that are output of some node call *)
+val node_call_svars : t -> StateVar.StateVarSet.t
 
 (** Return the scope of the node *)
 val scope_of_node : t -> Scope.t


### PR DESCRIPTION
When printing Lustre constraint representing the set of viable states, it uses a Lustre variable of the original model to refer to a node call output, as opposed to a node call reference, if a Lustre variable is available.