### PR TITLE
Give more detailed information about property types in all output formats

### DIFF
--- a/schemas/kind2-output.json
+++ b/schemas/kind2-output.json
@@ -639,7 +639,18 @@
                     "type": "integer"
                 },
                 "source": {
-                    "type": "string"
+                    "enum": [
+                        "Assumption",
+                        "Guarantee",
+                        "Generated",
+                        "NonVacuityCheck",
+                        "OneModeActive",
+                        "Ensure",
+                        "PropAnnot"
+                    ]
+                },
+                "isCandidate": {
+                    "type": "boolean"
                 },
                 "runtime": {
                     "$ref": "#/definitions/runtime"

--- a/schemas/kind2-output.json
+++ b/schemas/kind2-output.json
@@ -639,15 +639,7 @@
                     "type": "integer"
                 },
                 "source": {
-                    "enum": [
-                        "Assumption",
-                        "Guarantee",
-                        "Generated",
-                        "NonVacuityCheck",
-                        "OneModeActive",
-                        "Ensure",
-                        "PropAnnot"
-                    ]
+                    "type": "string"
                 },
                 "runtime": {
                     "$ref": "#/definitions/runtime"

--- a/schemas/kind2-output.xsd
+++ b/schemas/kind2-output.xsd
@@ -22,6 +22,19 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <!-- Property source-->
+  <xs:simpleType name="PropSource">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Assumption"/>
+      <xs:enumeration value="Guarantee"/>
+      <xs:enumeration value="Generated"/>
+      <xs:enumeration value="NonVacuityCheck"/>
+      <xs:enumeration value="OneModeActive"/>
+      <xs:enumeration value="Ensure"/>
+      <xs:enumeration value="PropAnnot"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <!-- Context of realizability check -->
   <xs:simpleType name="Context">
     <xs:restriction base="xs:string">
@@ -355,7 +368,8 @@
     <xs:attribute name="line" type="NonNegativeInteger"/>
     <xs:attribute name="column" type="NonNegativeInteger"/>
     <xs:attribute name="scope" type="xs:string"/>
-    <xs:attribute name="source" type="xs:string"/>
+    <xs:attribute name="source" type="PropSource"/>
+    <xs:attribute name="isCandidate" type="xs:boolean"/>
   </xs:complexType>
 
   <xs:complexType name="PostAnalysisStartType">

--- a/src/kEvent.ml
+++ b/src/kEvent.ml
@@ -794,8 +794,10 @@ let prop_attributes_xml trans_sys prop_name =
           Format.asprintf " line=\"%d\" column=\"%d\" source=\"Generated\"%a"
           lnum cnum pp_print_fname fname
     )
-    | Property.Candidate None -> ""
-    | Property.Candidate (Some source) -> get_attributes source
+    | Property.Candidate None -> " source=\"Candidate\""
+    | Property.Candidate (Some source) -> 
+      Format.asprintf " source=\"Candidate(%s)\""
+      (Property.string_of_source source)
     | Property.Instantiated (_, prop) ->
         get_attributes prop.Property.prop_source
     | Property.Assumption (pos, (scope, _)) ->
@@ -1157,8 +1159,10 @@ let prop_attributes_json ppf trans_sys prop_name =
             "%a\"line\" : %d,@,\"column\" : %d,@,\"source\" : \"Generated\",@,"
             pp_print_fname fname lnum cnum
     )
-    | Property.Candidate None -> ()
-    | Property.Candidate (Some source) -> get_attributes source
+    | Property.Candidate None -> Format.fprintf ppf "\"source\" : \"Candidate\",@,"
+    | Property.Candidate (Some source) -> 
+      Format.fprintf ppf "\"source\" : \"Candidate(%s)\",@,"
+      (Property.string_of_source source)
   in
 
   get_attributes prop.Property.prop_source

--- a/src/kEvent.ml
+++ b/src/kEvent.ml
@@ -311,7 +311,14 @@ let proved_pt mdl level trans_sys k prop =
   if 
     not (Property.prop_status_known (TransSys.get_prop_status trans_sys prop))
   then (
-    let cand_or_prop = (if TransSys.is_candidate trans_sys prop then  "Candidate" else "Property") in
+
+    let property = TransSys.property_of_name trans_sys prop in
+    let prop_type = match property.prop_source with 
+      | Candidate None -> "Candidate property"
+      | Candidate Some (Generated _) -> "Generated candidate property"
+      | Generated _ -> "Generated property"
+      | _ -> "Property"
+    in
     let k_val = (function ppf -> match k with
       | None -> ()
       | Some k -> Format.fprintf ppf "for k=%d " k) in
@@ -322,7 +329,7 @@ let proved_pt mdl level trans_sys k prop =
         !log_ppf
         "@[<hov>%t %s @{<blue_b>%s@} is valid %tby %a after %.3fs.@.@."
         success_tag
-        cand_or_prop
+        prop_type
         prop
         k_val
         pp_print_kind_module_pt mdl
@@ -332,7 +339,7 @@ let proved_pt mdl level trans_sys k prop =
         !log_ppf
         ("@[<hov>%t %s @{<blue_b>%s@} is unreachable in %d steps or more %tby %a after %.3fs.@.@.")
         failure_tag
-        cand_or_prop
+        prop_type
         prop
         ts
         k_val
@@ -343,7 +350,7 @@ let proved_pt mdl level trans_sys k prop =
         !log_ppf
         "@[<hov>%t %s @{<blue_b>%s@} is unreachable in %d steps or less %tby %a after %.3fs.@.@."
         failure_tag
-        cand_or_prop
+        prop_type
         prop
         ts
         k_val
@@ -354,7 +361,7 @@ let proved_pt mdl level trans_sys k prop =
         !log_ppf
         "@[<hov>%t %s @{<blue_b>%s@} is unreachable at step %d %tby %a after %.3fs.@.@."
         failure_tag
-        cand_or_prop
+        prop_type
         prop
         ts
         k_val
@@ -365,7 +372,7 @@ let proved_pt mdl level trans_sys k prop =
         !log_ppf
         "@[<hov>%t %s @{<blue_b>%s@} is unreachable between steps %d and %d %tby %a after %.3fs.@.@."
         failure_tag
-        cand_or_prop
+        prop_type
         prop
         ts1
         ts2
@@ -377,7 +384,7 @@ let proved_pt mdl level trans_sys k prop =
         !log_ppf
         "@[<hov>%t %s @{<blue_b>%s@} is unreachable %tby %a after %.3fs.@.@."
         failure_tag
-        cand_or_prop
+        prop_type
         prop
         k_val
         pp_print_kind_module_pt mdl

--- a/src/property.ml
+++ b/src/property.ml
@@ -100,18 +100,11 @@ and prop_source =
      properties *)
   | Candidate of prop_source option
 
