### PR TITLE
Any ops consts fix

### DIFF
--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -104,6 +104,10 @@ val defined_vars_with_pos: node_item -> (Lib.position * index) list
 val vars_of_ty_ids: typed_ident -> SI.t
 (** returns a singleton set with the only identifier in a typed identifier declaration *)
 
+val vars_of_type: lustre_type -> SI.t
+(** [vars_of_type ty] returns all variable identifiers that appear in the type [ty]
+    while excluding node call identifiers and refinement type bound variables *)
+
 val add_exp: Lib.position -> expr -> expr -> expr
 (** Return an AST that adds two expressions*)
 

--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -104,7 +104,7 @@ let rec eval_int_expr: TC.tc_context -> LA.expr -> (int, [> error]) result = fun
   function
   | LA.Ident (pos, i) ->
      (match (TC.lookup_const ctx i) with
-      | Some (const_expr, _) ->
+      | Some (const_expr, _, _) ->
          if is_normal_form ctx const_expr
          then int_value_of_const const_expr
          else (match const_expr with
@@ -150,7 +150,7 @@ and eval_bool_expr: TC.tc_context -> LA.expr -> (bool, [> error]) result = fun c
   function
   | LA.Ident (pos, i) ->
      (match (TC.lookup_const ctx i) with
-      | Some (const_expr, _) ->
+      | Some (const_expr, _, _) ->
          if is_normal_form ctx const_expr
          then bool_value_of_const const_expr
          else (match const_expr with
@@ -284,7 +284,7 @@ and simplify_expr ?(is_guarded = false) ctx =
   | LA.Const _ as c -> c
   | LA.Ident (_, i) as ident ->
      (match (TC.lookup_const ctx i) with
-      | Some (const_expr, _) ->
+      | Some (const_expr, _, _) ->
          (match const_expr with
           | LA.Ident (_, i') as ident' ->
              if HString.compare i i' = 0 (* If This is a free constant *)
@@ -418,10 +418,10 @@ let rec inline_constants_of_node_locals ctx = function
   | (LA.NodeConstDecl (pos1, (UntypedConst (pos2, i, e)))) :: t ->
     let e' = simplify_expr ctx e in
     let ctx = match (TC.lookup_ty ctx i) with
-      | None -> TC.add_untyped_const ctx i e'
+      | None -> TC.add_untyped_const ctx i e' Local
       | Some ty ->
         let ty' = inline_constants_of_lustre_type ctx ty in
-        TC.add_const ctx i e' ty'
+        TC.add_const ctx i e' ty' Local
     in
     let decl' = LA.NodeConstDecl (pos1, (UntypedConst (pos2, i, e'))) in
     let ctx', t' = inline_constants_of_node_locals ctx t in
@@ -429,7 +429,7 @@ let rec inline_constants_of_node_locals ctx = function
   | (LA.NodeConstDecl (pos1, (LA.TypedConst (pos2, i, e, ty)))) :: t ->
     let ty' = inline_constants_of_lustre_type ctx ty in
     let e' = simplify_expr ctx e in
-    let ctx' = TC.add_const ctx i e' ty' in
+    let ctx' = TC.add_const ctx i e' ty' Local in
     let ctx'', t' = inline_constants_of_node_locals ctx' t in
     let decl' = LA.NodeConstDecl (pos1, (TypedConst (pos2, i, e', ty'))) in
     ctx'', decl' :: t'
@@ -497,16 +497,16 @@ let substitute: TC.tc_context -> LA.declaration -> (TC.tc_context * LA.declarati
     let e' = simplify_expr ctx e in
     (match (TC.lookup_ty ctx i) with
       | None ->
-          (TC.add_untyped_const ctx i e'
+          (TC.add_untyped_const ctx i e' Global
           , ConstDecl (span, UntypedConst (pos', i, e')))
       | Some ty ->
         let ty' = inline_constants_of_lustre_type ctx ty in
-        let ctx' = TC.add_ty (TC.add_const ctx i e' ty') i ty' in
+        let ctx' = TC.add_ty (TC.add_const ctx i e' ty' Global) i ty' in
         (ctx', ConstDecl (span, UntypedConst (pos', i, e'))))
   | ConstDecl (span, TypedConst (pos', i, e, ty)) ->
     let ty' = inline_constants_of_lustre_type ctx ty in
     let e' = simplify_expr ctx e in
-    let ctx' = TC.add_ty (TC.add_const ctx i e' ty') i ty' in
+    let ctx' = TC.add_ty (TC.add_const ctx i e' ty' Global) i ty' in
     (ctx', ConstDecl (span, TypedConst (pos', i, e', ty')))
   | (LA.NodeDecl (span, (i, imported, params, ips, ops, ldecls, items, contract))) ->
     let ips' = inline_constants_of_const_clocked_type_decl ctx ips in

--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -311,10 +311,13 @@ let pp_print_type_binding: Format.formatter -> (LA.ident * tc_type) -> unit
   = fun ppf (i, ty) -> Format.fprintf ppf "(%a:%a)" LA.pp_print_ident i LA.pp_print_lustre_type ty
 (** Pretty print type bindings*)  
 
-let pp_print_val_binding: Format.formatter -> (LA.ident * (LA.expr * tc_type option)) -> unit
-  = fun ppf (i, (v, ty)) ->
-  Format.fprintf ppf "(%a:%a :-> %a)"
-    LA.pp_print_ident i (Lib.pp_print_option LA.pp_print_lustre_type) ty LA.pp_print_expr v
+let pp_print_val_binding: Format.formatter -> (LA.ident * (LA.expr * tc_type option * const_scope)) -> unit
+  = fun ppf (i, (v, ty, sc)) ->
+  Format.fprintf ppf "(%a:%a :-> %a (%s))"
+    LA.pp_print_ident i 
+    (Lib.pp_print_option LA.pp_print_lustre_type) ty 
+    LA.pp_print_expr v
+    (if sc = Local then "local" else "global")
 (** Pretty print value bindings (used for constants)*)
 
 let pp_print_ty_syns: Format.formatter -> ty_alias_store -> unit
@@ -326,8 +329,8 @@ let pp_print_tymap: Format.formatter -> ty_store -> unit
 (** Pretty print type binding context *)
                
 let pp_print_vstore: Format.formatter -> const_store -> unit
-  = fun  ppf m -> Lib.pp_print_list (fun ppf (i, (e, ty, _))
-    -> pp_print_val_binding ppf (i, (e, ty)))  ", " ppf (IMap.bindings m)
+  = fun  ppf m -> Lib.pp_print_list (fun ppf (i, (e, ty, sc))
+    -> pp_print_val_binding ppf (i, (e, ty, sc)))  ", " ppf (IMap.bindings m)
 (** Pretty print value store *)
 
 let pp_print_u_types: Format.formatter -> SI.t -> unit

--- a/src/lustre/typeCheckerContext.mli
+++ b/src/lustre/typeCheckerContext.mli
@@ -181,7 +181,7 @@ val pp_print_type_syn: Format.formatter -> (LA.ident * tc_type) -> unit
 val pp_print_type_binding: Format.formatter -> (LA.ident * tc_type) -> unit
 (** Pretty print type bindings*)  
 
-val pp_print_val_binding: Format.formatter -> (LA.ident * (LA.expr * tc_type option)) -> unit
+val pp_print_val_binding: Format.formatter -> (LA.ident * (LA.expr * tc_type option * const_scope)) -> unit
 (** Pretty print value bindings (used for constants)*)
 
 val pp_print_ty_syns: Format.formatter -> ty_alias_store -> unit

--- a/src/lustre/typeCheckerContext.mli
+++ b/src/lustre/typeCheckerContext.mli
@@ -25,6 +25,8 @@ module SI = LA.SI
 type tc_type  = LA.lustre_type
 (** Type alias for lustre type from LustreAst  *)
 
+type const_scope = Global | Local
+
 module IMap : sig
   (* everything that [Stdlib.Map] gives us  *)
   include (Map.S with type key = LA.ident)
@@ -41,7 +43,7 @@ type ty_alias_store = tc_type IMap.t
 type ty_store = tc_type IMap.t
 (** A store of identifier and their types*)
 
-type const_store = (LA.expr * tc_type option) IMap.t 
+type const_store = (LA.expr * tc_type option * const_scope) IMap.t 
 (** A Store of constant identifier and their (const) values with types. 
  *  The values of the associated identifiers should be evaluated to a 
  *  Bool or an Int at constant propogation phase of type checking *)
@@ -104,10 +106,11 @@ val lookup_node_ty: tc_context -> LA.ident -> tc_type option
 (** Lookup a node type *)
 
 val lookup_node_param_attr: tc_context -> LA.ident -> (HString.t * bool) list option
+(** Track whether node parameters are constant or not *)
 
 val lookup_node_param_ids: tc_context -> LA.ident -> HString.t list option
 
-val lookup_const: tc_context -> LA.ident -> (LA.expr * tc_type option) option
+val lookup_const: tc_context -> LA.ident -> (LA.expr * tc_type option * const_scope) option
 (** Lookup a constant identifier *)
 
 val lookup_variants: tc_context -> LA.ident -> LA.ident list option
@@ -137,10 +140,10 @@ val add_enum_variants: tc_context -> LA.ident -> LA.ident list -> tc_context
 val remove_ty: tc_context -> LA.ident -> tc_context
 (** Removes a type binding  *)
                   
-val add_const: tc_context -> LA.ident -> LA.expr -> tc_type -> tc_context
+val add_const: tc_context -> LA.ident -> LA.expr -> tc_type -> const_scope -> tc_context
 (** Adds a constant variable along with its expression and type  *)
 
-val add_untyped_const : tc_context -> LA.ident -> LA.expr -> tc_context
+val add_untyped_const : tc_context -> LA.ident -> LA.expr -> const_scope -> tc_context
 (** Adds a constant variable along with its type  *)
 
 val union: tc_context -> tc_context -> tc_context
@@ -149,7 +152,7 @@ val union: tc_context -> tc_context -> tc_context
 val singleton_ty: LA.ident -> tc_type -> tc_context
 (** Lifts the type binding as a typing context  *)
 
-val singleton_const: LA.ident -> LA.expr -> tc_type -> tc_context
+val singleton_const: LA.ident -> LA.expr -> tc_type -> const_scope -> tc_context
 (** Lifts the constant binding as a typing context  *)
 
 val extract_arg_ctx: LA.const_clocked_typed_decl -> tc_context

--- a/tests/regression/success/any_op_global_local_const.lus
+++ b/tests/regression/success/any_op_global_local_const.lus
@@ -1,0 +1,10 @@
+const q: int;
+
+node M(const n: int; const m: int) returns (A: int^n)
+(*@contract
+assume n > 0;
+*)
+let 
+  A = any { A: int^n | A[0] + m + q > 5} ;
+  check A[0] + m + q > 5;
+tel


### PR DESCRIPTION
Fix bug where local constants in 'any' operators were not included as parameters to the corresponding generated nodes. See the new test case for an example.

To distinguish between local and global constants, I added constant scope information to the type context (rather than passing a separate global_ctx variable with _only_ global context information throughout the whole module).