### PR TITLE
Define undefined variables with any operators

### DIFF
--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -739,6 +739,15 @@ let rec vars_of_struct_item = function
   | ArraySliceStructItem (_, i, _)
   | ArrayDef (_, i, _) -> SI.singleton i
 
+let rec vars_of_type = function 
+  | ArrayType (_, (ty, e)) -> SI.union (vars_of_type ty) (vars_without_node_call_ids e)
+  | TupleType (_, tys) | GroupType (_, tys) -> 
+    List.fold_left SI.union SI.empty (List.map vars_of_type tys)
+  | RecordType (_, _, tis) -> 
+    let vars = List.map (fun (_, _, ty) -> vars_of_type ty) tis in 
+    List.fold_left SI.union SI.empty vars
+  | Int _ | Int8 _ | Int16 _ | Int32 _ | Int64 _ | UInt8 _ | UInt16 _ | UInt32 _ | UInt64 _ | Bool _ 
+  | TVar _ | IntRange _ | Real _ | UserType _ | AbstractType _ | EnumType _ | History _ | TArr _ -> SI.empty
 
 let rec defined_vars_with_pos = function
   | Body (Equation (_, StructDef (_, ss), _)) -> List.flatten (List.map vars_of_struct_item_with_pos ss)

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -92,6 +92,9 @@ val vars_without_node_call_ids: expr -> SI.t
 (** [vars_without_node_call_ids e] returns all variable identifiers that appear in the expression [e]
     while excluding node call identifiers *)
 
+val calls_of_expr: expr -> SI.t 
+(** [calls_of_expr e] returns all node/function names for those nodes/functions called in [e] *)
+
 val vars_of_type: lustre_type -> SI.t
 (** [vars_of_type ty] returns all variable identifiers that appear in the type [ty]
     while excluding node call identifiers and refinement type bound variables *)

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -92,6 +92,10 @@ val vars_without_node_call_ids: expr -> SI.t
 (** [vars_without_node_call_ids e] returns all variable identifiers that appear in the expression [e]
     while excluding node call identifiers *)
 
+val vars_of_type: lustre_type -> SI.t
+(** [vars_of_type ty] returns all variable identifiers that appear in the type [ty]
+    while excluding node call identifiers and refinement type bound variables *)
+
 val vars_of_struct_item_with_pos: struct_item -> (Lib.position * index) list
 (** returns all variables that appear in a [struct_item] (the lhs of an equation) with associated positions *)
 

--- a/src/lustre/lustreDesugarAnyOps.ml
+++ b/src/lustre/lustreDesugarAnyOps.ml
@@ -67,7 +67,7 @@ fun global_ctx ctx node_name ->
     ) inputs in
     let name = mk_fresh_fn_name pos node_name in
     let generated_node = 
-      A.NodeDecl (span, 
+      A.FuncDecl (span, 
       (name, true, [], inputs, 
       [pos, id, ty, A.ClockTrue], [], [], Some contract)) 
     in

--- a/src/lustre/lustreDesugarAnyOps.ml
+++ b/src/lustre/lustreDesugarAnyOps.ml
@@ -67,7 +67,7 @@ fun global_ctx ctx node_name ->
     ) inputs in
     let name = mk_fresh_fn_name pos node_name in
     let generated_node = 
-      A.FuncDecl (span, 
+      A.NodeDecl (span, 
       (name, true, [], inputs, 
       [pos, id, ty, A.ClockTrue], [], [], Some contract)) 
     in

--- a/src/lustre/lustreDesugarAnyOps.ml
+++ b/src/lustre/lustreDesugarAnyOps.ml
@@ -1,18 +1,18 @@
 (* This file is part of the Kind 2 model checker.
 
-  Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
 
-  Licensed under the Apache License, Version 2.0 (the "License"); you
-  may not use this file except in compliance with the License.  You
-  may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0 
+   http://www.apache.org/licenses/LICENSE-2.0 
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-  implied. See the License for the specific language governing
-  permissions and limitations under the License. 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
 *)
 
 module A = LustreAst
@@ -191,38 +191,38 @@ fun global_ctx ctx node_name ->
 let desugar_contract: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> A.contract_node_equation list option -> A.contract_node_equation list option * A.declaration list =
 fun global_ctx ctx node_name contract -> 
   match contract with 
-    | Some contract_items -> 
-      let items, gen_nodes = (List.map (desugar_contract_item global_ctx ctx node_name) contract_items) |> List.split in
-      Some items, List.flatten gen_nodes
-    | None -> None, []
+  | Some contract_items -> 
+    let items, gen_nodes = (List.map (desugar_contract_item global_ctx ctx node_name) contract_items) |> List.split in
+    Some items, List.flatten gen_nodes
+  | None -> None, []
 
 let rec desugar_node_item: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> A.node_item -> A.node_item * A.declaration list =
 fun global_ctx ctx node_name ni ->
   match ni with
-    | A.Body (Equation (pos, lhs, rhs)) -> 
-      let rhs, gen_nodes = desugar_expr global_ctx ctx node_name rhs in 
-      A.Body (Equation (pos, lhs, rhs)), gen_nodes
-    | AnnotProperty (pos, name, e, k) -> 
-      let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
-      AnnotProperty(pos, name, e, k), gen_nodes
-    | IfBlock (pos, cond, nis1, nis2) -> 
-      let nis1, gen_nodes1 = List.map (desugar_node_item global_ctx ctx node_name) nis1 |> List.split in
-      let nis2, gen_nodes2 = List.map (desugar_node_item global_ctx ctx node_name) nis2 |> List.split in
-      let cond, gen_nodes3 = desugar_expr global_ctx ctx node_name cond in
-      A.IfBlock (pos, cond, nis1, nis2), List.flatten gen_nodes1 @ List.flatten gen_nodes2 @ gen_nodes3
-    | FrameBlock (pos, vars, nes, nis) -> 
-      let nes = List.map (fun x -> A.Body x) nes in
-      let nes, gen_nodes1 = List.map (desugar_node_item global_ctx ctx node_name) nes |> List.split in
-      let nes = List.map (fun ne -> match ne with
-        | A.Body (A.Equation _ as eq) -> eq
-        | _ -> assert false
-      ) nes in
-      let nis, gen_nodes2 = List.map (desugar_node_item global_ctx ctx node_name) nis |> List.split in
-      FrameBlock(pos, vars, nes, nis), List.flatten gen_nodes1 @ List.flatten gen_nodes2
-    | Body (Assert (pos, e)) ->
-      let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
-      Body (Assert (pos, e)), gen_nodes
-    | AnnotMain _ -> ni, []
+  | A.Body (Equation (pos, lhs, rhs)) -> 
+    let rhs, gen_nodes = desugar_expr global_ctx ctx node_name rhs in 
+    A.Body (Equation (pos, lhs, rhs)), gen_nodes
+  | AnnotProperty (pos, name, e, k) -> 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+    AnnotProperty(pos, name, e, k), gen_nodes
+  | IfBlock (pos, cond, nis1, nis2) -> 
+    let nis1, gen_nodes1 = List.map (desugar_node_item global_ctx ctx node_name) nis1 |> List.split in
+    let nis2, gen_nodes2 = List.map (desugar_node_item global_ctx ctx node_name) nis2 |> List.split in
+    let cond, gen_nodes3 = desugar_expr global_ctx ctx node_name cond in
+    A.IfBlock (pos, cond, nis1, nis2), List.flatten gen_nodes1 @ List.flatten gen_nodes2 @ gen_nodes3
+  | FrameBlock (pos, vars, nes, nis) -> 
+    let nes = List.map (fun x -> A.Body x) nes in
+    let nes, gen_nodes1 = List.map (desugar_node_item global_ctx ctx node_name) nes |> List.split in
+    let nes = List.map (fun ne -> match ne with
+      | A.Body (A.Equation _ as eq) -> eq
+      | _ -> assert false
+    ) nes in
+    let nis, gen_nodes2 = List.map (desugar_node_item global_ctx ctx node_name) nis |> List.split in
+    FrameBlock(pos, vars, nes, nis), List.flatten gen_nodes1 @ List.flatten gen_nodes2
+  | Body (Assert (pos, e)) ->
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+    Body (Assert (pos, e)), gen_nodes
+  | AnnotMain _ -> ni, []
 
 let define_output: A.clocked_typed_decl -> A.node_item = 
 fun output ->

--- a/src/lustre/lustreDesugarAnyOps.ml
+++ b/src/lustre/lustreDesugarAnyOps.ml
@@ -1,260 +1,309 @@
 (* This file is part of the Kind 2 model checker.
 
-   Copyright (c) 2022 by the Board of Trustees of the University of Iowa
+  Copyright (c) 2022 by the Board of Trustees of the University of Iowa
 
-   Licensed under the Apache License, Version 2.0 (the "License"); you
-   may not use this file except in compliance with the License.  You
-   may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License"); you
+  may not use this file except in compliance with the License.  You
+  may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0 
+  http://www.apache.org/licenses/LICENSE-2.0 
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied. See the License for the specific language governing
-   permissions and limitations under the License. 
- *)
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied. See the License for the specific language governing
+  permissions and limitations under the License. 
+*)
 
