### PR TITLE
Array length constraints and properties

### DIFF
--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -60,6 +60,12 @@ type t = {
     * HString.t (* Generated name for Range Expression *)
     * LustreAst.expr) (* Computed ranged expr *)
     list;
+  array_constraints : (
+    Lib.position
+    * HString.t (* Generated name for array constraint expression *)
+    * LustreAst.expr (* Computed expr *)
+    * string) (* Constraint textual description *)
+    list;
   expanded_variables : StringSet.t;
   equations :
     (LustreAst.typed_ident list (* quantified variables *)
@@ -104,6 +110,7 @@ let union ids1 ids2 = {
     contract_calls = StringMap.merge union_keys
       ids1.contract_calls ids2.contract_calls;
     subrange_constraints = ids1.subrange_constraints @ ids2.subrange_constraints;
+    array_constraints = ids1.array_constraints @ ids2.array_constraints;
     expanded_variables = StringSet.union ids1.expanded_variables ids2.expanded_variables;
     equations = ids1.equations @ ids2.equations;
     nonvacuity_props = StringSet.union ids1.nonvacuity_props ids2.nonvacuity_props;
@@ -126,6 +133,7 @@ let union_keys2 key id1 id2 = match key, id1, id2 with
     calls = [];
     contract_calls = StringMap.empty;
     subrange_constraints = [];
+    array_constraints = [];
     expanded_variables = StringSet.empty;
     equations = [];
     nonvacuity_props = StringSet.empty;

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -60,6 +60,12 @@ type t = {
     * HString.t (* Generated name for Range Expression *)
     * LustreAst.expr) (* Computed ranged expr *)
     list;
+  array_constraints : (
+    Lib.position
+    * HString.t (* Generated name for array constraint expression *)
+    * LustreAst.expr (* Computed expr *)
+    * string) (* Constraint textual description *)
+    list;
   expanded_variables : StringSet.t;
   equations :
     (LustreAst.typed_ident list (* quantified variables *)

--- a/src/lustre/lustreAbstractInterpretation.ml
+++ b/src/lustre/lustreAbstractInterpretation.ml
@@ -195,7 +195,7 @@ let rec interpret_program ty_ctx gids = function
   | h :: t -> union (interpret_decl ty_ctx gids h) (interpret_program ty_ctx gids t)
 
 and interpret_contract node_id ctx ty_ctx eqns =
-  let ty_ctx = TC.tc_ctx_of_contract ~ignore_modes:true ty_ctx eqns |> unwrap
+  let ty_ctx, _ = TC.tc_ctx_of_contract ~ignore_modes:true ty_ctx eqns |> unwrap
   in
   List.fold_left (fun acc eqn ->
       union acc (interpret_contract_eqn node_id acc ty_ctx eqn))
@@ -274,7 +274,7 @@ and interpret_node ty_ctx gids (id, _, _, ins, outs, locals, items, contract) =
     | None -> empty_context
   in
   let ty_ctx = List.fold_left
-    (fun ctx local -> TC.local_var_binding ctx local |> unwrap)
+    (fun ctx local -> TC.local_var_binding ctx local |> unwrap |> fst)
     ty_ctx
     locals 
   in
@@ -441,7 +441,7 @@ and interpret_expr_by_type node_id ctx ty_ctx ty proj expr : LA.lustre_type =
 
 and interpret_structured_expr f node_id ctx ty_ctx ty proj expr =
   let infer e =
-    let ty = TC.infer_type_expr ty_ctx e |> unwrap
+    let ty, _ = TC.infer_type_expr ty_ctx e |> unwrap
     in
     Ctx.expand_nested_type_syn ty_ctx ty
   in
@@ -492,7 +492,7 @@ and interpret_structured_expr f node_id ctx ty_ctx ty proj expr =
 
 and interpret_int_expr node_id ctx ty_ctx proj expr = 
   let infer e =
-    let ty = TC.infer_type_expr ty_ctx e |> unwrap
+    let ty, _ = TC.infer_type_expr ty_ctx e |> unwrap
     in
     let ty = Ctx.expand_nested_type_syn ty_ctx ty in 
     interpret_expr_by_type node_id ctx ty_ctx ty proj e

--- a/src/lustre/lustreArrayDependencies.ml
+++ b/src/lustre/lustreArrayDependencies.ml
@@ -291,7 +291,7 @@ and check_node_decl ctx ns decl =
     (Ctx.union input_ctx output_ctx)
   in
   let ctx = List.fold_left
-    (fun ctx local -> Chk.local_var_binding ctx local |> unwrap)
+    (fun ctx local -> Chk.local_var_binding ctx local |> unwrap |> fst)
     ctx
     locals
   in

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -76,9 +76,6 @@ module AIC = LustreAstInlineConstants
 module AI = LustreAbstractInterpretation
 module Ctx = TypeCheckerContext
 module Chk = LustreTypeChecker
-module R = Res
-
-let (let*) = Res.(>>=)
 
 type warning_kind = 
   | UnguardedPreWarning of A.expr

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1553,7 +1553,7 @@ and expand_node_calls_in_place info var count expr =
 
 and collect_array_constraints info map array_constraints_map = 
   StringMap.fold (fun id array_exprs acc1  ->  
-    let gids2 = List.fold_left (fun acc2 (array_expr, desc) ->
+    let gids = List.fold_left (fun acc2 (array_expr, desc) ->
       i := !i + 1;
       let output_expr = AH.rename_contract_vars array_expr in
       let prefix = HString.mk_hstring (string_of_int !i) in
@@ -1568,5 +1568,5 @@ and collect_array_constraints info map array_constraints_map =
         equations = [(info.quantified_variables, info.contract_scope, eq_lhs, array_expr)]; 
       }
     ) (empty ()) array_exprs in 
-    StringMap.merge union_keys2 acc1 (StringMap.singleton id gids2)
+    StringMap.merge union_keys2 acc1 (StringMap.singleton id gids)
   ) array_constraints_map map

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -66,15 +66,6 @@
 
      @author Andrew Marmaduke *)
 
-type error_kind = 
-  | InvalidArrayLengthConstraint of LustreAst.expr * LustreAst.expr
-
-type error = [
-  | `LustreAstNormalizerError of Lib.position * error_kind
-]
-
-val error_message: error_kind -> string
-
 type warning_kind =
   | UnguardedPreWarning of LustreAst.expr
   | UseOfAssertionWarning
@@ -91,7 +82,6 @@ val normalize : TypeCheckerContext.tc_context ->
     GeneratedIdentifiers.t GeneratedIdentifiers.StringMap.t ->
     (LustreAst.expr * string) list GeneratedIdentifiers.StringMap.t ->
   (LustreAst.declaration list * GeneratedIdentifiers.t GeneratedIdentifiers.StringMap.t *
-  [> `LustreAstNormalizerWarning of Lib.position * warning_kind] list, [> error])
-  result
+  [> `LustreAstNormalizerWarning of Lib.position * warning_kind] list)
 
 val pp_print_generated_identifiers : Format.formatter -> GeneratedIdentifiers.t -> unit

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -66,9 +66,14 @@
 
      @author Andrew Marmaduke *)
 
+type error_kind = 
+  | InvalidArrayLengthConstraint of LustreAst.expr * LustreAst.expr
+
 type error = [
-  | `LustreAstNormalizerError
+  | `LustreAstNormalizerError of Lib.position * error_kind
 ]
+
+val error_message: error_kind -> string
 
 type warning_kind =
   | UnguardedPreWarning of LustreAst.expr
@@ -84,8 +89,9 @@ val normalize : TypeCheckerContext.tc_context ->
   LustreAbstractInterpretation.context ->
   LustreAst.t ->
     GeneratedIdentifiers.t GeneratedIdentifiers.StringMap.t ->
+    (LustreAst.expr * string) list GeneratedIdentifiers.StringMap.t ->
   (LustreAst.declaration list * GeneratedIdentifiers.t GeneratedIdentifiers.StringMap.t *
-   [> `LustreAstNormalizerWarning of Lib.position * warning_kind] list, [> error])
+  [> `LustreAstNormalizerWarning of Lib.position * warning_kind] list, [> error])
   result
 
 val pp_print_generated_identifiers : Format.formatter -> GeneratedIdentifiers.t -> unit

--- a/src/lustre/lustreErrors.ml
+++ b/src/lustre/lustreErrors.ml
@@ -23,7 +23,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError of Lib.position * LustreAstNormalizer.error_kind
+  | `LustreAstNormalizerError of Lib.position
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr
@@ -37,7 +37,7 @@ let error_position error = match error with
   | `LustreAstDependenciesError (pos, _) -> pos
   | `LustreAstInlineConstantsError (pos, _) -> pos
   | `LustreAbstractInterpretationError (pos, _) -> pos
-  | `LustreAstNormalizerError (pos, _) -> pos
+  | `LustreAstNormalizerError pos -> pos
   | `LustreSyntaxChecksError (pos, _) -> pos
   | `LustreTypeCheckerError (pos, _) -> pos
   | `LustreUnguardedPreError (pos, _) -> pos
@@ -50,7 +50,7 @@ let error_message error = match error with
   | `LustreAstDependenciesError (_, kind) -> LustreAstDependencies.error_message kind
   | `LustreAstInlineConstantsError (_, kind) -> LustreAstInlineConstants.error_message kind
   | `LustreAbstractInterpretationError (_, kind) -> LustreAbstractInterpretation.error_message kind
-  | `LustreAstNormalizerError (_, kind) -> LustreAstNormalizer.error_message kind
+  | `LustreAstNormalizerError _ -> assert false
   | `LustreSyntaxChecksError (_, kind) -> LustreSyntaxChecks.error_message kind
   | `LustreTypeCheckerError (_, kind) -> LustreTypeChecker.error_message kind
   | `LustreUnguardedPreError (_, e) -> (Format.asprintf "@[<hov 2>Unguarded pre in expression@ %a@]" LA.pp_print_expr e)

--- a/src/lustre/lustreErrors.ml
+++ b/src/lustre/lustreErrors.ml
@@ -23,7 +23,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError of Lib.position
+  | `LustreAstNormalizerError
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr
@@ -37,7 +37,7 @@ let error_position error = match error with
   | `LustreAstDependenciesError (pos, _) -> pos
   | `LustreAstInlineConstantsError (pos, _) -> pos
   | `LustreAbstractInterpretationError (pos, _) -> pos
-  | `LustreAstNormalizerError pos -> pos
+  | `LustreAstNormalizerError -> assert false
   | `LustreSyntaxChecksError (pos, _) -> pos
   | `LustreTypeCheckerError (pos, _) -> pos
   | `LustreUnguardedPreError (pos, _) -> pos
@@ -50,7 +50,7 @@ let error_message error = match error with
   | `LustreAstDependenciesError (_, kind) -> LustreAstDependencies.error_message kind
   | `LustreAstInlineConstantsError (_, kind) -> LustreAstInlineConstants.error_message kind
   | `LustreAbstractInterpretationError (_, kind) -> LustreAbstractInterpretation.error_message kind
-  | `LustreAstNormalizerError _ -> assert false
+  | `LustreAstNormalizerError -> assert false
   | `LustreSyntaxChecksError (_, kind) -> LustreSyntaxChecks.error_message kind
   | `LustreTypeCheckerError (_, kind) -> LustreTypeChecker.error_message kind
   | `LustreUnguardedPreError (_, e) -> (Format.asprintf "@[<hov 2>Unguarded pre in expression@ %a@]" LA.pp_print_expr e)

--- a/src/lustre/lustreErrors.ml
+++ b/src/lustre/lustreErrors.ml
@@ -23,7 +23,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError
+  | `LustreAstNormalizerError of Lib.position * LustreAstNormalizer.error_kind
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr
@@ -37,7 +37,7 @@ let error_position error = match error with
   | `LustreAstDependenciesError (pos, _) -> pos
   | `LustreAstInlineConstantsError (pos, _) -> pos
   | `LustreAbstractInterpretationError (pos, _) -> pos
-  | `LustreAstNormalizerError -> assert false
+  | `LustreAstNormalizerError (pos, _) -> pos
   | `LustreSyntaxChecksError (pos, _) -> pos
   | `LustreTypeCheckerError (pos, _) -> pos
   | `LustreUnguardedPreError (pos, _) -> pos
@@ -50,7 +50,7 @@ let error_message error = match error with
   | `LustreAstDependenciesError (_, kind) -> LustreAstDependencies.error_message kind
   | `LustreAstInlineConstantsError (_, kind) -> LustreAstInlineConstants.error_message kind
   | `LustreAbstractInterpretationError (_, kind) -> LustreAbstractInterpretation.error_message kind
-  | `LustreAstNormalizerError -> assert false
+  | `LustreAstNormalizerError (_, kind) -> LustreAstNormalizer.error_message kind
   | `LustreSyntaxChecksError (_, kind) -> LustreSyntaxChecks.error_message kind
   | `LustreTypeCheckerError (_, kind) -> LustreTypeChecker.error_message kind
   | `LustreUnguardedPreError (_, e) -> (Format.asprintf "@[<hov 2>Unguarded pre in expression@ %a@]" LA.pp_print_expr e)

--- a/src/lustre/lustreErrors.mli
+++ b/src/lustre/lustreErrors.mli
@@ -24,7 +24,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError
+  | `LustreAstNormalizerError of Lib.position * LustreAstNormalizer.error_kind
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr

--- a/src/lustre/lustreErrors.mli
+++ b/src/lustre/lustreErrors.mli
@@ -24,7 +24,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError of Lib.position * LustreAstNormalizer.error_kind
+  | `LustreAstNormalizerError of Lib.position
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr

--- a/src/lustre/lustreErrors.mli
+++ b/src/lustre/lustreErrors.mli
@@ -24,7 +24,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError of Lib.position
+  | `LustreAstNormalizerError
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -52,7 +52,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError of Lib.position
+  | `LustreAstNormalizerError
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -52,7 +52,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError of Lib.position * LustreAstNormalizer.error_kind
+  | `LustreAstNormalizerError of Lib.position
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr
@@ -186,7 +186,7 @@ let type_check declarations =
     let abstract_interp_ctx = LIA.interpret_program inlined_global_ctx gids const_inlined_nodes_and_contracts in
 
     (* Step 15. Normalize AST: guard pres, abstract to locals where appropriate *)
-    let* (normalized_nodes_and_contracts, gids, warnings2) = 
+    let (normalized_nodes_and_contracts, gids, warnings2) = 
       LAN.normalize inlined_global_ctx abstract_interp_ctx const_inlined_nodes_and_contracts gids (GI.StringMap.merge TC.union_keys cons1 cons2)
     in
     

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -45,6 +45,7 @@ module LDF = LustreDesugarFrameBlocks
 module RMA = LustreRemoveMultAssign
 module LAD = LustreArrayDependencies
 module LDN = LustreDesugarAnyOps
+module GI = GeneratedIdentifiers
 
 type error = [
   | `LustreArrayDependencies of Lib.position * LustreArrayDependencies.error_kind
@@ -185,11 +186,8 @@ let type_check declarations =
     let abstract_interp_ctx = LIA.interpret_program inlined_global_ctx gids const_inlined_nodes_and_contracts in
 
     (* Step 15. Normalize AST: guard pres, abstract to locals where appropriate *)
-    (*!! TODO: Clean this up *)
-    let cons1 = GeneratedIdentifiers.StringMap.of_seq (TypeCheckerContext.IMap.to_seq cons1) in
-    let cons2 = GeneratedIdentifiers.StringMap.of_seq (TypeCheckerContext.IMap.to_seq cons2) in
     let* (normalized_nodes_and_contracts, gids, warnings2) = 
-      LAN.normalize inlined_global_ctx abstract_interp_ctx const_inlined_nodes_and_contracts gids (GeneratedIdentifiers.StringMap.merge LustreTypeChecker.union_keys cons1 cons2)
+      LAN.normalize inlined_global_ctx abstract_interp_ctx const_inlined_nodes_and_contracts gids (GI.StringMap.merge TC.union_keys cons1 cons2)
     in
     
       

--- a/src/lustre/lustreInput.mli
+++ b/src/lustre/lustreInput.mli
@@ -112,7 +112,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError of Lib.position * LustreAstNormalizer.error_kind
+  | `LustreAstNormalizerError of Lib.position
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr

--- a/src/lustre/lustreInput.mli
+++ b/src/lustre/lustreInput.mli
@@ -112,7 +112,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError
+  | `LustreAstNormalizerError of Lib.position * LustreAstNormalizer.error_kind
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr

--- a/src/lustre/lustreInput.mli
+++ b/src/lustre/lustreInput.mli
@@ -112,7 +112,7 @@ type error = [
   | `LustreAstDependenciesError of Lib.position * LustreAstDependencies.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
   | `LustreAbstractInterpretationError of Lib.position * LustreAbstractInterpretation.error_kind
-  | `LustreAstNormalizerError of Lib.position
+  | `LustreAstNormalizerError
   | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreTypeCheckerError of Lib.position * LustreTypeChecker.error_kind
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -2085,6 +2085,22 @@ and compile_node_decl gids is_function cstate ctx i ext inputs outputs locals it
     in
     assumes, guarantees, props
   (* ****************************************************************** *)
+  (* Generate Contract Constraints for Array constraints                *)
+  (* ****************************************************************** *)
+  in let props =
+  let create_constraint_name rexpr = 
+    Format.asprintf "@[<h>%a@]" A.pp_print_expr rexpr
+  in
+  let over_array_constraints p (pos, id, rexpr, prop_desc) =
+    let sv = H.find !map.state_var (mk_ident id) in
+    let name = create_constraint_name rexpr in
+    let name = prop_desc ^ " " ^ name in
+    let src = Property.Generated (Some pos, [sv]) in
+    (sv, name, src, Property.Invariant) :: p
+  in
+  List.fold_left over_array_constraints props gids.GI.array_constraints
+(* ****************************************************************** *)
+  (* ****************************************************************** *)
   (* Finalize Contracts and add Sofar assumption                        *)
   (* ****************************************************************** *)
   in let (contract, sofar_local, sofar_equation) =

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -197,8 +197,23 @@ let (>>=) = R.(>>=)
 let (let*) = R.(>>=)
 let (>>) = R.(>>)
 
+let global_id = HString.mk_hstring "_global"
+
 let type_error pos kind = Error (`LustreTypeCheckerError (pos, kind))
 (** [type_error] returns an [Error] of [tc_result] *)
+
+
+let union_keys key id1 id2 = match key, id1, id2 with
+  | _, None, None -> None
+  | _, (Some v), None -> Some v
+  | _, None, (Some v) -> Some v
+  | _, (Some v1), (Some v2) -> Some (v1 @ v2)
+
+let mk_array_prop_desc is_call_arg pos = 
+  let pos = (Lib.string_of_t Lib.pp_print_position pos) in
+  if is_call_arg
+  then "Node call argument at position " ^ pos ^ " has correct corresponding length argument"
+  else "Definition of variable at position " ^ pos ^ " respects array length constraint" 
 
 (**********************************************
  * Type inferring and type checking functions *
@@ -410,13 +425,13 @@ let update_ty_with_ctx node_ty call_params ctx arg_exprs =
     LH.apply_subst_in_type (List.combine call_param_len_idents array_len_exprs) node_ty
   )
 
-let rec infer_type_expr: tc_context -> LA.expr -> (tc_type, [> error]) result
+let rec infer_type_expr: tc_context -> LA.expr -> (tc_type * (LA.expr * string) list, [> error]) result
   = fun ctx -> function
   (* Identifiers *)
   | LA.Ident (pos, i) ->
     (match (lookup_ty ctx i) with
     | None -> type_error pos (UnboundIdentifier i) 
-    | Some ty -> R.ok ty)
+    | Some ty -> R.ok (ty, []))
   | LA.ModeRef (pos, ids) ->      
     let lookup_mode_ty ctx (ids:HString.t list) =
       match ids with
@@ -424,31 +439,31 @@ let rec infer_type_expr: tc_context -> LA.expr -> (tc_type, [> error]) result
       | rest -> let i = HString.concat (HString.mk_hstring "::") rest in 
                 match (lookup_ty ctx i) with
                 | None -> type_error pos (UnboundModeReference i)
-                | Some ty -> R.ok ty in
+                | Some ty -> R.ok (ty, []) in
     lookup_mode_ty ctx ids
   | LA.RecordProject (pos, e, fld) ->
-    let* rec_ty = infer_type_expr ctx e in
+    let* rec_ty, constraints = infer_type_expr ctx e in
     let rec_ty = expand_type_syn ctx rec_ty in
     (match rec_ty with
     | LA.RecordType (_, _, flds) ->
         let typed_fields = List.map (fun (_, i, ty) -> (i, ty)) flds in
         (match (List.assoc_opt fld typed_fields) with
-        | Some ty -> R.ok (expand_type_syn ctx ty)
+        | Some ty -> R.ok (expand_type_syn ctx ty, constraints)
         | None -> type_error pos (NotAFieldOfRecord fld))
     | _ -> type_error (LH.pos_of_expr e) (IlltypedRecordProjection rec_ty))
 
   | LA.TupleProject (pos, e1, i) ->
-    let* tup_ty = infer_type_expr ctx e1 in
+    let* tup_ty, constraints = infer_type_expr ctx e1 in
     let tup_ty = expand_type_syn ctx tup_ty in
     (match tup_ty with
     | LA.TupleType (pos, tys) as ty ->
         if List.length tys <= i
         then type_error pos (TupleIndexOutOfBounds (i, ty))
-        else R.ok (expand_type_syn ctx (List.nth tys i))
+        else R.ok (expand_type_syn ctx (List.nth tys i), constraints)
     | ty -> type_error pos (IlltypedTupleProjection ty))
 
   (* Values *)
-  | LA.Const (pos, c) -> R.ok (infer_type_const pos c)
+  | LA.Const (pos, c) -> R.ok (infer_type_const pos c, [])
 
   (* Operator applications *)
   | LA.UnaryOp (pos, op, e) ->
@@ -460,13 +475,13 @@ let rec infer_type_expr: tc_context -> LA.expr -> (tc_type, [> error]) result
     | Ite -> 
         infer_type_expr ctx con
         >>= (function
-            | Bool _ ->
-                infer_type_expr ctx e1 >>= fun e1_ty ->
-                infer_type_expr ctx e2 >>= fun e2_ty ->
-                eq_lustre_type ctx e1_ty e2_ty >>= fun eq_test ->
-                    if eq_test then R.ok e1_ty
+            | Bool _, cons1 ->
+                let* e1_ty, cons2 = infer_type_expr ctx e1 in
+                let* e2_ty, cons3 = infer_type_expr ctx e2 in
+                let* eq_test, cons4 = eq_lustre_type ctx e1_ty e2_ty in
+                    if eq_test then R.ok (e1_ty, cons1 @ cons2 @ cons3 @ cons4)
                     else type_error pos (UnequalIteBranchTypes (e1_ty, e2_ty))
-            | c_ty  ->  type_error pos  (ExpectedBooleanExpression c_ty))
+            | c_ty, _  ->  type_error pos  (ExpectedBooleanExpression c_ty))
     )
   | LA.ConvOp (pos, cop, e) ->
     infer_type_conv_op ctx pos e cop
@@ -505,13 +520,15 @@ let rec infer_type_expr: tc_context -> LA.expr -> (tc_type, [> error]) result
         )
         else (
           let infer_field ctx (p, i, exp, ty) =
-            let* exp_ty = infer_type_expr ctx exp in
-            let* eq = eq_lustre_type ctx ty exp_ty in
-            if eq then R.ok (p, i, ty)
+            let* exp_ty, cons1 = infer_type_expr ctx exp in
+            let* eq, cons2 = eq_lustre_type ctx ty exp_ty in
+            if eq then R.ok (p, i, ty, cons1 @ cons2)
             else type_error (LH.pos_of_expr exp) (ExpectedType (ty, exp_ty))
           in
-          let* fld_tys = R.seq (List.map (infer_field ctx) matches) in
-          R.ok (LA.RecordType (pos, name, fld_tys))
+          let* fld_tys_cons = R.seq (List.map (infer_field ctx) matches) in
+          let fld_tys = List.map (fun (a, b, c, _) -> (a, b, c)) fld_tys_cons in 
+          let cons = List.map (fun (_, _, _, d) -> d) fld_tys_cons in
+          R.ok (LA.RecordType (pos, name, fld_tys), List.flatten cons)
         )
       )
       | _ -> type_error pos (ExpectedRecordType ty)
@@ -519,26 +536,31 @@ let rec infer_type_expr: tc_context -> LA.expr -> (tc_type, [> error]) result
   | LA.GroupExpr (pos, struct_type, exprs) ->
     (match struct_type with
     | LA.ExprList ->
-        R.seq (List.map (infer_type_expr ctx) exprs)
-        >>= fun tys -> R.ok (LA.GroupType (pos, tys))
+        let* tys_cons = R.seq (List.map (infer_type_expr ctx) exprs) in
+        let tys, cons = List.split tys_cons in
+        R.ok (LA.GroupType (pos, tys), List.flatten cons)
     | LA.TupleExpr ->
-        R.seq (List.map (infer_type_expr ctx) exprs)
-        >>= fun tys -> R.ok (LA.TupleType (pos, tys))
+        let* tys_cons = R.seq (List.map (infer_type_expr ctx) exprs) in
+        let tys, cons = List.split tys_cons in
+        R.ok (LA.TupleType (pos, tys), List.flatten cons)
     | LA.ArrayExpr ->
         R.seq (List.map (infer_type_expr ctx) exprs)
-        >>= (fun tys ->
+        >>= (fun tys_cons ->
+        let tys, cons1 = List.split tys_cons in
         let elty = List.hd tys in
-        R.ifM (R.seqM (&&) true (List.map (eq_lustre_type ctx elty) tys))
-          (let arr_ty = List.hd tys in
-                let arr_size = LA.Const (pos, Num (List.length tys |> string_of_int |> HString.mk_hstring)) in
-                R.ok (LA.ArrayType (pos, (arr_ty, arr_size))))
-          (type_error pos UnequalArrayExpressionType)))
+        let f = (fun (b1, exprs1) (b2, exprs2) -> b1 && b2, exprs1 @ exprs2) in 
+        let* b, cons2 = (R.seqM f (true, []) (List.map (eq_lustre_type ctx elty) tys)) in
+        if b
+        then (let arr_ty = List.hd tys in
+              let arr_size = LA.Const (pos, Num (List.length tys |> string_of_int |> HString.mk_hstring)) in
+              R.ok (LA.ArrayType (pos, (arr_ty, arr_size)), List.flatten cons1 @ cons2))
+        else (type_error pos UnequalArrayExpressionType)))
     
   (* Update structured expressions *)
   | LA.ArrayConstr (pos, b_expr, sup_expr) -> (
-    let* b_ty = infer_type_expr ctx b_expr in
+    let* b_ty, cons = infer_type_expr ctx b_expr in
     check_array_size_expr ctx sup_expr
-    >> R.ok (LA.ArrayType (pos, (b_ty, sup_expr)))
+    >> R.ok (LA.ArrayType (pos, (b_ty, sup_expr)), cons)
   )
   | LA.StructUpdate (pos, r, i_or_ls, e) ->
     if List.length i_or_ls != 1
@@ -548,26 +570,26 @@ let rec infer_type_expr: tc_context -> LA.expr -> (tc_type, [> error]) result
       | LA.Label (pos, l) ->  
           infer_type_expr ctx r
           >>= (function 
-              | RecordType (_, _, flds) as r_ty ->
+              | RecordType (_, _, flds) as r_ty, cons1 ->
                   (let typed_fields = List.map (fun (_, i, ty) -> (i, ty)) flds in
                   (match (List.assoc_opt l typed_fields) with
                     | Some f_ty ->
                       infer_type_expr ctx e
-                      >>= (fun e_ty -> 
-                        R.ifM (eq_lustre_type ctx f_ty e_ty)
-                          (R.ok r_ty)
-                          (type_error pos (TypeMismatchOfRecordLabel (l, f_ty, e_ty))))
+                      >>= (fun (e_ty, cons2) -> 
+                        let* b, cons3 = (eq_lustre_type ctx f_ty e_ty) in
+                        if b                     then R.ok (r_ty, cons1 @ cons2 @ cons3)
+                        else (type_error pos (TypeMismatchOfRecordLabel (l, f_ty, e_ty))))
                     | None -> type_error pos (NotAFieldOfRecord l)))
-              | r_ty -> type_error pos (IlltypedRecordUpdate r_ty))
+              | r_ty, _ -> type_error pos (IlltypedRecordUpdate r_ty))
       | LA.Index (_, e) -> type_error pos (ExpectedLabel e))
   | LA.ArrayIndex (pos, e, i) ->
-    let* index_type =  infer_type_expr ctx i in
+    let* index_type, cons1 =  infer_type_expr ctx i in
     let index_type = expand_type_syn ctx index_type in
     if is_expr_int_type ctx i
     then infer_type_expr ctx e
         >>= (function
-              | ArrayType (_, (b_ty, _)) -> R.ok b_ty
-              | ty -> type_error pos (IlltypedArrayIndex ty))
+              | ArrayType (_, (b_ty, _)), cons2 -> R.ok (b_ty, cons1 @ cons2)
+              | ty, _ -> type_error pos (IlltypedArrayIndex ty))
     else type_error pos (ExpectedIntegerTypeForArrayIndex index_type)
 
   (* Quantified expressions *)
@@ -584,28 +606,30 @@ let rec infer_type_expr: tc_context -> LA.expr -> (tc_type, [> error]) result
   | LA.When (_, e, _) -> infer_type_expr ctx e
   | LA.Condact (pos, c, _, node, args, defaults) ->
     check_type_expr ctx c (Bool pos)
-    >> infer_type_expr ctx (Call (pos, node, args))
-    >>= fun r_ty ->
-    R.seq (List.map (infer_type_expr ctx) defaults)
-    >>= (fun d_tys -> 
-      R.ifM (eq_lustre_type ctx r_ty (GroupType (pos, d_tys)))
-        (R.ok r_ty)
-        (type_error pos IlltypedDefaults))
+    >> let* r_ty, cons1 = infer_type_expr ctx (Call (pos, node, args)) in
+    let* d_tys_cons = R.seq (List.map (infer_type_expr ctx) defaults) in
+    let d_tys, cons2 = List.split d_tys_cons in
+    let* b, cons3 = (eq_lustre_type ctx r_ty (GroupType (pos, d_tys))) in
+    if b
+    then R.ok (r_ty, cons1 @ List.flatten cons2 @ cons3)
+    else (type_error pos IlltypedDefaults)
   | LA.Activate (pos, node, cond, _, args) ->
     check_type_expr ctx cond (Bool pos)
     >> infer_type_expr ctx (Call (pos, node, args))
   | LA.Merge (pos, i, mcases) as e ->
-    infer_type_expr ctx (LA.Ident (pos, i)) >>= fun ty ->
-      let mcases_ids, mcases_exprs = List.split mcases in
-      let case_tys = mcases_exprs |> List.map (infer_type_expr ctx) in
-      check_merge_exhaustive ctx pos ty mcases_ids >>
-      check_merge_clock e ty >>
-      R.seq case_tys
-      >>= fun tys ->
-      let main_ty = List.hd tys in
-      R.ifM (R.seqM (&&) true (List.map (eq_lustre_type ctx main_ty) tys))
-      (R.ok main_ty)
-      (type_error pos (IlltypedMerge main_ty))
+    let* ty, cons1 = infer_type_expr ctx (LA.Ident (pos, i)) in
+    let mcases_ids, mcases_exprs = List.split mcases in
+    let case_tys = mcases_exprs |> List.map (infer_type_expr ctx) in
+    check_merge_exhaustive ctx pos ty mcases_ids >>
+    check_merge_clock e ty >>
+    R.seq case_tys >>= fun tys_cons ->
+    let tys, cons2 = List.split tys_cons in
+    let main_ty = List.hd tys in
+    let f = (fun (b1, exprs1) (b2, exprs2) -> b1 && b2, exprs1 @ exprs2) in 
+    let* b, cons3 = (R.seqM f (true, []) (List.map (eq_lustre_type ctx main_ty) tys)) in
+    if b
+    then R.ok (main_ty, cons1 @ List.flatten cons2 @ cons3)
+    else (type_error pos (IlltypedMerge main_ty))
   | LA.RestartEvery (pos, node, args, cond) ->
     check_type_expr ctx cond (LA.Bool pos)
     >> infer_type_expr ctx (LA.Call (pos, node, args))
@@ -613,33 +637,37 @@ let rec infer_type_expr: tc_context -> LA.expr -> (tc_type, [> error]) result
   (* Temporal operators *)
   | LA.Pre (_, e) -> infer_type_expr ctx e
   | LA.Arrow (pos, e1, e2) ->
-    infer_type_expr ctx e1 >>= fun ty1 ->
-    infer_type_expr ctx e2 >>= fun ty2 ->
-    R.ifM (eq_lustre_type ctx ty1 ty2)
-      (R.ok ty1)
-      (type_error pos (IlltypedArrow (ty1, ty2)))
+    let* ty1, cons1 = infer_type_expr ctx e1 in
+    let* ty2, cons2 = infer_type_expr ctx e2 in
+    let* b, cons3 = eq_lustre_type ctx ty1 ty2 in 
+    if b
+    then (R.ok (ty1, cons1 @ cons2 @ cons3))
+    else (type_error pos (IlltypedArrow (ty1, ty2)))
      
   (* Node calls *)
   | LA.Call (pos, i, arg_exprs) -> (
     Debug.parse "Inferring type for node call %a" LA.pp_print_ident i ;
-    let infer_type_node_args: tc_context -> LA.expr list -> (tc_type, [> error]) result =
+    let infer_type_node_args: tc_context -> LA.expr list -> (tc_type * (LA.expr * string) list, [> error]) result =
     fun ctx args ->
-      let* arg_tys = R.seq (List.map (infer_type_expr ctx) args) in
-      if List.length arg_tys = 1 then R.ok (List.hd arg_tys)
-      else R.ok (LA.GroupType (pos, arg_tys))
+      let* res = R.seq (List.map (infer_type_expr ctx) args) in
+      let arg_tys, cons = List.split res in
+      if List.length arg_tys = 1 then R.ok (List.hd arg_tys, List.hd cons)
+      else R.ok (LA.GroupType (pos, arg_tys), List.flatten cons)
     in
     match (lookup_node_param_ids ctx i), (lookup_node_ty ctx i) with
     | Some call_params, Some node_ty -> (
       (* Express exp_arg_tys and exp_ret_tys in terms of the current context *)
       let node_ty = update_ty_with_ctx node_ty call_params ctx arg_exprs in
+
       let exp_arg_tys, exp_ret_tys = match node_ty with 
-        | TArr (_, exp_arg_tys, exp_ret_tys) -> exp_arg_tys, exp_ret_tys 
+        | LA.TArr (_, exp_arg_tys, exp_ret_tys) -> exp_arg_tys, exp_ret_tys 
         | _ -> assert false 
       in
-      let* given_arg_tys = infer_type_node_args ctx arg_exprs in
-      let* are_equal = eq_lustre_type ctx exp_arg_tys given_arg_tys in
+      let* given_arg_tys, cons1 = infer_type_node_args ctx arg_exprs in
+      let* are_equal, cons2 = eq_lustre_type ~is_call_arg:true ctx given_arg_tys exp_arg_tys in
       if are_equal then
-        (check_constant_args ctx i arg_exprs >> (R.ok exp_ret_tys))
+        let* ctx = (check_constant_args ctx i arg_exprs >> (R.ok exp_ret_tys)) in 
+        R.ok (ctx, cons1 @ cons2)
       else
         (type_error pos (IlltypedCall (exp_arg_tys, given_arg_tys)))
     )
@@ -648,14 +676,15 @@ let rec infer_type_expr: tc_context -> LA.expr -> (tc_type, [> error]) result
   )
 (** Infer the type of a [LA.expr] with the types of free variables given in [tc_context] *)
 
-and check_type_expr: tc_context -> LA.expr -> tc_type -> (unit, [> error]) result
+and check_type_expr: tc_context -> LA.expr -> tc_type -> ((LA.expr * string) list, [> error]) result
   = fun ctx expr exp_ty ->
   match expr with
   (* Identifiers *)
   | Ident (pos, i) as ident ->
-    infer_type_expr ctx ident >>= fun ty ->
-    R.guard_with (eq_lustre_type ctx ty exp_ty)
-      (type_error pos (IlltypedIdentifier (i, exp_ty, ty)))
+    let* ty, cons1 = infer_type_expr ctx ident in
+    let* b, cons2 = (eq_lustre_type ctx ty exp_ty) in
+    if b then R.ok (cons1 @ cons2)
+    else (type_error pos (IlltypedIdentifier (i, exp_ty, ty)))
   | ModeRef (pos, ids) ->
     let id = (match ids with
               | [] -> failwith ("empty mode name")
@@ -666,102 +695,130 @@ and check_type_expr: tc_context -> LA.expr -> tc_type -> (unit, [> error]) resul
 
   (* Operators *)
   | UnaryOp (pos, op, e) ->
-    infer_type_unary_op ctx pos e op
-    >>= fun inf_ty -> R.guard_with (eq_lustre_type ctx inf_ty exp_ty) (type_error pos (UnificationFailed (exp_ty, inf_ty)))
+    let* inf_ty, cons1 = infer_type_unary_op ctx pos e op in
+    let* b, cons2 = (eq_lustre_type ctx inf_ty exp_ty) in
+    if b
+    then R.ok (cons1 @ cons2) 
+    else (type_error pos (UnificationFailed (exp_ty, inf_ty)))
   | BinaryOp (pos, op, e1, e2) -> 
-    infer_type_binary_op ctx pos op e1 e2 >>= fun inf_ty ->
-    R.guard_with (eq_lustre_type ctx inf_ty exp_ty) (type_error pos (UnificationFailed (exp_ty, inf_ty)))
+    let* inf_ty, cons1 = infer_type_binary_op ctx pos op e1 e2 in
+    let* b, cons2 = eq_lustre_type ctx inf_ty exp_ty in
+    if b then R.ok (cons1 @ cons2) 
+    else (type_error pos (UnificationFailed (exp_ty, inf_ty)))
   | LA.TernaryOp (pos, _, con, e1, e2) ->
     infer_type_expr ctx con
     >>= (function 
-        | Bool _ ->
-            infer_type_expr ctx e1
-            >>= fun ty1 -> infer_type_expr ctx e2
-            >>= fun ty2 -> R.guard_with (eq_lustre_type ctx ty1 ty2)
-                            (type_error pos (UnificationFailed (ty1, ty2)))
-        | ty -> type_error pos (ExpectedType ((Bool pos), ty)))
+        | Bool _, cons1 ->
+          let* ty1, cons2 = infer_type_expr ctx e1 in 
+          let* ty2, cons3 = infer_type_expr ctx e2 in
+          let* b, cons4 = eq_lustre_type ctx ty1 ty2 in 
+          if b then R.ok (cons1 @ cons2 @ cons3 @ cons4)
+          else (type_error pos (UnificationFailed (ty1, ty2)))
+        | ty, _ -> type_error pos (ExpectedType ((Bool pos), ty)))
   | ConvOp (pos, cvop, e) ->
-    infer_type_conv_op ctx pos e cvop >>= fun inf_ty ->
-    R.guard_with (eq_lustre_type ctx inf_ty exp_ty)
-      (type_error pos (UnificationFailed (exp_ty, inf_ty)))
+    let* inf_ty, cons1 = infer_type_conv_op ctx pos e cvop in
+    let* b, cons2 = eq_lustre_type ctx inf_ty exp_ty in 
+    if b then R.ok (cons1 @ cons2)
+    else (type_error pos (UnificationFailed (exp_ty, inf_ty)))
   | CompOp (pos, cop, e1, e2) ->
-    infer_type_comp_op ctx pos e1 e2 cop >>= fun inf_ty ->
-    R.guard_with (eq_lustre_type ctx inf_ty exp_ty)
-      (type_error pos (UnificationFailed (exp_ty, inf_ty)))
+    let* inf_ty, cons1 = infer_type_comp_op ctx pos e1 e2 cop in
+    let* b, cons2 = (eq_lustre_type ctx inf_ty exp_ty) in
+    if b then 
+    R.ok (cons1 @ cons2)
+    else (type_error pos (UnificationFailed (exp_ty, inf_ty)))
 
   (* Values/Constants *)
   | Const (pos, c) ->
     let cty = infer_type_const pos c in
-    R.guard_with (eq_lustre_type ctx cty exp_ty)
-      (type_error pos (UnificationFailed (exp_ty, cty)))
+    let* b, cons = (eq_lustre_type ctx cty exp_ty) in 
+    if b then R.ok cons 
+    else (type_error pos (UnificationFailed (exp_ty, cty)))
 
   (* Structured expressions *)
   | RecordExpr (pos, name, flds) ->
     let (ids, es) = List.split flds in
     let mk_ty_ident p i t = (p, i, t) in
-    let* inf_tys = R.seq (List.map (infer_type_expr ctx) es) in
+    let* inf_tys_cons = R.seq (List.map (infer_type_expr ctx) es) in
+    let inf_tys, cons1 = List.split inf_tys_cons in
     let inf_r_ty = LA.RecordType (pos, name, (List.map2 (mk_ty_ident pos) ids inf_tys)) in
-    R.guard_with (eq_lustre_type ctx exp_ty inf_r_ty)
-      (type_error pos (UnificationFailed (exp_ty, inf_r_ty)))
+    let* b, cons2 = (eq_lustre_type ctx inf_r_ty exp_ty) in
+    if b then R.ok (List.flatten cons1 @ cons2)
+    else (type_error pos (UnificationFailed (exp_ty, inf_r_ty)))
   | GroupExpr (pos, group_ty, es) ->
     (match group_ty with
     (* These should be tuple type  *)
     | ExprList ->
-        R.seq (List.map (infer_type_expr ctx) es) >>= fun inf_tys ->
+        let* inf_tys_cons = R.seq (List.map (infer_type_expr ctx) es) in 
+        let inf_tys, cons1 = List.split inf_tys_cons in 
         let inf_ty = LA.GroupType (pos, inf_tys) in
-        (R.guard_with (eq_lustre_type ctx exp_ty inf_ty)
-          (type_error pos (ExpectedType (exp_ty, inf_ty))))
+        let* b, cons2 = (eq_lustre_type ctx inf_ty exp_ty) in
+        if b then 
+        R.ok (List.flatten cons1 @ cons2)
+        else (type_error pos (ExpectedType (exp_ty, inf_ty)))
       | TupleExpr ->
-        R.seq (List.map (infer_type_expr ctx) es) >>= fun inf_tys ->
+        let* inf_tys_cons = R.seq (List.map (infer_type_expr ctx) es) in
+        let inf_tys, cons1 = List.split inf_tys_cons in 
         let inf_ty = LA.TupleType (pos, inf_tys) in
-        (R.guard_with (eq_lustre_type ctx exp_ty inf_ty)
-          (type_error pos (ExpectedType (exp_ty, inf_ty))))
+        let* b, cons2 = (eq_lustre_type ctx inf_ty exp_ty) in
+        if b     then R.ok (List.flatten cons1 @ cons2) 
+        else (type_error pos (ExpectedType (exp_ty, inf_ty)))
     (* This should be array type *)
     | ArrayExpr ->
-        R.seq (List.map (infer_type_expr ctx) es) >>= fun inf_tys ->
+        let* inf_tys_cons = R.seq (List.map (infer_type_expr ctx) es) in
+        let inf_tys, cons1 = List.split inf_tys_cons in
         if List.length inf_tys < 1
         then type_error pos EmptyArrayExpression
         else
           let elty = List.hd inf_tys in
-          R.ifM (R.seqM (&&) true (List.map (eq_lustre_type ctx elty) inf_tys))
-            (let arr_ty = List.hd inf_tys in
+          let f = (fun (b1, exprs1) (b2, exprs2) -> b1 && b2, exprs1 @ exprs2) in
+          let* b, cons2 = (R.seqM f (true, []) (List.map (eq_lustre_type ctx elty) inf_tys)) in
+          if b
+          then (
+            let arr_ty = List.hd inf_tys in
             let arr_size = LA.Const (pos, Num (List.length inf_tys |> string_of_int |> HString.mk_hstring)) in
-            (R.guard_with (eq_lustre_type ctx exp_ty (LA.ArrayType (pos, (arr_ty, arr_size))))
-                (type_error pos (ExpectedType (exp_ty, arr_ty)))))
-            (type_error pos UnequalArrayExpressionType))
-
+            let* b, cons3 = (eq_lustre_type ctx (LA.ArrayType (pos, (arr_ty, arr_size))) exp_ty) in (
+            if b         then R.ok (List.flatten cons1 @ cons2 @ cons3)
+            else (type_error pos (ExpectedType (exp_ty, arr_ty))))
+          )
+          else (type_error pos UnequalArrayExpressionType)
+      )
   (* Update of structured expressions *)
   | StructUpdate (pos, r, i_or_ls, e) ->
     if List.length i_or_ls != 1
     then type_error pos (Unsupported ("List of labels or indices for structure update is not supported"))
     else (match List.hd  i_or_ls with
-          | LA.Label (pos, l) ->  
-            infer_type_expr ctx r
-            >>= (fun r_ty ->
+          | LA.Label (pos, l) ->  (
+            let* r_ty, cons1 = infer_type_expr ctx r in 
               match r_ty with
               | RecordType (_, _, flds) ->
                 (let typed_fields = List.map (fun (_, i, ty) -> (i, ty)) flds in
                   (match (List.assoc_opt l typed_fields) with
-                  | Some ty -> check_type_expr ctx e ty 
+                  | Some ty -> 
+                    let* cons2  = check_type_expr ctx e ty in 
+                    R.ok (cons1 @ cons2)
                   | None -> type_error pos (NotAFieldOfRecord l)))
-              | _ -> type_error pos (IlltypedRecordUpdate r_ty))
+              | _ -> type_error pos (IlltypedRecordUpdate r_ty)
+            )
           | LA.Index (_, e) -> type_error pos (ExpectedLabel e))
 
   (* Array constructor*)
   | ArrayConstr (pos, b_exp, sup_exp) ->
-    infer_type_expr ctx b_exp >>= fun b_ty ->
-    infer_type_expr ctx sup_exp >>= fun _ ->
+    let* b_ty, cons1 = infer_type_expr ctx b_exp in
+    let* _ = infer_type_expr ctx sup_exp in
     let arr_ty = (LA.ArrayType (pos, (b_ty, sup_exp))) in
-    R.guard_with (eq_lustre_type ctx exp_ty arr_ty)
-      (type_error pos (ExpectedType (exp_ty, arr_ty)))
+    let* b, cons2 = (eq_lustre_type ctx arr_ty exp_ty) in
+    if b then R.ok (cons1 @ cons2)
+    else (type_error pos (ExpectedType (exp_ty, arr_ty)))
+
   | ArrayIndex (pos, e, idx) ->
-    infer_type_expr ctx idx >>= fun index_type -> 
+    let* index_type, cons1 = infer_type_expr ctx idx in
     if is_expr_int_type ctx idx
-    then infer_type_expr ctx e >>= fun inf_arr_ty ->
+    then let* inf_arr_ty, cons2 = infer_type_expr ctx e in
         (match inf_arr_ty with
           | ArrayType (_, (arr_b_ty, _)) ->
-            R.guard_with(eq_lustre_type ctx arr_b_ty exp_ty)
-              (type_error pos (ExpectedType (exp_ty, arr_b_ty)))
+            let* b, cons3  = (eq_lustre_type ctx exp_ty arr_b_ty) in
+            if b         then R.ok (cons1 @ cons2 @ cons3)
+            else (type_error pos (ExpectedType (exp_ty, arr_b_ty)))
           | _ -> type_error pos (ExpectedArrayType inf_arr_ty))
     else type_error pos (ExpectedIntegerTypeForArrayIndex index_type)
 
@@ -784,23 +841,25 @@ and check_type_expr: tc_context -> LA.expr -> tc_type -> (unit, [> error]) resul
   (* Clock operators *)
   | When (_, e, _) -> check_type_expr ctx e exp_ty
   | Condact (pos, c, _, node, args, defaults) ->
-    check_type_expr ctx c (Bool pos)
-    >> check_type_expr ctx (Call (pos, node, args)) exp_ty
-    >>  R.seq (List.map (infer_type_expr ctx) defaults)
-    >>= fun d_tys -> R.guard_with (eq_lustre_type ctx exp_ty (GroupType (pos, d_tys)))
-                      (type_error pos IlltypedDefaults)
+    let* cons1 = check_type_expr ctx c (Bool pos) in 
+    let* cons2 = check_type_expr ctx (Call (pos, node, args)) exp_ty in
+    let* d_tys_cons =  R.seq (List.map (infer_type_expr ctx) defaults) in 
+    let d_tys, cons3 = List.split d_tys_cons in
+    let* b, cons4 = eq_lustre_type ctx (GroupType (pos, d_tys)) exp_ty in
+    if b then R.ok (cons1 @ cons2 @ List.flatten cons3 @ cons4)
+    else (type_error pos IlltypedDefaults)
   | Activate (pos, node, cond, _, args) -> 
     check_type_expr ctx cond (Bool pos)
     >> check_type_expr ctx (Call (pos, node, args)) exp_ty 
   | Merge (pos, i, mcases) as e ->
-    infer_type_expr ctx (LA.Ident (pos, i)) >>= fun ty ->
+    let* ty, cons1 = infer_type_expr ctx (LA.Ident (pos, i)) in
     let mcases_ids, mcases_exprs = List.split mcases in
-    let check_mcases = R.seq_
+    let* cons2 = R.seq
       (List.map (fun e -> check_type_expr ctx e exp_ty) mcases_exprs)
     in
-    check_mcases
-      >> check_merge_exhaustive ctx pos ty mcases_ids
+      check_merge_exhaustive ctx pos ty mcases_ids
       >> check_merge_clock e ty
+      >> R.ok (cons1 @ List.flatten cons2)
   | RestartEvery (pos, node, args, cond) ->
     check_type_expr ctx cond (LA.Bool pos)
     >> check_type_expr ctx (LA.Call (pos, node, args)) exp_ty
@@ -813,7 +872,8 @@ and check_type_expr: tc_context -> LA.expr -> tc_type -> (unit, [> error]) resul
 
   (* Node calls *)
   | Call (pos, i, args) ->
-    let* arg_tys = R.seq (List.map (infer_type_expr ctx) args) in
+    let* arg_tys_cons = R.seq (List.map (infer_type_expr ctx) args) in
+    let arg_tys, cons1 = List.split arg_tys_cons in
     let arg_ty = if List.length arg_tys = 1 then List.hd arg_tys
                 else GroupType (pos, arg_tys) in
     (match (lookup_node_ty ctx i), (lookup_node_param_ids ctx i) with
@@ -822,32 +882,33 @@ and check_type_expr: tc_context -> LA.expr -> tc_type -> (unit, [> error]) resul
     | Some ty, Some call_params -> 
       (* Express ty in terms of the current context *)
       let ty = update_ty_with_ctx ty call_params ctx args in
-      let* b = (eq_lustre_type ctx ty (LA.TArr (pos, arg_ty, exp_ty))) in
-      if b then R.ok ()
+      let* b, cons2 = (eq_lustre_type ctx (LA.TArr (pos, arg_ty, exp_ty)) ty) in
+      if b then R.ok (List.flatten cons1 @ cons2) 
       else (type_error pos (MismatchedNodeType (i, (TArr (pos, arg_ty, exp_ty)), ty))))
 (** Type checks an expression and returns [ok] 
  * if the expected type is the given type [tc_type]  
  * returns an [Error of string] otherwise *)
 
-and infer_type_unary_op: tc_context -> Lib.position -> LA.expr -> LA.unary_operator -> (tc_type, [> error]) result
+and infer_type_unary_op: tc_context -> Lib.position -> LA.expr -> LA.unary_operator -> (tc_type * (LA.expr * string) list, [> error]) result
   = fun ctx pos e op ->
-  infer_type_expr ctx e >>= fun ty -> 
+  let* ty, cons1 = infer_type_expr ctx e in
   match op with
   | LA.Not ->
-    R.ifM (eq_lustre_type ctx ty (Bool pos))
-      (R.ok (LA.Bool pos))
-      (type_error pos (ExpectedType (LA.Bool pos, ty)))
+    let* b, cons2 = (eq_lustre_type ctx ty (Bool pos)) in
+    if b
+    then (R.ok (LA.Bool pos, cons1 @ cons2))
+    else (type_error pos (ExpectedType (LA.Bool pos, ty)))
   | LA.BVNot ->
     if LH.is_type_machine_int ty
-    then R.ok ty
+    then R.ok (ty, cons1)
     else type_error pos (IlltypedBitNot ty)
   | LA.Uminus ->
     if (LH.is_type_num ty)
-    then R.ok ty
+    then R.ok (ty, cons1)
     else type_error pos (IlltypedUnaryMinus ty)
 (** Infers type of unary operator application *)
 
-and are_args_num: tc_context -> Lib.position -> tc_type -> tc_type -> (bool, [> error]) result
+and are_args_num: tc_context -> Lib.position -> tc_type -> tc_type -> (bool * (LA.expr * string) list, [> error]) result
   = fun ctx pos ty1 ty2 ->
   let num1 = HString.mk_hstring "1" in
   let num_tys = [
@@ -862,172 +923,191 @@ and are_args_num: tc_context -> Lib.position -> tc_type -> tc_type -> (bool, [> 
     ; LA.Int64 pos
     ; LA.IntRange (pos, Some (Const (pos, Num num1)), Some (Const (pos, Num num1))) 
     ; LA.Real pos] in
-  let are_equal_types: tc_context -> tc_type -> tc_type -> tc_type -> (bool, [> error]) result
+  let are_equal_types: tc_context -> tc_type -> tc_type -> tc_type -> (bool * (LA.expr * string) list, [> error]) result
     = fun ctx ty1 ty2 ty ->
-    R.seqM (&&) true [ eq_lustre_type ctx ty1 ty
-                    ; eq_lustre_type ctx ty2 ty ] in
-  R.seqM (||) false (List.map (are_equal_types ctx ty1 ty2) num_tys) 
+    let f = (fun (b1, exprs1) (b2, exprs2) -> b1 && b2, exprs1 @ exprs2) in  
+    R.seqM f (true, []) [ eq_lustre_type ctx ty1 ty
+                        ; eq_lustre_type ctx ty2 ty ] 
+    in
+  let f = (fun (b1, exprs1) (b2, exprs2) -> b1 || b2, exprs1 @ exprs2) in
+  R.seqM f (false, []) (List.map (are_equal_types ctx ty1 ty2) num_tys) 
 (** This is an ugly fix till we have polymorphic unification, may be qualified types? *)
   
 and infer_type_binary_op: tc_context -> Lib.position
                           -> LA.binary_operator -> LA.expr -> LA.expr
-                          -> (tc_type, [> error]) result
+                          -> (tc_type * (LA.expr * string) list, [> error]) result
   = fun ctx pos op e1 e2 ->
-  infer_type_expr ctx e1 >>= fun ty1 ->
-  infer_type_expr ctx e2 >>= fun ty2 ->
+  let* ty1, cons1 = infer_type_expr ctx e1 in
+  let* ty2, cons2 = infer_type_expr ctx e2 in
   match op with
   | LA.And | LA.Or | LA.Xor | LA.Impl ->
-    R.ifM (eq_lustre_type ctx ty1 (Bool pos))
-      (R.ifM (eq_lustre_type ctx ty2 (Bool pos))
-        (R.ok (LA.Bool pos))
-        (type_error pos (ExpectedType ((LA.Bool pos), ty2))))
-      (type_error pos (ExpectedType ((LA.Bool pos), ty1)))
+    let* b1, cons3 = (eq_lustre_type ctx ty1 (Bool pos)) in
+    if b1
+    then (
+      let* b2, cons4 = (eq_lustre_type ctx ty2 (Bool pos)) in
+      if b2 
+      then (R.ok (LA.Bool pos, cons1 @ cons2 @ cons3 @ cons4))
+      else (type_error pos (ExpectedType ((LA.Bool pos), ty2)))
+    )
+    else (type_error pos (ExpectedType ((LA.Bool pos), ty1)))
   | LA.Mod ->
     if LH.is_type_int_or_machine_int ty1 && LH.is_type_int_or_machine_int ty2
-    then (R.ifM (eq_lustre_type ctx ty1 ty2)
-            (R.ok ty1)
-            (type_error pos (UnificationFailed (ty1, ty2))))
+    then (
+      let* b, cons3 = (eq_lustre_type ctx ty1 ty2) in
+      if b
+      then R.ok (ty1, cons1 @ cons2 @ cons3)
+      else (type_error pos (UnificationFailed (ty1, ty2)))
+    )
     else (type_error pos (ExpectedIntegerTypes (ty1, ty2)))
   | LA.Plus | LA.Minus | LA.Times | LA.Div ->
-    are_args_num ctx pos ty1 ty2 >>= fun is_num ->
+    let* is_num, cons3 = are_args_num ctx pos ty1 ty2 in
     if is_num
-    then R.ok ty2
+    then R.ok (ty2, cons1 @ cons2 @ cons3)
     else type_error pos (ExpectedNumberTypes (ty1, ty2))
   | LA.IntDiv ->
     if LH.is_type_int_or_machine_int ty1 && LH.is_type_int_or_machine_int ty2
-    then (R.ifM (eq_lustre_type ctx ty1 ty2)
-            (R.ok ty1)
-            (type_error pos (UnificationFailed (ty1, ty2))))
+    then (
+      let* b, cons3 = (eq_lustre_type ctx ty1 ty2) in 
+      if b   then R.ok (ty1, cons1 @ cons2 @ cons3)
+      else (type_error pos (UnificationFailed (ty1, ty2)))
+    )
     else type_error pos (ExpectedIntegerTypes (ty1, ty2))
   | LA.BVAnd | LA.BVOr ->
-    R.ifM (eq_lustre_type ctx ty1 ty2)
+    let* b, cons3 = (eq_lustre_type ctx ty1 ty2) in 
+    if b then  
       (if LH.is_type_machine_int ty1 && LH.is_type_machine_int ty2
-      then R.ok ty2
+      then R.ok (ty2, cons1 @ cons2 @ cons3)
       else type_error pos (ExpectedMachineIntegerTypes (ty1, ty2)))
-      (type_error pos (UnificationFailed (ty1, ty2)))
+    else (type_error pos (UnificationFailed (ty1, ty2)))
   | LA.BVShiftL | LA.BVShiftR ->
     if (LH.is_type_signed_machine_int ty1 || LH.is_type_unsigned_machine_int ty1)
     then (if (LH.is_type_unsigned_machine_int ty2
               && LH.is_machine_type_of_associated_width (ty1, ty2))
-          then R.ok ty1
+          then R.ok (ty1, cons1 @ cons2)
           else type_error pos (ExpectedBitShiftConstantOfSameWidth ty1))
     else type_error pos (ExpectedBitShiftMachineIntegerType ty1)
 (** infers the type of binary operators  *)
 
 and infer_type_conv_op: tc_context -> Lib.position
                         ->  LA.expr -> LA.conversion_operator
-                        -> (tc_type, [> error]) result
+                        -> (tc_type * (LA.expr * string) list, [> error]) result
   = fun ctx pos e op ->
-  infer_type_expr ctx e >>= fun ty ->
+  let* ty, cons = infer_type_expr ctx e in
   match op with
   | ToInt ->
     if LH.is_type_num ty
-    then R.ok (LA.Int pos)
+    then R.ok (LA.Int pos, cons)
     else type_error pos (InvalidConversion (ty, (Int pos)))
   | ToReal ->
     if LH.is_type_real_or_int ty
-    then R.ok (LA.Real pos)
+    then R.ok (LA.Real pos, cons)
     else type_error pos (InvalidConversion (ty, (Real pos)))
   | ToInt8 ->
     if LH.is_type_signed_machine_int ty || LH.is_type_int ty
-    then R.ok (LA.Int8 pos)
+    then R.ok (LA.Int8 pos, cons)
     else type_error pos (InvalidConversion (ty, (Int8 pos)))
   | ToInt16 ->
     if LH.is_type_signed_machine_int ty || LH.is_type_int ty
-    then R.ok (LA.Int16 pos)
+    then R.ok (LA.Int16 pos, cons)
     else type_error pos (InvalidConversion (ty, (Int16 pos)))
   | ToInt32 ->
     if LH.is_type_signed_machine_int ty || LH.is_type_int ty
-    then R.ok (LA.Int32 pos)
+    then R.ok (LA.Int32 pos, cons)
     else type_error pos (InvalidConversion (ty, (Int32 pos)))
   | ToInt64 ->
     if LH.is_type_signed_machine_int ty || LH.is_type_int ty
-    then R.ok (LA.Int64 pos)
+    then R.ok (LA.Int64 pos, cons)
     else type_error pos (InvalidConversion (ty, (Int64 pos)))
   | ToUInt8 ->
     if LH.is_type_unsigned_machine_int ty || LH.is_type_int ty
-    then R.ok (LA.UInt8 pos)
+    then R.ok (LA.UInt8 pos, cons)
     else type_error pos (InvalidConversion (ty, (UInt8 pos)))
   | ToUInt16 ->
     if LH.is_type_unsigned_machine_int ty || LH.is_type_int ty
-    then R.ok (LA.UInt16 pos)
+    then R.ok (LA.UInt16 pos, cons)
     else type_error pos (InvalidConversion (ty, (UInt16 pos)))
   | ToUInt32 ->
     if LH.is_type_unsigned_machine_int ty || LH.is_type_int ty
-    then R.ok (LA.UInt32 pos)
+    then R.ok (LA.UInt32 pos, cons)
     else type_error pos (InvalidConversion (ty, (UInt32 pos)))
   | ToUInt64 ->
     if LH.is_type_unsigned_machine_int ty || LH.is_type_int ty
-    then R.ok (LA.UInt64 pos)
+    then R.ok (LA.UInt64 pos, cons)
     else type_error pos (InvalidConversion (ty, (UInt64 pos)))
 (** Converts from given type to the intended type aka casting *)
     
 and infer_type_comp_op: tc_context -> Lib.position -> LA.expr -> LA.expr
-                        -> LA.comparison_operator -> (tc_type, [> error]) result
+                        -> LA.comparison_operator -> (tc_type * (LA.expr * string) list, [> error]) result
   = fun ctx pos e1 e2 op ->
-  infer_type_expr ctx e1 >>= fun ty1 ->
-  infer_type_expr ctx e2 >>= fun ty2 ->
+  let* ty1, cons1 = infer_type_expr ctx e1 in
+  let* ty2, cons2 = infer_type_expr ctx e2 in
   match op with
   | Neq  | Eq ->
-    R.ifM (eq_lustre_type ctx ty1 ty2)
-      (if LH.type_contains_array ty1 then
-         type_error pos (Unsupported "Extensional array equality is not supported")
-       else
-         R.ok (LA.Bool pos)
-      )
-      (type_error pos (UnificationFailed (ty1, ty2)))
-  | Lte  | Lt  | Gte | Gt ->
-    are_args_num ctx pos ty1 ty2
-    >>= fun is_num ->
+    let* b, cons3 = (eq_lustre_type ctx ty1 ty2) in
+    if b then (
+      if LH.type_contains_array ty1 
+      then type_error pos (Unsupported "Extensional array equality is not supported")
+      else R.ok (LA.Bool pos, cons1 @ cons2 @ cons3)
+    )
+    else (type_error pos (UnificationFailed (ty1, ty2)))
+  | Lte | Lt  | Gte | Gt ->
+    let* is_num, cons3 = are_args_num ctx pos ty1 ty2 in
     if is_num
-    then R.ok (LA.Bool pos)
+    then R.ok (LA.Bool pos, cons1 @ cons2 @ cons3)
     else type_error pos (ExpectedIntegerTypes (ty1, ty2))
 (** infer the type of comparison operator application *)
                   
-and check_type_record_proj: Lib.position -> tc_context -> LA.expr -> LA.index -> tc_type -> (unit, [> error]) result =
+and check_type_record_proj: Lib.position -> tc_context -> LA.expr -> LA.index -> tc_type -> ((LA.expr * string) list, [> error]) result =
   fun pos ctx expr idx exp_ty -> 
   infer_type_expr ctx expr
   >>= function
-  | RecordType (_, _, flds) ->
+  | RecordType (_, _, flds), cons1 ->
     (match (List.find_opt (fun (_, i, _) -> i = idx) flds) with 
     | None -> type_error pos (NotAFieldOfRecord idx)
-    | Some f -> R.ok f)
-    >>= fun (_, _, fty) ->
-    R.guard_with (eq_lustre_type ctx fty exp_ty)
-      (type_error pos (UnificationFailed (exp_ty, fty)))
-  | rec_ty -> type_error (LH.pos_of_expr expr) (IlltypedRecordProjection rec_ty)
+    | Some f -> R.ok (f, cons1))
+    >>= fun ((_, _, fty), cons1) ->
+    let* b, cons2 = (eq_lustre_type ctx fty exp_ty) in 
+    if b then R.ok (cons1 @ cons2)
+    else (type_error pos (UnificationFailed (exp_ty, fty)))
+  | rec_ty, _ -> type_error (LH.pos_of_expr expr) (IlltypedRecordProjection rec_ty)
 
-and check_type_tuple_proj : Lib.position -> tc_context -> LA.expr -> int -> tc_type -> (unit, [> error]) result =
+and check_type_tuple_proj : Lib.position -> tc_context -> LA.expr -> int -> tc_type -> ((LA.expr * string) list, [> error]) result =
   fun pos ctx expr idx exp_ty ->
   infer_type_expr ctx expr
   >>= function
-  | TupleType (_, tys) as ty ->
+  | TupleType (_, tys) as ty, cons ->
     if List.length tys <= idx
     then type_error pos (TupleIndexOutOfBounds (idx, ty))
-    else R.ok (List.nth tys idx)
-    >>= fun ity ->
-    R.guard_with (eq_lustre_type ctx ity exp_ty)
-      (type_error pos (UnificationFailed (exp_ty, ity)))
-  | ty -> type_error (LH.pos_of_expr expr) (IlltypedTupleProjection ty)
+    else R.ok (List.nth tys idx, cons)
+    >>= fun (ity, cons1) ->
+    let* b, cons2 = (eq_lustre_type ctx ity exp_ty) in
+    if b then R.ok (cons1 @ cons2)
+    else (type_error pos (UnificationFailed (exp_ty, ity)))
+  | ty, _ -> type_error (LH.pos_of_expr expr) (IlltypedTupleProjection ty)
 
-and check_type_const_decl: tc_context -> LA.const_decl -> tc_type -> (unit, [> error]) result =
+and check_type_const_decl: tc_context -> LA.const_decl -> tc_type -> ((LA.expr * string) list, [> error]) result =
   fun ctx const_decl exp_ty ->
   match const_decl with
   | FreeConst (pos, i, _) ->
     (match (lookup_ty ctx i) with
     | None -> failwith "Free constant should have an associated type"
-    | Some inf_ty -> R.guard_with (eq_lustre_type ctx inf_ty exp_ty)
-      (type_error pos (IlltypedIdentifier (i, inf_ty, exp_ty))))
+    | Some inf_ty -> 
+      let* b, cons = (eq_lustre_type ctx inf_ty exp_ty) in
+      if b
+      then R.ok cons
+      else (type_error pos (IlltypedIdentifier (i, inf_ty, exp_ty))))
   | UntypedConst (pos, i, e) ->
-    infer_type_expr ctx e
-    >>= fun inf_ty ->
-    R.guard_with (eq_lustre_type ctx inf_ty exp_ty)
-      (type_error pos (IlltypedIdentifier (i, exp_ty, inf_ty)))
+    let* inf_ty, cons1 = infer_type_expr ctx e in
+    let* b, cons2 = (eq_lustre_type ctx inf_ty exp_ty) in
+    if b then R.ok (cons1 @ cons2)
+    else (type_error pos (IlltypedIdentifier (i, exp_ty, inf_ty)))
   | TypedConst (pos, i, exp, _) ->
-    infer_type_expr ctx exp
-    >>= fun inf_ty -> R.guard_with (eq_lustre_type ctx inf_ty exp_ty)
-                        (type_error pos (IlltypedIdentifier (i, exp_ty, inf_ty)))
-and local_var_binding: tc_context -> LA.node_local_decl -> (tc_context, [> error]) result = fun ctx ->
+    let* inf_ty, cons1 = infer_type_expr ctx exp in
+    let* b, cons2 = (eq_lustre_type ctx inf_ty exp_ty) in 
+    if b then R.ok (cons1 @ cons2)
+    else (type_error pos (IlltypedIdentifier (i, exp_ty, inf_ty)))
+
+and local_var_binding: tc_context -> LA.node_local_decl -> (tc_context * (LA.expr * string) list, [> error]) result = fun ctx ->
     function
     | LA.NodeConstDecl (_, const_decls) ->
       Debug.parse "Extracting typing context from const declaration: %a"
@@ -1036,9 +1116,9 @@ and local_var_binding: tc_context -> LA.node_local_decl -> (tc_context, [> error
     | LA.NodeVarDecl (pos, (_, v, ty, _)) ->
       if (member_ty ctx v) then type_error pos (Redeclaration v)
       else check_type_well_formed ctx ty
-          >> R.ok (add_ty ctx v ty)
-                     
-and check_type_node_decl: Lib.position -> tc_context -> LA.node_decl -> (unit, [> error]) result
+          >> R.ok (add_ty ctx v ty, [])
+
+and check_type_node_decl: Lib.position -> tc_context -> LA.node_decl -> ((LA.expr * string) list, [> error]) result
   = fun pos ctx
         (node_name, is_extern, params, input_vars, output_vars, ldecls, items, contract)
         ->
@@ -1076,25 +1156,27 @@ and check_type_node_decl: Lib.position -> tc_context -> LA.node_decl -> (unit, [
     Debug.parse "Local Typing Context after extracting ips/ops/consts {%a}"
       pp_print_tc_context ctx_plus_ops_and_ips;
     (* Type check the contract *)
-    (match contract with
-      | None -> R.ok ()
+    let* cons1 = (match contract with
+      | None -> R.ok ([])
       | Some c ->
-        tc_ctx_of_contract ctx_plus_ops_and_ips c >>= fun con_ctx ->
+        let* con_ctx, cons1 = tc_ctx_of_contract ctx_plus_ops_and_ips c in
         Debug.parse "Checking node contract with context %a"
           pp_print_tc_context con_ctx;
-        check_type_contract (arg_ids, ret_ids) con_ctx c)
+        let* cons2 = check_type_contract (arg_ids, ret_ids) con_ctx c in 
+        R.ok (cons1 @ cons2)) in
       (* if the node is extern, we will not have any body to typecheck *)
-      >> if is_extern
+      if is_extern
       then R.ok ( Debug.parse "External Node, no body to type check."
-                ; Debug.parse "TC declaration node %a done }" LA.pp_print_ident node_name)
+                ; Debug.parse "TC declaration node %a done }" LA.pp_print_ident node_name; [])
       else (
         (* add local variable binding in the context *)
-        let* local_var_ctxts = R.seq (List.map (local_var_binding ctx_plus_ips) ldecls) in
+        let* local_var_ctxts_cons = R.seq (List.map (local_var_binding ctx_plus_ips) ldecls) in
+        let local_var_ctxts, cons2 = List.split local_var_ctxts_cons in
         (* Local TC context is input vars + output vars + local const + var decls *)
         let local_ctx = List.fold_left union ctx_plus_ops_and_ips local_var_ctxts in
         Debug.parse "Local Typing Context with local state: {%a}" pp_print_tc_context local_ctx;
         (* Type check the node items now that we have all the local typing context *)
-        let check_items = R.seq_ (List.map (do_item local_ctx) items) in
+        let* cons3 = R.seq (List.map (do_item local_ctx) items) in
         (* check that the LHS of the equations are not args to node *)
         let check_lhs_eqns = List.map (fun (pos, v) ->
             if SI.mem v arg_ids then
@@ -1105,9 +1187,9 @@ and check_type_node_decl: Lib.position -> tc_context -> LA.node_decl -> (unit, [
         in
         Debug.parse "TC declaration node %a done }"
           LA.pp_print_ident node_name;
-        check_items >> check_lhs_eqns >> R.ok ()))
+        check_lhs_eqns >> R.ok (cons1 @ List.flatten cons2 @ List.flatten cons3)))
 
-and do_node_eqn: tc_context -> LA.node_equation -> (unit, [> error]) result = fun ctx ->
+and do_node_eqn: tc_context -> LA.node_equation -> ((LA.expr * string) list, [> error]) result = fun ctx ->
   function
   | LA.Assert (pos, e) ->
     Debug.parse "Checking assertion: %a" LA.pp_print_expr e;
@@ -1129,32 +1211,36 @@ and do_node_eqn: tc_context -> LA.node_equation -> (unit, [> error]) result = fu
     Debug.parse "Checking node equation lhs=%a; rhs=%a"
       LA.pp_print_eq_lhs lhs
       LA.pp_print_expr e;
-    let* ty = infer_type_expr new_ctx e in
+    let* ty, cons1 = infer_type_expr new_ctx e in
     Debug.parse "RHS has type %a for lhs %a" LA.pp_print_lustre_type ty LA.pp_print_eq_lhs lhs;
-    check_type_struct_def new_ctx lhs ty
+    let* cons2  = check_type_struct_def new_ctx lhs ty in 
+    R.ok (cons1 @ cons2)
 
-and do_item: tc_context -> LA.node_item -> (unit, [> error]) result = fun ctx ->
+and do_item: tc_context -> LA.node_item -> ((LA.expr * string) list, [> error]) result = fun ctx ->
   function
   | LA.Body eqn -> do_node_eqn ctx eqn
   | LA.IfBlock (pos, e, l1, l2) ->
-    let* guard_type = infer_type_expr ctx e in
+    let* guard_type, cons1 = infer_type_expr ctx e in
     (match guard_type with
-      | Bool _ -> (R.seq_ ((List.map (do_item ctx) l1) @ (List.map (do_item ctx) l2)))
+      | Bool _ -> 
+        let* cons2 = (R.seq ((List.map (do_item ctx) l1) @ (List.map (do_item ctx) l2))) in
+        R.ok (cons1 @ List.flatten cons2)
       | e_ty -> type_error pos  (ExpectedBooleanExpression e_ty)
     )
   | LA.FrameBlock (pos, vars, nes, nis) -> 
     let vars = List.map snd vars in
     let reassigned_consts = (SI.filter (fun e -> (member_val ctx e)) (SI.of_list vars)) in
-    R.seq_ (
+    let* cons = R.seq (
       (
         if ((SI.cardinal reassigned_consts) = 0) 
-        then R.ok ()
+        then R.ok ([])
         else type_error pos (DisallowedReassignment reassigned_consts)
       ) :: (List.map (do_node_eqn ctx) nes) @ (List.map (do_item ctx) nis) 
-    )
+    ) in 
+    R.ok (List.flatten cons)
   | LA.AnnotMain _ as ann ->
     Debug.parse "Node Item Skipped (Main Annotation): %a" LA.pp_print_node_item ann
-    ; R.ok ()
+    ; R.ok []
   | LA.AnnotProperty (_, _, e1, Provided e2) as ann ->
     Debug.parse "Checking Node Item (Annotation Property): %a (%a)"
       LA.pp_print_node_item ann LA.pp_print_expr e1
@@ -1164,7 +1250,7 @@ and do_item: tc_context -> LA.node_item -> (unit, [> error]) result = fun ctx ->
       LA.pp_print_node_item ann LA.pp_print_expr e
     ; check_type_expr ctx e (Bool (LH.pos_of_expr e))
   
-and check_type_struct_item: tc_context -> LA.struct_item -> tc_type -> (unit, [> error]) result
+and check_type_struct_item: tc_context -> LA.struct_item -> tc_type -> ((LA.expr * string) list, [> error]) result
   = fun ctx st exp_ty ->
   match st with
   | SingleIdent (pos, i) ->
@@ -1173,14 +1259,15 @@ and check_type_struct_item: tc_context -> LA.struct_item -> tc_type -> (unit, [>
         (Impossible ("Could not find Identifier " ^ (HString.string_of_hstring i)))
       | Some ty -> R.ok ty)
     in
-    let* inferred_is_expected1 = eq_lustre_type ctx exp_ty inf_ty in
-    let* inferred_is_expected2 = eq_lustre_type ctx exp_ty (GroupType (pos, [inf_ty])) in
+    let* inferred_is_expected1, cons1 = eq_lustre_type ~pos:pos ctx inf_ty exp_ty in
+    let* inferred_is_expected2, cons2 = eq_lustre_type ~pos:pos ctx (GroupType (pos, [inf_ty])) exp_ty in
+    let cons = if inferred_is_expected1 then cons1 else cons2 in
     if inferred_is_expected1 || inferred_is_expected2 then
       if member_val ctx i then 
         type_error pos (Impossible ("Constant "
           ^ (HString.string_of_hstring i)
           ^ " cannot be re-defined"))
-        else R.ok ()
+        else R.ok (cons)
     else
       type_error pos (ExpectedType (exp_ty, inf_ty))
 
@@ -1204,7 +1291,7 @@ and check_type_struct_item: tc_context -> LA.struct_item -> tc_type -> (unit, [>
   | FieldSelection _ -> Lib.todo __LOC__
   | ArraySliceStructItem _ -> Lib.todo __LOC__
 
-and check_type_struct_def: tc_context -> LA.eq_lhs -> tc_type -> (unit, [> error]) result
+and check_type_struct_def: tc_context -> LA.eq_lhs -> tc_type -> ((LA.expr * string) list, [> error]) result
   = fun ctx (StructDef (pos, lhss)) exp_ty ->
   (* This is a structured type, and we would want the expected type exp_ty to be a tuple type *)
   (Debug.parse "Checking if structure definition: %a has type %a \nwith local context %a"
@@ -1224,7 +1311,9 @@ and check_type_struct_def: tc_context -> LA.eq_lhs -> tc_type -> (unit, [> error
         then check_type_struct_item ctx (List.hd lhss) exp_ty 
         else (* Case 2. LHS is a compound statment *)
           if List.length lhss = List.length exp_ty_lst
-          then R.seq_ (List.map2 (check_type_struct_item ctx) lhss exp_ty_lst)
+          then 
+            let* cons = R.seq (List.map2 (check_type_struct_item ctx) lhss exp_ty_lst) in 
+            R.ok (List.flatten cons)
           else type_error pos (MismatchOfEquationType (Some lhss, exp_ty))
     (* We are dealing with simple types, so lhs has to be a singleton list *)
     | _ -> if (List.length lhss != 1)
@@ -1236,14 +1325,16 @@ and check_type_struct_def: tc_context -> LA.eq_lhs -> tc_type -> (unit, [> error
  * should match the type of the right hand side expression *)
 
 (* Difference between this and tc_ctx_contract_node_eqn? *)
-and tc_ctx_contract_eqn: tc_context -> LA.contract_node_equation -> (tc_context, [> error]) result
+and tc_ctx_contract_eqn: tc_context -> LA.contract_node_equation -> (tc_context * (LA.expr * string) list, [> error]) result
   = fun ctx -> function
   | GhostConst c -> tc_ctx_const_decl ctx c
-  | GhostVars vs -> tc_ctx_contract_vars ctx vs
-  | Assume _ -> R.ok ctx
-  | Guarantee _ -> R.ok ctx
-  | AssumptionVars _ -> R.ok ctx
-  | Mode (pos, name, _, _) -> R.ok (add_ty ctx name (Bool pos)) 
+  | GhostVars vs -> 
+    let* ctx = tc_ctx_contract_vars ctx vs in 
+    R.ok (ctx, [])
+  | Assume _ -> R.ok (ctx, [])
+  | Guarantee _ -> R.ok (ctx, [])
+  | AssumptionVars _ -> R.ok (ctx, [])
+  | Mode (pos, name, _, _) -> R.ok (add_ty ctx name (Bool pos), []) 
   | ContractCall (_, cc, _, _) ->
     match (lookup_contract_exports ctx cc) with
     | None -> failwith ("Cannot find exports for contract "
@@ -1251,9 +1342,9 @@ and tc_ctx_contract_eqn: tc_context -> LA.contract_node_equation -> (tc_context,
     | Some m -> R.ok (List.fold_left
       (fun c (i, ty) -> add_ty c (HString.concat (HString.mk_hstring "::") [cc;i]) ty)
       ctx
-      (IMap.bindings m)) 
+      (IMap.bindings m), []) 
 
-and check_type_contract_decl: tc_context -> LA.contract_node_decl -> (unit, [> error]) result
+and check_type_contract_decl: tc_context -> LA.contract_node_decl -> ((LA.expr * string) list, [> error]) result
   = fun ctx (cname, _, args, rets, contract) ->
   let arg_ids = LA.SI.of_list (List.map (fun arg -> LH.extract_ip_ty arg |> fst) args) in
   let ret_ids = LA.SI.of_list (List.map (fun ret -> LH.extract_op_ty ret |> fst) rets) in
@@ -1263,29 +1354,31 @@ and check_type_contract_decl: tc_context -> LA.contract_node_decl -> (unit, [> e
   let ret_ctx = List.fold_left union arg_ctx (List.map extract_ret_ctx rets) in
   let local_const_ctx = List.fold_left union ret_ctx (List.map extract_consts args) in
   (* forbid subranges in the arguments or return types *)
-  R.seq (List.map (fun (pos, i, ty, _, _) -> 
+  let* cons1 = R.seq (List.map (fun (pos, i, ty, _, _) -> 
     let ty = expand_nested_type_syn arg_ctx ty in
     if LH.type_contains_subrange ty then type_error pos (DisallowedSubrangeInContractReturn (true, i, ty))
-    else Ok ())
-    args)
-  >> R.seq (List.map (fun (pos, i, ty, _) -> 
+    else Ok ([]))
+    args) in 
+  let* cons2 = R.seq (List.map (fun (pos, i, ty, _) -> 
     let ty = expand_nested_type_syn ret_ctx ty in
     if LH.type_contains_subrange ty then type_error pos (DisallowedSubrangeInContractReturn (false, i, ty))
-    else Ok ())
-    rets)
+    else Ok ([]))
+    rets) in
   (* get the local const var declarations into the context *)
-  >> R.seq (List.map (tc_ctx_contract_eqn local_const_ctx) contract)
-  >>= fun ctxs ->
+  let* ctxs_cons = R.seq (List.map (tc_ctx_contract_eqn local_const_ctx) contract) in
+  let ctxs, cons3 = List.split ctxs_cons in 
   let local_ctx = List.fold_left union local_const_ctx ctxs in
   Debug.parse "Local Typing Context {%a}" pp_print_tc_context local_ctx;
   check_type_contract (arg_ids, ret_ids) local_ctx contract
-    >> R.ok (Debug.parse "TC Contract Decl %a done }" LA.pp_print_ident cname)
+    >> R.ok (Debug.parse "TC Contract Decl %a done }" LA.pp_print_ident cname; 
+             List.flatten cons1 @ List.flatten cons2 @ List.flatten cons3)
 
-and check_type_contract: (LA.SI.t * LA.SI.t) -> tc_context -> LA.contract -> (unit, [> error]) result
+and check_type_contract: (LA.SI.t * LA.SI.t) -> tc_context -> LA.contract -> ((LA.expr * string) list, [> error]) result
   = fun node_params ctx eqns ->
-  R.seq_ (List.map (check_contract_node_eqn node_params ctx) eqns)
+  (let* cons = R.seq (List.map (check_contract_node_eqn node_params ctx) eqns) in
+  R.ok (List.flatten cons))
 
-and check_contract_node_eqn: (LA.SI.t * LA.SI.t) -> tc_context -> LA.contract_node_equation -> (unit, [> error]) result
+and check_contract_node_eqn: (LA.SI.t * LA.SI.t) -> tc_context -> LA.contract_node_equation -> ((LA.expr * string) list, [> error]) result
   = fun node_params ctx eqn ->
   Debug.parse "Checking node's contract equation: %a" LA.pp_print_contract_item eqn
   ; match eqn with
@@ -1295,20 +1388,21 @@ and check_contract_node_eqn: (LA.SI.t * LA.SI.t) -> tc_context -> LA.contract_no
       match List.find_opt (fun (_, id) -> LA.SI.mem id io_params |> not) ids with
       | Some (pos, id) ->
         type_error pos (AssumptionMustBeInputOrOutput id)
-      | None -> R.ok ()
+      | None -> R.ok []
     )
     | GhostConst (FreeConst (_, _, exp_ty) as c) -> check_type_const_decl ctx c exp_ty
     | GhostConst (TypedConst (_, _, _, exp_ty) as c) -> check_type_const_decl ctx c exp_ty
-    | GhostConst (UntypedConst _) -> R.ok ()
+    | GhostConst (UntypedConst _) -> R.ok []
     | GhostVars v -> let node_eqn = contract_eqn_to_node_eqn v in do_node_eqn ctx node_eqn
     | Assume (pos, _, _, e) ->
       check_type_expr ctx e (Bool pos)
          
     | Guarantee (pos, _, _, e) -> check_type_expr ctx e (Bool pos)
     | Mode (pos, _, reqs, ensures) ->
-      R.seq_ (Lib.list_apply (List.map (check_type_expr ctx)
+      let* cons = R.seq (Lib.list_apply (List.map (check_type_expr ctx)
                                 (List.map (fun (_,_, e) -> e) (reqs @ ensures)))
-                (Bool pos))
+                (Bool pos)) in 
+      R.ok (List.flatten cons)
       
     | ContractCall (pos, cname, args, rets) ->
       let arg_ids =
@@ -1321,14 +1415,16 @@ and check_contract_node_eqn: (LA.SI.t * LA.SI.t) -> tc_context -> LA.contract_no
       let common_ids = LA.SI.inter arg_ids ret_ids in
       if (LA.SI.equal common_ids LA.SI.empty)
       then 
-        let* ret_tys = R.seq (List.map (infer_type_expr ctx)
+        let* ret_tys_cons = R.seq (List.map (infer_type_expr ctx)
           (List.map (fun i -> LA.Ident (pos, i)) rets))
         in
+        let ret_tys, cons1 = List.split ret_tys_cons in
         let ret_ty = if List.length ret_tys = 1
           then List.hd ret_tys
           else LA.GroupType (pos, ret_tys)
         in
-        let* arg_tys = R.seq(List.map (infer_type_expr ctx) args) in
+        let* arg_tys_cons = R.seq(List.map (infer_type_expr ctx) args) in
+        let arg_tys, cons2 = List.split arg_tys_cons in
         let arg_ty = if List.length arg_tys = 1
           then List.hd arg_tys
           else LA.GroupType (pos, arg_tys)
@@ -1336,8 +1432,9 @@ and check_contract_node_eqn: (LA.SI.t * LA.SI.t) -> tc_context -> LA.contract_no
         let exp_ty = LA.TArr (pos, arg_ty, ret_ty) in
         (match (lookup_contract_ty ctx cname) with
         | Some inf_ty -> 
-            R.guard_with (eq_lustre_type ctx inf_ty exp_ty)
-              (type_error pos (MismatchedNodeType (cname, exp_ty, inf_ty)))
+            let* b, cons3 = eq_lustre_type ctx inf_ty exp_ty in 
+            if b then R.ok (List.flatten cons1 @ List.flatten cons2 @ cons3)
+            else (type_error pos (MismatchedNodeType (cname, exp_ty, inf_ty)))
         | None -> type_error pos (Impossible ("Undefined or not in scope contract name "
           ^ (HString.string_of_hstring cname))))
       else type_error pos (NodeInputOutputShareIdentifier common_ids)
@@ -1349,28 +1446,30 @@ and contract_eqn_to_node_eqn: LA.contract_ghost_vars -> LA.node_equation
     ) in
     Equation(pos1, lhs, expr)
 
-and tc_ctx_const_decl: tc_context -> LA.const_decl -> (tc_context, [> error]) result
+and tc_ctx_const_decl: tc_context -> LA.const_decl -> (tc_context * (LA.expr * string) list, [> error]) result
   = fun ctx ->
   function
   | LA.FreeConst (pos, i, ty) ->
     check_type_well_formed ctx ty
     >> if member_ty ctx i
        then type_error pos (Redeclaration i)
-       else R.ok (add_ty (add_const ctx i (LA.Ident (pos, i)) ty) i ty)
+       else R.ok (add_ty (add_const ctx i (LA.Ident (pos, i)) ty) i ty, [])
   | LA.UntypedConst (pos, i, e) ->
     if member_ty ctx i then
       type_error pos (Redeclaration i)
     else (
-      let* ty = infer_type_expr ctx e in
-      check_and_add_constant_definition ctx i e ty
+      let* ty, cons = infer_type_expr ctx e in
+      let* ctx = check_and_add_constant_definition ctx i e ty in 
+      R.ok (ctx, cons)
     )
   | LA.TypedConst (pos, i, e, exp_ty) ->
     check_type_well_formed ctx exp_ty >>
     if member_ty ctx i then
       type_error pos (Redeclaration i)
     else
-      check_type_expr (add_ty ctx i exp_ty) e exp_ty
-      >> check_and_add_constant_definition ctx i e exp_ty
+      let* cons = check_type_expr (add_ty ctx i exp_ty) e exp_ty in
+      let* ctx = check_and_add_constant_definition ctx i e exp_ty in 
+      R.ok (ctx, cons)
 (** Fail if a duplicate constant is detected  *)
   
 and tc_ctx_contract_vars: tc_context -> LA.contract_ghost_vars -> (tc_context, [> error]) result 
@@ -1435,63 +1534,68 @@ and tc_ctx_of_node_decl: Lib.position -> tc_context -> LA.node_decl -> (tc_conte
     R.ok (let ctx = add_ty_node ctx nname fun_ty in add_node_param_attr ctx nname ip)
 (** computes the type signature of node or a function and its node summary*)
 
-and tc_ctx_contract_node_eqn ?(ignore_modes = false) ctx =
+and tc_ctx_contract_node_eqn ?(ignore_modes = false) (ctx, cons) =
   function
-  | LA.GhostConst c -> tc_ctx_const_decl ctx c
-  | LA.GhostVars vs -> tc_ctx_contract_vars ctx vs
+  | LA.GhostConst c -> 
+    let* ctx, cons2 = tc_ctx_const_decl ctx c
+    in R.ok (ctx, cons @ cons2) 
+  | LA.GhostVars vs -> 
+    let* ctx = tc_ctx_contract_vars ctx vs in 
+    R.ok (ctx, cons)
   | LA.Mode (pos, mname, _, _) ->
-    if ignore_modes then R.ok ctx
+    if ignore_modes then R.ok (ctx, [])
     else if (member_ty ctx mname) then
       type_error pos (Redeclaration mname)
-    else R.ok (add_ty ctx mname (Bool pos))
+    else R.ok (add_ty ctx mname (Bool pos), cons)
   | LA.ContractCall (p, cc, _, _) ->
     (match (lookup_contract_exports ctx cc) with
     | None -> type_error p (Impossible ("Cannot find contract " ^ (HString.string_of_hstring cc)))
     | Some m -> R.ok (List.fold_left
       (fun c (i, ty) -> add_ty c (HString.concat (HString.mk_hstring "::") [cc;i]) ty)
       ctx
-      (IMap.bindings m))) 
-  | _ -> R.ok ctx
+      (IMap.bindings m), cons)) 
+  | _ -> R.ok (ctx, cons)
                          
-and tc_ctx_of_contract ?(ignore_modes = false) ctx con =
-  R.seq_chain (tc_ctx_contract_node_eqn ~ignore_modes) ctx con
+and tc_ctx_of_contract: ?ignore_modes:bool -> tc_context -> LA.contract -> (tc_context * (LA.expr * string) list, [> error ]) result  
+  = fun ?(ignore_modes = false) ctx con ->
+  R.seq_chain (tc_ctx_contract_node_eqn ~ignore_modes) (ctx, []) con
 
-and extract_exports: LA.ident -> tc_context -> LA.contract -> (tc_context, [> error]) result
-  = let exports_from_eqn: tc_context -> LA.contract_node_equation -> ((LA.ident * tc_type) list, [> error]) result
+and extract_exports: LA.ident -> tc_context -> LA.contract -> (tc_context * (LA.expr * string) list, [> error]) result
+  = let exports_from_eqn: tc_context -> LA.contract_node_equation -> ((LA.ident * tc_type * (LA.expr * string) list) list, [> error]) result
       = fun ctx -> 
       function
-      | LA.GhostConst (FreeConst (_, i, ty)) -> R.ok [(i, ty)]
+      | LA.GhostConst (FreeConst (_, i, ty)) -> R.ok [(i, ty, [])]
       | LA.GhostConst (UntypedConst (_, i, e)) ->
-        infer_type_expr ctx e >>= fun ty -> 
-        R.ok [(i, ty)]
+        let* ty, cons = infer_type_expr ctx e in
+        R.ok [(i, ty, cons)]
       | LA.GhostConst (TypedConst (_, i, _, ty)) ->
-        R.ok [(i, ty)]
+        R.ok [(i, ty, [])]
       | LA.GhostVars (_, (GhostVarDec (_, tis)), _) ->
-        R.ok (List.map (fun (_, i, ty) -> (i, ty)) tis)
+        R.ok (List.map (fun (_, i, ty) -> (i, ty, [])) tis)
       | LA.Mode (pos, mname, _, _) ->
         if (member_ty ctx mname)
         then type_error pos (Redeclaration mname)
-        else R.ok [(mname, (LA.Bool pos))] 
+        else R.ok [(mname, (LA.Bool pos), [])] 
       | LA.ContractCall (p, cc, _, _) ->
         (match (lookup_contract_exports ctx cc) with
         | None -> type_error p (Impossible ("Cannot find contract " ^ (HString.string_of_hstring cc)))
         | Some m -> R.ok (List.map
-          (fun (k, v) -> (HString.concat (HString.mk_hstring "::") [cc;k], v))
+          (fun (k, v) -> (HString.concat (HString.mk_hstring "::") [cc;k], v, []))
           (IMap.bindings m)))
       | _ -> R.ok [] in
     fun cname ctx contract ->
     (R.seq_chain
-      (fun (exp_acc, lctx) e ->
-        exports_from_eqn lctx e >>= fun id_tys ->
+      (fun (exp_acc, lctx, cons) e ->
+        let* id_tys = exports_from_eqn lctx e in
         R.ok (List.fold_left
-          (fun (a, c) (i, ty) -> (IMap.add i ty a, add_ty c i ty))
-          (exp_acc, lctx) id_tys))
-      (IMap.empty, ctx) contract) >>=
-    fun (exports, _) -> R.ok (add_contract_exports ctx cname exports)  
+          (fun (a, c, cons1) (i, ty, cons2) -> (IMap.add i ty a, add_ty c i ty, cons1 @ cons2))
+          (exp_acc, lctx, cons) id_tys))
+      (IMap.empty, ctx, []) contract) >>=
+    fun (exports, _, cons) -> R.ok (add_contract_exports ctx cname exports, cons)  
                  
 and tc_ctx_of_contract_node_decl: Lib.position -> tc_context
                                   -> LA.contract_node_decl
-                                  -> (tc_context, [> error]) result
+                                  -> (tc_context * (LA.expr * string) list, [> error]) result
   = fun pos ctx (cname, _, inputs, outputs, contract) ->
   Debug.parse
     "Extracting type of contract declaration: %a"
@@ -1499,36 +1603,45 @@ and tc_ctx_of_contract_node_decl: Lib.position -> tc_context
   ; if (member_contract ctx cname)
     then type_error pos (Redeclaration cname)
     else build_node_fun_ty pos ctx inputs outputs >>= fun fun_ty ->
-        extract_exports cname ctx contract >>= fun export_ctx  ->  
-        R.ok (add_ty_contract (union ctx export_ctx) cname fun_ty)
+        let* export_ctx, cons = extract_exports cname ctx contract in
+        R.ok ((add_ty_contract (union ctx export_ctx) cname fun_ty), cons)
 
-and tc_ctx_of_declaration: tc_context -> LA.declaration -> (tc_context, [> error]) result
-    = fun ctx' ->
+and tc_ctx_of_declaration: (tc_context * ((LA.expr * string) list IMap.t)) -> LA.declaration -> (tc_context * ((LA.expr * string) list IMap.t), [> error]) result
+    = fun (ctx', m1) ->
     function
-    | LA.ConstDecl (_, const_decl) -> tc_ctx_const_decl ctx' const_decl
+    | LA.ConstDecl (_, const_decl) -> 
+      let* ctx, cons = tc_ctx_const_decl ctx' const_decl in 
+      let m2 = IMap.singleton global_id cons in
+      R.ok (ctx, IMap.merge union_keys m1 m2)
     | LA.NodeDecl ({LA.start_pos=pos}, node_decl) ->
-      tc_ctx_of_node_decl pos ctx' node_decl
-    | LA.FuncDecl ({LA.start_pos=pos}, node_decl) ->
-      tc_ctx_of_node_decl pos ctx' node_decl
-    | LA.ContractNodeDecl ({LA.start_pos=pos}, contract_decl) ->
-      tc_ctx_of_contract_node_decl pos ctx' contract_decl
-    | _ -> R.ok ctx'
+      let* ctx = tc_ctx_of_node_decl pos ctx' node_decl in 
+      R.ok (ctx, m1)
+    | LA.FuncDecl ({LA.start_pos=pos}, func_decl) ->
+      let* ctx = tc_ctx_of_node_decl pos ctx' func_decl in 
+      R.ok (ctx, m1)
+    | LA.ContractNodeDecl ({LA.start_pos=pos}, ((id, _, _, _, _) as contract_decl)) ->
+      let* ctx, cons = tc_ctx_of_contract_node_decl pos ctx' contract_decl in 
+      let m2 = IMap.singleton id cons in 
+      R.ok (ctx, IMap.merge union_keys m1 m2)
+    | _ -> R.ok (ctx', m1)
 
-and tc_context_of: tc_context -> LA.t -> (tc_context, [> error]) result
+and tc_context_of: tc_context -> LA.t -> (tc_context * (LA.expr * string) list IMap.t, [> error]) result
   = fun ctx decls ->
-  R.seq_chain (tc_ctx_of_declaration) ctx decls 
+  R.seq_chain (tc_ctx_of_declaration) (ctx, IMap.empty) decls 
 (** Obtain a global typing context, get constants and function decls*)
   
-and build_type_and_const_context (* : tc_context -> LA.t -> (tc_context, [> error]) result *)
+and build_type_and_const_context : tc_context -> LA.t -> (tc_context * (LA.expr * string) list IMap.t, [> error]) result 
   = fun ctx ->
   function
-  | [] -> R.ok ctx
+  | [] -> R.ok (ctx, IMap.empty)
   | LA.TypeDecl (_, ty_decl) :: rest ->
     let* ctx' = tc_ctx_of_ty_decl ctx ty_decl in
     build_type_and_const_context ctx' rest
   | ConstDecl (_, const_decl) :: rest ->
-    let* ctx' = tc_ctx_const_decl ctx const_decl in
-    build_type_and_const_context ctx' rest                   
+    let* ctx', cons1 = tc_ctx_const_decl ctx const_decl in
+    let m1 = IMap.singleton global_id cons1 in
+    let* ctx, m2 = build_type_and_const_context ctx' rest in 
+    R.ok (ctx, IMap.merge union_keys m1 m2)                   
   | _ :: rest -> build_type_and_const_context ctx rest  
 (** Process top level type declarations and make a type context with 
  * user types, enums populated *)
@@ -1538,8 +1651,8 @@ and check_const_integer_expr ctx kind e =
   | Error (`LustreTypeCheckerError (pos, UnboundNodeName _)) ->
     type_error pos
       (ExpectedConstant (kind, "node call or choose operator"))
-  | Ok ty ->
-    let* eq = eq_lustre_type ctx ty (LA.Int (LH.pos_of_expr e)) in
+  | Ok (ty, _) ->
+    let* eq, _ = eq_lustre_type ctx ty (LA.Int (LH.pos_of_expr e)) in
     if eq then
       check_expr_is_constant ctx kind e
     else
@@ -1603,43 +1716,47 @@ and build_node_fun_ty: Lib.position -> tc_context
   >>  R.ok (LA.TArr (pos, arg_ty, ret_ty))
 (** Function type for nodes will be [TupleType ips] -> [TupleTy outputs]  *)
 
-and eq_lustre_type : tc_context -> LA.lustre_type -> LA.lustre_type -> (bool, [> error]) result
-  = fun ctx t1 t2 ->
+and eq_lustre_type : ?is_call_arg: bool -> ?pos: Lib.position -> tc_context -> LA.lustre_type -> LA.lustre_type -> (bool * (LA.expr * string) list, [> error]) result
+  = fun ?(is_call_arg = false) ?(pos = Lib.dummy_pos) ctx t1 t2 ->
   match (t1, t2) with
   (* Type Variable *)
-  | TVar (_, i1), TVar (_, i2) -> R.ok (i1 = i2)
+  | TVar (_, i1), TVar (_, i2) -> R.ok (i1 = i2, [])
 
   (* Simple types *)
-  | Bool _, Bool _ -> R.ok true
-  | Int _, Int _ -> R.ok true
-  | UInt8 _, UInt8 _ -> R.ok true
-  | UInt16 _, UInt16 _ -> R.ok true              
-  | UInt32 _, UInt32 _ -> R.ok true
-  | UInt64 _,UInt64 _ -> R.ok true 
-  | Int8 _, Int8 _ -> R.ok true 
-  | Int16 _, Int16 _ -> R.ok true
-  | Int32 _, Int32 _ -> R.ok true
-  | Int64 _, Int64 _ -> R.ok true
-  | Real _, Real _ -> R.ok true
+  | Bool _, Bool _ -> R.ok (true, [])
+  | Int _, Int _ -> R.ok (true, [])
+  | UInt8 _, UInt8 _ -> R.ok (true, [])
+  | UInt16 _, UInt16 _ -> R.ok (true, [])              
+  | UInt32 _, UInt32 _ -> R.ok (true, [])
+  | UInt64 _,UInt64 _ -> R.ok (true, []) 
+  | Int8 _, Int8 _ -> R.ok (true, []) 
+  | Int16 _, Int16 _ -> R.ok (true, [])
+  | Int32 _, Int32 _ -> R.ok (true, [])
+  | Int64 _, Int64 _ -> R.ok (true, [])
+  | Real _, Real _ -> R.ok (true, [])
 
   (* Integer Range *)
-  | IntRange _, IntRange _ -> R.ok true
-  | IntRange _, Int _ -> R.ok true
-  | Int _, IntRange _ -> R.ok true
+  | IntRange _, IntRange _ -> R.ok (true, [])
+  | IntRange _, Int _ -> R.ok (true, [])
+  | Int _, IntRange _ -> R.ok (true, [])
 
   (* Lustre V6 features *)
-  | UserType (_, i1), UserType (_, i2) -> R.ok (i1 = i2)
-  | AbstractType (_, i1), AbstractType (_, i2) -> R.ok (i1 = i2)
+  | UserType (_, i1), UserType (_, i2) -> R.ok (i1 = i2, [])
+  | AbstractType (_, i1), AbstractType (_, i2) -> R.ok (i1 = i2, [])
   | TupleType (_, tys1), TupleType (_, tys2) ->
     if List.length tys1 = List.length tys2
-    then (R.seqM (&&) true (List.map2 (eq_lustre_type ctx) tys1 tys2))
-    else R.ok false
+    then 
+      let f = (fun (b1, exprs1) (b2, exprs2) -> b1 && b2, exprs1 @ exprs2) in   
+      (R.seqM f (true, []) (List.map2 (eq_lustre_type ~is_call_arg ~pos ctx) tys1 tys2))
+    else R.ok (false, [])
   (* For Equality for group types, flatten out the structures  *)
   | GroupType (_, tys1), GroupType (_, tys2) ->
     let (ftys1, ftys2) = LH.flatten_group_types tys1, LH.flatten_group_types tys2 in 
     if List.length ftys1 = List.length ftys2
-    then (R.seqM (&&) true (List.map2 (eq_lustre_type ctx) ftys1 ftys2))
-    else R.ok false
+    then 
+      let f = (fun (b1, exprs1) (b2, exprs2) -> b1 && b2, exprs1 @ exprs2) in
+      (R.seqM f (true, []) (List.map2 (eq_lustre_type ~is_call_arg ~pos ctx) ftys1 ftys2))
+    else R.ok (false, [])
   | RecordType (_, n1, tys1), RecordType (_, n2, tys2) ->
     if List.length tys1 = List.length tys2
     then (
@@ -1647,21 +1764,24 @@ and eq_lustre_type : tc_context -> LA.lustre_type -> LA.lustre_type -> (bool, [>
         (LH.sort_typed_ident tys1)
         (LH.sort_typed_ident tys2))
       in
-      R.ok (List.fold_left (&&) true isEqs && n1 == n2)
+      let f = (fun (b1, exprs1) (b2, exprs2) -> b1 && b2, exprs1 @ exprs2) in
+      let b, cons = List.fold_left f (true, []) isEqs in
+      R.ok (b && n1 == n2, cons)
     )
-    else R.ok false
-  | ArrayType (_, arr1), ArrayType (_, arr2) -> eq_type_array ctx arr1 arr2 
+    else R.ok (false, [])
+  | ArrayType (_, arr1), ArrayType (_, arr2) -> eq_type_array ~is_call_arg ~pos ctx arr1 arr2 
   | EnumType (_, n1, is1), EnumType (_, n2, is2) ->
     if List.length is1 = List.length is2
     then
       R.ok (n1 = n2 &&
-        (List.fold_left (&&) true (List.map2 (=) (LH.sort_idents is1) (LH.sort_idents is2))))
+        (List.fold_left (&&) true (List.map2 (=) (LH.sort_idents is1) (LH.sort_idents is2))), [])
     else
-      R.ok false
+      R.ok (false, [])
   (* node/function type *)
   | TArr (_, arg_ty1, ret_ty1), TArr (_, arg_ty2, ret_ty2) ->
-    R.seqM (&&) true [ eq_lustre_type ctx arg_ty1 arg_ty2
-                    ; eq_lustre_type ctx ret_ty1 ret_ty2 ]
+    let f = (fun (b1, exprs1) (b2, exprs2) -> b1 && b2, exprs1 @ exprs2) in
+    R.seqM f (true, []) [ eq_lustre_type ~is_call_arg ~pos ctx arg_ty1 arg_ty2
+                        ; eq_lustre_type ~is_call_arg ~pos ctx ret_ty1 ret_ty2 ]
 
   (* special case for type synonyms *)
   | UserType (pos, u), ty
@@ -1673,67 +1793,84 @@ and eq_lustre_type : tc_context -> LA.lustre_type -> LA.lustre_type -> (bool, [>
             ^ (HString.string_of_hstring u)))
         | Some ty -> R.ok ty)
       in
-      eq_lustre_type ctx ty ty_alias
-    else R.ok false
+      eq_lustre_type ~is_call_arg ~pos ctx ty ty_alias
+    else R.ok (false, [])
   (* Another special case for GroupType equality *)
   | GroupType (_, tys), t
   | t, GroupType (_, tys) ->
     if List.length tys = 1
-    then (eq_lustre_type ctx (List.hd tys) t)
-    else R.ok false  
-  | _, _ -> R.ok false
+    then (eq_lustre_type ~is_call_arg ~pos ctx (List.hd tys) t)
+    else R.ok (false, [])
+  | _, _ -> R.ok (false, [])
 (** Compute Equality for lustre types  *)
 
-and is_expr_int_type: tc_context -> LA.expr -> bool  = fun ctx e ->
+and is_expr_int_type: tc_context -> LA.expr -> bool = fun ctx e ->
   R.safe_unwrap false
-    (infer_type_expr ctx e
-      >>= fun ty -> eq_lustre_type ctx ty (LA.Int (LH.pos_of_expr e)))
+    (let* ty, _ = infer_type_expr ctx e in 
+     let* res, _ = eq_lustre_type ctx ty (LA.Int (LH.pos_of_expr e)) in 
+     R.ok res)
 (** Checks if the expr is of type Int. This will be useful 
- * in evaluating array sizes that we need to have as constant integers
- * while declaring the array type *)
+ *  in evaluating array sizes that we need to have as constant integers
+ *  while declaring the array type *)
   
