### PR TITLE
Fix soundness bug in IC3IA engine

### DIFF
--- a/tests/regression/falsifiable/ic3ia_bug.lus
+++ b/tests/regression/falsifiable/ic3ia_bug.lus
@@ -1,0 +1,6 @@
+node N() returns (ok:bool);
+let
+  assert (true -> pre ok);
+  ok = false;
+  --%PROPERTY ok;
+tel


### PR DESCRIPTION
The system definition should only be asserted when solving inductive relative queries. Otherwise, get_bad_cube might incorrectly use assumptions on the state at the beginning of a transition.

Fixes #1036