### PR TITLE
Fix bug that erroneously disallowed refinement type assumptions from referencing global constants

### DIFF
--- a/tests/regression/success/assumption_on_global_const.lus
+++ b/tests/regression/success/assumption_on_global_const.lus
@@ -1,0 +1,6 @@
+const c: int;
+
+node N(const t: int; x: int | x < c) returns (y: int;);
+let
+   check true;
+tel

--- a/tests/regression/success/assumption_on_global_const.lus
+++ b/tests/regression/success/assumption_on_global_const.lus
@@ -1,6 +1,6 @@
 const c: int;
 
-node N(const t: int; x: int | x < c) returns (y: int;);
+node N(x: int | x < c) returns ();
 let
    check true;
 tel


### PR DESCRIPTION
 See tests/regression/success/assumption_on_global_const.lus as an example that triggers the bug