### PR TITLE
Fix bug when checking realizability but not environment

### DIFF
--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -333,14 +333,19 @@ let of_channel old_frontend only_parse in_ch =
               (* If checking realizability, then 
                 we are actually checking realizability of Kind 2-generated imported nodes representing 
                 the (1) the main node's contract instrumented with type info and 
-                    (2) the main node's enviornment *)
-              if (not main_lustre_node.is_extern) && List.mem `CONTRACTCK (Flags.enabled ()) then 
-                [LustreIdent.mk_string_ident (LGI.contract_tag ^ s);
-                LustreIdent.mk_string_ident (LGI.inputs_tag ^ s)]
-              else if main_lustre_node.is_extern && List.mem `CONTRACTCK (Flags.enabled ()) then 
-                [s_ident;
-                LustreIdent.mk_string_ident (LGI.inputs_tag ^ s)]
-              else [s_ident]
+                    (2) the main node's enviornment, if environment checking is enabled *)
+              let main_nodes = 
+                if (not main_lustre_node.is_extern) && List.mem `CONTRACTCK (Flags.enabled ()) then 
+                  [LustreIdent.mk_string_ident (LGI.contract_tag ^ s);]
+                else [s_ident] 
+              in
+              let main_nodes = 
+                if (Flags.Contracts.check_environment ()) && List.mem `CONTRACTCK (Flags.enabled ()) then
+                  LustreIdent.mk_string_ident (LGI.inputs_tag ^ s) :: main_nodes 
+                else 
+                  main_nodes 
+                in 
+              main_nodes
             (* User-specified main node in command-line input might not exist *)
             with Not_found -> 
               let msg =


### PR DESCRIPTION
Fix bug that was triggered when calling kind 2 with realizability checking enabled but environment checking disabled, e.g. 

`kind2 --enable CONTRACTCK --lus_main N --check_environment false check_env_bug.lus`

with Lustre file 

```
-- check_env_bug.lus
node imported N() returns (y:int);
```