-and eq_typed_ident: tc_context -> LA.typed_ident -> LA.typed_ident -> (bool, [> error]) result =
+and eq_typed_ident: tc_context -> LA.typed_ident -> LA.typed_ident -> (bool * (LA.expr * string) list, [> error]) result =
   fun ctx (_, _, ty1) (_, _, ty2) -> eq_lustre_type ctx ty1 ty2
 (** Compute type equality for [LA.typed_ident] *)
 
-and eq_type_array: tc_context -> (LA.lustre_type * LA.expr) -> (LA.lustre_type * LA.expr) -> (bool, [> error]) result
-  = fun ctx (ty1, e1) (ty2, e2) ->
+and eq_type_array: ?is_call_arg: bool -> ?pos: Lib.position -> tc_context -> (LA.lustre_type * LA.expr) -> (LA.lustre_type * LA.expr) -> (bool * (LA.expr * string) list, [> error]) result
+  = fun ?(is_call_arg = false) ?(pos = Lib.dummy_pos) ctx (ty1, e1) (ty2, e2)   ->
   (* eq_lustre_type ctx ty1 ty2 *)
-  R.ifM (eq_lustre_type ctx ty1 ty2)
+  let* b, constraints = eq_lustre_type ctx ty1 ty2 in
+  if b
+  then 
     (* Are the array sizes equal numerals? *)
     ( match IC.eval_int_expr ctx e1, IC.eval_int_expr ctx e2 with
-      | Ok l1,  Ok l2  -> R.ok (l1 = l2)
+      | Ok l1,  Ok l2  -> R.ok (l1 = l2, constraints)
       | Error _ , _ | _, Error _ ->
         (* Are the array sizes syntactically identical? *)
         match LH.syn_expr_equal None e1 e2 with
-        | Ok b -> R.ok b
-        | Error _ -> R.ok false) 
-    (R.ok false)
+        | Ok b -> 
+          if b then R.ok (true, constraints) 
+          else 
+            let pos = if pos = Lib.dummy_pos then (LustreAstHelpers.pos_of_expr e2) else pos in
+            let desc = mk_array_prop_desc is_call_arg pos in
+            R.ok (
+              true, (LA.CompOp(Lib.dummy_pos, Eq, e1, e2), desc) 
+              :: constraints
+            )
+        | Error _ -> R.ok (false, constraints)) 
+  else (R.ok (true, constraints))
 (** Compute equality for [LA.ArrayType].
    If there are free constants in the size, the eval function will fail,
    but we want to pass such cases, as there might be some
    value assigment to the free constant that satisfies the type checker. 
-   Hence, silently return true with a leap of faith. *)         
+   Hence, silently return true and defer later checks to the model checking phase. *)         
 
                                  
-let rec type_check_group: tc_context -> LA.t ->  (unit, [> error]) result list
+let rec type_check_group: tc_context -> LA.t ->  ((LA.expr * string) list IMap.t, [> error]) result
   = fun global_ctx
   -> function
