### PR TITLE
Do not transform enum types to abstract types

### DIFF
--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -488,16 +488,8 @@ let rec inline_constants_of_contract: TC.tc_context -> LA.contract -> LA.contrac
 let substitute: TC.tc_context -> LA.declaration -> (TC.tc_context * LA.declaration) = fun ctx ->
   function
   | TypeDecl (span, AliasType (pos, i, t)) ->
-    let ctx', t' =
-      match t with
-      | LA.EnumType _ ->
-        (* Special handling is applied to enum types (see type_check_infer_globals) *)
-        ctx, t
-      | _ ->
-        let t' = inline_constants_of_lustre_type ctx t in
-        TC.add_ty_syn ctx i t', t'
-    in
-    ctx', LA.TypeDecl (span, AliasType (pos, i, t'))
+    let t' = inline_constants_of_lustre_type ctx t in
+    TC.add_ty_syn ctx i t', LA.TypeDecl (span, AliasType (pos, i, t'))
   | ConstDecl (span, FreeConst (pos, id, ty)) ->
     let ty' = inline_constants_of_lustre_type ctx ty in
     ctx, ConstDecl (span, FreeConst (pos, id, ty'))

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -623,19 +623,8 @@ and compile_ast_type
   | A.UserType (_, ident) ->
     StringMap.find ident cstate.type_alias
   | A.AbstractType (_, ident) ->
-    (match StringMap.find_opt ident cstate.type_alias with
-      | Some candidate ->
-        (* The typechecker transforms enum types to abstract types (not sure why) 
-          here we check if the ident in fact names an enum type *)
-        let ident = HString.string_of_hstring ident in
-        let bindings = X.bindings candidate in
-        let (head_index, ty) = List.hd bindings in
-        if List.length bindings = 1 && head_index = X.empty_index && Type.is_enum ty then
-          candidate
-        else X.singleton [X.AbstractTypeIndex ident] Type.t_int
-      | None ->
-        let ident = HString.string_of_hstring ident in
-        X.singleton [X.AbstractTypeIndex ident] Type.t_int)
+    let ident = HString.string_of_hstring ident in
+    X.singleton [X.AbstractTypeIndex ident] Type.t_int
   | A.RecordType (_, _, record_fields) ->
     let over_fields = fun a (_, i, t) ->
       let i = HString.string_of_hstring i in


### PR DESCRIPTION
Commit 5439c29 introduced this transformation (I do not know why), but it was the source of several bugs (see 54ded7a, c2d6105). This commit removes the transformation.