### PR TITLE
docs: add missing fi in frame code block

### DIFF
--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -1011,6 +1011,7 @@ will also generate the two warnings as discussed in the previous paragraph.
          y1 = 0;
       else
          y2 = 1;
+      fi
    tel
 
 Restrictions


### PR DESCRIPTION
The code block at the bottom of the section on [frame conditions](https://kind.cs.uiowa.edu/kind2_user_docs/v2.2.0/2_input/1_lustre.html#frame-conditions) is missing the closing `fi`.