### PR TITLE
Fix bug with normalization of multidimensional arrays

### DIFF
--- a/tests/regression/success/multi_indices_array.lus
+++ b/tests/regression/success/multi_indices_array.lus
@@ -1,0 +1,5 @@
+node N() returns (out: int^4^4);
+let
+  out[i][j] = 0 -> pre (out[i][j] + 1);
+  check out[0][0] = 0 -> true;
+tel


### PR DESCRIPTION
The test case (included below) used to throw an exception due to two bugs in normalization. In the first place, the generated `nexpr` threw away all indices except for the first index. In the second place, if there was a normalized expression under a `pre` with indices, only one of those indices was pushed "outside" the pre, (potentially) creating malformed expressions.

Note--I don't fully understand why the second change is necessary; maybe we should discuss this before merging.
```
node N() returns (out: int^4^4);
let
  out[i][j] = 0 -> pre (out[i][j] + 1);
  check out[0][0] = 0 -> true;
tel
```