### PR TITLE
Fix lustreAstNormalizer assert failure

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1341,8 +1341,6 @@ and normalize_expr ?guard info map =
     else
       let ivars = info.inductive_variables in
       let pos = AH.pos_of_expr expr in
-      A.pp_print_expr Format.std_formatter expr;
-      Ctx.pp_print_tc_context Format.std_formatter info.context;
       let ty = if expr_has_inductive_var ivars expr then
         (StringMap.choose_opt info.inductive_variables) |> get |> snd
       else Chk.infer_type_expr info.context expr |> unwrap


### PR DESCRIPTION
Fix bug illustrated in following example: 
```
node imported W(b: bool) returns (a: int; r: bool);

node main(c : bool) returns (t: int; a: int; b: bool);
let
  if c then
    a, b = W(t = 34);
  fi
tel
```