### PR TITLE
Update the set of inlinable functions

### DIFF
--- a/.github/actions/build-kind2/action.yml
+++ b/.github/actions/build-kind2/action.yml
@@ -25,7 +25,7 @@ runs:
       echo "::endgroup::"
 
   - name: Set up OCaml ${{ steps.ocaml-variant.outputs.tag }}
-    uses: ocaml/setup-ocaml@v2
+    uses: ocaml/setup-ocaml@v3
     with:
       ocaml-compiler: ${{ steps.ocaml-variant.outputs.compiler }}
 

--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -754,6 +754,9 @@ let rec type_contains_enum_or_subrange ctx = function
   | Int8 _ |Int16 _ |Int32 _ | Int64 _
   | AbstractType _ -> false
 
+let type_contains_ref_or_subrange ctx ty =
+  type_contains_ref ctx ty || type_contains_subrange ctx ty
+
 let rec type_contains_enum_subrange_reftype ctx = function
   | LA.IntRange _
   | EnumType _ 

--- a/src/lustre/typeCheckerContext.mli
+++ b/src/lustre/typeCheckerContext.mli
@@ -283,6 +283,8 @@ val type_contains_enum_or_subrange : tc_context -> LA.lustre_type -> bool
 val type_contains_ref : tc_context -> LA.lustre_type -> bool
 (** Returns true if the lustre type expression contains a RefinementType or if it is an RefinementType *)
 
+val type_contains_ref_or_subrange : tc_context -> LA.lustre_type -> bool
+
 val type_contains_enum_subrange_reftype : tc_context -> LA.lustre_type -> bool
 (** Returns true if the lustre type expression contains an EnumType/IntRange or if it is an EnumType/IntRange *)
 


### PR DESCRIPTION
A function that can be abstracted because it has a contract with guarantees or modes, or outputs with refinement types or subrange types, must be marked as transparent to allow it to be inlined.