### PR TITLE
Array frame fix

### DIFF
--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -197,7 +197,7 @@ let error_message kind = match kind with
   | GlobalConstRefType id -> "Definition of global constant '" ^ HString.string_of_hstring id ^ "' has refinement type (not yet supported)"
   | QuantifiedAbstractType id -> "Variable '" ^ HString.string_of_hstring id ^ "' with type that contains an abstract type (or type variable) cannot be quantified"
   | InvalidPolymorphicCall id -> "Call to node, contract, or user type '" ^ HString.string_of_hstring id ^ "' passes an incorrect number of type parameters"
-  | InvalidNumberOfIndices id -> "Recursive definition of array '" ^ HString.string_of_hstring id ^ "' must use an index for every array dimension"
+  | InvalidNumberOfIndices id -> "Recursive definition of array '" ^ HString.string_of_hstring id ^ "' must use one (and only one) index for every array dimension"
 
 type warning_kind = 
   | UnusedBoundVariableWarning of HString.t

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -100,6 +100,7 @@ type error_kind = Unknown of string
   | GlobalConstRefType of HString.t
   | QuantifiedAbstractType of HString.t
   | InvalidPolymorphicCall of HString.t
+  | InvalidNumberOfIndices of HString.t
 
 type error = [
   | `LustreTypeCheckerError of Lib.position * error_kind
@@ -196,6 +197,7 @@ let error_message kind = match kind with
   | GlobalConstRefType id -> "Definition of global constant '" ^ HString.string_of_hstring id ^ "' has refinement type (not yet supported)"
   | QuantifiedAbstractType id -> "Variable '" ^ HString.string_of_hstring id ^ "' with type that contains an abstract type (or type variable) cannot be quantified"
   | InvalidPolymorphicCall id -> "Call to node, contract, or user type '" ^ HString.string_of_hstring id ^ "' passes an incorrect number of type parameters"
+  | InvalidNumberOfIndices id -> "Recursive definition of array '" ^ HString.string_of_hstring id ^ "' must use an index for every array dimension"
 
 type warning_kind = 
   | UnusedBoundVariableWarning of HString.t
@@ -936,6 +938,20 @@ let rec infer_type_expr: tc_context -> HString.t option -> LA.expr -> (tc_type *
   )
 (** Infer the type of a [LA.expr] with the types of free variables given in [tc_context] *)
 
+and check_array_dimensions pos ctx base_e idxs =
+  let ty = lookup_ty ctx base_e |> Option.get in
+  let* ty = expand_type_syn_reftype_history_subrange ctx ty in
+  let rec calc_number_of_array_dimensions ty = 
+    match ty with 
+    | LustreAst.ArrayType (_, (ty, _)) -> 
+      1 + calc_number_of_array_dimensions ty
+    | _ -> 0
+  in 
+  let num_dimensions = calc_number_of_array_dimensions ty in 
+  if List.length idxs != num_dimensions then 
+    (type_error pos (InvalidNumberOfIndices base_e))
+  else R.ok ()
+
 and check_type_expr: tc_context -> HString.t option -> LA.expr -> tc_type -> ([> warning] list, [> error]) result
   = fun ctx nname expr exp_ty ->
   match expr with
@@ -1591,6 +1607,7 @@ and check_type_struct_item: tc_context -> HString.t -> LA.struct_item -> tc_type
       else R.ok ())
       (type_error pos (ExpectedType (exp_ty, inf_ty))) *)
   | ArrayDef (pos, base_e, idxs) ->
+    check_array_dimensions pos ctx base_e idxs >>
     let array_idx_expr =
       List.fold_left (fun e i -> LA.ArrayIndex (pos, e, i))
         (LA.Ident (pos, base_e))

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -85,6 +85,7 @@ type error_kind = Unknown of string
   | GlobalConstRefType of HString.t
   | QuantifiedAbstractType of HString.t
   | InvalidPolymorphicCall of HString.t
+  | InvalidNumberOfIndices of HString.t
 
 type error = [
   | `LustreTypeCheckerError of Lib.position * error_kind

--- a/tests/ounit/lustre/lustreTypeChecker/array_frame.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/array_frame.lus
@@ -1,0 +1,5 @@
+node top () returns (out: int^5^5)
+let
+    out[i] = [ i, i+1, i+2, i+3, i+4 ];
+    check out[0][0] = 0;
+tel

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -679,6 +679,10 @@ let _ = run_test_tt_main ("frontend LustreTypeChecker error tests" >::: [
     match load_file "./lustreTypeChecker/bad_subrange_bound_1.lus" with
     | Error (`LustreTypeCheckerError (_, ExpectedConstant _)) -> true
     | _ -> false);
+  mk_test "test illegal array definition without enough indices" (fun () ->
+    match load_file "./lustreTypeChecker/array_frame.lus" with
+    | Error (`LustreTypeCheckerError (_, InvalidNumberOfIndices _)) -> true
+    | _ -> false);
 ])
 
 (* *************************************************************************** *)

