### PR TITLE
Lift restriction on array accesses

### DIFF
--- a/src/lustre/lustreArrayDependencies.mli
+++ b/src/lustre/lustreArrayDependencies.mli
@@ -21,7 +21,6 @@
 
 type error_kind = Unknown of string
   | ComplicatedExpr of LustreAst.expr
-  | ExprMissingIndex of HString.t * LustreAst.expr
   | Cycle of HString.t list
 
 val error_message: error_kind -> string

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -190,7 +190,7 @@ let _ = run_test_tt_main ("frontend lustreArrayDependencies error tests" >::: [
     | _ -> false);
   mk_test "test invalid inductive array def 3" (fun () ->
     match load_file "./lustreArrayDependencies/inductive_array3.lus" with
-    | Error (`LustreArrayDependencies  (_, ExprMissingIndex _)) -> true
+    | Error (`LustreArrayDependencies  (_, ComplicatedExpr _)) -> true
     | _ -> false);
   mk_test "test invalid inductive array def 4" (fun () ->
     match load_file "./lustreArrayDependencies/inductive_array4.lus" with
@@ -198,7 +198,7 @@ let _ = run_test_tt_main ("frontend lustreArrayDependencies error tests" >::: [
     | _ -> false);
   mk_test "test invalid inductive array def 5" (fun () ->
     match load_file "./lustreArrayDependencies/inductive_array5.lus" with
-    | Error (`LustreArrayDependencies  (_, ExprMissingIndex _)) -> true
+    | Error (`LustreArrayDependencies  (_, ComplicatedExpr _)) -> true
     | _ -> false);
   mk_test "test invalid inductive array def 6" (fun () ->
     match load_file "./lustreArrayDependencies/inductive_array6.lus" with

--- a/tests/regression/success/test_recursive_array_def.lus
+++ b/tests/regression/success/test_recursive_array_def.lus
@@ -1,3 +1,17 @@
+
+node sum (const n: int; A: int ^ n) returns (s: int);
+var cumul: int ^ n;
+let
+  cumul[i] = if i = 0 then A[0] else A[i] + cumul[i-1];
+  s = cumul[n-1];
+tel
+
+node slice (const n: int; A: int ^ n; const low: int; const up: int)
+returns (B : int ^ (up-low));
+let
+  B[i] = A[low + i];
+tel
+
 node a(A: int^5) returns (B: int^5)
 let
   B[i] = A[i] + 1;


### PR DESCRIPTION
Array accesses of the form `A[0]` and `A[n-i]` are allowed if they do not occur (directly or indirectly) in the definition of the array `A` itself.