-  | [] -> [R.ok ()]
+  | [] -> R.ok (IMap.empty)
   (* skip over type declarations and const_decls*)
   | (LA.TypeDecl _ :: rest) 
   | LA.ConstDecl _ :: rest -> type_check_group global_ctx rest  
-  | LA.NodeDecl (span, node_decl) :: rest ->
+  | LA.NodeDecl (span, ((id, _, _, _, _, _, _, _) as node_decl)) :: rest ->
     let { LA.start_pos = pos } = span in
-    (check_type_node_decl pos global_ctx node_decl)
-    :: type_check_group global_ctx rest
-  | LA.FuncDecl (span, node_decl):: rest ->
+    let* cons = check_type_node_decl pos global_ctx node_decl in 
+    let m1 = IMap.singleton id cons  in
+    let* m2 = (type_check_group global_ctx rest) in
+    R.ok (IMap.merge union_keys m1 m2)
+  | LA.FuncDecl (span, ((id, _, _, _, _, _, _, _) as node_decl)):: rest ->
     let { LA.start_pos = pos } = span in
-    (check_type_node_decl pos global_ctx node_decl)
-    :: type_check_group global_ctx rest
-  | LA.ContractNodeDecl (_, contract_decl) :: rest ->
-    (check_type_contract_decl global_ctx contract_decl)
-    :: type_check_group global_ctx rest
+    let* cons = (check_type_node_decl pos global_ctx node_decl) in
+    let m1 = IMap.singleton id cons in
+    let* m2 = type_check_group global_ctx rest in 
+    R.ok (IMap.merge union_keys m1 m2)
+  | LA.ContractNodeDecl (_, ((id, _, _, _, _) as contract_decl)) :: rest ->
+    let* cons = (check_type_contract_decl global_ctx contract_decl) in 
+    let m1 = IMap.singleton id cons in 
+    let* m2 = type_check_group global_ctx rest in 
+    R.ok (IMap.merge union_keys m1 m2)
   | LA.NodeParamInst  _ :: rest ->
     type_check_group global_ctx rest
 (** By this point, all the circularity should be resolved,
@@ -1759,51 +1896,52 @@ let get_node_ctx ctx (_, _, _, inputs, outputs, locals, _, _) =
     (union input_ctx output_ctx) in
   let rec helper ctx locals = match locals with
     | local :: locals -> 
-      let* ctx = local_var_binding ctx local in 
+      let* ctx, _ = local_var_binding ctx local in 
       helper ctx locals
     | [] -> R.ok ctx in
   helper ctx locals
 
 
-let type_check_decl_grps: tc_context -> LA.t list -> (unit, [> error]) result list
+let type_check_decl_grps: tc_context -> LA.t list -> ((LA.expr * string) list IMap.t, [> error]) result
   = fun ctx decls ->
     Debug.parse ("@.===============================================@."
       ^^ "Phase: Type checking declaration Groups@."
       ^^"===============================================@.");
-    List.concat (List.map (fun decl -> type_check_group ctx decl) decls)
+    let* maps = R.seq (List.map (fun decl -> type_check_group ctx decl) decls) in 
+    R.ok (List.fold_left (fun acc map -> IMap.merge union_keys acc map) IMap.empty maps)
 (** Typecheck a list of independent groups using a global context*)
 
 (**************************************************************************************
  * The main functions of the file that kicks off type checking or type inference flow  *
  ***************************************************************************************)
 
-let type_check_infer_globals: tc_context -> LA.t -> (tc_context, [> error]) result
+let type_check_infer_globals: tc_context -> LA.t -> (tc_context * (LA.expr * string) list IMap.t, [> error]) result
   = fun ctx prg ->
     Debug.parse ("@.===============================================@."
       ^^ "Building TC Global Context@."
       ^^"===============================================@.");
     (* Build base constant and type context *)
-    let* global_ctx = build_type_and_const_context ctx prg in
-    R.ok global_ctx
+    let* global_ctx, cons = build_type_and_const_context ctx prg in
+    R.ok (global_ctx, cons)
 
-let type_check_infer_nodes_and_contracts: tc_context -> LA.t -> (tc_context, [> error]) result
+let type_check_infer_nodes_and_contracts: tc_context -> LA.t -> (tc_context * ((LA.expr * string) list IMap.t), [> error]) result
   = fun ctx prg -> 
   (* type check the nodes and contract decls using this base typing context  *)
   Debug.parse ("@.===============================================@."
     ^^ "Building node and contract Context@."
     ^^"===============================================@.");
   (* Build base constant and type context *)
-  let* global_ctx = tc_context_of ctx prg in
+  let* global_ctx, m1 = tc_context_of ctx prg in
   Debug.parse ("@.===============================================@."
     ^^ "Type checking declaration Groups@." 
     ^^ "with TC Context@.%a@."
     ^^"===============================================@.")
     pp_print_tc_context global_ctx;
-  let checked_decls = R.seq_ (type_check_decl_grps global_ctx [prg]) in
+  let* m2 = type_check_decl_grps global_ctx [prg] in
   Debug.parse ("@.===============================================@."
     ^^ "Type checking declaration Groups Done@."
     ^^"===============================================@.");
-  checked_decls >> R.ok global_ctx
+  R.ok (global_ctx, IMap.merge union_keys m1 m2)
 
 (* 
    Local Variables:

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -81,6 +81,7 @@ type error_kind = Unknown of string
   | SubrangeArgumentMustBeConstantInteger of LA.expr
   | IntervalMustHaveBound
   | ExpectedRecordType of tc_type
+  | GlobalArrayConstraint of LA.expr
 
 type error = [
   | `LustreTypeCheckerError of Lib.position * error_kind

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -90,20 +90,22 @@ type error = [
 
 val error_message: error_kind -> string
 
+val union_keys: 'a -> 'b list option -> 'b list option -> 'b list option
+
 val type_error: Lib.position -> error_kind -> ('a, [> error]) result 
 (** [type_error] returns an [Error] of [tc_result] *)
-     
-val type_check_infer_globals: tc_context -> LA.t -> (tc_context, [> error]) result  
+      
+val type_check_infer_globals: tc_context -> LA.t -> (tc_context * (LA.expr * string) list IMap.t, [> error]) result  
 (** Typechecks the toplevel globals i.e. constant decls and type decls. It returns 
     a [Ok (tc_context)] if it succeeds or and [Error of String] if the typechecker fails *)
 
-val type_check_infer_nodes_and_contracts: tc_context -> LA.t -> (tc_context, [> error]) result
+val type_check_infer_nodes_and_contracts: tc_context -> LA.t -> (tc_context * ((LA.expr * string) list IMap.t), [> error]) result
 (** Typechecks and infers type for the nodes and contracts. It returns
     a [Ok (tc_context)] if it succeeds or and [Error of String] if the typechecker fails *)
 
-val tc_ctx_of_contract: ?ignore_modes:bool -> tc_context -> LA.contract -> (tc_context, [> error]) result
+val tc_ctx_of_contract: ?ignore_modes:bool -> tc_context -> LA.contract -> (tc_context * (LA.expr * string) list, [> error ]) result
 
-val local_var_binding: tc_context -> LA.node_local_decl -> (tc_context, [> error]) result
+val local_var_binding: tc_context -> LA.node_local_decl -> (tc_context * (LA.expr * string) list, [> error]) result
 
 val get_node_ctx : tc_context ->
   'a * 'b * 'c * LA.const_clocked_typed_decl list *
@@ -115,16 +117,17 @@ val build_node_fun_ty : Lib.position ->
   LA.const_clocked_typed_decl list ->
   LA.clocked_typed_decl list -> (tc_type, [> error ]) result
 
-val infer_type_expr: tc_context -> LA.expr -> (tc_type, [> error]) result
+val infer_type_expr: tc_context -> LA.expr -> (tc_type * (LA.expr * string) list, [> error]) result
 (** Infer type of Lustre expression given a typing context *)
 
-val eq_lustre_type : tc_context -> LA.lustre_type -> LA.lustre_type -> (bool, [> error]) result
+val eq_lustre_type : ?is_call_arg: bool -> ?pos:Lib.position -> tc_context -> LA.lustre_type -> LA.lustre_type -> (bool * (LA.expr * string) list, [> error]) result
 (** Check if two lustre types are equal *)
 
 (* 
-   Local Variables:
-   compile-command: "make -k -C .."
-   indent-tabs-mode: nil
-   End: 
+    Local Variables:
+    compile-command: "make -k -C .."
+    indent-tabs-mode: nil
+    End: 
 *)
-                                
+                                    
+    

--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -27,16 +27,10 @@ module LH = LustreAstHelpers
 type tc_type  = LA.lustre_type
 (** Type alias for lustre type from LustreAst  *)
 
-module IMap = struct
-  (* everything that [Stdlib.Map] gives us  *)
-  include Map.Make(struct
-              type t = LA.ident
-              let compare i1 i2 = HString.compare i1 i2
-            end)
-  let keys: 'a t -> key list = fun m -> List.map fst (bindings m)
-end
+module IMap = HString.HStringMap
 (** Map for types with identifiers as keys *)
 
+let keys m = List.map fst (IMap.bindings m)
 
 type enum_variants = LA.ident list IMap.t
 (** A store of the variants for defined enumeration types *)
@@ -288,7 +282,7 @@ let extract_consts: LA.const_clocked_typed_decl -> tc_context
 (** Extracts constants as a typing constant  *)
 
 let get_constant_ids: tc_context -> LA.ident list
-  = fun ctx -> IMap.keys ctx.vl_ctx
+  = fun ctx -> keys ctx.vl_ctx
 (** Returns the constants declared in the typing context  *)
 
 let lookup_contract_exports: tc_context -> LA.ident -> ty_store option

--- a/src/lustre/typeCheckerContext.mli
+++ b/src/lustre/typeCheckerContext.mli
@@ -25,11 +25,7 @@ module SI = LA.SI
 type tc_type  = LA.lustre_type
 (** Type alias for lustre type from LustreAst  *)
 
-module IMap : sig
-  (* everything that [Stdlib.Map] gives us  *)
-  include (Map.S with type key = LA.ident)
-  val keys: 'a t -> key list
-end
+module IMap = HString.HStringMap
 (** Map for types with identifiers as keys *)
 
 type enum_variants = LA.ident list IMap.t

--- a/src/utils/Res.ml
+++ b/src/utils/Res.ml
@@ -67,6 +67,11 @@ let safe_unwrap: 'a -> ('a, 'e) result -> 'a =
   fun d -> function
         | Ok v -> v
         | _ -> d
+
+let splitM: (('a * 'b) list, 'e) result -> (('a list *'b list), 'e) result
+  = fun list -> match list with 
+    | Ok list -> Ok (List.split list)
+    | Error e ->  Error e
              
 (** Unwraps a result. *)
 let unwrap = function

--- a/src/utils/Res.mli
+++ b/src/utils/Res.mli
@@ -64,6 +64,9 @@ val seq_: (unit, 'e) result list -> (unit, 'e) result
 val ifM: (bool, 'e) result -> ('a, 'e) result -> ('a, 'e) result -> ('a, 'e) result  
 (** This is an if .. then .. else lifted in monadic world *)
 
+val splitM: (('a * 'b) list, 'e) result -> ('a list * 'b list, 'e) result
+(** List.split, lifted to the monadic world *)
+
 val guard_with: (bool, 'e) result -> (unit, 'e) result -> (unit, 'e) result
 (** converts a monadic boolean condition into a guard *)
   

--- a/tests/regression/falsifiable/arrays_constructor.lus
+++ b/tests/regression/falsifiable/arrays_constructor.lus
@@ -1,0 +1,11 @@
+node M(const m: int) returns (A: int^3);
+let
+  A = 0^m;
+tel
+
+node N() returns(A: int^3);
+let
+  A = M(2);
+  check A[0] = 0;
+  --%MAIN;
+tel

--- a/tests/regression/falsifiable/arrays_literal.lus
+++ b/tests/regression/falsifiable/arrays_literal.lus
@@ -1,0 +1,12 @@
+node M(const m: int) returns (A: int^m);
+let
+  A = [1, 2, 3, 4];
+tel
+
+node N() returns(A: int^3);
+  const n = 3;
+let
+  A = M(n);
+  check A[0] = 1;
+  --%MAIN;
+tel

--- a/tests/regression/falsifiable/arrays_record.lus
+++ b/tests/regression/falsifiable/arrays_record.lus
@@ -1,0 +1,9 @@
+const a,b:int;
+
+type T = struct { A: int^a; f: bool };
+
+node N(B: int^b) returns (o: T);
+let
+  o = T { A = B; f=true };
+  check o.A[0]>0;
+tel

--- a/tests/regression/falsifiable/arrays_record2.lus
+++ b/tests/regression/falsifiable/arrays_record2.lus
@@ -1,0 +1,9 @@
+const a:int;
+
+type T = struct { A: int^a; f: bool };
+
+node N(x: T) returns (o: T);
+let
+  o = x;
+  check o.A[0]>0;
+tel

--- a/tests/regression/falsifiable/arrays_record3.lus
+++ b/tests/regression/falsifiable/arrays_record3.lus
@@ -1,0 +1,14 @@
+const a,b:int;
+
+type T = struct { A: int^a; f: bool };
+
+node N(x: T) returns (o: T);
+let
+  o = M();
+  check o.A[0]>0;
+tel
+
+node M () returns (o: T);
+let
+
+tel

--- a/tests/regression/falsifiable/arrays_tuple.lus
+++ b/tests/regression/falsifiable/arrays_tuple.lus
@@ -1,0 +1,7 @@
+const a: int;
+
+node N(x: [int^(3), bool]) returns (o: [int^(a + 3 - a), bool]);
+let
+  o = x;
+  check o.%0[0]>0;
+tel

--- a/tests/regression/success/arrays_basic.lus
+++ b/tests/regression/success/arrays_basic.lus
@@ -1,0 +1,4 @@
+node N(x: int^3) returns (o: int^3);
+let
+  o = x;
+tel

--- a/tests/regression/success/arrays_call.lus
+++ b/tests/regression/success/arrays_call.lus
@@ -1,0 +1,10 @@
+node M(const m: int; A: int^m) returns (B: int^m);
+let
+tel
+
+node N(A: int^3) returns (B: int^3);
+let
+  B = M(3, A);
+  check B[0] = 1 or B[0] <> 1;
+  --%MAIN;
+tel

--- a/tests/regression/success/arrays_call_double_nested.lus
+++ b/tests/regression/success/arrays_call_double_nested.lus
@@ -1,0 +1,18 @@
+node P(const n: int; A: int^n) returns (B: int^(n-1);); 
+let
+tel
+
+node Q(const n: int; A: int^n) returns (B: int^(n-1);); 
+let
+tel
+
+node M(const m: int; const n: int; A: int^m; B: int^n) returns (E: int^m; F: int^n);
+let
+tel
+
+node N(A: int^2; B: int^5) returns (C: int^2; D: int^3);
+let
+  C,D = M(2, 3, A, P(4, Q(5, B)));
+  check C[0] = 1 or C[0] <> 1;
+  --%MAIN;
+tel

--- a/tests/regression/success/arrays_call_double_nested2.lus
+++ b/tests/regression/success/arrays_call_double_nested2.lus
@@ -1,0 +1,18 @@
+node P(const n: int; A: int^n; B: int^(n-1)) returns (C: int^(n-1);); 
+let
+tel
+
+node Q(const n: int; A: int^n) returns (B: int^(n-1); C:int^(n-2);); 
+let
+tel
+
+node M(const m: int; const n: int; A: int^m; B: int^n) returns (E: int^m; F: int^n);
+let
+tel
+
+node N(A: int^2; B: int^5) returns (C: int^2; D: int^3);
+let
+  C,D = M(2, 3, A, P(4, Q(5, B)));
+  check C[0] = 1 or C[0] <> 1;
+  --%MAIN;
+tel

--- a/tests/regression/success/arrays_call_len_expr.lus
+++ b/tests/regression/success/arrays_call_len_expr.lus
@@ -1,0 +1,11 @@
+node M(const m: int; const n: int; A: int^(m+n)) returns (B: int^m);
+let
+
+tel
+
+node N(A: int^5) returns (B: int^3);
+let
+  B = M(3, 2, A);
+  check B[0] = 1 or B[0] <> 1;
+  --%MAIN;
+tel

--- a/tests/regression/success/arrays_call_mult.lus
+++ b/tests/regression/success/arrays_call_mult.lus
@@ -1,0 +1,15 @@
+node P(const m: int; A: int^m) returns (y: int);
+let
+tel
+
+node M(const m: int; const n: int; A: int^m; B: int^n) returns (E: int^m; F: int^n);
+let
+tel
+
+node N(A: int^2; B: int^3) returns (C: int^2; D: int^3; y: int);
+let
+  C,D = M(2, 3, A, B);
+  y = P(2, A);
+  check C[0] = 1 or C[0] <> 1;
+  --%MAIN;
+tel

--- a/tests/regression/success/arrays_call_nested.lus
+++ b/tests/regression/success/arrays_call_nested.lus
@@ -1,0 +1,14 @@
+node P(const n: int) returns (B: int^(n-1););
+let
+tel
+
+node M(const m: int; const n: int; A: int^m; B: int^n) returns (E: int^m; F: int^n);
+let
+tel
+
+node N(A: int^2; B: int^3) returns (C: int^2; D: int^3);
+let
+  C,D = M(2, 3, A, P(4));
+  check C[0] = 1 or C[0] <> 1; 
+  --%MAIN;
+tel

--- a/tests/regression/success/arrays_const.lus
+++ b/tests/regression/success/arrays_const.lus
@@ -1,0 +1,10 @@
+const a:int;
+
+node N() returns (o: int^(-1 + a + 1));
+let
+  o = M();
+tel
+
+node M () returns (A: int^(a + 0));
+let
+tel

--- a/tests/regression/success/arrays_multidimensional.lus
+++ b/tests/regression/success/arrays_multidimensional.lus
@@ -1,0 +1,11 @@
+node M(const m: int; const n: int) returns (A: int^m^n);
+let
+  A = [[5, 6], [5, 6], [5, 6]];
+tel
+
+node N() returns(A: int^2^3);
+let
+  A = M(2, 3);
+  check A[0][0] = 5;
+  --%MAIN;
+tel

--- a/tests/regression/success/arrays_multidimensional2.lus
+++ b/tests/regression/success/arrays_multidimensional2.lus
@@ -1,0 +1,11 @@
+node M(const m: int; const n: int) returns (A: int^m^n);
+let
+  A = 0^2^3;
+tel
+
+node N() returns(A: int^2^3);
+let
+  A = M(2, 3);
+  check A[0][0] = 0;
+  --%MAIN;
+tel

--- a/tests/regression/success/arrays_multidimensional3.lus
+++ b/tests/regression/success/arrays_multidimensional3.lus
@@ -1,0 +1,11 @@
+node M(const m: int; const n: int) returns (A: [int^m^n, int]);
+let
+  A = {0^2^3, 0};
+tel
+
+node N() returns(A: [int^2^3, int]);
+let
+  A = M(2, 3);
+  check A.%1 = 0;
+  --%MAIN;
+tel


### PR DESCRIPTION
Generate array length constraints in the type checker, and then generate associated properties later in the pipeline