--- a/tests/regression/falsifiable/array_frame.lus
+++ b/tests/regression/falsifiable/array_frame.lus
@@ -1,0 +1,41 @@
+node M() returns (A: int^4)
+let
+  A = [0, 1, 2, 3];
+tel
+
+node N(in: int^4) returns (A1, A2, A3, A4, A5, A6, A7, A8: int^4; B1, B2: int^4^4);
+let
+  frame (A1, A2, A3, A4, A5, A6, A7, A8, B1, B2)
+    A1[i] = i;
+    A2[i] = i;
+    A3[i] = i;
+    A4[i] = i;
+    B1[i][j] = i+j;
+    A5 = [0, 1, 2, 3];
+    A6 = 0^4;
+    A7 = in; 
+    A8 = M();
+    B2 = 0^4^4;
+  let
+    A1 = pre [0, 1, 2, 3]; -- A1[i] = i -> pre [0, 1, 2, 3][i];
+    A2 = pre (0^4); -- A2[i] = i -> pre 0^4[i];
+    A3 = pre in; -- A3[i] = i -> pre in[i];
+    A4 = pre M(); -- A4[i] = i -> pre M()[i];
+    B1 = pre 0^4^4; -- B1[i][j] = i + j -> pre 0^4^4[i][j]
+    A5[i] = pre A5[i] + 1; -- A5[i] = [0, 1, 2, 3][i] -> pre A5[i] + 1;
+    A6[i] = pre A6[i] + 1; -- A6[i] = 0^4[i] -> pre A6[i] + 1;
+    A7[i] = pre A7[i] + 1; -- A7[i] = in[i] -> pre A7[i] + 1;
+    A8[i] = pre A8[i] + 1; -- A8[i] = M()[i] -> pre A8[i] + 1;
+    B2[i][j] = pre B2[i][j] + 1; -- B2[i][j] = 0^4^4[i][j] -> pre B2[i][j] + 1;
+  tel
+
+  check true -> A1[0] = 0;
+  check true -> A2[0] = 0;
+  check true -> A3[0] = 0;
+  check true -> A4[0] = 0;
+  check true -> A5[0] = 1;
+  check true -> A6[0] = 1;
+  check true -> A7[0] = 1;
+  check true -> A8[0] = 1;
+
+tel


### PR DESCRIPTION
This PR accomplishes two tasks.

1. Address the bug in the following example, where frame blocks and arrays with mixed indexed/nonindexed definitions did not work properly (see changes to `lustreDesugarFrameBlocks.ml`
```
node N() returns (A: int^N);
let
  frame (A)
    A = 0^N;
    --A[i] = 0;
  let
    A[i] = pre A[i] + 1;
  tel
  check true -> A[0]=1;
tel
```

2. Restrict the definitions of multi-dimensional arrays such that if indices are used, there must be an index for each dimension. For example, if ```B: int^4^4```, it can be defined with ```B = <expr>``` or ```B[i][j] = <expr>```, but not with ```B[i] = <expr>```. (see changes to `lustreTypeChecker.ml`