### PR TITLE
Apply slicing in IC3IA engine instances

### DIFF
--- a/src/certif/certifChecker.ml
+++ b/src/certif/certifChecker.ml
@@ -2397,7 +2397,8 @@ let mk_inst init_flag sys formal_vars =
       ) StateVar.StateVarMap.(empty, empty) formal_vars
   in
   sys,
-  [ { TransSys.pos = Lib.dummy_pos;
+  [ { TransSys.uid = -1;
+      TransSys.pos = Lib.dummy_pos;
       map_down;
       map_up;
       guard_clock = (fun _ t -> t);

--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -18,6 +18,8 @@
 
 open Lib
 
+exception UnsupportedFeature of string
+
 module TS = Term.TermSet
 module CS = Cube.CubeSet
 module CM = Cube.CubeMap
@@ -847,8 +849,8 @@ let propogate_blocked_cubes solver in_sys param sys prop_name predicates frames 
   loop frames 1
 
 
-let main fwd prop in_sys param sys =
-   
+let main_ic3ia fwd prop in_sys param sys =
+
    let solver = mk_solver sys in
 
    let prop_name = prop.Property.prop_name in
@@ -931,3 +933,45 @@ let main fwd prop in_sys param sys =
   | Terminate -> ();
 
    SMTSolver.delete_instance solver
+
+let main fwd prop in_sys param sys =
+
+  let param = Analysis.param_clone param in
+
+  let sys =
+    (* Only slice if the property does not contain instantiated variables *)
+    (* The current slicing procedure works on the input system, not the transition system *)
+    match prop.Property.prop_source with
+    | Assumption _ -> sys (* An instantiated var is also involved, local sofar var *)
+    | Instantiated _ -> sys
+    | _ -> fst (InputSystem.trans_sys_of_analysis ~slice_to_prop:prop in_sys param)
+  in
+  (*Format.printf "%a" (TransSys.pp_print_subsystems true) sys;*)
+
+  let open TermLib in
+  let open TermLib.FeatureSet in
+  (match TransSys.get_logic sys with
+  | `Inferred l when mem A l ->
+    let msg =
+      Format.sprintf "IC3IA disabled for property %s: arrays are not supported."
+        prop.Property.prop_name
+    in
+    raise (UnsupportedFeature msg)
+  | _ -> () ) ;
+
+  let check_system_is_supported itp_solver =
+    if TransSys.subsystem_includes_function_symbol sys then
+      let msg =
+        Format.sprintf "IC3IA (%s) disabled for property %s: system includes an abstract function. \
+          Use MathSAT or SMTInterpol instead."
+          itp_solver prop.Property.prop_name
+      in
+      raise (UnsupportedFeature msg)
+  in
+
+  (match Flags.Smt.itp_solver () with
+  | `cvc5_QE -> check_system_is_supported "cvc5qe"
+  | `Z3_QE -> check_system_is_supported "Z3qe"
+  | _ -> () ) ;
+
+  main_ic3ia fwd prop in_sys param sys

--- a/src/ic3ia/IC3IA.mli
+++ b/src/ic3ia/IC3IA.mli
@@ -27,6 +27,8 @@
 
     @author Daniel Larraz *)
 
+exception UnsupportedFeature of string
+
 (** Entry point *)
 val main : bool -> Property.t -> 'a InputSystem.t -> Analysis.param -> TransSys.t -> unit
     

--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -403,6 +403,7 @@ let trans_sys_of_analysis (type s)
 ?(preserve_sig = false)
 ?(slice_nodes = Flags.slice_nodes ())
 ?(add_functional_constraints = Flags.Contracts.enforce_func_congruence ())
+?slice_to_prop
 : s t -> Analysis.param -> TransSys.t * s t = function
 
   | Lustre (main_subs, globals, ast) -> (
@@ -413,7 +414,8 @@ let trans_sys_of_analysis (type s)
             {
               preserve_sig;
               slice_nodes;
-              add_functional_constraints
+              add_functional_constraints;
+              slice_to_prop
             }
           in
           trans_sys_of_nodes

--- a/src/inputSystem.mli
+++ b/src/inputSystem.mli
@@ -73,6 +73,7 @@ val trans_sys_of_analysis:
   ?preserve_sig:bool ->
   ?slice_nodes:bool ->
   ?add_functional_constraints: bool ->
+  ?slice_to_prop:Property.t ->
   'a t -> Analysis.param -> TransSys.t * 'a t
 
 (** Output a path in the input system *)

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -262,7 +262,8 @@ let status_of_exn process status = function
     (* Return exit status and signal number. *)
     ExitCodes.kid_status + s
   (* Runtime failure. *)
-  | IC3.UnsupportedFeature msg -> (
+  | IC3.UnsupportedFeature msg 
+  | IC3IA.UnsupportedFeature msg -> (
     KEvent.log L_warn "%s" msg;
     status
   )
@@ -524,14 +525,7 @@ let create_processes modules sys =
   | [] -> processes, []
   | _ -> (
     if Flags.IC3IA.max_processes () > 0 then
-      let open TermLib in
-      let open TermLib.FeatureSet in
-      match TransSys.get_logic sys with
-      | `Inferred l when mem A l ->
-        KEvent.log L_warn 
-          "IC3IA disabled: arrays are not supported." ;
-        processes, []
-      | _ -> (
+      (
         let qe_itp_support_model =
           let check_system_is_supported itp_solver =
             let supported =

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -98,6 +98,9 @@ type call_cond =
 (* A call of a node *)
 type node_call = {
 
+  (* A unique numerical id *)
+  call_id : int;
+
   (* Position of node call in input file *)
   call_pos : position;
 

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -61,6 +61,9 @@ type call_cond =
     dummy position. *)
 type node_call = {
 
+  call_id : int;
+  (* A unique numerical id *)
+
   call_pos : position;
   (** Position of node call in input file *)
 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -71,7 +71,8 @@ type identifier_maps = {
   node_name : HString.t option;
   assume_count : int;
   guarantee_count : int;
-  poracle_count : int
+  poracle_count : int;
+  call_count : int;
 }
 
 
@@ -124,7 +125,8 @@ let empty_identifier_maps node_name = {
   node_name = node_name;
   assume_count = 0;
   guarantee_count = 0;
-  poracle_count = 1
+  poracle_count = 1;
+  call_count = 1;
 }
 
 let empty_compiler_state () = { 
@@ -1248,7 +1250,10 @@ and compile_node node_scope pos ctx cstate map outputs cond restart ident args d
     | None, Some r -> [N.CRestart r]
     | Some c, Some r -> [N.CActivate c; N.CRestart r]
   in
+  let call_id = !map.call_count in
+  map := {!map with call_count = call_id + 1 };
   let node_call = {
+    N.call_id = call_id;
     N.call_pos = pos;
     N.call_node_name = ident;
     N.call_cond = cond_state_var;

--- a/src/lustre/lustreSimplify.ml
+++ b/src/lustre/lustreSimplify.ml
@@ -1900,7 +1900,8 @@ and eval_node_call
       let res = D.map E.mk_var output_state_vars in
       (* Create node call *)
       let node_call = 
-        { N.call_pos = pos;
+        { N.call_id = -1; (* Call_id is not implemented in old frontend *)
+          N.call_pos = pos;
           N.call_node_name = ident;
           N.call_cond = cond_state_var;
           N.call_inputs = input_state_vars;

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -1120,7 +1120,9 @@ let root_and_leaves_of_impl
         |> SVS.union (roots_of_props props)
                                           
       (* Use instead of roots from properties and contracts *)
-      | Some r -> r )
+      | Some r -> 
+        (roots_of_contract_ass contract)
+        |> SVS.union r )
 
     |> add_roots_of_asserts asserts
 

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -33,7 +33,6 @@ module P = Property
 
 module SVS = StateVar.StateVarSet
 module SVM = StateVar.StateVarMap
-module SCM = Scope.Map
 module TM = Type.TypeMap
 
 
@@ -41,26 +40,29 @@ type settings = {
   preserve_sig: bool;
   slice_nodes: bool;
   add_functional_constraints: bool;
+  slice_to_prop: P.t option
 }
 
 let default_settings = {
   preserve_sig = false ;
   slice_nodes = Flags.slice_nodes () ;
   add_functional_constraints = Flags.Contracts.enforce_func_congruence () ;
+  slice_to_prop = None
 }
 
-
+(*
 (* Hash map from node scopes to their index for fresh state variables.
    Used to make sure fresh state variables are indeed fresh after a restart,
    without risking to reach [MAXINT]. *)
-let scope_index_map = ref SCM.empty
+let scope_index_map = ref Scope.Map.empty
 (* Returns a fresh index for a scope. *)
 let index_of_scope s =
   let curr =
-    try !scope_index_map |> SCM.find s with Not_found -> 0
+    try !scope_index_map |> Scope.Map.find s with Not_found -> 0
   in
-  scope_index_map := !scope_index_map |> SCM.add s (curr + 1) ;
+  scope_index_map := !scope_index_map |> Scope.Map.add s (curr + 1) ;
   curr
+*)
 
 (* Transition system and information needed when calling it *)
 type node_def = {
@@ -89,7 +91,7 @@ type node_def = {
      Properties of the callees of the node *)
   properties : P.t list;
 
-  history_svars: (StateVar.t * StateVar.t) list TM.t;
+  history_svars: (StateVar.t list) SVM.t TM.t;
 
   ctr_svars: StateVar.t list ;
 }
@@ -694,11 +696,19 @@ let call_terms_of_node_call mk_fresh_state_var globals
       (fun state_var (locals, call_locals, (state_var_map_up, state_var_map_down)) -> 
 
          (* Create a fresh state variable in the caller *)
-         let inst_state_var = 
+         let inst_state_var =
+           let name =
+             let row, col = row_col_of_pos call_pos in
+             Format.asprintf "inst_%a_l%dc%d_%a"
+               (I.pp_print_ident true) call_node_name
+               row col
+               StateVar.pp_print_state_var state_var
+           in
            mk_fresh_state_var
              ?is_const:(Some (StateVar.is_const state_var))
              ?for_inv_gen:(Some true)
              ?inst_for_sv:(Some state_var)
+             name
              (StateVar.type_of_state_var state_var)
          in
 
@@ -729,16 +739,22 @@ let call_terms_of_node_call mk_fresh_state_var globals
 
   let node_hist_svars =
     let lifted_hist_svars =
-      history_svars |> TM.map (fun l ->
-        l |> List.map (fun (sv, h_sv) ->
+      history_svars |> TM.map (fun m ->
+        SVM.fold (fun sv l acc ->
           let sv' = lift_state_var state_var_map_up sv in
-          let h_sv' = lift_state_var state_var_map_up h_sv in
-          sv', h_sv'
+          let l' =
+            List.map (fun h_sv -> lift_state_var state_var_map_up h_sv) l
+          in
+          SVM.add sv' l' acc
         )
+        m
+        SVM.empty
       )
     in
     TM.union
-      (fun _ l1 l2 -> Some (l1 @ l2))
+      (fun _ m1 m2 -> Some (SVM.union (fun _ l1 l2 ->
+        Some (l1 @ l2)
+      ) m1 m2))
       lifted_hist_svars
       node_hist_svars
   in
@@ -1131,11 +1147,19 @@ let rec constraints_of_node_calls
           else
 
             (* Create fresh shadow variable for input *)
-            let shadow_sv = 
+            let shadow_sv =
+              let name =
+                let row, col = row_col_of_pos call_pos in
+                Format.asprintf "shw_%a_l%dc%d_%a"
+                  (I.pp_print_ident true) call_node_name
+                  row col
+                  StateVar.pp_print_state_var formal_sv
+              in
               mk_fresh_state_var
                 ?is_const:None
                 ?for_inv_gen:(Some false)
                 ?inst_for_sv:(Some formal_sv)
+                name
                 (StateVar.type_of_state_var formal_sv) 
             in
 
@@ -1218,10 +1242,18 @@ let rec constraints_of_node_calls
     in
 
     let has_ticked =
+      let name =
+        let row, col = row_col_of_pos call_pos in
+        Format.asprintf "tck_%a_l%dc%d_%a"
+          (I.pp_print_ident true) call_node_name
+          row col 
+          StateVar.pp_print_state_var clock
+      in
       mk_fresh_state_var
         ?is_const:None
         ?for_inv_gen:(Some false)
         ?inst_for_sv:(Some clock)
+        name
         Type.t_bool
     in
 
@@ -1496,11 +1528,15 @@ let constraints_of_history_congruence
       let acc =
         List.fold_left
           (fun acc (sv2, h_sv2) ->
-            let sv_eq =
-              if StateVar.equal_state_vars sv1 sv2 then Term.t_true
-              else mk_eq sv1 sv2
+            let cond =
+              if StateVar.equal_state_vars sv1 sv2 then None
+              else
+                let name =
+                  Format.sprintf "eq_vars_%d_%d" (StateVar.uid sv1) (StateVar.uid sv2)
+                in 
+                Some (name, mk_eq sv1 sv2)
             in
-            (sv_eq, mk_eq h_sv1 h_sv2) :: acc
+            (cond, mk_eq h_sv1 h_sv2) :: acc
           )
           acc
           tl
@@ -1508,7 +1544,29 @@ let constraints_of_history_congruence
       mk_pairs acc tl
     in
     TM.fold
-      (fun _ l acc -> mk_pairs acc l)
+      (fun _ m acc ->
+        let l =
+          SVM.bindings m
+          |> List.map (fun (sv, l) -> (sv, List.hd l))
+        in
+        SVM.fold (fun _ l' acc ->
+          match l' with
+          | []  -> assert false
+          | [_] -> acc
+          | _ -> (
+            let eqs =
+              l' |> List.map (fun h_sv ->
+                Var.mk_state_var_instance h_sv TransSys.init_base
+                |> Term.mk_var
+              )
+              |> Term.mk_eq
+            in
+            (None, eqs) :: acc
+          )
+        )
+        m
+        (mk_pairs acc l)
+      )
       history_svars
       []
   in
@@ -1518,13 +1576,18 @@ let constraints_of_history_congruence
   *)
   let all_inputs_equal, rest =
     pairs
-    |> List.partition (fun (t, _) -> Term.equal t Term.t_true)
+    |> List.fold_left (fun (l1, l2) (cond, o) ->
+        match cond with
+        | None -> (o :: l1, l2)
+        | Some (name, i) -> (l1, (name, (i, o)) :: l2)
+      )
+      ([], [])
   in
 
   let add_constraints_for_vars_equal init_terms trans_terms =
     let init_terms =
       all_inputs_equal
-      |> List.fold_left (fun init_terms (_,o_base) ->
+      |> List.fold_left (fun init_terms o_base ->
         o_base :: init_terms
       )
       init_terms
@@ -1532,7 +1595,7 @@ let constraints_of_history_congruence
 
     let trans_terms =
       all_inputs_equal
-      |> List.fold_left (fun trans_terms (_,o_base) ->
+      |> List.fold_left (fun trans_terms o_base ->
         let offset =
           Numeral.(TransSys.trans_base - TransSys.init_base)
         in
@@ -1546,12 +1609,13 @@ let constraints_of_history_congruence
 
   let add_constraints_for_rest init_terms trans_terms =
     let local_and_terms =
-      rest |> List.map (fun terms ->
+      rest |> List.map (fun (name, terms) ->
         let fresh_svar =
           mk_fresh_state_var
             ?is_const:(Some false)
             ?for_inv_gen:(Some true)
             ?inst_for_sv:None
+            name
             Type.t_bool
         in
         (fresh_svar, terms)
@@ -1968,14 +2032,14 @@ let rec trans_sys_of_node'
 
       (* Create a fresh state variable *)
       let mk_fresh_state_var
-          ?(basename=I.inst_ident)
           ?is_const
           ?for_inv_gen
           ?inst_for_sv
+          name
           state_var_type =
 
         (* Increment counter for fresh state variables *)
-        let index = index_of_scope scope in
+        (*let index = index_of_scope scope in*)
 
         (* Create state variable *)
         let fsv =
@@ -1983,8 +2047,9 @@ let rec trans_sys_of_node'
             ~is_input:false
             ?is_const:is_const
             ?for_inv_gen:for_inv_gen
-            ((I.push_index basename index)
-             |> I.string_of_ident true)
+            name
+            (*((I.push_index I.inst_ident index) 
+             |> I.string_of_ident true)*)
             (N.scope_of_node node @ I.reserved_scope)
             state_var_type
         in
@@ -2304,7 +2369,7 @@ let rec trans_sys_of_node'
             trans_terms
           =
             constraints_of_node_calls
-              (mk_fresh_state_var ~basename:I.inst_ident)
+              mk_fresh_state_var
               globals
               trans_sys_defs
               []  (* No lifted locals *)
@@ -2321,15 +2386,22 @@ let rec trans_sys_of_node'
           let history_svars =
             let history_svars' =
               history_svars |> TM.map (fun l ->
-                l |> List.filter (fun (sv, h_sv) ->
-                  List.exists (StateVar.equal_state_vars sv) all_state_vars
-                  &&
-                  List.exists (StateVar.equal_state_vars h_sv) all_state_vars
+                l |> List.fold_left (fun acc (sv, h_sv) ->
+                  if List.exists (StateVar.equal_state_vars sv) all_state_vars
+                     &&
+                     List.exists (StateVar.equal_state_vars h_sv) all_state_vars
+                  then
+                    SVM.add sv [h_sv] acc
+                  else
+                    acc
                 )
+                SVM.empty
               )
             in
             TM.union
-              (fun _ l1 l2 -> Some (l1 @ l2))
+              (fun _ m1 m2 -> Some (SVM.union (fun _ l1 l2 ->
+                Some (l1 @ l2)
+              ) m1 m2))
               history_svars'
               lifted_hist_svars
           in
@@ -2341,7 +2413,7 @@ let rec trans_sys_of_node'
           =
             if I.equal node_name top_name then
               constraints_of_history_congruence
-                (mk_fresh_state_var ~basename:I.eq_vars_ident)
+                mk_fresh_state_var
                 history_svars
                 init_terms
                 trans_terms
@@ -2760,12 +2832,19 @@ let trans_sys_of_nodes
     let preserve_sig, slice_nodes =
       options.preserve_sig, options.slice_nodes
     in
-    S.slice_to_abstraction
-      ~preserve_sig slice_nodes analysis_param subsystem'
+    match options.slice_to_prop with
+    | None -> 
+      S.slice_to_abstraction
+        ~preserve_sig slice_nodes analysis_param subsystem'
+    | Some prop ->
+      let vars =
+        Term.state_vars_of_term prop.P.prop_term
+      in
+      S.slice_to_abstraction_and_property
+        ~preserve_sig analysis_param vars subsystem'
   in
 
   let nodes = N.nodes_of_subsystem subsystem' in
-
 
   let { trans_sys } =   
 

--- a/src/lustre/lustreTransSys.mli
+++ b/src/lustre/lustreTransSys.mli
@@ -20,6 +20,7 @@ type settings = {
   preserve_sig: bool;
   slice_nodes: bool;
   add_functional_constraints: bool;
+  slice_to_prop: Property.t option;
 }
 
 val default_settings: settings

--- a/src/nativeInput.ml
+++ b/src/nativeInput.ml
@@ -233,6 +233,7 @@ let subsystems_of_sexpr = function
     in
 
     let inst = {
+      TransSys.uid = -1;
       TransSys.pos = Lib.dummy_pos;
       map_down;
       map_up;

--- a/src/terms/stateVar.ml
+++ b/src/terms/stateVar.ml
@@ -209,6 +209,7 @@ let string_of_state_var s = string_of_t pp_print_state_var s
 (* Accessor function                                                     *)
 (* ********************************************************************* *)
 
+let uid { Hashcons.tag } = tag
 
 (* Identifier of a state variable *)
 let name_of_state_var { Hashcons.node = (n, _) } = n

--- a/src/terms/stateVar.mli
+++ b/src/terms/stateVar.mli
@@ -91,6 +91,9 @@ val import : t -> t
 
 (** {1 Accessor functions} *)
 
+(** Return a unique numerical identifier *)
+val uid : t -> int
+
 (** Return a previously declared state variable *)
 val state_var_of_string : string * string list -> t 
 

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -38,8 +38,10 @@ type pred_def = UfSymbol.t * (Var.t list * Term.t)
 (* Instance of a subsystem *)
 type instance = 
   {
+    (* Unique identifier of the instance *)
+    uid : int;
 
-    (* Position as a unique identifier of the instance *)
+    (* Position of the call *)
     pos : position;
 
     (* Map from state variables of the called system to the state variables of

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -73,9 +73,16 @@ type pred_def = UfSymbol.t * (Var.t list * Term.t)
 (** Instance of a subsystem *)
 type instance = 
   {
+    uid : int;
+    (** Unique identifier of the instance *)
 
     pos : Lib.position;
-    (** Position as a unique identifier of the instance *)
+    (** Position of the call.
+
+        It is used as a unique identifier, which works provided
+        the call is not expanded in the definition of an array.
+        TODO: Change code to use uid for equality instead.
+    *)
 
     map_down : StateVar.t StateVar.StateVarMap.t;
     (** Map from the state variables of this system to the state


### PR DESCRIPTION
Each IC3IA engine instance applies slicing to the transition system for the property it is checking. This ensures that an engine instance only shuts down if the sliced system contains unsupported features. Previously, all instances would shut down if any property included unsupported features.