### PR TITLE
Environment realizability with contract import fix

### DIFF
--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -28,6 +28,37 @@ let unwrap = function
   | Ok x -> x 
   | Error _ -> assert false
 
+let contract_node_decl_to_contracts
+= fun ctx (id, params, inputs, outputs, (pos, base_contract)) -> 
+  let contract' = List.filter_map (fun ci -> 
+    match ci with
+    | A.GhostConst _ | GhostVars _ -> Some ci
+    | A.Assume (pos, name, b, expr) -> Some (A.Guarantee (pos, name, b, expr))
+    | A.ContractCall (pos, name, ty_args, ips, ops) -> 
+      let name = HString.concat2 (HString.mk_hstring ".inputs_") name in
+      Some (A.ContractCall (pos, name, ty_args, ips, ops))
+    | A.Guarantee _ | A.AssumptionVars _ | A.Mode _  -> None
+  ) base_contract in
+  let gen_node_id = HString.concat2 (HString.mk_hstring inputs_tag) id in
+  let inputs2, outputs2 = 
+    List.map (fun (p, id, ty, cl) -> (p, id, ty, cl, false)) outputs, 
+    List.map (fun (p, id, ty, cl, _) -> (p, id, ty, cl)) inputs 
+  in
+  (* Since we are omitting assumptions from environment realizability checks,
+     we need to chase base types for environment inputs *)
+  let inputs2 = List.map (fun (p, id, ty, cl, b) -> 
+    let ty = Chk.expand_type_syn_reftype_history_subrange ctx ty |> unwrap in 
+    (p, id, ty, cl, b)
+  ) inputs2 in
+  (* We generate two imported nodes: One for the input node's contract (w/ type info), and another 
+     for the input node's inputs/environment *)
+  let environment = gen_node_id, params, inputs2, outputs2, (pos, contract') in
+  if Flags.Contracts.check_environment () 
+  then 
+    let ctx, _ = LustreTypeChecker.tc_ctx_of_contract_node_decl pos ctx environment |> unwrap in
+    [environment], ctx 
+  else [], ctx
+
 let node_decl_to_contracts 
 = fun pos ctx (id, extern, _, params, inputs, outputs, locals, _, contract) ->
   let base_contract = match contract with | None -> [] | Some (_, contract) -> contract in 
@@ -35,7 +66,10 @@ let node_decl_to_contracts
     match ci with
     | A.GhostConst _ | GhostVars _ -> Some ci
     | A.Assume (pos, name, b, expr) -> Some (A.Guarantee (pos, name, b, expr))
-    | _ -> None
+    | A.ContractCall (pos, name, ty_args, ips, ops) -> 
+      let name = HString.concat2 (HString.mk_hstring ".inputs_") name in
+      Some (A.ContractCall (pos, name, ty_args, ips, ops))
+    | A.Guarantee _ | A.AssumptionVars _ | A.Mode _  -> None
   ) base_contract in
   let locals_as_outputs = List.map (fun local_decl -> match local_decl with 
     | A.NodeConstDecl (pos, FreeConst (_, id, ty)) 
@@ -64,11 +98,20 @@ let node_decl_to_contracts
      for the input node's inputs/environment *)
   if extern then 
     let environment = gen_node_id, extern, A.Opaque, params, inputs2, outputs2, [], node_items, contract' in
-    if Flags.Contracts.check_environment () then [environment] else []
+    if Flags.Contracts.check_environment () then 
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx environment |> unwrap in
+      [environment], ctx
+    else [], ctx
   else
     let environment = gen_node_id, extern', A.Opaque, params, inputs2, outputs2, [], node_items, contract' in
     let contract = (gen_node_id2, extern', A.Opaque, params, inputs, locals_as_outputs @ outputs, [], node_items, contract) in
-    if Flags.Contracts.check_environment () then [environment; contract] else [contract]
+    if Flags.Contracts.check_environment () then 
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx environment |> unwrap in
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx contract |> unwrap in
+      [environment; contract], ctx 
+    else 
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx contract |> unwrap in
+      [contract], ctx
 
 (* NOTE: Currently, we do not allow global constants to have refinement types. 
    If we decide to support this in the future, then we need to add necessary refinement type information 
@@ -83,36 +126,41 @@ let type_to_contract: Lib.position -> HString.t -> A.lustre_type -> HString.t li
   let node_items = [A.AnnotMain(pos, true)] in 
   Some (NodeDecl (span, (gen_node_id, true, A.Opaque, ps, [], [(pos, id, ty, A.ClockTrue)], [], node_items, None)))
 
-let gen_imp_nodes:  Ctx.tc_context -> A.declaration list -> A.declaration list 
+let gen_imp_nodes  : Ctx.tc_context -> A.declaration list -> A.declaration list * Ctx.tc_context 
 = fun ctx decls -> 
-  List.fold_left (fun acc decl -> 
+  let decls, ctx = List.fold_left (fun (acc_decls, acc_ctx) decl -> 
     match decl with 
     | A.ConstDecl (_, FreeConst _)
-    | A.ConstDecl (_, TypedConst _) -> acc
+    | A.ConstDecl (_, TypedConst _) -> acc_decls, acc_ctx
     | A.TypeDecl (_, AliasType (p, id, ps, ty)) -> 
       (match type_to_contract p id ty ps with 
-      | Some decl1 -> decl1 :: acc
-      | None -> acc)
+      | Some decl1 -> decl1 :: acc_decls, acc_ctx
+      | None -> acc_decls, acc_ctx)
     | A.TypeDecl (_, FreeType _)
-    | A.ConstDecl (_, UntypedConst _) -> acc
+    | A.ConstDecl (_, UntypedConst _) -> acc_decls, acc_ctx
     | A.NodeDecl (span, ((p, e, opac, ps, ips, ops, locs, _, c) as node_decl)) ->
       (* Add main annotations to imported nodes *)
       let node_decl = 
         if e then p, e, opac, ps, ips, ops, locs, [A.AnnotMain (span.start_pos, true)], c
         else node_decl 
       in
-      let decls = node_decl_to_contracts span.start_pos ctx node_decl in
+      let decls, acc_ctx = node_decl_to_contracts span.start_pos acc_ctx node_decl in
       let decls = List.map (fun decl -> A.NodeDecl (span, decl)) decls in
-      A.NodeDecl(span, node_decl) :: decls @ acc
+      A.NodeDecl(span, node_decl) :: decls @ acc_decls, acc_ctx
     | A.FuncDecl (span, ((p, e, opac, ps, ips, ops, locs, _, c) as func_decl)) ->
       (* Add main annotations to imported functions *)
       let func_decl = 
         if e then p, e, opac, ps, ips, ops, locs, [A.AnnotMain (span.start_pos, true)], c
         else func_decl 
       in
-      let decls = node_decl_to_contracts span.start_pos ctx func_decl in
+      let decls, acc_ctx = node_decl_to_contracts span.start_pos acc_ctx func_decl in
       let decls = List.map (fun decl -> A.FuncDecl (span, decl)) decls in
-      A.FuncDecl(span, func_decl) :: decls @ acc
-    | A.ContractNodeDecl _ 
-    | A.NodeParamInst _ -> decl :: acc
-  ) [] decls |> List.rev
+      A.FuncDecl(span, func_decl) :: decls @ acc_decls, acc_ctx
+    | A.ContractNodeDecl (span, contract_node_decl) -> 
+      let decls, acc_ctx = contract_node_decl_to_contracts acc_ctx contract_node_decl in 
+      let decls = List.map (fun decl -> A.ContractNodeDecl (span, decl)) decls in
+      A.ContractNodeDecl (span, contract_node_decl) :: decls @ acc_decls, acc_ctx
+    | A.NodeParamInst _ -> decl :: acc_decls, acc_ctx
+  ) ([], ctx) decls 
+  in 
+  List.rev decls, ctx

--- a/src/lustre/lustreGenRefTypeImpNodes.mli
+++ b/src/lustre/lustreGenRefTypeImpNodes.mli
@@ -19,10 +19,11 @@
 
 
 module A = LustreAst
+module Ctx = TypeCheckerContext
 
 val inputs_tag : string 
 val contract_tag : string
 val type_tag : string
 val poly_gen_node_tag : string
 
-val gen_imp_nodes : TypeCheckerContext.tc_context ->  A.declaration list -> A.declaration list
+val gen_imp_nodes : Ctx.tc_context ->  A.declaration list -> A.declaration list * Ctx.tc_context 

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -173,12 +173,13 @@ let type_check declarations =
       LspInfo.print_ast_info global_ctx declarations;
 
     (* Step 9. Generate imported nodes associated with refinement types if realizability checking is enabled *)
-    let sorted_node_contract_decls = 
+    let sorted_node_contract_decls, global_ctx = 
       if List.mem `CONTRACTCK (Flags.enabled ()) 
       then 
-        LGI.gen_imp_nodes global_ctx const_inlined_type_and_consts @
-        LGI.gen_imp_nodes global_ctx sorted_node_contract_decls 
-      else sorted_node_contract_decls
+        let decls1, ctx1 = LGI.gen_imp_nodes global_ctx const_inlined_type_and_consts in 
+        let decls2, ctx2 = LGI.gen_imp_nodes global_ctx sorted_node_contract_decls in
+        decls1 @ decls2, TypeCheckerContext.union ctx1 ctx2
+      else sorted_node_contract_decls, global_ctx
     in
 
     (* Step 10. Remove multiple assignment from if blocks and frame blocks *)

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -190,6 +190,12 @@ val infer_type_expr: tc_context ->  HString.t option -> LA.expr -> (tc_type * [>
 val eq_lustre_type : tc_context -> LA.lustre_type -> LA.lustre_type -> (bool, [> error]) result
 (** Check if two lustre types are equal *)
 
+val tc_ctx_of_contract_node_decl: Lib.position -> tc_context
+  -> LA.contract_node_decl
+  -> (tc_context * [> warning] list, [> error]) result
+
+val tc_ctx_of_node_decl: Lib.position -> tc_context -> LA.node_decl -> (tc_context * [> warning] list, [> error]) result
+
 (* 
    Local Variables:
    compile-command: "make -k -C .."


### PR DESCRIPTION
Fixes kind2-mc/kind2-dev#150

A more in-depth test case (`N` is correctly reported unrealizable due to `S2`'s input refinement type assumption of `false`): 
```
contract S1(x: int) returns (y: int);
let
  import S2(x) returns (y);
tel

contract S2(x: int | false) returns (y: int | false);
let
    assume true;
    guarantee false or false;
tel

node imported N(x:int) returns (y: int);
(*@contract
  import S1(x) returns (y);
*)
```