### PR TITLE
Add support for function calls with arguments containing quantified vars

### DIFF
--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -39,6 +39,7 @@ type t = {
   locals : 
   (LustreAst.lustre_type)
     StringMap.t;
+  asserts : (Lib.position * LustreAst.expr) list;
   contract_calls :
     (Lib.position
     * (Lib.position * HString.t) list (* contract scope *)
@@ -52,7 +53,8 @@ type t = {
     * LustreAst.expr (* restart expression *)
     * HString.t (* node name *)
     * (LustreAst.expr list) (* node arguments *)
-    * (LustreAst.expr list option)) (* node argument defaults *)
+    * (LustreAst.expr list option) (* node argument defaults *)
+    * bool) (* Was call inlined? *)
     list;
   subrange_constraints : (source
     * (Lib.position * HString.t) list (* contract scope  *)
@@ -104,6 +106,7 @@ let union_keys key id1 id2 = match key, id1, id2 with
 
 let union ids1 ids2 = {
     locals = StringMap.merge union_keys ids1.locals ids2.locals;
+    asserts = ids1.asserts @ ids2.asserts;
     array_constructors = StringMap.merge union_keys
       ids1.array_constructors ids2.array_constructors;
     node_args = ids1.node_args @ ids2.node_args;
@@ -130,6 +133,7 @@ let union_keys2 key id1 id2 = match key, id1, id2 with
   
 let empty () = {
   locals = StringMap.empty;
+  asserts = [];
   array_constructors = StringMap.empty;
   node_args = [];
   oracles = [];

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -39,6 +39,7 @@ type t = {
   locals : 
   (LustreAst.lustre_type)
     StringMap.t;
+  asserts : (Lib.position * LustreAst.expr) list;
   contract_calls :
     (Lib.position
     * (Lib.position * HString.t) list (* contract scope *)
@@ -52,7 +53,8 @@ type t = {
     * LustreAst.expr (* restart expression *)
     * HString.t (* node name *)
     * (LustreAst.expr list) (* node arguments *)
-    * (LustreAst.expr list option)) (* node argument defaults *)
+    * (LustreAst.expr list option) (* node argument defaults *)
+    * bool) (* Was call inlined? *)
     list;
   subrange_constraints : (source
     * (Lib.position * HString.t) list (* contract scope  *)

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -55,6 +55,11 @@ val substitute_naive : HString.t -> expr -> expr -> expr
 (** Substitute second param for first param in third param. 
     AnyOp and Quantifier are not supported due to introduction of bound variables. *)
 
+val apply_subst_in_expr : (HString.t * expr) list -> expr -> expr
+(** [apply_subst_in_expr s e] applies the substitution defined by association list [s]
+    to the expression [e]
+    AnyOp and Quantifier are not supported due to introduction of bound variables. *)
+
 val apply_subst_in_type : (HString.t * expr) list -> lustre_type -> lustre_type
 (** [apply_subst_in_type s t] applies the substitution defined by association list [s]
     to the expressions of (possibly dependent) type [t]

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -101,6 +101,7 @@ val mk_enum_range_expr : TypeCheckerContext.tc_context ->
 
 val normalize : TypeCheckerContext.tc_context ->
   LustreAbstractInterpretation.context ->
+  LustreAst.SI.t ->
   LustreAst.t ->
     GeneratedIdentifiers.t GeneratedIdentifiers.StringMap.t ->
   (LustreAst.declaration list * GeneratedIdentifiers.t GeneratedIdentifiers.StringMap.t *

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -124,6 +124,8 @@ type node_call = {
       [merge] operator.*)
   call_defaults : E.t D.t option;
 
+  (* Whether this call was inlined or not *)
+  call_inlined : bool;
 }
 
 

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -102,6 +102,8 @@ type node_call = {
       If the option value is not [None], the keys of the index match
       those in the {!t.outputs} field of the called node. *)
 
+  call_inlined : bool;
+  (** Whether this call was inlined or not *)
 }
 
 

--- a/src/lustre/lustreSimplify.ml
+++ b/src/lustre/lustreSimplify.ml
@@ -1911,7 +1911,8 @@ and eval_node_call
           N.call_inputs = input_state_vars;
           N.call_oracles = oracle_state_vars;
           N.call_outputs = output_state_vars;
-          N.call_defaults = defaults } 
+          N.call_defaults = defaults;
+          N.call_inlined = false }
       in
       (* Add node call to context *)
       let ctx = C.add_node_call ctx pos node_call in

--- a/src/lustre/lustreSyntaxChecks.mli
+++ b/src/lustre/lustreSyntaxChecks.mli
@@ -76,3 +76,6 @@ val no_mismatched_clock : bool -> LA.expr -> ([> warning ] list, [> error]) resu
 
   Note: type information is needed for this check, causing this check to
   be called in the lustreTypeChecker *)
+
+val no_quant_vars_in_calls_to_non_inlinable_funcs :
+  LA.SI.t -> LA.t -> ([> warning ] list, [> error]) result

--- a/src/lustre/lustreUserFunctions.ml
+++ b/src/lustre/lustreUserFunctions.ml
@@ -1,0 +1,84 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2024 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+module A = LustreAst
+module AH = LustreAstHelpers
+module Ctx = TypeCheckerContext
+
+module IdSet = A.SI
+
+let valid_outputs ctx = function
+  | [(_, _, ty, _)] -> ( (* single output variable *)
+    not (Ctx.type_contains_array ctx ty)
+  )
+  | _ -> false
+
+let valid_locals ctx locals =
+  locals |> List.for_all (function
+  | A.NodeConstDecl (_, TypedConst (_,_,_,ty)) ->
+    not (Ctx.type_contains_array ctx ty)
+  | A.NodeConstDecl _ -> true
+  | NodeVarDecl (_, (_, _, ty, _)) ->
+    not (Ctx.type_contains_array ctx ty)
+  )
+
+let valid_items set items =
+  items |> List.for_all (function
+    | A.Body (Equation (_, StructDef (_, [A.SingleIdent _]), rhs)) ->
+      IdSet.subset (AH.calls_of_expr rhs) set
+    | AnnotProperty _ -> true
+    | A.Body (Equation (_, _, _))
+    | Body (Assert _)
+    | AnnotMain _ -> false
+    | FrameBlock _
+    | IfBlock _ -> assert false (* desugared earlier in pipeline *)
+  )
+
+let is_output_defined outputs items =
+  let output_id =
+    match outputs with
+    | [(_, id, _, _)] -> id
+    | _ -> assert false
+  in
+  items |> List.exists (function
+    | A.Body (Equation (_, StructDef (_, [A.SingleIdent (_, id)]), _)) ->
+      HString.equal id output_id
+    | _ -> false
+  )
+
+let is_inlinable set ctx opac contract outputs locals items =
+  (opac = A.Transparent || contract = None) &&
+  valid_outputs ctx outputs &&
+  valid_locals ctx locals &&
+  valid_items set items &&
+  is_output_defined outputs items
+
+let inlinable_functions ctx decls =
+  List.fold_left (fun set dcl ->
+    match dcl with
+    (* A non-imported function *)
+    | A.FuncDecl (_, (id, false, opac, [], _, outputs, locals, items, contract)) -> (
+      if is_inlinable set ctx opac contract outputs locals items then
+        IdSet.add id set
+      else
+        set
+    )
+    | _ -> set
+  )
+  IdSet.empty
+  decls

--- a/src/lustre/lustreUserFunctions.mli
+++ b/src/lustre/lustreUserFunctions.mli
@@ -1,0 +1,22 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2024 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0 
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License. 
+
+*)
+
+val inlinable_functions :
+  TypeCheckerContext.tc_context ->
+  LustreAst.declaration list ->
+  LustreAst.SI.t

--- a/src/lustre/typeCheckerContext.mli
+++ b/src/lustre/typeCheckerContext.mli
@@ -289,6 +289,9 @@ val type_contains_enum_subrange_reftype : tc_context -> LA.lustre_type -> bool
 val type_contains_abstract : tc_context -> tc_type -> bool
 (** Returns true if the lustre type expression contains an abstract type (including polymorphic type variable) or if it is an abstract type *)
 
+val type_contains_array: tc_context -> tc_type -> bool
+(** Returns true if the lustre type expression contains an array *)
+
 val ty_vars_of_expr: tc_context -> LA.index -> LA.expr -> SI.t
 (** [ty_vars_of_type ctx node_name e] returns all type variable identifiers that appear in the expression [e] *)
 


### PR DESCRIPTION
Currently, only calls to functions that meet all the following criteria are accepted: they are fully specified, either have no contract or are annotated as transparent, do not include asserts or array definitions, and have only one output.

Requires: #1112 (amended in #1114)