### PR TITLE
Disallow quantified variables in history type constructor

### DIFF
--- a/src/lustre/lustreSyntaxChecks.mli
+++ b/src/lustre/lustreSyntaxChecks.mli
@@ -52,6 +52,7 @@ type error_kind = Unknown of string
   | IllegalClockExprInActivate of LustreAst.expr
   | OpaqueWithoutContract of LustreAst.ident
   | TransparentWithoutBody of LustreAst.ident
+  | IllegalHistoryVar of LustreAst.ident
 
 type error = [
   | `LustreSyntaxChecksError of Lib.position * error_kind

--- a/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_1.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_1.lus
@@ -1,0 +1,4 @@
+node N(x: int) returns (y: int); 
+let 
+    check forall (n: int) forall (z: history(n)) true; 
+tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_2.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_2.lus
@@ -1,0 +1,4 @@
+node N(x: int) returns (y: int); 
+let 
+    check forall (n: int; z: history(n)) true;  
+tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_3.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_3.lus
@@ -1,0 +1,4 @@
+node N(x: int) returns (y: int); 
+let 
+    check forall (z: history(z)) true;  
+tel

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -170,6 +170,18 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
     match load_file "./lustreSyntaxChecks/transparent_no_body.lus" with
     | Error (`LustreSyntaxChecksError (_, TransparentWithoutBody _)) -> true
     | _ -> false);
+  mk_test "test history type constructor with quantified variable 1" (fun () ->
+    match load_file "./lustreSyntaxChecks/history_quantified_var_1.lus" with
+    | Error (`LustreSyntaxChecksError (_, IllegalHistoryVar _)) -> true
+    | _ -> false);
+  mk_test "test history type constructor with quantified variable 2" (fun () ->
+    match load_file "./lustreSyntaxChecks/history_quantified_var_2.lus" with
+    | Error (`LustreSyntaxChecksError (_, IllegalHistoryVar _)) -> true
+    | _ -> false);
+  mk_test "test history type constructor with quantified variable 3" (fun () ->
+    match load_file "./lustreSyntaxChecks/history_quantified_var_3.lus" with
+    | Error (`LustreSyntaxChecksError (_, IllegalHistoryVar _)) -> true
+    | _ -> false);
 ])
 
 (* *************************************************************************** *)


### PR DESCRIPTION
For examples, see the new test cases