-let rec string_of_source = function 
-| PropAnnot _ -> "PropAnnot"
-| Generated _ -> "Generated"
-| Instantiated _ -> "Instantiated"
-| Assumption _ -> "Assumption"
-| Guarantee _ -> "Guarantee"
-| GuaranteeOneModeActive _ -> "OneModeActive"
-| GuaranteeModeImplication _ -> "ModeImplication"
-| NonVacuityCheck _ -> "NonVacuityCheck"
-| Candidate None -> "Candidate"
-| Candidate (Some source) -> "Candidate(" ^ string_of_source source ^ ")"
-
+let rec is_candidate = function 
+| Candidate _ -> true
+| PropAnnot _ | Generated _ | Instantiated _ | Assumption _ 
+| Guarantee _ | GuaranteeOneModeActive _ | GuaranteeModeImplication _
+| NonVacuityCheck _ -> false
 
 let copy t = { t with prop_status = t.prop_status }
 

--- a/src/property.ml
+++ b/src/property.ml
@@ -100,6 +100,17 @@ and prop_source =
      properties *)
   | Candidate of prop_source option
 
+let string_of_source = function 
+| PropAnnot _ -> "PropAnnot"
+| Generated _ -> "Generated"
+| Instantiated _ -> "Instantiated"
+| Assumption _ -> "Assumption"
+| Guarantee _ -> "Guarantee"
+| GuaranteeOneModeActive _ -> "OneModeActive"
+| GuaranteeModeImplication _ -> "ModeImplication"
+| NonVacuityCheck _ -> "NonVacuityCheck"
+| Candidate _ -> "Candidate"
+
 
 let copy t = { t with prop_status = t.prop_status }
 

--- a/src/property.ml
+++ b/src/property.ml
@@ -100,7 +100,7 @@ and prop_source =
      properties *)
   | Candidate of prop_source option
 
-let rec is_candidate = function 
+let is_candidate = function 
 | Candidate _ -> true
 | PropAnnot _ | Generated _ | Instantiated _ | Assumption _ 
 | Guarantee _ | GuaranteeOneModeActive _ | GuaranteeModeImplication _

--- a/src/property.ml
+++ b/src/property.ml
@@ -100,7 +100,7 @@ and prop_source =
      properties *)
   | Candidate of prop_source option
 
-let string_of_source = function 
+let rec string_of_source = function 
 | PropAnnot _ -> "PropAnnot"
 | Generated _ -> "Generated"
 | Instantiated _ -> "Instantiated"
@@ -109,7 +109,8 @@ let string_of_source = function
 | GuaranteeOneModeActive _ -> "OneModeActive"
 | GuaranteeModeImplication _ -> "ModeImplication"
 | NonVacuityCheck _ -> "NonVacuityCheck"
-| Candidate _ -> "Candidate"
+| Candidate None -> "Candidate"
+| Candidate (Some source) -> "Candidate(" ^ string_of_source source ^ ")"
 
 
 let copy t = { t with prop_status = t.prop_status }

--- a/src/property.mli
+++ b/src/property.mli
@@ -103,6 +103,8 @@ val copy : t -> t
 (** Pretty-prints a property source. *)
 val pp_print_prop_source : Format.formatter -> prop_source -> unit
 
+val string_of_source : prop_source -> string
+
 (** Pretty-prints a property status. *)
 val pp_print_prop_status : Format.formatter -> prop_status -> unit
 

--- a/src/property.mli
+++ b/src/property.mli
@@ -103,7 +103,8 @@ val copy : t -> t
 (** Pretty-prints a property source. *)
 val pp_print_prop_source : Format.formatter -> prop_source -> unit
 
-val string_of_source : prop_source -> string
+(** Returns true iff the input property source is candidate *)
+val is_candidate : prop_source -> bool
 
 (** Pretty-prints a property status. *)
 val pp_print_prop_status : Format.formatter -> prop_status -> unit


### PR DESCRIPTION
Most importantly, all output types (JSON, XML, and terminal) now distinguish between candidate, generated, and candidate generated properties. This allows for accurate fine-grained filtering of properties generated by abstract interpretation.