### PR TITLE
Env realizability imports fix

### DIFF
--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -47,7 +47,7 @@ type t = {
     StringMap.t;
   oracles : (HString.t * LustreAst.lustre_type * LustreAst.expr) list;
   ib_oracles : (HString.t * LustreAst.lustre_type) list;
-  gen_ghost_vars : HString.t list; 
+  gen_ghost_vars : (HString.t * LustreAst.lustre_type * LustreAst.expr) list; 
   calls : (Lib.position (* node call position *)
     * HString.t (* abstracted output *)
     * LustreAst.expr (* condition expression *)

--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -73,7 +73,8 @@ type t = {
     (LustreAst.typed_ident list (* quantified variables *)
     * (Lib.position * HString.t) list (* contract scope  *)
     * LustreAst.eq_lhs
-    * LustreAst.expr)
+    * LustreAst.expr
+    * source option) (* Record the source of the equation if generated before normalization step *)
     list;
   nonvacuity_props: StringSet.t;
   array_literal_vars: StringSet.t;

--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -47,7 +47,6 @@ type t = {
     StringMap.t;
   oracles : (HString.t * LustreAst.lustre_type * LustreAst.expr) list;
   ib_oracles : (HString.t * LustreAst.lustre_type) list;
-  gen_ghost_vars : (HString.t * LustreAst.lustre_type * LustreAst.expr) list; 
   calls : (Lib.position (* node call position *)
     * HString.t (* abstracted output *)
     * LustreAst.expr (* condition expression *)
@@ -113,11 +112,6 @@ let union ids1 ids2 = {
     node_args = ids1.node_args @ ids2.node_args;
     oracles = ids1.oracles @ ids2.oracles;
     ib_oracles = ids1.ib_oracles @ ids2.ib_oracles;
-    (* Prevent duplicates *)
-    gen_ghost_vars = List.fold_left (fun acc element -> 
-      if (List.mem element acc) then acc
-      else element :: acc
-    ) ids1.gen_ghost_vars ids2.gen_ghost_vars;
     calls = ids1.calls @ ids2.calls;
     contract_calls = StringMap.merge union_keys
       ids1.contract_calls ids2.contract_calls;
@@ -144,7 +138,6 @@ let empty () = {
   node_args = [];
   oracles = [];
   ib_oracles = [];
-  gen_ghost_vars = [];
   calls = [];
   contract_calls = StringMap.empty;
   subrange_constraints = [];

--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -113,7 +113,11 @@ let union ids1 ids2 = {
     node_args = ids1.node_args @ ids2.node_args;
     oracles = ids1.oracles @ ids2.oracles;
     ib_oracles = ids1.ib_oracles @ ids2.ib_oracles;
-    gen_ghost_vars = ids1.gen_ghost_vars @ ids2.gen_ghost_vars;
+    (* Prevent duplicates *)
+    gen_ghost_vars = List.fold_left (fun acc element -> 
+      if (List.mem element acc) then acc
+      else element :: acc
+    ) ids1.gen_ghost_vars ids2.gen_ghost_vars;
     calls = ids1.calls @ ids2.calls;
     contract_calls = StringMap.merge union_keys
       ids1.contract_calls ids2.contract_calls;

--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -47,6 +47,7 @@ type t = {
     StringMap.t;
   oracles : (HString.t * LustreAst.lustre_type * LustreAst.expr) list;
   ib_oracles : (HString.t * LustreAst.lustre_type) list;
+  gen_ghost_vars : HString.t list; 
   calls : (Lib.position (* node call position *)
     * HString.t (* abstracted output *)
     * LustreAst.expr (* condition expression *)
@@ -112,6 +113,7 @@ let union ids1 ids2 = {
     node_args = ids1.node_args @ ids2.node_args;
     oracles = ids1.oracles @ ids2.oracles;
     ib_oracles = ids1.ib_oracles @ ids2.ib_oracles;
+    gen_ghost_vars = ids1.gen_ghost_vars @ ids2.gen_ghost_vars;
     calls = ids1.calls @ ids2.calls;
     contract_calls = StringMap.merge union_keys
       ids1.contract_calls ids2.contract_calls;
@@ -138,6 +140,7 @@ let empty () = {
   node_args = [];
   oracles = [];
   ib_oracles = [];
+  gen_ghost_vars = [];
   calls = [];
   contract_calls = StringMap.empty;
   subrange_constraints = [];

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -47,7 +47,7 @@ type t = {
     StringMap.t;
   oracles : (HString.t * LustreAst.lustre_type * LustreAst.expr) list;
   ib_oracles : (HString.t * LustreAst.lustre_type) list;
-  gen_ghost_vars : HString.t list; 
+  gen_ghost_vars : (HString.t * LustreAst.lustre_type * LustreAst.expr) list; 
   calls : (Lib.position (* node call position *)
     * HString.t (* abstracted output *)
     * LustreAst.expr (* condition expression *)

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -73,7 +73,8 @@ type t = {
     (LustreAst.typed_ident list (* quantified variables *)
     * (Lib.position * HString.t) list (* contract scope  *)
     * LustreAst.eq_lhs
-    * LustreAst.expr)
+    * LustreAst.expr
+    * source option) (* Record the source of the equation if generated before normalization step *)
     list;
   nonvacuity_props: StringSet.t;
   array_literal_vars: StringSet.t; (* Variables equal to an array literal *)

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -47,6 +47,7 @@ type t = {
     StringMap.t;
   oracles : (HString.t * LustreAst.lustre_type * LustreAst.expr) list;
   ib_oracles : (HString.t * LustreAst.lustre_type) list;
+  gen_ghost_vars : HString.t list; 
   calls : (Lib.position (* node call position *)
     * HString.t (* abstracted output *)
     * LustreAst.expr (* condition expression *)

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -47,7 +47,6 @@ type t = {
     StringMap.t;
   oracles : (HString.t * LustreAst.lustre_type * LustreAst.expr) list;
   ib_oracles : (HString.t * LustreAst.lustre_type) list;
-  gen_ghost_vars : (HString.t * LustreAst.lustre_type * LustreAst.expr) list; 
   calls : (Lib.position (* node call position *)
     * HString.t (* abstracted output *)
     * LustreAst.expr (* condition expression *)

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -285,7 +285,7 @@ let pp_print_generated_identifiers ppf gids =
     (pp_print_list pp_print_node_arg "\n") gids.node_args
     (pp_print_list pp_print_local "\n") locals_list
     (pp_print_list pp_print_local "\n") gids.ib_oracles
-    (pp_print_list HString.pp_print_hstring "\n") gids.gen_ghost_vars
+    (pp_print_list pp_print_oracle "\n") gids.gen_ghost_vars
     (pp_print_list pp_print_call "\n") gids.calls
     (pp_print_list pp_print_subrange_constraint "\n") gids.subrange_constraints
     (pp_print_list pp_print_refinement_type_constraint "\n") gids.refinement_type_constraints
@@ -1123,6 +1123,7 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
 
   Res.ok (ast, map, warnings)
 
+(*!! TODO: Extend this for gen_ghost_vars(?) *)
 and normalize_gid_equations info gids_map node_id =
   match StringMap.find_opt node_id gids_map with
   | None -> empty(), []

--- a/src/lustre/lustreDesugarFrameBlocks.ml
+++ b/src/lustre/lustreDesugarFrameBlocks.ml
@@ -72,12 +72,6 @@ let warn_unguarded_pres nis pos =
     | _ -> []
   ) nis
 
-let split3 triples =
-  let xs = List.map (fun (x, _, _) -> x) triples in
-  let ys = List.map (fun (_, y, _) -> y) triples in
-  let zs = List.map (fun (_, _, z) -> z) triples in
-  xs, ys, zs
-
 (** Parses an expression and replaces any ITE oracles with the 'fill'
     expression (which is stuttering, ie, 'pre variable').
 *)
@@ -341,7 +335,7 @@ let desugar_frame_blocks sorted_node_contract_decls =
   let desugar_node_decl decl = (match decl with
     | A.NodeDecl (s, ((node_id, b, o, nps, cctds, ctds, nlds, nis2, co))) ->
       let* res = R.seq (List.map (desugar_node_item node_id) nis2) in
-      let decls, nis, warnings = split3 res in
+      let decls, nis, warnings = Lib.split3 res in
       let warnings = List.flatten warnings in 
       R.ok (A.NodeDecl (s, (node_id, b, o, nps, cctds, ctds,
                        (List.flatten decls) @ nlds, List.flatten nis, co)), warnings) 

--- a/src/lustre/lustreErrors.ml
+++ b/src/lustre/lustreErrors.ml
@@ -29,6 +29,7 @@ type error = [
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr
   | `LustreParserError of Lib.position * string
   | `LustreDesugarIfBlocksError of Lib.position * LustreDesugarIfBlocks.error_kind
+  | `LustreGenRefTypeImpNodesError of Lib.position * LustreGenRefTypeImpNodes.error_kind
   | `LustreDesugarFrameBlocksError of Lib.position * LustreDesugarFrameBlocks.error_kind
 ]
 
@@ -43,6 +44,7 @@ let error_position error = match error with
   | `LustreUnguardedPreError (pos, _) -> pos
   | `LustreParserError (pos, _) -> pos
   | `LustreDesugarIfBlocksError (pos, _) -> pos
+  | `LustreGenRefTypeImpNodesError (pos, _) -> pos
   | `LustreDesugarFrameBlocksError (pos, _) -> pos
 
 let error_message error = match error with
@@ -56,4 +58,5 @@ let error_message error = match error with
   | `LustreUnguardedPreError (_, e) -> (Format.asprintf "@[<hov 2>Unguarded pre in expression@ %a@]" LA.pp_print_expr e)
   | `LustreParserError (_, e) -> e
   | `LustreDesugarIfBlocksError (_, kind) -> LustreDesugarIfBlocks.error_message kind
+  | `LustreGenRefTypeImpNodesError (_, kind) -> LustreGenRefTypeImpNodes.error_message kind
   | `LustreDesugarFrameBlocksError (_, kind) -> LustreDesugarFrameBlocks.error_message kind

--- a/src/lustre/lustreErrors.mli
+++ b/src/lustre/lustreErrors.mli
@@ -30,6 +30,7 @@ type error = [
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr
   | `LustreParserError of Lib.position * string
   | `LustreDesugarIfBlocksError of Lib.position * LustreDesugarIfBlocks.error_kind
+  | `LustreGenRefTypeImpNodesError of Lib.position * LustreGenRefTypeImpNodes.error_kind
   | `LustreDesugarFrameBlocksError of Lib.position * LustreDesugarFrameBlocks.error_kind
 ]
 

--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -28,6 +28,37 @@ let unwrap = function
   | Ok x -> x 
   | Error _ -> assert false
 
+let contract_node_decl_to_contracts
+= fun ctx (id, params, inputs, outputs, (pos, base_contract)) -> 
+  let contract' = List.filter_map (fun ci -> 
+    match ci with
+    | A.GhostConst _ | GhostVars _ -> Some ci
+    | A.Assume (pos, name, b, expr) -> Some (A.Guarantee (pos, name, b, expr))
+    | A.ContractCall (pos, name, ty_args, ips, ops) -> 
+      let name = HString.concat2 (HString.mk_hstring ".inputs_") name in
+      Some (A.ContractCall (pos, name, ty_args, ips, ops))
+    | A.Guarantee _ | A.AssumptionVars _ | A.Mode _  -> None
+  ) base_contract in
+  let gen_node_id = HString.concat2 (HString.mk_hstring inputs_tag) id in
+  let inputs2, outputs2 = 
+    List.map (fun (p, id, ty, cl) -> (p, id, ty, cl, false)) outputs, 
+    List.map (fun (p, id, ty, cl, _) -> (p, id, ty, cl)) inputs 
+  in
+  (* Since we are omitting assumptions from environment realizability checks,
+     we need to chase base types for environment inputs *)
+  let inputs2 = List.map (fun (p, id, ty, cl, b) -> 
+    let ty = Chk.expand_type_syn_reftype_history_subrange ctx ty |> unwrap in 
+    (p, id, ty, cl, b)
+  ) inputs2 in
+  (* We generate two imported nodes: One for the input node's contract (w/ type info), and another 
+     for the input node's inputs/environment *)
+  let environment = gen_node_id, params, inputs2, outputs2, (pos, contract') in
+  if Flags.Contracts.check_environment () 
+  then 
+    let ctx, _ = LustreTypeChecker.tc_ctx_of_contract_node_decl pos ctx environment |> unwrap in
+    [environment], ctx 
+  else [], ctx
+
 let node_decl_to_contracts 
 = fun pos ctx (id, extern, _, params, inputs, outputs, locals, _, contract) ->
   let base_contract = match contract with | None -> [] | Some (_, contract) -> contract in 
@@ -35,7 +66,10 @@ let node_decl_to_contracts
     match ci with
     | A.GhostConst _ | GhostVars _ -> Some ci
     | A.Assume (pos, name, b, expr) -> Some (A.Guarantee (pos, name, b, expr))
-    | _ -> None
+    | A.ContractCall (pos, name, ty_args, ips, ops) -> 
+      let name = HString.concat2 (HString.mk_hstring ".inputs_") name in
+      Some (A.ContractCall (pos, name, ty_args, ips, ops))
+    | A.Guarantee _ | A.AssumptionVars _ | A.Mode _  -> None
   ) base_contract in
   let locals_as_outputs = List.map (fun local_decl -> match local_decl with 
     | A.NodeConstDecl (pos, FreeConst (_, id, ty)) 
@@ -64,11 +98,20 @@ let node_decl_to_contracts
      for the input node's inputs/environment *)
   if extern then 
     let environment = gen_node_id, extern, A.Opaque, params, inputs2, outputs2, [], node_items, contract' in
-    if Flags.Contracts.check_environment () then [environment] else []
+    if Flags.Contracts.check_environment () then 
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx environment |> unwrap in
+      [environment], ctx
+    else [], ctx
   else
     let environment = gen_node_id, extern', A.Opaque, params, inputs2, outputs2, [], node_items, contract' in
     let contract = (gen_node_id2, extern', A.Opaque, params, inputs, locals_as_outputs @ outputs, [], node_items, contract) in
-    if Flags.Contracts.check_environment () then [environment; contract] else [contract]
+    if Flags.Contracts.check_environment () then 
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx environment |> unwrap in
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx contract |> unwrap in
+      [environment; contract], ctx 
+    else 
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx contract |> unwrap in
+      [contract], ctx
 
 (* NOTE: Currently, we do not allow global constants to have refinement types. 
    If we decide to support this in the future, then we need to add necessary refinement type information 
@@ -83,36 +126,41 @@ let type_to_contract: Lib.position -> HString.t -> A.lustre_type -> HString.t li
   let node_items = [A.AnnotMain(pos, true)] in 
   Some (NodeDecl (span, (gen_node_id, true, A.Opaque, ps, [], [(pos, id, ty, A.ClockTrue)], [], node_items, None)))
 
-let gen_imp_nodes:  Ctx.tc_context -> A.declaration list -> A.declaration list 
+let gen_imp_nodes  : Ctx.tc_context -> A.declaration list -> A.declaration list * Ctx.tc_context 
 = fun ctx decls -> 
-  List.fold_left (fun acc decl -> 
+  let decls, ctx = List.fold_left (fun (acc_decls, acc_ctx) decl -> 
     match decl with 
     | A.ConstDecl (_, FreeConst _)
-    | A.ConstDecl (_, TypedConst _) -> acc
+    | A.ConstDecl (_, TypedConst _) -> acc_decls, acc_ctx
     | A.TypeDecl (_, AliasType (p, id, ps, ty)) -> 
       (match type_to_contract p id ty ps with 
-      | Some decl1 -> decl1 :: acc
-      | None -> acc)
+      | Some decl1 -> decl1 :: acc_decls, acc_ctx
+      | None -> acc_decls, acc_ctx)
     | A.TypeDecl (_, FreeType _)
-    | A.ConstDecl (_, UntypedConst _) -> acc
+    | A.ConstDecl (_, UntypedConst _) -> acc_decls, acc_ctx
     | A.NodeDecl (span, ((p, e, opac, ps, ips, ops, locs, _, c) as node_decl)) ->
       (* Add main annotations to imported nodes *)
       let node_decl = 
         if e then p, e, opac, ps, ips, ops, locs, [A.AnnotMain (span.start_pos, true)], c
         else node_decl 
       in
-      let decls = node_decl_to_contracts span.start_pos ctx node_decl in
+      let decls, acc_ctx = node_decl_to_contracts span.start_pos acc_ctx node_decl in
       let decls = List.map (fun decl -> A.NodeDecl (span, decl)) decls in
-      A.NodeDecl(span, node_decl) :: decls @ acc
+      A.NodeDecl(span, node_decl) :: decls @ acc_decls, acc_ctx
     | A.FuncDecl (span, ((p, e, opac, ps, ips, ops, locs, _, c) as func_decl)) ->
       (* Add main annotations to imported functions *)
       let func_decl = 
         if e then p, e, opac, ps, ips, ops, locs, [A.AnnotMain (span.start_pos, true)], c
         else func_decl 
       in
-      let decls = node_decl_to_contracts span.start_pos ctx func_decl in
+      let decls, acc_ctx = node_decl_to_contracts span.start_pos acc_ctx func_decl in
       let decls = List.map (fun decl -> A.FuncDecl (span, decl)) decls in
-      A.FuncDecl(span, func_decl) :: decls @ acc
-    | A.ContractNodeDecl _ 
-    | A.NodeParamInst _ -> decl :: acc
-  ) [] decls |> List.rev
+      A.FuncDecl(span, func_decl) :: decls @ acc_decls, acc_ctx
+    | A.ContractNodeDecl (span, contract_node_decl) -> 
+      let decls, acc_ctx = contract_node_decl_to_contracts acc_ctx contract_node_decl in 
+      let decls = List.map (fun decl -> A.ContractNodeDecl (span, decl)) decls in
+      A.ContractNodeDecl (span, contract_node_decl) :: decls @ acc_decls, acc_ctx
+    | A.NodeParamInst _ -> decl :: acc_decls, acc_ctx
+  ) ([], ctx) decls 
+  in 
+  List.rev decls, ctx

--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -32,12 +32,12 @@ let unwrap = function
 (* [i] is module state used to guarantee newly created identifiers are unique *)
 let i = ref 0
 
-let mk_fresh_ghost_var () =
+let mk_fresh_ghost_var ty rhs =
   i := !i + 1;
   let prefix = HString.mk_hstring (string_of_int !i) in
   let name = HString.concat2 prefix (HString.mk_hstring "_ghost") in
   let gids = { (GI.empty ()) with
-    gen_ghost_vars = [name]; 
+    gen_ghost_vars = [name, ty, rhs]; 
   } in 
   name, gids
   
@@ -64,7 +64,7 @@ let contract_node_decl_to_contracts
         | TArr(_, _, ty) when i = 1 -> ty
         | _ -> assert false
         in 
-        let gen_ghost_var, gids = mk_fresh_ghost_var () in
+        let gen_ghost_var, gids = mk_fresh_ghost_var ghost_var_ty expr in
         gen_ghost_var,
         [A.GhostVars (pos, (GhostVarDec (pos, [(pos, gen_ghost_var, ghost_var_ty)])), expr)],
         gids
@@ -121,9 +121,10 @@ let node_decl_to_contracts
         | TArr(_, _, ty) when i = 1 -> ty
         | _ -> assert false
         in 
-        let gen_ghost_var, gids = mk_fresh_ghost_var () in
+        let gen_ghost_var, gids = mk_fresh_ghost_var ghost_var_ty expr in
         gen_ghost_var,
-        [A.GhostVars (pos, (GhostVarDec (pos, [(pos, gen_ghost_var, ghost_var_ty)])), expr)],
+        (* [A.GhostVars (pos, (GhostVarDec (pos, [(pos, gen_ghost_var, ghost_var_ty)])), expr)], *)
+        [],
         gids
       ) ips |> Lib.split3 in
       Some (

--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -32,12 +32,13 @@ let unwrap = function
 (* [i] is module state used to guarantee newly created identifiers are unique *)
 let i = ref 0
 
-let mk_fresh_ghost_var ty rhs =
+let mk_fresh_ghost_var pos cname ty rhs =
   i := !i + 1;
   let prefix = HString.mk_hstring (string_of_int !i) in
   let name = HString.concat2 prefix (HString.mk_hstring "_ghost") in
   let gids = { (GI.empty ()) with
-    gen_ghost_vars = [name, ty, rhs]; 
+    locals = GI.StringMap.singleton name ty; 
+    equations = [([], [pos, cname], A.StructDef(pos, [SingleIdent (pos, name)]), rhs)];
   } in 
   name, gids
   
@@ -64,7 +65,7 @@ let contract_node_decl_to_contracts
         | TArr(_, _, ty) when i = 0 -> ty
         | _ -> assert false
         in 
-        let gen_ghost_var, gids = mk_fresh_ghost_var ghost_var_ty expr in
+        let gen_ghost_var, gids = mk_fresh_ghost_var pos id ghost_var_ty expr in
         gen_ghost_var,
         gids
       ) ips |> List.split in
@@ -121,7 +122,7 @@ let node_decl_to_contracts
           | TArr(_, _, ty) when i = 1 -> ty
           | _ -> assert false
           in 
-          let gen_ghost_var, gids = mk_fresh_ghost_var ghost_var_ty expr in
+          let gen_ghost_var, gids = mk_fresh_ghost_var pos id ghost_var_ty expr in
           gen_ghost_var,
           gids
         ) ips |> List.split in

--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -47,13 +47,15 @@ let unwrap = function
 (* [i] is module state used to guarantee newly created identifiers are unique *)
 let i = ref 0
 
-let mk_fresh_ghost_var pos cname ty rhs =
+let mk_fresh_ghost_var pos ty rhs =
   i := !i + 1;
   let prefix = HString.mk_hstring (string_of_int !i) in
   let name = HString.concat2 prefix (HString.mk_hstring "_ghost") in
   let gids = { (GI.empty ()) with
     locals = GI.StringMap.singleton name ty; 
-    equations = [([], [pos, cname], A.StructDef(pos, [SingleIdent (pos, name)]), rhs, Some GI.Ghost)];
+    (* No contract scope is given because we are currently disallowing mode references in contract 
+       assumptions during environment realizability checks. *)
+    equations = [([], [], A.StructDef(pos, [SingleIdent (pos, name)]), rhs, Some GI.Ghost)];
   } in 
   name, gids
 
@@ -108,7 +110,7 @@ let contract_node_decl_to_contracts
         | TArr(_, _, ty) when i = 0 -> ty
         | _ -> assert false
         in 
-        let gen_ghost_var, gids = mk_fresh_ghost_var pos id ghost_var_ty expr in
+        let gen_ghost_var, gids = mk_fresh_ghost_var pos ghost_var_ty expr in
         gen_ghost_var,
         gids
       ) ips |> List.split in
@@ -168,7 +170,7 @@ let node_decl_to_contracts
           | TArr(_, _, ty) when i = 1 -> ty
           | _ -> assert false
           in 
-          let gen_ghost_var, gids = mk_fresh_ghost_var pos id ghost_var_ty expr in
+          let gen_ghost_var, gids = mk_fresh_ghost_var pos ghost_var_ty expr in
           gen_ghost_var,
           gids
         ) ips |> List.split in

--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -18,6 +18,7 @@
 module A = LustreAst
 module Chk = LustreTypeChecker
 module Ctx = TypeCheckerContext
+module GI = GeneratedIdentifiers
 
 let inputs_tag = ".inputs_"
 let contract_tag = ".contract_"
@@ -28,17 +29,52 @@ let unwrap = function
   | Ok x -> x 
   | Error _ -> assert false
 
+(* [i] is module state used to guarantee newly created identifiers are unique *)
+let i = ref 0
+
+let mk_fresh_ghost_var () =
+  i := !i + 1;
+  let prefix = HString.mk_hstring (string_of_int !i) in
+  let name = HString.concat2 prefix (HString.mk_hstring "_ghost") in
+  let gids = { (GI.empty ()) with
+    gen_ghost_vars = [name]; 
+  } in 
+  name, gids
+  
 let contract_node_decl_to_contracts
 = fun ctx (id, params, inputs, outputs, (pos, base_contract)) -> 
-  let contract' = List.filter_map (fun ci -> 
+  let contract', gids = List.filter_map (fun ci -> 
     match ci with
-    | A.GhostConst _ | GhostVars _ -> Some ci
-    | A.Assume (pos, name, b, expr) -> Some (A.Guarantee (pos, name, b, expr))
+    | A.GhostConst _ | GhostVars _ -> Some ([ci], GI.empty ())
+    | A.Assume (pos, name, b, expr) -> Some ([A.Guarantee (pos, name, b, expr)], GI.empty ())
     | A.ContractCall (pos, name, ty_args, ips, ops) -> 
       let name = HString.concat2 (HString.mk_hstring ".inputs_") name in
-      Some (A.ContractCall (pos, name, ty_args, ips, ops))
+      (* Since we are flipping the inputs and outputs of the generated contract, 
+         we also need to flip inputs and outputs of the call *)
+      let ips' = List.map (fun id -> A.Ident (pos, id)) ops in
+      let ops', gen_ghost_variables, gids = List.mapi (fun i expr -> match expr with 
+      | A.Ident (_, id) -> id, [], GI.empty ()
+      (* Input is not a simple identifier, so we have to generate a ghost variable 
+         to store the output *)
+      | expr -> 
+        let called_contract_ty = Ctx.lookup_contract_ty ctx name in 
+        let ghost_var_ty = match Option.get called_contract_ty with 
+        | TArr (_, _, GroupType (_, tys)) -> 
+          List.nth tys i  
+        | TArr(_, _, ty) when i = 1 -> ty
+        | _ -> assert false
+        in 
+        let gen_ghost_var, gids = mk_fresh_ghost_var () in
+        gen_ghost_var,
+        [A.GhostVars (pos, (GhostVarDec (pos, [(pos, gen_ghost_var, ghost_var_ty)])), expr)],
+        gids
+      ) ips |> Lib.split3 in
+      Some (
+        List.flatten gen_ghost_variables @ [A.ContractCall (pos, name, ty_args, ips', ops')], 
+        List.fold_left GI.union ( GI.empty ()) gids
+      )
     | A.Guarantee _ | A.AssumptionVars _ | A.Mode _  -> None
-  ) base_contract in
+  ) base_contract |> List.split in
   let gen_node_id = HString.concat2 (HString.mk_hstring inputs_tag) id in
   let inputs2, outputs2 = 
     List.map (fun (p, id, ty, cl) -> (p, id, ty, cl, false)) outputs, 
@@ -50,27 +86,52 @@ let contract_node_decl_to_contracts
     let ty = Chk.expand_type_syn_reftype_history_subrange ctx ty |> unwrap in 
     (p, id, ty, cl, b)
   ) inputs2 in
+  let contract' = List.flatten contract' in
   (* We generate a contract representing this contract's inputs/environment *)
   let environment = gen_node_id, params, inputs2, outputs2, (pos, contract') in
+  let gids = List.fold_left GI.union (GI.empty ()) gids |> GI.StringMap.singleton gen_node_id in
   if Flags.Contracts.check_environment () 
   then 
     (* Update ctx with info about the generated contract *)
     let ctx, _ = LustreTypeChecker.tc_ctx_of_contract_node_decl pos ctx environment |> unwrap in
-    [environment], ctx 
-  else [], ctx
+    [environment], ctx, gids 
+  else [], ctx, gids
 
 let node_decl_to_contracts 
 = fun pos ctx (id, extern, _, params, inputs, outputs, locals, _, contract) ->
   let base_contract = match contract with | None -> [] | Some (_, contract) -> contract in 
-  let contract' = List.filter_map (fun ci -> 
+  let contract', gids = List.filter_map (fun ci -> 
     match ci with
-    | A.GhostConst _ | GhostVars _ -> Some ci
-    | A.Assume (pos, name, b, expr) -> Some (A.Guarantee (pos, name, b, expr))
+    | A.GhostConst _ | GhostVars _ -> Some ([ci], GI.empty ())
+    | A.Assume (pos, name, b, expr) -> Some ([A.Guarantee (pos, name, b, expr)], GI.empty ())
     | A.ContractCall (pos, name, ty_args, ips, ops) -> 
       let name = HString.concat2 (HString.mk_hstring ".inputs_") name in
-      Some (A.ContractCall (pos, name, ty_args, ips, ops))
+      (* Since we are flipping the inputs and outputs of the generated contract, 
+         we also need to flip inputs and outputs of the call *)
+      let ips' = List.map (fun id -> A.Ident (pos, id)) ops in
+      let ops', gen_ghost_variables, gids = List.mapi (fun i expr -> match expr with 
+      | A.Ident (_, id) -> id, [], GI.empty ()
+      (* Input is not a simple identifier, so we have to generate a ghost variable 
+         to store the output *)
+      | expr -> 
+        let called_contract_ty = Ctx.lookup_contract_ty ctx name in 
+        let ghost_var_ty = match Option.get called_contract_ty with 
+        | TArr (_, _, GroupType (_, tys)) -> 
+          List.nth tys i  
+        | TArr(_, _, ty) when i = 1 -> ty
+        | _ -> assert false
+        in 
+        let gen_ghost_var, gids = mk_fresh_ghost_var () in
+        gen_ghost_var,
+        [A.GhostVars (pos, (GhostVarDec (pos, [(pos, gen_ghost_var, ghost_var_ty)])), expr)],
+        gids
+      ) ips |> Lib.split3 in
+      Some (
+        List.flatten gen_ghost_variables @ [A.ContractCall (pos, name, ty_args, ips', ops')], 
+        List.fold_left GI.union ( GI.empty ()) gids
+      )
     | A.Guarantee _ | A.AssumptionVars _ | A.Mode _  -> None
-  ) base_contract in
+  ) base_contract |> List.split in
   let locals_as_outputs = List.map (fun local_decl -> match local_decl with 
     | A.NodeConstDecl (pos, FreeConst (_, id, ty)) 
     | A.NodeConstDecl (pos, TypedConst (_, id, _, ty)) ->  Some (pos, id, ty, A.ClockTrue)
@@ -78,6 +139,7 @@ let node_decl_to_contracts
       Some (pos, id, ty, cl)
     | _ -> None
   ) locals |> List.filter_map Fun.id in 
+  let contract' = List.flatten contract' in 
   let contract' = if contract' = [] then None else Some (pos, contract') in
   let extern' = true in 
   (* To prevent slicing, we mark generated imported nodes as main nodes *)
@@ -94,6 +156,7 @@ let node_decl_to_contracts
     let ty = Chk.expand_type_syn_reftype_history_subrange ctx ty |> unwrap in 
     (p, id, ty, cl, b)
   ) inputs2 in
+  let gids = List.fold_left GI.union (GI.empty ()) gids |> GI.StringMap.singleton gen_node_id in
   (* We potentially generate two imported nodes: One for the input node's contract (w/ type info), and another 
      for the input node's inputs/environment *)
   if extern then 
@@ -101,8 +164,8 @@ let node_decl_to_contracts
     if Flags.Contracts.check_environment () then 
       (* Update ctx with info about the generated node *)
       let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx environment |> unwrap in
-      [environment], ctx
-    else [], ctx
+      [environment], ctx, gids
+    else [], ctx, gids
   else
     let environment = gen_node_id, extern', A.Opaque, params, inputs2, outputs2, [], node_items, contract' in
     let contract = (gen_node_id2, extern', A.Opaque, params, inputs, locals_as_outputs @ outputs, [], node_items, contract) in
@@ -110,11 +173,11 @@ let node_decl_to_contracts
       (* Update ctx with info about the generated nodes *)
       let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx environment |> unwrap in
       let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx contract |> unwrap in
-      [environment; contract], ctx 
+      [environment; contract], ctx, gids 
     else 
       (* Update ctx with info about the generated node *)
       let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx contract |> unwrap in
-      [contract], ctx
+      [contract], ctx, gids
 
 (* NOTE: Currently, we do not allow global constants to have refinement types. 
    If we decide to support this in the future, then we need to add necessary refinement type information 
@@ -129,41 +192,44 @@ let type_to_contract: Lib.position -> HString.t -> A.lustre_type -> HString.t li
   let node_items = [A.AnnotMain(pos, true)] in 
   Some (NodeDecl (span, (gen_node_id, true, A.Opaque, ps, [], [(pos, id, ty, A.ClockTrue)], [], node_items, None)))
 
-let gen_imp_nodes: Ctx.tc_context -> A.declaration list -> A.declaration list * Ctx.tc_context 
+let gen_imp_nodes: Ctx.tc_context -> A.declaration list -> A.declaration list * Ctx.tc_context * GI.t HString.HStringMap.t
 = fun ctx decls -> 
-  let decls, ctx = List.fold_left (fun (acc_decls, acc_ctx) decl -> 
+  let decls, ctx, gids = List.fold_left (fun (acc_decls, acc_ctx, acc_gids) decl -> 
     match decl with 
     | A.ConstDecl (_, FreeConst _)
-    | A.ConstDecl (_, TypedConst _) -> acc_decls, acc_ctx
+    | A.ConstDecl (_, TypedConst _) -> acc_decls, acc_ctx, acc_gids
     | A.TypeDecl (_, AliasType (p, id, ps, ty)) -> 
       (match type_to_contract p id ty ps with 
-      | Some decl1 -> decl1 :: acc_decls, acc_ctx
-      | None -> acc_decls, acc_ctx)
+      | Some decl1 -> decl1 :: acc_decls, acc_ctx, acc_gids
+      | None -> acc_decls, acc_ctx, acc_gids)
     | A.TypeDecl (_, FreeType _)
-    | A.ConstDecl (_, UntypedConst _) -> acc_decls, acc_ctx
+    | A.ConstDecl (_, UntypedConst _) -> acc_decls, acc_ctx, acc_gids
     | A.NodeDecl (span, ((p, e, opac, ps, ips, ops, locs, _, c) as node_decl)) ->
       (* Add main annotations to imported nodes *)
       let node_decl = 
         if e then p, e, opac, ps, ips, ops, locs, [A.AnnotMain (span.start_pos, true)], c
         else node_decl 
       in
-      let decls, acc_ctx = node_decl_to_contracts span.start_pos acc_ctx node_decl in
+      let decls, acc_ctx, gids = node_decl_to_contracts span.start_pos acc_ctx node_decl in
       let decls = List.map (fun decl -> A.NodeDecl (span, decl)) decls in
-      A.NodeDecl(span, node_decl) :: decls @ acc_decls, acc_ctx
+      A.NodeDecl(span, node_decl) :: decls @ acc_decls, acc_ctx, 
+      GI.StringMap.merge GI.union_keys2 gids acc_gids
     | A.FuncDecl (span, ((p, e, opac, ps, ips, ops, locs, _, c) as func_decl)) ->
       (* Add main annotations to imported functions *)
       let func_decl = 
         if e then p, e, opac, ps, ips, ops, locs, [A.AnnotMain (span.start_pos, true)], c
         else func_decl 
       in
-      let decls, acc_ctx = node_decl_to_contracts span.start_pos acc_ctx func_decl in
+      let decls, acc_ctx, gids = node_decl_to_contracts span.start_pos acc_ctx func_decl in
       let decls = List.map (fun decl -> A.FuncDecl (span, decl)) decls in
-      A.FuncDecl(span, func_decl) :: decls @ acc_decls, acc_ctx
+      A.FuncDecl(span, func_decl) :: decls @ acc_decls, acc_ctx, 
+      GI.StringMap.merge GI.union_keys2 gids acc_gids
     | A.ContractNodeDecl (span, contract_node_decl) -> 
-      let decls, acc_ctx = contract_node_decl_to_contracts acc_ctx contract_node_decl in 
+      let decls, acc_ctx, gids = contract_node_decl_to_contracts acc_ctx contract_node_decl in 
       let decls = List.map (fun decl -> A.ContractNodeDecl (span, decl)) decls in
-      A.ContractNodeDecl (span, contract_node_decl) :: decls @ acc_decls, acc_ctx
-    | A.NodeParamInst _ -> decl :: acc_decls, acc_ctx
-  ) ([], ctx) decls 
+      A.ContractNodeDecl (span, contract_node_decl) :: decls @ acc_decls, acc_ctx, 
+      GI.StringMap.merge GI.union_keys2 gids acc_gids
+    | A.NodeParamInst _ -> decl :: acc_decls, acc_ctx, acc_gids
+  ) ([], ctx, GI.StringMap.empty) decls 
   in 
-  List.rev decls, ctx
+  List.rev decls, ctx, gids

--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -38,7 +38,7 @@ let mk_fresh_ghost_var pos cname ty rhs =
   let name = HString.concat2 prefix (HString.mk_hstring "_ghost") in
   let gids = { (GI.empty ()) with
     locals = GI.StringMap.singleton name ty; 
-    equations = [([], [pos, cname], A.StructDef(pos, [SingleIdent (pos, name)]), rhs)];
+    equations = [([], [pos, cname], A.StructDef(pos, [SingleIdent (pos, name)]), rhs, Some GI.Ghost)];
   } in 
   name, gids
   

--- a/src/lustre/lustreGenRefTypeImpNodes.mli
+++ b/src/lustre/lustreGenRefTypeImpNodes.mli
@@ -20,10 +20,11 @@
 
 module A = LustreAst
 module Ctx = TypeCheckerContext
+module GI = GeneratedIdentifiers
 
 val inputs_tag : string 
 val contract_tag : string
 val type_tag : string
 val poly_gen_node_tag : string
 
-val gen_imp_nodes : Ctx.tc_context ->  A.declaration list -> A.declaration list * Ctx.tc_context 
+val gen_imp_nodes : Ctx.tc_context ->  A.declaration list -> A.declaration list * Ctx.tc_context * GI.t HString.HStringMap.t

--- a/src/lustre/lustreGenRefTypeImpNodes.mli
+++ b/src/lustre/lustreGenRefTypeImpNodes.mli
@@ -19,10 +19,11 @@
 
 
 module A = LustreAst
+module Ctx = TypeCheckerContext
 
 val inputs_tag : string 
 val contract_tag : string
 val type_tag : string
 val poly_gen_node_tag : string
 
-val gen_imp_nodes : TypeCheckerContext.tc_context ->  A.declaration list -> A.declaration list
+val gen_imp_nodes : Ctx.tc_context ->  A.declaration list -> A.declaration list * Ctx.tc_context 

--- a/src/lustre/lustreGenRefTypeImpNodes.mli
+++ b/src/lustre/lustreGenRefTypeImpNodes.mli
@@ -27,4 +27,13 @@ val contract_tag : string
 val type_tag : string
 val poly_gen_node_tag : string
 
-val gen_imp_nodes : Ctx.tc_context ->  A.declaration list -> A.declaration list * Ctx.tc_context * GI.t HString.HStringMap.t
+type error_kind = 
+  | EnvRealizabilityCheckModeRefAssumption
+
+val error_message : error_kind -> string
+
+type error = [
+  | `LustreGenRefTypeImpNodesError of Lib.position * error_kind
+]
+
+val gen_imp_nodes : Ctx.tc_context ->  A.declaration list -> (A.declaration list * Ctx.tc_context * GI.t HString.HStringMap.t, [> error]) result

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -49,6 +49,7 @@ module LFR = LustreFlattenRefinementTypes
 module LGI = LustreGenRefTypeImpNodes
 module LIP = LustreInstantiatePolyNodes
 module LUF = LustreUserFunctions
+module GI = GeneratedIdentifiers
 
 type error = [
   | `LustreArrayDependencies of Lib.position * LustreArrayDependencies.error_kind
@@ -173,17 +174,19 @@ let type_check declarations =
       LspInfo.print_ast_info global_ctx declarations;
 
     (* Step 9. Generate imported nodes associated with refinement types if realizability checking is enabled *)
-    let sorted_node_contract_decls, global_ctx = 
+    let sorted_node_contract_decls, global_ctx, gids = 
       if List.mem `CONTRACTCK (Flags.enabled ()) 
       then 
-        let decls1, ctx1 = LGI.gen_imp_nodes global_ctx const_inlined_type_and_consts in 
-        let decls2, ctx2 = LGI.gen_imp_nodes global_ctx sorted_node_contract_decls in
-        decls1 @ decls2, TypeCheckerContext.union ctx1 ctx2
-      else sorted_node_contract_decls, global_ctx
+        let decls1, ctx1, gids1 = LGI.gen_imp_nodes global_ctx const_inlined_type_and_consts in 
+        let decls2, ctx2, gids2 = LGI.gen_imp_nodes global_ctx sorted_node_contract_decls in
+        decls1 @ decls2, 
+        TypeCheckerContext.union ctx1 ctx2, 
+        GI.StringMap.merge GI.union_keys2 gids1 gids2
+      else sorted_node_contract_decls, global_ctx, GI.StringMap.empty
     in
 
     (* Step 10. Remove multiple assignment from if blocks and frame blocks *)
-    let sorted_node_contract_decls, gids = RMA.remove_mult_assign global_ctx sorted_node_contract_decls in
+    let sorted_node_contract_decls, gids = RMA.remove_mult_assign global_ctx gids sorted_node_contract_decls in
 
     (* Step 11. Desugar imperative if block to ITEs *)
     let* (sorted_node_contract_decls, gids) = (LDI.desugar_if_blocks global_ctx sorted_node_contract_decls gids) in

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -173,12 +173,13 @@ let type_check declarations =
       LspInfo.print_ast_info global_ctx declarations;
 
     (* Step 9. Generate imported nodes associated with refinement types if realizability checking is enabled *)
-    let sorted_node_contract_decls = 
+    let sorted_node_contract_decls, global_ctx = 
       if List.mem `CONTRACTCK (Flags.enabled ()) 
       then 
-        LGI.gen_imp_nodes global_ctx const_inlined_type_and_consts @
-        LGI.gen_imp_nodes global_ctx sorted_node_contract_decls 
-      else sorted_node_contract_decls
+        let decls1, ctx1 = LGI.gen_imp_nodes global_ctx const_inlined_type_and_consts in 
+        let decls2, ctx2 = LGI.gen_imp_nodes global_ctx sorted_node_contract_decls in
+        decls1 @ decls2, TypeCheckerContext.union ctx1 ctx2
+      else sorted_node_contract_decls, global_ctx
     in
 
     (* Step 10. Remove multiple assignment from if blocks and frame blocks *)

--- a/src/lustre/lustreInput.mli
+++ b/src/lustre/lustreInput.mli
@@ -119,6 +119,7 @@ type error = [
   | `LustreUnguardedPreError of Lib.position * LustreAst.expr
   | `LustreParserError of Lib.position * string
   | `LustreDesugarIfBlocksError of Lib.position * LustreDesugarIfBlocks.error_kind
+  | `LustreGenRefTypeImpNodesError of Lib.position * LustreGenRefTypeImpNodes.error_kind
   | `LustreDesugarFrameBlocksError of Lib.position * LustreDesugarFrameBlocks.error_kind
 ]
 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1302,12 +1302,6 @@ and compile_contract_variables cstate gids ctx map contract_scope node_scope con
           let expr_ident = mk_ident id in
           let (ident, contract_namespace) = extract_namespace id in
           let index_types = compile_ast_type cstate ctx map ty in
-          let gen_ghost_vars = List.map (fun (a, _, _) -> a) gids.GI.gen_ghost_vars in
-          let source = 
-            if List.mem id gen_ghost_vars
-            then N.Generated 
-            else N.Ghost 
-          in
           let over_indices = fun index index_type accum -> (
             let possible_state_var = (
               mk_state_var
@@ -1318,7 +1312,7 @@ and compile_contract_variables cstate gids ctx map contract_scope node_scope con
                 ident
                 index
                 index_type
-                (Some source)
+                (Some N.Ghost)
               )
             in
             match possible_state_var with

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1297,30 +1297,13 @@ and compile_contract_variables cstate gids ctx map contract_scope node_scope con
         (id |> HString.mk_hstring |> mk_ident, [prefix; ref])
       | _ -> assert false
     in
-    let extract_orig_name name = 
-      let name = HString.string_of_hstring name in
-      let parts = String.split_on_char '_' name in
-      match parts with
-      | _ :: _ :: tail ->
-        let id = String.concat "_" tail in
-        id |> HString.mk_hstring
-      | _ -> assert false
-    in
-    let gen_gvars = gids.GI.gen_ghost_vars in 
-    let gen_gvars = List.map (fun (id, ty, expr) -> 
-      let pos = AH.pos_of_expr expr in
-      pos, A.GhostVarDec (pos, [(pos, id, ty)]), expr
-    ) gen_gvars in
     let over_vars (gvar_accum, eq_accum) = fun (pos, (A.GhostVarDec (_, tis)), expr) ->
         let extract_local ((_, id, ty)) = (
           let expr_ident = mk_ident id in
           let (ident, contract_namespace) = extract_namespace id in
           let index_types = compile_ast_type cstate ctx map ty in
           let gen_ghost_vars = List.map (fun (a, _, _) -> a) gids.GI.gen_ghost_vars in
-          HString.pp_print_hstring Format.std_formatter id;
-          print_endline "got here";
           let source = 
-            (* if List.mem (extract_orig_name id) gen_ghost_vars *)
             if List.mem id gen_ghost_vars
             then N.Generated 
             else N.Ghost 
@@ -1350,7 +1333,7 @@ and compile_contract_variables cstate gids ctx map contract_scope node_scope con
         let eq_lhs = A.StructDef (pos, struct_items) in
         let eq_rhs = expr in
         (List.map extract_local tis) @ gvar_accum, (pos, eq_lhs, eq_rhs) :: eq_accum
-    in List.fold_left over_vars ([], []) (gvars @ gen_gvars)
+    in List.fold_left over_vars ([], []) gvars
   (* ****************************************************************** *)
   (* Contract Modes                                                     *)
   (* ****************************************************************** *)

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1999,7 +1999,7 @@ and compile_node_decl gids_map is_function opac cstate ctx i ext params inputs o
   (* Generated Equations                                                *)
   (* ****************************************************************** *)
   in let gequations =
-    let over_equations = fun eqns (qvars, contract_scope, lhs, ast_expr) ->
+    let over_equations = fun eqns (qvars, contract_scope, lhs, ast_expr, _) ->
       map := { !map with contract_scope };
       let eq_lhs, indexes = match lhs with
         | A.StructDef (_, []) -> X.empty, 0

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1306,13 +1306,22 @@ and compile_contract_variables cstate gids ctx map contract_scope node_scope con
         id |> HString.mk_hstring
       | _ -> assert false
     in
+    let gen_gvars = gids.GI.gen_ghost_vars in 
+    let gen_gvars = List.map (fun (id, ty, expr) -> 
+      let pos = AH.pos_of_expr expr in
+      pos, A.GhostVarDec (pos, [(pos, id, ty)]), expr
+    ) gen_gvars in
     let over_vars (gvar_accum, eq_accum) = fun (pos, (A.GhostVarDec (_, tis)), expr) ->
         let extract_local ((_, id, ty)) = (
           let expr_ident = mk_ident id in
           let (ident, contract_namespace) = extract_namespace id in
           let index_types = compile_ast_type cstate ctx map ty in
+          let gen_ghost_vars = List.map (fun (a, _, _) -> a) gids.GI.gen_ghost_vars in
+          HString.pp_print_hstring Format.std_formatter id;
+          print_endline "got here";
           let source = 
-            if List.mem (extract_orig_name id) gids.GI.gen_ghost_vars
+            (* if List.mem (extract_orig_name id) gen_ghost_vars *)
+            if List.mem id gen_ghost_vars
             then N.Generated 
             else N.Ghost 
           in
@@ -1341,7 +1350,7 @@ and compile_contract_variables cstate gids ctx map contract_scope node_scope con
         let eq_lhs = A.StructDef (pos, struct_items) in
         let eq_rhs = expr in
         (List.map extract_local tis) @ gvar_accum, (pos, eq_lhs, eq_rhs) :: eq_accum
-    in List.fold_left over_vars ([], []) gvars
+    in List.fold_left over_vars ([], []) (gvars @ gen_gvars)
   (* ****************************************************************** *)
   (* Contract Modes                                                     *)
   (* ****************************************************************** *)

--- a/src/lustre/lustreRemoveMultAssign.ml
+++ b/src/lustre/lustreRemoveMultAssign.ml
@@ -100,7 +100,7 @@ let create_new_eqs ctx lhs expr =
       let arrayids_new = get_array_ids sis in
       let expr = LAH.replace_idents arrayids_original arrayids_new expr in
       let gids2 = { (GI.empty ()) with 
-        equations = [([], [], A.StructDef(pos, sis), expr)];
+        equations = [([], [], A.StructDef(pos, sis), expr, Some GI.Output)];
       } in
       let eqs = List.map (fun x -> A.Body x) eqs in
         (

--- a/src/lustre/lustreRemoveMultAssign.ml
+++ b/src/lustre/lustreRemoveMultAssign.ml
@@ -173,7 +173,7 @@ let desugar_node_decl ctx decl = match decl with
   
 (** Desugars a declaration list to remove multiple assignment from if blocks and frame
     blocks. *)
-let remove_mult_assign ctx sorted_node_contract_decls = 
-  let decls, gids = List.map (desugar_node_decl ctx) sorted_node_contract_decls |> List.split in
-  let gids = List.fold_left (GI.StringMap.merge GI.union_keys2) GI.StringMap.empty gids in
+let remove_mult_assign ctx gids sorted_node_contract_decls = 
+  let decls, gids2 = List.map (desugar_node_decl ctx) sorted_node_contract_decls |> List.split in
+  let gids = List.fold_left (GI.StringMap.merge GI.union_keys2) gids gids2 in
   decls, gids

--- a/src/lustre/lustreRemoveMultAssign.mli
+++ b/src/lustre/lustreRemoveMultAssign.mli
@@ -43,4 +43,4 @@
 
 (** Desugars a declaration list to remove multiple assignment from if blocks and frame
     blocks. *)
-val remove_mult_assign : TypeCheckerContext.tc_context -> LustreAst.declaration list -> LustreAst.declaration list * GeneratedIdentifiers.t GeneratedIdentifiers.StringMap.t
+val remove_mult_assign : TypeCheckerContext.tc_context -> GeneratedIdentifiers.t HString.HStringMap.t -> LustreAst.declaration list -> LustreAst.declaration list * GeneratedIdentifiers.t GeneratedIdentifiers.StringMap.t

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -190,6 +190,12 @@ val infer_type_expr: tc_context ->  HString.t option -> LA.expr -> (tc_type * [>
 val eq_lustre_type : tc_context -> LA.lustre_type -> LA.lustre_type -> (bool, [> error]) result
 (** Check if two lustre types are equal *)
 
+val tc_ctx_of_contract_node_decl: Lib.position -> tc_context
+  -> LA.contract_node_decl
+  -> (tc_context * [> warning] list, [> error]) result
+
+val tc_ctx_of_node_decl: Lib.position -> tc_context -> LA.node_decl -> (tc_context * [> warning] list, [> error]) result
+
 (* 
    Local Variables:
    compile-command: "make -k -C .."

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -1349,6 +1349,12 @@ let split_dot s =
   let n = (index s '.') in
   sub s 0 n, sub s (n+1) (length s - n - 1)
 
+let split3 triples =
+  let xs = List.map (fun (x, _, _) -> x) triples in
+  let ys = List.map (fun (_, y, _) -> y) triples in
+  let zs = List.map (fun (_, _, z) -> z) triples in
+  xs, ys, zs
+
 
 (* Extract scope from a concatenated name *)
 let extract_scope_name name =

--- a/src/utils/lib.mli
+++ b/src/utils/lib.mli
@@ -147,6 +147,9 @@ val list_suffix : 'a list -> int -> 'a list
     the second will contain all indices from [n,len) *)
 val list_split : int -> 'a list -> ('a list * 'a list)
 
+(** [split3 l] takes a list of triples and produces a triple of lists *)
+val split3 : ('a * 'b * 'c) list -> 'a list * 'b list * 'c list
+
 (** [chain_list \[e1; e2; ...\]] is [\[\[e1; e2\]; \[e2; e3\]; ... \]] *)
 val chain_list : 'a list -> 'a list list 
 


### PR DESCRIPTION
Fixes kind2-mc/kind2-dev#150

Also see below for a more in depth test case, which correctly report N's environment as unrealizable because initially, it is not possible for x+2 to be less than 0 and x + (3+l) (which is  x + (3+0) = x+3) to be greater than 0.

However, N2's environment is correctly reported as realizable.

```
contract S1(x, y: int) returns (z: bool);
let
  assume x < 0 and 0 < y;
tel

node M (x: int) returns (y: int)
let
 y = x;
tel

node imported N(x:int) returns (y: bool; y2: int);
(*@contract
  var l: int = 0 -> pre (M(4 + 2));
  var m: int = 3;
  import S1(x+2, x+ (3 + l)) returns (y);
  guarantee y2 + l > 0;
*)

node imported N2(x:int) returns (y: bool; y2: int);
(*@contract
  var m: int = 1;
  var l: int = 2 + m;
  import S1(x+0, x+ (1 + l)) returns (y);
  guarantee y2 + l > 0;
*)
```

Another related note:

Normalization of mode references is complicated (in the normalizer, we normalize every chain of contract calls separately), but this is tricky with our current infrastructure where some generated identifiers are being created earlier in the pipeline (at `lustreGenRefTypeImpNodes.ml`). Due to this, we have temporarily disabled mode references in assumptions for node environment realizability checks (see the assumption in node `N` in the following example). 

```
node H (u:bool) returns (v:bool);
let
   v = not u;
tel;

contract A (a:bool) returns (b:bool) ;
let
  assume a;
  assume H(a);
  guarantee not b;
  mode Am (
      require a;
      ensure not b;
  );
tel

contract B (x:bool) returns (y:bool) ;
let
  var v: bool = not (not x);

  assume H(x);
  import A (x) returns (y);
  mode Bm (
      require x;
      require v;
      require v;
      ensure ::A::Am;
  );
tel

contract C (n:bool) returns (m:bool);
let
    import B (n) returns (m);
    import A (n) returns (m);
tel

node N (u:bool) returns (v:bool);
(*@contract
  var h1: bool = not u;
  import C (h1) returns (v);
  assume ::C::B::A::Am;
*)
let
   v = u;
tel;
```