- module A = LustreAst
- module Ctx = TypeCheckerContext
- module Chk = LustreTypeChecker
- module AH = LustreAstHelpers
- 
- (* [i] is module state used to guarantee newly created identifiers are unique *)
- let i = ref 0
- 
- let mk_fresh_fn_name pos node_name =
-   i := !i + 1;
-   let node_name = HString.concat2 node_name (HString.mk_hstring ".") in
-   let pos = Lib.string_of_t Lib.pp_print_line_and_column pos in
-   let pos = String.sub pos 1 (String.length pos - 2) |> HString.mk_hstring in
-   let name = (HString.mk_hstring "any_") in
-   let name = HString.concat2 name pos in
-   HString.concat2 node_name name
- 
- let rec desugar_expr ctx node_name = function
-   | A.AnyOp (pos, (_, id, ty), expr1, expr2_opt) -> 
-     let span = { A.start_pos = pos; A.end_pos = Lib.dummy_pos } in
-     let contract = match expr2_opt with 
-       | None -> [A.Guarantee (AH.pos_of_expr expr1, None, false, expr1)]
-       | Some expr2 -> [A.Assume (AH.pos_of_expr expr2, None, false, expr2);
-                        A.Guarantee (AH.pos_of_expr expr1, None, false, expr1)] 
-     in
-     let inputs =
-       let vars_of_expr1 = AH.vars_without_node_call_ids expr1 in
-       match expr2_opt with
-       | None -> Ctx.SI.elements (Ctx.SI.diff vars_of_expr1 (Ctx.SI.singleton id))
-       | Some expr2 ->
-         let vars_of_expr1_and_expr2 =
-           Ctx.SI.union vars_of_expr1 (AH.vars_without_node_call_ids expr2)
-         in
-         Ctx.SI.elements (Ctx.SI.diff vars_of_expr1_and_expr2 (Ctx.SI.singleton id))
-     in
-     (* Constants don't need to be passed as a parameter to generated node *)
-     let inputs = List.filter (fun i -> not (Ctx.member_val ctx i)) inputs in 
-     let inputs_call = List.map (fun str -> A.Ident (pos, str)) inputs in
-     let ctx = Ctx.add_ty ctx id ty in
-     let inputs = List.map (fun input -> (pos, input, Ctx.lookup_ty ctx input, A.ClockTrue)) inputs in
-     let inputs = List.map (fun (p, inp, opt, cl) -> match opt with 
-       | Some ty -> p, inp, ty, cl, false 
-       | None -> assert false
-     ) inputs in
-     let name = mk_fresh_fn_name pos node_name in
-     let generated_node = 
-       A.NodeDecl (span, 
-       (name, true, [], inputs, 
-       [pos, id, ty, A.ClockTrue], [], [], Some contract)) 
-     in
-     A.Call(pos, name, inputs_call), [generated_node]
- 
-   | Ident _ as e -> e, []
-   | ModeRef (_, _) as e -> e, []
-   | Const (_, _) as e -> e, []
-   | RecordProject (pos, e, idx) -> 
-     let e, gen_nodes = desugar_expr ctx node_name e in
-     RecordProject (pos, e, idx), gen_nodes
-   | TupleProject (pos, e, idx) -> 
-     let e, gen_nodes = desugar_expr ctx node_name e in
-     TupleProject (pos, e, idx), gen_nodes
-   | UnaryOp (pos, op, e) -> 
-     let e, gen_nodes = desugar_expr ctx node_name e in
-     UnaryOp (pos, op, e), gen_nodes
-   | BinaryOp (pos, op, e1, e2) ->
-     let e1, gen_nodes1 = desugar_expr ctx node_name e1 in
-     let e2, gen_nodes2 = desugar_expr ctx node_name e2 in
-     BinaryOp (pos, op, e1, e2), gen_nodes1 @ gen_nodes2
-   | TernaryOp (pos, op, e1, e2, e3) ->
-     let e1, gen_nodes1 = desugar_expr ctx node_name e1 in
-     let e2, gen_nodes2 = desugar_expr ctx node_name e2 in
-     let e3, gen_nodes3 = desugar_expr ctx node_name e3 in
-     TernaryOp (pos, op, e1, e2, e3), gen_nodes1 @ gen_nodes2 @ gen_nodes3
-   | ConvOp (pos, op, e) -> 
-     let e, gen_nodes = desugar_expr ctx node_name e in
-     ConvOp (pos, op, e), gen_nodes
-   | CompOp (pos, op, e1, e2) ->
-     let e1, gen_nodes1 = desugar_expr ctx node_name e1 in
-     let e2, gen_nodes2 = desugar_expr ctx node_name e2 in
-     CompOp (pos, op, e1, e2), gen_nodes1 @ gen_nodes2
-   | RecordExpr (pos, ident, expr_list) ->
-     let id_list, exprs_gen_nodes = 
-       List.map (fun (i, e) -> (i, (desugar_expr ctx node_name) e)) expr_list |> List.split 
-     in
-     let expr_list, gen_nodes = List.split exprs_gen_nodes in
-     RecordExpr (pos, ident, List.combine id_list expr_list), List.flatten gen_nodes
-   | GroupExpr (pos, kind, expr_list) ->
-     let expr_list, gen_nodes = List.map (desugar_expr ctx node_name) expr_list |> List.split in
-     GroupExpr (pos, kind, expr_list), List.flatten gen_nodes
-   | StructUpdate (pos, e1, idx, e2) ->
-     let e1, gen_nodes1 = desugar_expr ctx node_name e1 in
-     let e2, gen_nodes2 = desugar_expr ctx node_name e2 in
-     StructUpdate (pos, e1, idx, e2), gen_nodes1 @ gen_nodes2
-   | ArrayConstr (pos, e1, e2) ->
-     let e1, gen_nodes1 = desugar_expr ctx node_name e1 in
-     let e2, gen_nodes2 = desugar_expr ctx node_name e2 in
-     ArrayConstr (pos, e1, e2), gen_nodes1 @ gen_nodes2
-   | ArrayIndex (pos, e1, e2) ->
-     let e1, gen_nodes1 = desugar_expr ctx node_name e1 in
-     let e2, gen_nodes2 = desugar_expr ctx node_name e2 in
-     ArrayIndex (pos, e1, e2), gen_nodes1 @ gen_nodes2
-   | Quantifier (pos, kind, idents, e) ->
-     let e, gen_nodes = desugar_expr ctx node_name e in
-     Quantifier (pos, kind, idents, e), gen_nodes
-   | When (pos, e, clock) -> 
-     let e, gen_nodes = desugar_expr ctx node_name e in
-     When (pos, e, clock), gen_nodes
-   | Condact (pos, e1, e2, id, expr_list1, expr_list2) ->
-     let e1, gen_nodes1 = desugar_expr ctx node_name e1 in
-     let e2, gen_nodes2 = desugar_expr ctx node_name e2 in
-     let expr_list1, gen_nodes3 = List.map (desugar_expr ctx node_name) expr_list1 |> List.split in
-     let expr_list2, gen_nodes4 = List.map (desugar_expr ctx node_name) expr_list2 |> List.split in
-     Condact (pos, e1, e2, id, expr_list1, expr_list2), gen_nodes1 @ gen_nodes2 @ 
-                                                       List.flatten gen_nodes3 @ List.flatten gen_nodes4
-   | Activate (pos, ident, e1, e2, expr_list) ->
-     let e1, gen_nodes1 = desugar_expr ctx node_name e1 in
-     let e2, gen_nodes2 = desugar_expr ctx node_name e2 in
-     Activate (pos, ident, e1, e2, expr_list), gen_nodes1 @ gen_nodes2
-   | Merge (pos, ident, expr_list) ->
-     let id_list, exprs_gen_nodes = 
-       List.map (fun (i, e) -> (i, (desugar_expr ctx node_name) e)) expr_list |> List.split 
-     in
-     let expr_list, gen_nodes = List.split exprs_gen_nodes in
-     Merge (pos, ident, List.combine id_list expr_list), List.flatten gen_nodes
-   | RestartEvery (pos, ident, expr_list, e) ->
-     let expr_list, gen_nodes1 = List.map (desugar_expr ctx node_name) expr_list |> List.split in
-     let e, gen_nodes2 = desugar_expr ctx node_name e in
-     RestartEvery (pos, ident, expr_list, e), List.flatten gen_nodes1 @ gen_nodes2
-   | Pre (pos, e) -> 
-     let e, gen_nodes = desugar_expr ctx node_name e in
-     Pre (pos, e), gen_nodes
-   | Arrow (pos, e1, e2) -> 
-     let e1, gen_nodes1 = desugar_expr ctx node_name e1 in
-     let e2, gen_nodes2 = desugar_expr ctx node_name e2 in
-     Arrow (pos, e1, e2), gen_nodes1 @ gen_nodes2
-   | Call (pos, id, expr_list) ->
-     let expr_list, gen_nodes = List.map (desugar_expr ctx node_name) expr_list |> List.split in
-     Call (pos, id, expr_list), List.flatten gen_nodes
+module A = LustreAst
+module Ctx = TypeCheckerContext
+module Chk = LustreTypeChecker
+module AH = LustreAstHelpers
 
- let desugar_contract_item ctx node_name ci = 
-    match ci with 
-      | A.GhostVars (pos, lhs, e) -> 
-        let e, gen_nodes = desugar_expr ctx node_name e in 
-        A.GhostVars (pos, lhs, e), gen_nodes
-      | Assume (pos, name, b, e) ->
-        let e, gen_nodes = desugar_expr ctx node_name e in 
-        Assume (pos, name, b, e), gen_nodes
-      | Guarantee (pos, name, b, e) -> 
-        let e, gen_nodes = desugar_expr ctx node_name e in 
-        Guarantee (pos, name, b, e), gen_nodes
-      | Mode (pos, i, reqs, enss) ->
-        let (reqs, gen_nodes1) = 
-          List.map (fun (pos, id, expr) -> (pos, id, desugar_expr ctx node_name expr)) reqs |> 
-          List.map (fun (pos, id, (expr, decls)) -> ((pos, id, expr), decls)) |> 
-          List.split in 
-        let (enss, gen_nodes2) = 
-          List.map (fun (pos, id, expr) -> (pos, id, desugar_expr ctx node_name expr)) enss |> 
-          List.map (fun (pos, id, (expr, decls)) -> ((pos, id, expr), decls)) |> 
-          List.split in 
-        Mode (pos, i, reqs, enss), (List.flatten gen_nodes1) @ (List.flatten gen_nodes2)
-      | ContractCall (pos, i, exprs, ids) -> 
-        let (exprs, gen_nodes) = List.map (desugar_expr ctx node_name) exprs |> List.split in 
-        ContractCall (pos, i, exprs, ids), List.flatten gen_nodes
-      | GhostConst _ 
-      | AssumptionVars _ -> ci, []
+(* [i] is module state used to guarantee newly created identifiers are unique *)
+let i = ref 0
 
-  let desugar_contract ctx node_name contract = 
-    match contract with 
-      | Some contract_items -> 
-        let items, gen_nodes = (List.map (desugar_contract_item ctx node_name) contract_items) |> List.split in
-        Some items, List.flatten gen_nodes
-      | None -> None, []
- 
- let rec desugar_node_item ctx node_name ni =
-   match ni with
-     | A.Body (Equation (pos, lhs, rhs)) -> 
-       let rhs, gen_nodes = desugar_expr ctx node_name rhs in 
-       A.Body (Equation (pos, lhs, rhs)), gen_nodes
-     | AnnotProperty (pos, name, e, k) -> 
-       let e, gen_nodes = desugar_expr ctx node_name e in 
-       AnnotProperty(pos, name, e, k), gen_nodes
-     | IfBlock (pos, cond, nis1, nis2) -> 
-       let nis1, gen_nodes1 = List.map (desugar_node_item ctx node_name) nis1 |> List.split in
-       let nis2, gen_nodes2 = List.map (desugar_node_item ctx node_name) nis2 |> List.split in
-       let cond, gen_nodes3 = desugar_expr ctx node_name cond in
-       A.IfBlock (pos, cond, nis1, nis2), List.flatten gen_nodes1 @ List.flatten gen_nodes2 @ gen_nodes3
-     | FrameBlock (pos, vars, nes, nis) -> 
-       let nes = List.map (fun x -> A.Body x) nes in
-       let nes, gen_nodes1 = List.map (desugar_node_item ctx node_name) nes |> List.split in
-       let nes = List.map (fun ne -> match ne with
-         | A.Body (A.Equation _ as eq) -> eq
-         | _ -> assert false
-       ) nes in
-       let nis, gen_nodes2 = List.map (desugar_node_item ctx node_name) nis |> List.split in
-       FrameBlock(pos, vars, nes, nis), List.flatten gen_nodes1 @ List.flatten gen_nodes2
-     | Body (Assert (pos, e)) ->
-       let e, gen_nodes = desugar_expr ctx node_name e in 
-       Body (Assert (pos, e)), gen_nodes
-     | AnnotMain _ -> ni, []
-     
- 
- let desugar_any_ops ctx decls = 
-   let decls =
-   List.fold_left (fun decls decl ->
-     match decl with
-      | A.NodeDecl (span, ((id, ext, params, inputs, outputs, locals, items, contract) as d)) -> 
+let mk_fresh_fn_name: Lib.position -> HString.t -> HString.t = 
+fun pos node_name ->
+  i := !i + 1;
+  let node_name = HString.concat2 node_name (HString.mk_hstring ".") in
+  let pos = Lib.string_of_t Lib.pp_print_line_and_column pos in
+  let pos = String.sub pos 1 (String.length pos - 2) |> HString.mk_hstring in
+  let name = (HString.mk_hstring "any_") in
+  let name = HString.concat2 name pos in
+  HString.concat2 node_name name
+
+let rec desugar_expr: Ctx.tc_context -> Ctx.tc_context -> HString.t -> A.expr -> A.expr * A.declaration list =
+fun global_ctx ctx node_name -> 
+  function
+  | A.AnyOp (pos, (_, id, ty), expr1, expr2_opt) -> 
+    let span = { A.start_pos = pos; A.end_pos = Lib.dummy_pos } in
+    let contract = match expr2_opt with 
+      | None -> [A.Guarantee (AH.pos_of_expr expr1, None, false, expr1)]
+      | Some expr2 -> [A.Assume (AH.pos_of_expr expr2, None, false, expr2);
+                      A.Guarantee (AH.pos_of_expr expr1, None, false, expr1)] 
+    in
+    let inputs =
+      let vars_of_expr1 = AH.vars_without_node_call_ids expr1 in
+      let vars_of_exprs = match expr2_opt with
+      | None -> (Ctx.SI.diff vars_of_expr1 (Ctx.SI.singleton id))
+      | Some expr2 ->
+        let vars_of_expr1_and_expr2 =
+          Ctx.SI.union vars_of_expr1 (AH.vars_without_node_call_ids expr2)
+        in
+        (Ctx.SI.diff vars_of_expr1_and_expr2 (Ctx.SI.singleton id)) in 
+      Ctx.SI.union vars_of_exprs (AH.vars_of_type ty) |> Ctx.SI.elements
+    in
+    (* Global constants don't need to be passed as a parameter to generated node *)
+    let inputs = List.filter (fun i -> not (Ctx.member_val global_ctx i)) inputs in 
+    let inputs_call = List.map (fun str -> A.Ident (pos, str)) inputs in
+    let ctx = Ctx.add_ty ctx id ty in
+    let inputs = List.map (fun input -> (pos, input, Ctx.lookup_ty ctx input, A.ClockTrue)) inputs in
+    let inputs = List.map (fun (p, inp, opt, cl) -> match opt with 
+      | Some ty -> 
+        let is_const = match Ctx.lookup_const ctx inp with | Some _ -> true | None -> false in
+        p, inp, ty, cl, is_const 
+      | None -> assert false
+    ) inputs in
+    let name = mk_fresh_fn_name pos node_name in
+    let generated_node = 
+      A.NodeDecl (span, 
+      (name, true, [], inputs, 
+      [pos, id, ty, A.ClockTrue], [], [], Some contract)) 
+    in
+    A.Call(pos, name, inputs_call), [generated_node]
+
+  | Ident _ as e -> e, []
+  | ModeRef (_, _) as e -> e, []
+  | Const (_, _) as e -> e, []
+  | RecordProject (pos, e, idx) -> 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    RecordProject (pos, e, idx), gen_nodes
+  | TupleProject (pos, e, idx) -> 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    TupleProject (pos, e, idx), gen_nodes
+  | UnaryOp (pos, op, e) -> 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    UnaryOp (pos, op, e), gen_nodes
+  | BinaryOp (pos, op, e1, e2) ->
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    BinaryOp (pos, op, e1, e2), gen_nodes1 @ gen_nodes2
+  | TernaryOp (pos, op, e1, e2, e3) ->
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    let e3, gen_nodes3 = desugar_expr global_ctx ctx node_name e3 in
+    TernaryOp (pos, op, e1, e2, e3), gen_nodes1 @ gen_nodes2 @ gen_nodes3
+  | ConvOp (pos, op, e) -> 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    ConvOp (pos, op, e), gen_nodes
+  | CompOp (pos, op, e1, e2) ->
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    CompOp (pos, op, e1, e2), gen_nodes1 @ gen_nodes2
+  | RecordExpr (pos, ident, expr_list) ->
+    let id_list, exprs_gen_nodes = 
+      List.map (fun (i, e) -> (i, (desugar_expr global_ctx ctx node_name) e)) expr_list |> List.split 
+    in
+    let expr_list, gen_nodes = List.split exprs_gen_nodes in
+    RecordExpr (pos, ident, List.combine id_list expr_list), List.flatten gen_nodes
+  | GroupExpr (pos, kind, expr_list) ->
+    let expr_list, gen_nodes = List.map (desugar_expr global_ctx ctx node_name) expr_list |> List.split in
+    GroupExpr (pos, kind, expr_list), List.flatten gen_nodes
+  | StructUpdate (pos, e1, idx, e2) ->
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    StructUpdate (pos, e1, idx, e2), gen_nodes1 @ gen_nodes2
+  | ArrayConstr (pos, e1, e2) ->
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    ArrayConstr (pos, e1, e2), gen_nodes1 @ gen_nodes2
+  | ArrayIndex (pos, e1, e2) ->
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    ArrayIndex (pos, e1, e2), gen_nodes1 @ gen_nodes2
+  | Quantifier (pos, kind, idents, e) ->
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    Quantifier (pos, kind, idents, e), gen_nodes
+  | When (pos, e, clock) -> 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    When (pos, e, clock), gen_nodes
+  | Condact (pos, e1, e2, id, expr_list1, expr_list2) ->
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    let expr_list1, gen_nodes3 = List.map (desugar_expr global_ctx ctx node_name) expr_list1 |> List.split in
+    let expr_list2, gen_nodes4 = List.map (desugar_expr global_ctx ctx node_name) expr_list2 |> List.split in
+    Condact (pos, e1, e2, id, expr_list1, expr_list2), gen_nodes1 @ gen_nodes2 @ 
+                                                      List.flatten gen_nodes3 @ List.flatten gen_nodes4
+  | Activate (pos, ident, e1, e2, expr_list) ->
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    Activate (pos, ident, e1, e2, expr_list), gen_nodes1 @ gen_nodes2
+  | Merge (pos, ident, expr_list) ->
+    let id_list, exprs_gen_nodes = 
+      List.map (fun (i, e) -> (i, (desugar_expr global_ctx ctx node_name) e)) expr_list |> List.split 
+    in
+    let expr_list, gen_nodes = List.split exprs_gen_nodes in
+    Merge (pos, ident, List.combine id_list expr_list), List.flatten gen_nodes
+  | RestartEvery (pos, ident, expr_list, e) ->
+    let expr_list, gen_nodes1 = List.map (desugar_expr global_ctx ctx node_name) expr_list |> List.split in
+    let e, gen_nodes2 = desugar_expr global_ctx ctx node_name e in
+    RestartEvery (pos, ident, expr_list, e), List.flatten gen_nodes1 @ gen_nodes2
+  | Pre (pos, e) -> 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    Pre (pos, e), gen_nodes
+  | Arrow (pos, e1, e2) -> 
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    Arrow (pos, e1, e2), gen_nodes1 @ gen_nodes2
+  | Call (pos, id, expr_list) ->
+    let expr_list, gen_nodes = List.map (desugar_expr global_ctx ctx node_name) expr_list |> List.split in
+    Call (pos, id, expr_list), List.flatten gen_nodes
+
+let desugar_contract_item: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> A.contract_node_equation -> A.contract_node_equation * A.declaration list =
+fun global_ctx ctx node_name ->
+  function
+  | A.GhostVars (pos, lhs, e) -> 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+    A.GhostVars (pos, lhs, e), gen_nodes
+  | Assume (pos, name, b, e) ->
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+    Assume (pos, name, b, e), gen_nodes
+  | Guarantee (pos, name, b, e) -> 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+    Guarantee (pos, name, b, e), gen_nodes
+  | Mode (pos, i, reqs, enss) ->
+    let (reqs, gen_nodes1) = 
+      List.map (fun (pos, id, expr) -> (pos, id, desugar_expr global_ctx ctx node_name expr)) reqs |> 
+      List.map (fun (pos, id, (expr, decls)) -> ((pos, id, expr), decls)) |> 
+      List.split in 
+    let (enss, gen_nodes2) = 
+      List.map (fun (pos, id, expr) -> (pos, id, desugar_expr global_ctx ctx node_name expr)) enss |> 
+      List.map (fun (pos, id, (expr, decls)) -> ((pos, id, expr), decls)) |> 
+      List.split in 
+    Mode (pos, i, reqs, enss), (List.flatten gen_nodes1) @ (List.flatten gen_nodes2)
+  | ContractCall (pos, i, exprs, ids) -> 
+    let (exprs, gen_nodes) = List.map (desugar_expr global_ctx ctx node_name) exprs |> List.split in 
+    ContractCall (pos, i, exprs, ids), List.flatten gen_nodes
+  | GhostConst _ 
+  | AssumptionVars _ as ci -> ci, []
+
+let desugar_contract: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> A.contract_node_equation list option -> A.contract_node_equation list option * A.declaration list =
+fun global_ctx ctx node_name contract -> 
+  match contract with 
+    | Some contract_items -> 
+      let items, gen_nodes = (List.map (desugar_contract_item global_ctx ctx node_name) contract_items) |> List.split in
+      Some items, List.flatten gen_nodes
+    | None -> None, []
+
+let rec desugar_node_item: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> A.node_item -> A.node_item * A.declaration list =
+fun global_ctx ctx node_name ni ->
+  match ni with
+    | A.Body (Equation (pos, lhs, rhs)) -> 
+      let rhs, gen_nodes = desugar_expr global_ctx ctx node_name rhs in 
+      A.Body (Equation (pos, lhs, rhs)), gen_nodes
+    | AnnotProperty (pos, name, e, k) -> 
+      let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+      AnnotProperty(pos, name, e, k), gen_nodes
+    | IfBlock (pos, cond, nis1, nis2) -> 
+      let nis1, gen_nodes1 = List.map (desugar_node_item global_ctx ctx node_name) nis1 |> List.split in
+      let nis2, gen_nodes2 = List.map (desugar_node_item global_ctx ctx node_name) nis2 |> List.split in
+      let cond, gen_nodes3 = desugar_expr global_ctx ctx node_name cond in
+      A.IfBlock (pos, cond, nis1, nis2), List.flatten gen_nodes1 @ List.flatten gen_nodes2 @ gen_nodes3
+    | FrameBlock (pos, vars, nes, nis) -> 
+      let nes = List.map (fun x -> A.Body x) nes in
+      let nes, gen_nodes1 = List.map (desugar_node_item global_ctx ctx node_name) nes |> List.split in
+      let nes = List.map (fun ne -> match ne with
+        | A.Body (A.Equation _ as eq) -> eq
+        | _ -> assert false
+      ) nes in
+      let nis, gen_nodes2 = List.map (desugar_node_item global_ctx ctx node_name) nis |> List.split in
+      FrameBlock(pos, vars, nes, nis), List.flatten gen_nodes1 @ List.flatten gen_nodes2
+    | Body (Assert (pos, e)) ->
+      let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+      Body (Assert (pos, e)), gen_nodes
+    | AnnotMain _ -> ni, []
+
+let define_output: A.clocked_typed_decl -> A.node_item = 
+fun output ->
+  let (pos, id, ty, _) = output in
+  A.Body (Equation (pos, StructDef(pos, [SingleIdent(pos, id)]), 
+                        AnyOp(pos, (pos, id, ty), Const(pos, True), None)))
+
+let is_undefined_output: A.clocked_typed_decl -> A.node_item list -> bool = 
+fun output items -> 
+  (* Search for definition *)
+  let (_, id, _, _) = output in
+  let rec find_def item = match item with 
+    | A.Body (A.Equation (_, StructDef (_, sis), _)) -> 
+      let definition = List.find_opt (fun si -> match si with 
+        | A.SingleIdent (_, id2) -> id = id2
+        | ArrayDef (_, id2, _) -> id = id2
+        | _ -> assert false
+      ) sis in 
+      definition != None
+    | IfBlock (_, _, nes1, nes2) -> 
+      List.map find_def nes1 @ (List.map find_def nes2) 
+      |> List.filter Fun.id |> (fun lst -> List.length lst > 0)
+    | FrameBlock (_, vars, _, _) -> 
+      let definition = List.find_opt (fun (_, id2) -> id = id2) vars in 
+      definition != None
+    | A.Body (Assert _)  | AnnotMain _ | AnnotProperty _ -> false  
+  in
+  let definition = List.find_opt find_def items in 
+  (* If no definition, then output is undefined *)
+  definition = None
+
+  
+let define_undefined_variables: A.clocked_typed_decl list -> A.node_item list -> A.node_item list
+= fun outputs items -> 
+  let items2 = List.map (fun output -> 
+    if is_undefined_output output items then [define_output output] else []
+  ) outputs |> List.flatten in 
+  items @ items2
+
+let desugar_any_ops: Ctx.tc_context -> A.declaration list -> A.declaration list = 
+fun global_ctx decls -> 
+  let decls =
+  List.fold_left (fun decls decl ->
+    match decl with
+    | A.NodeDecl (span, ((id, ext, params, inputs, outputs, locals, items, contract) as d)) -> 
+    (
+      match Chk.get_node_ctx global_ctx d with 
+        | Ok ctx ->
+          let items = if not ext then define_undefined_variables outputs items else items in 
+          let items, gen_nodes = List.map (desugar_node_item global_ctx ctx id) items |> List.split in 
+          let contract, gen_nodes2 = desugar_contract global_ctx ctx id contract in
+          let gen_nodes = List.flatten gen_nodes in
+          decls @ gen_nodes @ gen_nodes2 @ [A.NodeDecl (span, (id, ext, params, inputs, outputs, locals, items, contract))]
+        (* If there is an error in context collection, it will be detected later in type checking *)
+        | Error _ -> decl :: decls
+    )
+    | A.FuncDecl (span, ((id, ext, params, inputs, outputs, locals, items, contract) as d)) -> 
+    (
+      match Chk.get_node_ctx global_ctx d with 
+        | Ok ctx -> 
+          let items = if not ext then define_undefined_variables outputs items else items in 
+          let items, gen_nodes = List.map (desugar_node_item global_ctx ctx id) items |> List.split in 
+          let contract, gen_nodes2 = desugar_contract global_ctx ctx id contract in
+          let gen_nodes = List.flatten gen_nodes in
+          decls @ gen_nodes @ gen_nodes2 @ [A.FuncDecl (span, (id, ext, params, inputs, outputs, locals, items, contract))]
+        (* If there is an error in context collection, it will be detected later in type checking *)
+        | Error _ -> decl :: decls
+    )
+    | A.ContractNodeDecl (span, (id, params, inputs, outputs, contract)) -> 
       (
-        match Chk.get_node_ctx ctx d with 
-          | Ok ctx ->
-            let items, gen_nodes = List.map (desugar_node_item ctx id) items |> List.split in 
-            let contract, gen_nodes2 = desugar_contract ctx id contract in
-            let gen_nodes = List.flatten gen_nodes in
-            decls @ gen_nodes @ gen_nodes2 @ [A.NodeDecl (span, (id, ext, params, inputs, outputs, locals, items, contract))]
-         (* If there is an error in context collection, it will be detected later in type checking *)
-         | Error _ -> decl :: decls
-      )
-      | A.FuncDecl (span, ((id, ext, params, inputs, outputs, locals, items, contract) as d)) -> 
-      (
-        match Chk.get_node_ctx ctx d with 
+        match Chk.get_node_ctx global_ctx (id, (), (), inputs, outputs, [], (), ()) with (* Unit type params are unused in function *)
           | Ok ctx -> 
-            let items, gen_nodes = List.map (desugar_node_item ctx id) items |> List.split in 
-            let contract, gen_nodes2 = desugar_contract ctx id contract in
-            let gen_nodes = List.flatten gen_nodes in
-            decls @ gen_nodes @ gen_nodes2 @ [A.FuncDecl (span, (id, ext, params, inputs, outputs, locals, items, contract))]
-         (* If there is an error in context collection, it will be detected later in type checking *)
+            let contract, gen_nodes = desugar_contract global_ctx ctx id (Some contract) in
+            let contract = match contract with 
+              | Some contract -> contract 
+              | None -> assert false in (* Must have a contract *)
+            decls @ gen_nodes @ [A.ContractNodeDecl (span, (id, params, inputs, outputs, contract))]
+          (* If there is an error in context collection, it will be detected later in type checking *)
           | Error _ -> decl :: decls
       )
-      | A.ContractNodeDecl (span, (id, params, inputs, outputs, contract)) -> 
-        (
-          match Chk.get_node_ctx ctx ((), (), (), inputs, outputs, [], (), ()) with (* Unit type params are unused in function *)
-            | Ok ctx -> 
-              let contract, gen_nodes = desugar_contract ctx id (Some contract) in
-              let contract = match contract with 
-                | Some contract -> contract 
-                | None -> assert false in (* Must have a contract *)
-              decls @ gen_nodes @ [A.ContractNodeDecl (span, (id, params, inputs, outputs, contract))]
-           (* If there is an error in context collection, it will be detected later in type checking *)
-            | Error _ -> decl :: decls
-        )
-      | _ -> decl :: decls
-   ) [] decls in 
+    | _ -> decl :: decls
+  ) [] decls in 
   decls
 

--- a/src/lustre/lustreDesugarAnyOps.ml
+++ b/src/lustre/lustreDesugarAnyOps.ml
@@ -234,32 +234,30 @@ let is_undefined_output: A.clocked_typed_decl -> A.node_item list -> bool =
 fun output items -> 
   (* Search for definition *)
   let (_, id, _, _) = output in
-  let rec find_def item = match item with 
-    | A.Body (A.Equation (_, StructDef (_, sis), _)) -> 
-      let definition = List.find_opt (fun si -> match si with 
+  let rec include_definition_for_id = function
+    | A.Body (A.Equation (_, StructDef (_, sis), _)) ->
+      sis |> List.exists (function
         | A.SingleIdent (_, id2) -> id = id2
         | ArrayDef (_, id2, _) -> id = id2
         | _ -> assert false
-      ) sis in 
-      definition != None
-    | IfBlock (_, _, nes1, nes2) -> 
-      List.map find_def nes1 @ (List.map find_def nes2) 
-      |> List.filter Fun.id |> (fun lst -> List.length lst > 0)
-    | FrameBlock (_, vars, _, _) -> 
-      let definition = List.find_opt (fun (_, id2) -> id = id2) vars in 
-      definition != None
-    | A.Body (Assert _)  | AnnotMain _ | AnnotProperty _ -> false  
+      )
+    | IfBlock (_, _, nes1, nes2) ->
+        List.exists include_definition_for_id nes1 ||
+        List.exists include_definition_for_id nes2
+    | FrameBlock (_, vars, _, _) ->
+      List.exists (fun (_, id2) -> id = id2) vars
+    | A.Body (Assert _)  | AnnotMain _ | AnnotProperty _ -> false
   in
-  let definition = List.find_opt find_def items in 
-  (* If no definition, then output is undefined *)
-  definition = None
+  not (List.exists include_definition_for_id items)
 
   
 let define_undefined_variables: A.clocked_typed_decl list -> A.node_item list -> A.node_item list
 = fun outputs items -> 
-  let items2 = List.map (fun output -> 
-    if is_undefined_output output items then [define_output output] else []
-  ) outputs |> List.flatten in 
+  let items2 =
+    List.fold_left (fun acc output ->
+      if is_undefined_output output items then define_output output :: acc else acc
+    ) [] outputs
+  in
   items @ items2
 
 let desugar_any_ops: Ctx.tc_context -> A.declaration list -> A.declaration list = 

--- a/src/lustre/lustreDesugarAnyOps.ml
+++ b/src/lustre/lustreDesugarAnyOps.ml
@@ -33,8 +33,8 @@ fun pos node_name ->
   let name = HString.concat2 name pos in
   HString.concat2 node_name name
 
-let rec desugar_expr: Ctx.tc_context -> Ctx.tc_context -> HString.t -> A.expr -> A.expr * A.declaration list =
-fun global_ctx ctx node_name -> 
+let rec desugar_expr: Ctx.tc_context -> Ctx.tc_context -> HString.t -> HString.t list -> A.expr -> A.expr * A.declaration list =
+fun global_ctx ctx node_name fun_ids -> 
   function
   | A.AnyOp (pos, (_, id, ty), expr1, expr2_opt) -> 
     let span = { A.start_pos = pos; A.end_pos = Lib.dummy_pos } in
@@ -66,10 +66,27 @@ fun global_ctx ctx node_name ->
       | None -> assert false
     ) inputs in
     let name = mk_fresh_fn_name pos node_name in
+    (* If the any op expressions are temporal or call a node, we generate an imported node. 
+       Otherwise, we generate an imported function. *)
+    let has_pre_arrow_or_node_call = match expr2_opt with 
+      | Some expr2 -> 
+        let node_calls1 = AH.calls_of_expr expr1 |> Ctx.SI.elements |> List.filter (fun i -> not (List.mem i fun_ids)) in 
+        let node_calls2 = AH.calls_of_expr expr2 |> Ctx.SI.elements |> List.filter (fun i -> not (List.mem i fun_ids)) in 
+        (AH.has_pre_or_arrow expr1 != None) || node_calls1 != [] || 
+        (AH.has_pre_or_arrow expr2 != None) || node_calls2 != []
+      | None -> 
+        let node_calls1 = AH.calls_of_expr expr1 |> Ctx.SI.elements |> List.filter (fun i -> not (List.mem i fun_ids)) in 
+        (AH.has_pre_or_arrow expr1 != None) || (node_calls1 != []) 
+    in
     let generated_node = 
-      A.NodeDecl (span, 
-      (name, true, [], inputs, 
-      [pos, id, ty, A.ClockTrue], [], [], Some contract)) 
+      if has_pre_arrow_or_node_call then
+        A.NodeDecl (span, 
+        (name, true, [], inputs, 
+        [pos, id, ty, A.ClockTrue], [], [], Some contract)) 
+      else 
+        A.FuncDecl (span, 
+        (name, true, [], inputs, 
+        [pos, id, ty, A.ClockTrue], [], [], Some contract)) 
     in
     A.Call(pos, name, inputs_call), [generated_node]
 
@@ -77,150 +94,150 @@ fun global_ctx ctx node_name ->
   | ModeRef (_, _) as e -> e, []
   | Const (_, _) as e -> e, []
   | RecordProject (pos, e, idx) -> 
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in
     RecordProject (pos, e, idx), gen_nodes
   | TupleProject (pos, e, idx) -> 
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in
     TupleProject (pos, e, idx), gen_nodes
   | UnaryOp (pos, op, e) -> 
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in
     UnaryOp (pos, op, e), gen_nodes
   | BinaryOp (pos, op, e1, e2) ->
-    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
-    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name fun_ids e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name fun_ids e2 in
     BinaryOp (pos, op, e1, e2), gen_nodes1 @ gen_nodes2
   | TernaryOp (pos, op, e1, e2, e3) ->
-    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
-    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
-    let e3, gen_nodes3 = desugar_expr global_ctx ctx node_name e3 in
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name fun_ids e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name fun_ids e2 in
+    let e3, gen_nodes3 = desugar_expr global_ctx ctx node_name fun_ids e3 in
     TernaryOp (pos, op, e1, e2, e3), gen_nodes1 @ gen_nodes2 @ gen_nodes3
   | ConvOp (pos, op, e) -> 
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in
     ConvOp (pos, op, e), gen_nodes
   | CompOp (pos, op, e1, e2) ->
-    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
-    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name fun_ids e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name fun_ids e2 in
     CompOp (pos, op, e1, e2), gen_nodes1 @ gen_nodes2
   | RecordExpr (pos, ident, expr_list) ->
     let id_list, exprs_gen_nodes = 
-      List.map (fun (i, e) -> (i, (desugar_expr global_ctx ctx node_name) e)) expr_list |> List.split 
+      List.map (fun (i, e) -> (i, (desugar_expr global_ctx ctx node_name fun_ids) e)) expr_list |> List.split 
     in
     let expr_list, gen_nodes = List.split exprs_gen_nodes in
     RecordExpr (pos, ident, List.combine id_list expr_list), List.flatten gen_nodes
   | GroupExpr (pos, kind, expr_list) ->
-    let expr_list, gen_nodes = List.map (desugar_expr global_ctx ctx node_name) expr_list |> List.split in
+    let expr_list, gen_nodes = List.map (desugar_expr global_ctx ctx node_name fun_ids) expr_list |> List.split in
     GroupExpr (pos, kind, expr_list), List.flatten gen_nodes
   | StructUpdate (pos, e1, idx, e2) ->
-    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
-    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name fun_ids e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name fun_ids e2 in
     StructUpdate (pos, e1, idx, e2), gen_nodes1 @ gen_nodes2
   | ArrayConstr (pos, e1, e2) ->
-    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
-    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name fun_ids e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name fun_ids e2 in
     ArrayConstr (pos, e1, e2), gen_nodes1 @ gen_nodes2
   | ArrayIndex (pos, e1, e2) ->
-    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
-    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name fun_ids e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name fun_ids e2 in
     ArrayIndex (pos, e1, e2), gen_nodes1 @ gen_nodes2
   | Quantifier (pos, kind, idents, e) ->
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in
     Quantifier (pos, kind, idents, e), gen_nodes
   | When (pos, e, clock) -> 
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in
     When (pos, e, clock), gen_nodes
   | Condact (pos, e1, e2, id, expr_list1, expr_list2) ->
-    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
-    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
-    let expr_list1, gen_nodes3 = List.map (desugar_expr global_ctx ctx node_name) expr_list1 |> List.split in
-    let expr_list2, gen_nodes4 = List.map (desugar_expr global_ctx ctx node_name) expr_list2 |> List.split in
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name fun_ids e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name fun_ids e2 in
+    let expr_list1, gen_nodes3 = List.map (desugar_expr global_ctx ctx node_name fun_ids) expr_list1 |> List.split in
+    let expr_list2, gen_nodes4 = List.map (desugar_expr global_ctx ctx node_name fun_ids) expr_list2 |> List.split in
     Condact (pos, e1, e2, id, expr_list1, expr_list2), gen_nodes1 @ gen_nodes2 @ 
                                                       List.flatten gen_nodes3 @ List.flatten gen_nodes4
   | Activate (pos, ident, e1, e2, expr_list) ->
-    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
-    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name fun_ids e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name fun_ids e2 in
     Activate (pos, ident, e1, e2, expr_list), gen_nodes1 @ gen_nodes2
   | Merge (pos, ident, expr_list) ->
     let id_list, exprs_gen_nodes = 
-      List.map (fun (i, e) -> (i, (desugar_expr global_ctx ctx node_name) e)) expr_list |> List.split 
+      List.map (fun (i, e) -> (i, (desugar_expr global_ctx ctx node_name fun_ids) e)) expr_list |> List.split 
     in
     let expr_list, gen_nodes = List.split exprs_gen_nodes in
     Merge (pos, ident, List.combine id_list expr_list), List.flatten gen_nodes
   | RestartEvery (pos, ident, expr_list, e) ->
-    let expr_list, gen_nodes1 = List.map (desugar_expr global_ctx ctx node_name) expr_list |> List.split in
-    let e, gen_nodes2 = desugar_expr global_ctx ctx node_name e in
+    let expr_list, gen_nodes1 = List.map (desugar_expr global_ctx ctx node_name fun_ids) expr_list |> List.split in
+    let e, gen_nodes2 = desugar_expr global_ctx ctx node_name fun_ids e in
     RestartEvery (pos, ident, expr_list, e), List.flatten gen_nodes1 @ gen_nodes2
   | Pre (pos, e) -> 
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in
     Pre (pos, e), gen_nodes
   | Arrow (pos, e1, e2) -> 
-    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name e1 in
-    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name e2 in
+    let e1, gen_nodes1 = desugar_expr global_ctx ctx node_name fun_ids e1 in
+    let e2, gen_nodes2 = desugar_expr global_ctx ctx node_name fun_ids e2 in
     Arrow (pos, e1, e2), gen_nodes1 @ gen_nodes2
   | Call (pos, id, expr_list) ->
-    let expr_list, gen_nodes = List.map (desugar_expr global_ctx ctx node_name) expr_list |> List.split in
+    let expr_list, gen_nodes = List.map (desugar_expr global_ctx ctx node_name fun_ids) expr_list |> List.split in
     Call (pos, id, expr_list), List.flatten gen_nodes
 
-let desugar_contract_item: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> A.contract_node_equation -> A.contract_node_equation * A.declaration list =
-fun global_ctx ctx node_name ->
+let desugar_contract_item: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> HString.t list -> A.contract_node_equation -> A.contract_node_equation * A.declaration list =
+fun global_ctx ctx node_name fun_ids ->
   function
   | A.GhostVars (pos, lhs, e) -> 
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in 
     A.GhostVars (pos, lhs, e), gen_nodes
   | Assume (pos, name, b, e) ->
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in 
     Assume (pos, name, b, e), gen_nodes
   | Guarantee (pos, name, b, e) -> 
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in 
     Guarantee (pos, name, b, e), gen_nodes
   | Mode (pos, i, reqs, enss) ->
     let (reqs, gen_nodes1) = 
-      List.map (fun (pos, id, expr) -> (pos, id, desugar_expr global_ctx ctx node_name expr)) reqs |> 
+      List.map (fun (pos, id, expr) -> (pos, id, desugar_expr global_ctx ctx node_name fun_ids expr)) reqs |> 
       List.map (fun (pos, id, (expr, decls)) -> ((pos, id, expr), decls)) |> 
       List.split in 
     let (enss, gen_nodes2) = 
-      List.map (fun (pos, id, expr) -> (pos, id, desugar_expr global_ctx ctx node_name expr)) enss |> 
+      List.map (fun (pos, id, expr) -> (pos, id, desugar_expr global_ctx ctx node_name fun_ids expr)) enss |> 
       List.map (fun (pos, id, (expr, decls)) -> ((pos, id, expr), decls)) |> 
       List.split in 
     Mode (pos, i, reqs, enss), (List.flatten gen_nodes1) @ (List.flatten gen_nodes2)
   | ContractCall (pos, i, exprs, ids) -> 
-    let (exprs, gen_nodes) = List.map (desugar_expr global_ctx ctx node_name) exprs |> List.split in 
+    let (exprs, gen_nodes) = List.map (desugar_expr global_ctx ctx node_name fun_ids) exprs |> List.split in 
     ContractCall (pos, i, exprs, ids), List.flatten gen_nodes
   | GhostConst _ 
   | AssumptionVars _ as ci -> ci, []
 
-let desugar_contract: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> A.contract_node_equation list option -> A.contract_node_equation list option * A.declaration list =
-fun global_ctx ctx node_name contract -> 
+let desugar_contract: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> HString.t list -> A.contract_node_equation list option -> A.contract_node_equation list option * A.declaration list =
+fun global_ctx ctx node_name fun_ids contract -> 
   match contract with 
   | Some contract_items -> 
-    let items, gen_nodes = (List.map (desugar_contract_item global_ctx ctx node_name) contract_items) |> List.split in
+    let items, gen_nodes = (List.map (desugar_contract_item global_ctx ctx node_name fun_ids) contract_items) |> List.split in
     Some items, List.flatten gen_nodes
   | None -> None, []
 
-let rec desugar_node_item: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> A.node_item -> A.node_item * A.declaration list =
-fun global_ctx ctx node_name ni ->
+let rec desugar_node_item: Ctx.tc_context ->  Ctx.tc_context -> HString.t -> HString.t list -> A.node_item -> A.node_item * A.declaration list =
+fun global_ctx ctx node_name fun_ids ni ->
   match ni with
   | A.Body (Equation (pos, lhs, rhs)) -> 
-    let rhs, gen_nodes = desugar_expr global_ctx ctx node_name rhs in 
+    let rhs, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids rhs in 
     A.Body (Equation (pos, lhs, rhs)), gen_nodes
   | AnnotProperty (pos, name, e, k) -> 
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in 
     AnnotProperty(pos, name, e, k), gen_nodes
   | IfBlock (pos, cond, nis1, nis2) -> 
-    let nis1, gen_nodes1 = List.map (desugar_node_item global_ctx ctx node_name) nis1 |> List.split in
-    let nis2, gen_nodes2 = List.map (desugar_node_item global_ctx ctx node_name) nis2 |> List.split in
-    let cond, gen_nodes3 = desugar_expr global_ctx ctx node_name cond in
+    let nis1, gen_nodes1 = List.map (desugar_node_item global_ctx ctx node_name fun_ids) nis1 |> List.split in
+    let nis2, gen_nodes2 = List.map (desugar_node_item global_ctx ctx node_name fun_ids) nis2 |> List.split in
+    let cond, gen_nodes3 = desugar_expr global_ctx ctx node_name fun_ids cond in
     A.IfBlock (pos, cond, nis1, nis2), List.flatten gen_nodes1 @ List.flatten gen_nodes2 @ gen_nodes3
   | FrameBlock (pos, vars, nes, nis) -> 
     let nes = List.map (fun x -> A.Body x) nes in
-    let nes, gen_nodes1 = List.map (desugar_node_item global_ctx ctx node_name) nes |> List.split in
+    let nes, gen_nodes1 = List.map (desugar_node_item global_ctx ctx node_name fun_ids) nes |> List.split in
     let nes = List.map (fun ne -> match ne with
       | A.Body (A.Equation _ as eq) -> eq
       | _ -> assert false
     ) nes in
-    let nis, gen_nodes2 = List.map (desugar_node_item global_ctx ctx node_name) nis |> List.split in
+    let nis, gen_nodes2 = List.map (desugar_node_item global_ctx ctx node_name fun_ids) nis |> List.split in
     FrameBlock(pos, vars, nes, nis), List.flatten gen_nodes1 @ List.flatten gen_nodes2
   | Body (Assert (pos, e)) ->
-    let e, gen_nodes = desugar_expr global_ctx ctx node_name e in 
+    let e, gen_nodes = desugar_expr global_ctx ctx node_name fun_ids e in 
     Body (Assert (pos, e)), gen_nodes
   | AnnotMain _ -> ni, []
 
@@ -262,16 +279,20 @@ let define_undefined_variables: A.clocked_typed_decl list -> A.node_item list ->
 
 let desugar_any_ops: Ctx.tc_context -> A.declaration list -> A.declaration list = 
 fun global_ctx decls -> 
+  let fun_ids = List.filter_map 
+    (fun decl -> match decl with | A.FuncDecl (_, (id, _, _, _, _, _, _, _)) -> Some id | _ -> None) 
+    decls 
+  in
   let decls =
   List.fold_left (fun decls decl ->
     match decl with
     | A.NodeDecl (span, ((id, ext, params, inputs, outputs, locals, items, contract) as d)) -> 
     (
-      match Chk.get_node_ctx global_ctx d with 
+      match Chk.get_node_ctx Ctx.empty_tc_context d with 
         | Ok ctx ->
           let items = if not ext then define_undefined_variables outputs items else items in 
-          let items, gen_nodes = List.map (desugar_node_item global_ctx ctx id) items |> List.split in 
-          let contract, gen_nodes2 = desugar_contract global_ctx ctx id contract in
+          let items, gen_nodes = List.map (desugar_node_item global_ctx ctx id fun_ids) items |> List.split in 
+          let contract, gen_nodes2 = desugar_contract global_ctx ctx id fun_ids contract in
           let gen_nodes = List.flatten gen_nodes in
           decls @ gen_nodes @ gen_nodes2 @ [A.NodeDecl (span, (id, ext, params, inputs, outputs, locals, items, contract))]
         (* If there is an error in context collection, it will be detected later in type checking *)
@@ -279,11 +300,11 @@ fun global_ctx decls ->
     )
     | A.FuncDecl (span, ((id, ext, params, inputs, outputs, locals, items, contract) as d)) -> 
     (
-      match Chk.get_node_ctx global_ctx d with 
+      match Chk.get_node_ctx Ctx.empty_tc_context d with 
         | Ok ctx -> 
           let items = if not ext then define_undefined_variables outputs items else items in 
-          let items, gen_nodes = List.map (desugar_node_item global_ctx ctx id) items |> List.split in 
-          let contract, gen_nodes2 = desugar_contract global_ctx ctx id contract in
+          let items, gen_nodes = List.map (desugar_node_item global_ctx ctx id fun_ids ) items |> List.split in 
+          let contract, gen_nodes2 = desugar_contract global_ctx ctx id fun_ids contract in
           let gen_nodes = List.flatten gen_nodes in
           decls @ gen_nodes @ gen_nodes2 @ [A.FuncDecl (span, (id, ext, params, inputs, outputs, locals, items, contract))]
         (* If there is an error in context collection, it will be detected later in type checking *)
@@ -291,9 +312,9 @@ fun global_ctx decls ->
     )
     | A.ContractNodeDecl (span, (id, params, inputs, outputs, contract)) -> 
       (
-        match Chk.get_node_ctx global_ctx (id, (), (), inputs, outputs, [], (), ()) with (* Unit type params are unused in function *)
+        match Chk.get_node_ctx Ctx.empty_tc_context (id, (), (), inputs, outputs, [], (), ()) with (* Unit type params are unused in function *)
           | Ok ctx -> 
-            let contract, gen_nodes = desugar_contract global_ctx ctx id (Some contract) in
+            let contract, gen_nodes = desugar_contract global_ctx ctx id fun_ids (Some contract) in
             let contract = match contract with 
               | Some contract -> contract 
               | None -> assert false in (* Must have a contract *)

--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -49,7 +49,6 @@ type error_kind = Unknown of string
   | QuantifiedVariableInPre of HString.t
   | QuantifiedVariableInNodeArgument of HString.t * HString.t
   | SymbolicArrayIndexInNodeArgument of HString.t * HString.t
-  | AnyOpInFunction
   | NodeCallInFunction of HString.t
   | NodeCallInRefinableContract of string * HString.t
   | NodeCallInConstant of HString.t
@@ -98,7 +97,6 @@ let error_message kind = match kind with
   | SymbolicArrayIndexInNodeArgument (idx, node) -> "Symbolic array index '"
     ^ HString.string_of_hstring idx ^ "' is not allowed in an argument to the node call '"
     ^ HString.string_of_hstring node ^ "'"
-  | AnyOpInFunction -> "Illegal any operator in function"
   | NodeCallInFunction node -> "Illegal call to node '"
     ^ HString.string_of_hstring node ^ "', functions and function contracts can only call other functions, not nodes"
   | NodeCallInRefinableContract (kind, node) -> "Illegal call to " ^ kind ^ " '"
@@ -570,7 +568,6 @@ let no_calls_to_node ctx = function
     let check_nodes = StringMap.mem i ctx.nodes in
     if check_nodes then syntax_error pos (NodeCallInFunction i)
     else Ok ()
-  | AnyOp (pos, _, _, _) -> syntax_error pos AnyOpInFunction
   | _ -> Ok ()
 
 (* Note: this check is simpler if done after the contract imports have all been

--- a/src/lustre/lustreSyntaxChecks.mli
+++ b/src/lustre/lustreSyntaxChecks.mli
@@ -30,7 +30,6 @@ type error_kind = Unknown of string
   | QuantifiedVariableInPre of HString.t
   | QuantifiedVariableInNodeArgument of HString.t * HString.t
   | SymbolicArrayIndexInNodeArgument of HString.t * HString.t
-  | AnyOpInFunction
   | NodeCallInFunction of HString.t
   | NodeCallInRefinableContract of string * HString.t
   | NodeCallInConstant of HString.t

--- a/src/lustre/typeCheckerContext.mli
+++ b/src/lustre/typeCheckerContext.mli
@@ -74,7 +74,7 @@ val member_contract: tc_context -> LA.ident -> bool
 (** Checks if the contract name is in the context *)
 
 val member_node: tc_context -> LA.ident -> bool
-(** Checks if the node name is in the context *)
+(** Checks if the function/node name is in the context *)
   
 val member_u_types : tc_context -> LA.ident -> bool
 (** Checks of the type identifier is a user defined type *)


### PR DESCRIPTION
This PR also fixes a bug where the imported node generated from an "any" operator erroneously omitted local constants in the set of inputs to the generated node. For example, consider:

```
node M(const n: int) returns (A: int^n)
let
  A = any int^n;
tel
```

In the imported node generated from `any int^n`, `n` was (incorrectly) not included as an input parameter.