### PR TITLE
Monomorphize gids

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -285,8 +285,9 @@ let pp_print_generated_identifiers ppf gids =
   A.pp_print_eq_lhs lhs
   A.pp_print_expr expr
   in
-  Format.fprintf ppf "%a\n%a\n%a\n%a\n%a\n%a\n%a\n%a\n%a\n"
+  Format.fprintf ppf "%a\n%a\n%a\n%a\n%a\n%a\n%a\n%a\n%a\n%a\n"
     (pp_print_list pp_print_oracle "\n") gids.oracles
+    (pp_print_list pp_print_local "\n") gids.ib_oracles
     (pp_print_list pp_print_array_ctor "\n") array_ctor_list
     (pp_print_list pp_print_node_arg "\n") gids.node_args
     (pp_print_list pp_print_local "\n") locals_list

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -285,7 +285,6 @@ let pp_print_generated_identifiers ppf gids =
     (pp_print_list pp_print_array_ctor "\n") array_ctor_list
     (pp_print_list pp_print_node_arg "\n") gids.node_args
     (pp_print_list pp_print_local "\n") locals_list
-    (pp_print_list pp_print_local "\n") gids.ib_oracles
     (pp_print_list pp_print_call "\n") gids.calls
     (pp_print_list pp_print_subrange_constraint "\n") gids.subrange_constraints
     (pp_print_list pp_print_refinement_type_constraint "\n") gids.refinement_type_constraints

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -203,7 +203,7 @@ let type_check declarations =
     let abstract_interp_ctx = LIA.interpret_program inlined_global_ctx gids const_inlined_nodes_and_contracts in
 
     (* Step 16. Instantiate polymorphic nodes with concrete types *)
-    let inlined_global_ctx, const_inlined_nodes_and_contracts = LIP.instantiate_polymorphic_nodes inlined_global_ctx const_inlined_nodes_and_contracts in
+    let inlined_global_ctx, gids, const_inlined_nodes_and_contracts = LIP.instantiate_polymorphic_nodes inlined_global_ctx gids const_inlined_nodes_and_contracts in
 
     (* Step 17. Flatten refinement types *)
     let const_inlined_type_and_consts = LFR.flatten_ref_types inlined_global_ctx const_inlined_type_and_consts in

--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -202,13 +202,13 @@ let rec gen_poly_decl: Ctx.tc_context -> GI.t GI.StringMap.t -> HString.t option
         let ty = Chk.instantiate_type_variables ctx Lib.dummy_pos nname ty ty_args |> unwrap in 
         (id, ty)
       ) polymorphic_gids.ib_oracles in
-      let geqs = List.map (fun (q_vars, sc, lhs, expr) -> 
+      let geqs = List.map (fun (q_vars, sc, lhs, expr, source) -> 
         let q_vars = List.map (fun (pos, id, ty) -> 
           let ty = Chk.instantiate_type_variables ctx pos nname ty ty_args |> unwrap in 
           pos, id, ty
         ) q_vars in 
         let expr = Chk.instantiate_type_variables_expr ctx nname ty_args expr |> unwrap in
-        (q_vars, sc, lhs, expr)
+        (q_vars, sc, lhs, expr, source)
       ) polymorphic_gids.equations in
 
       (* Recursively create new polymorphic instantiations, e.g. if the gids contain call M<<int>> *)
@@ -220,9 +220,9 @@ let rec gen_poly_decl: Ctx.tc_context -> GI.t GI.StringMap.t -> HString.t option
         let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids (Some nname) acc_node_decls_map ty in 
         ctx, gids, decls @ acc_decls, (id, ty) :: acc_ib_oracles, node_decls_map
       ) (ctx, gids, decls, [], node_decls_map) ib_oracles in 
-      let ctx, gids, decls, geqs, node_decls_map = List.fold_left (fun (ctx, gids, acc_decls, acc_geqs, acc_node_decls_map) (q_vars, sc, lhs, expr) -> 
+      let ctx, gids, decls, geqs, node_decls_map = List.fold_left (fun (ctx, gids, acc_decls, acc_geqs, acc_node_decls_map) (q_vars, sc, lhs, expr, source) -> 
         let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids (Some nname) acc_node_decls_map expr in 
-        ctx, gids, decls @ acc_decls, (q_vars, sc, lhs, expr) :: acc_geqs, node_decls_map
+        ctx, gids, decls @ acc_decls, (q_vars, sc, lhs, expr, source) :: acc_geqs, node_decls_map
       ) (ctx, gids, decls, [], node_decls_map) geqs in 
 
       let monomorphized_gids = { polymorphic_gids with locals = glocals; equations = geqs; ib_oracles = ib_oracles; } in

--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -92,9 +92,9 @@ let build_node_fun_ty
    and type arguments, return the associated generated polymorphic node name, a new declaration for the 
    polymorphic node instantiation (if it hasn't already been created), and the updated map of 
    node names to polymorphic instantiations *)
-let rec gen_poly_decl: Ctx.tc_context -> HString.t option -> (A.declaration * A.lustre_type list list) HString.HStringMap.t ->
-                   HString.t -> A.lustre_type list -> Ctx.tc_context * HString.t *  A.declaration list * (A.declaration * A.lustre_type list list) HString.HStringMap.t 
-= fun ctx caller_nname node_decls_map nname ty_args ->
+let rec gen_poly_decl: Ctx.tc_context -> GI.t GI.StringMap.t -> HString.t option -> (A.declaration * A.lustre_type list list) HString.HStringMap.t ->
+                   HString.t -> A.lustre_type list -> Ctx.tc_context * GI.t GI.StringMap.t * HString.t *  A.declaration list * (A.declaration * A.lustre_type list list) HString.HStringMap.t 
+= fun ctx gids caller_nname node_decls_map nname ty_args ->
   (* Check for pre-existing instantiation of the node before compiling a new one *)
   let decl, tyss = GI.StringMap.find nname node_decls_map in 
   let find_decl tys = 
@@ -114,7 +114,7 @@ let rec gen_poly_decl: Ctx.tc_context -> HString.t option -> (A.declaration * A.
   | Some i -> 
     let prefix =  LustreGenRefTypeImpNodes.poly_gen_node_tag ^ (string_of_int i) ^ "_" in
     let pnname = HString.concat2 (HString.mk_hstring prefix) nname in
-    ctx, pnname, [], node_decls_map   
+    ctx, gids, pnname, [], node_decls_map   
   (* Creating new polymorphic instantiation *) 
   | None ->
     let span, is_function, is_contract, ext, opac, ips, ops, locs, nis, c =
@@ -189,61 +189,101 @@ let rec gen_poly_decl: Ctx.tc_context -> HString.t option -> (A.declaration * A.
         Ctx.add_ty_node ctx pnname node_ty, 
         NodeDecl (span, (pnname, ext, opac, ps, ips, ops, locs, nis, c))
     in
+    
+    let ctx, gids, decls, node_decls_map = match GI.StringMap.find_opt nname gids with
+    | None -> ctx, gids, [], node_decls_map 
+    | Some polymorphic_gids -> 
+
+      (* Create monomorphization of gids for this new generated declaration *)
+      let glocals = GI.StringMap.map (fun ty -> 
+        Chk.instantiate_type_variables ctx Lib.dummy_pos nname ty ty_args |> unwrap 
+      ) polymorphic_gids.locals in 
+      let ib_oracles = List.map (fun (id, ty) -> 
+        let ty = Chk.instantiate_type_variables ctx Lib.dummy_pos nname ty ty_args |> unwrap in 
+        (id, ty)
+      ) polymorphic_gids.ib_oracles in
+      let geqs = List.map (fun (q_vars, sc, lhs, expr) -> 
+        let q_vars = List.map (fun (pos, id, ty) -> 
+          let ty = Chk.instantiate_type_variables ctx pos nname ty ty_args |> unwrap in 
+          pos, id, ty
+        ) q_vars in 
+        let expr = Chk.instantiate_type_variables_expr ctx nname ty_args expr |> unwrap in
+        (q_vars, sc, lhs, expr)
+      ) polymorphic_gids.equations in
+
+      (* Recursively create new polymorphic instantiations, e.g. if the gids contain call M<<int>> *)
+      let ctx, gids, decls, glocals, node_decls_map = GI.StringMap.fold (fun id ty (ctx, gids, acc_decls, acc_glocals, acc_node_decls_map) -> 
+        let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids (Some nname) acc_node_decls_map ty in 
+        ctx, gids, decls @ acc_decls, GI.StringMap.add id ty acc_glocals, node_decls_map
+      ) glocals (ctx, gids, [], GI.StringMap.empty, node_decls_map) in
+      let ctx, gids, decls, ib_oracles, node_decls_map = List.fold_left (fun (ctx, gids, acc_decls, acc_ib_oracles, acc_node_decls_map) (id, ty) -> 
+        let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids (Some nname) acc_node_decls_map ty in 
+        ctx, gids, decls @ acc_decls, (id, ty) :: acc_ib_oracles, node_decls_map
+      ) (ctx, gids, decls, [], node_decls_map) ib_oracles in 
+      let ctx, gids, decls, geqs, node_decls_map = List.fold_left (fun (ctx, gids, acc_decls, acc_geqs, acc_node_decls_map) (q_vars, sc, lhs, expr) -> 
+        let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids (Some nname) acc_node_decls_map expr in 
+        ctx, gids, decls @ acc_decls, (q_vars, sc, lhs, expr) :: acc_geqs, node_decls_map
+      ) (ctx, gids, decls, [], node_decls_map) geqs in 
+
+      let monomorphized_gids = { polymorphic_gids with locals = glocals; equations = geqs; ib_oracles = ib_oracles; } in
+      let gids = GI.StringMap.add pnname monomorphized_gids gids in 
+      ctx, gids, decls, node_decls_map
+    in
 
     (* Recursively create new instantiations (this node could use the given polymorphic 
     instantiation to call another polymorphic node *)
-    let ctx, decls, node_decls_map = gen_poly_decls_decls ctx node_decls_map [called_decl] in
+    let ctx, gids, decls, node_decls_map = gen_poly_decls_decls ctx gids node_decls_map (decls @ [called_decl]) in
 
-    ctx, pnname, decls, node_decls_map                     
+    ctx, gids, pnname, decls, node_decls_map                     
 
-and gen_poly_decls_ty: Ctx.tc_context -> HString.t option -> (A.declaration * A.lustre_type list list) HString.HStringMap.t ->
-                           A.lustre_type -> Ctx.tc_context * A.lustre_type * A.declaration list * (A.declaration * A.lustre_type list list) HString.HStringMap.t
-= fun ctx nname node_decls_map ty -> match ty with
+and gen_poly_decls_ty: Ctx.tc_context -> GI.t GI.StringMap.t -> HString.t option -> (A.declaration * A.lustre_type list list) HString.HStringMap.t ->
+                           A.lustre_type -> Ctx.tc_context * GI.t GI.StringMap.t * A.lustre_type * A.declaration list * (A.declaration * A.lustre_type list list) HString.HStringMap.t
+= fun ctx gids nname node_decls_map ty -> match ty with
   | A.TupleType (p, tys) -> 
-    let ctx, tys, decls, node_decls_map = List.fold_left (fun (ctx, acc_tys, acc_decls, acc_node_decls_map) ty -> 
-      let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx nname acc_node_decls_map ty in 
-      ctx, acc_tys @ [ty], decls @ acc_decls, node_decls_map
-    ) (ctx, [], [], node_decls_map) tys in 
-    ctx, TupleType (p, tys), decls, node_decls_map
+    let ctx, gids, tys, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_tys, acc_decls, acc_node_decls_map) ty -> 
+      let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids nname acc_node_decls_map ty in 
+      ctx, gids, acc_tys @ [ty], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], [], node_decls_map) tys in 
+    ctx, gids, TupleType (p, tys), decls, node_decls_map
   | GroupType (p, tys) -> 
-    let ctx, tys, decls, node_decls_map = List.fold_left (fun (ctx, acc_tys, acc_decls, acc_node_decls_map) ty -> 
-      let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx nname acc_node_decls_map ty in 
-      ctx, acc_tys @ [ty], decls @ acc_decls, node_decls_map
-    ) (ctx, [], [], node_decls_map) tys in 
-    ctx, GroupType (p, tys), decls, node_decls_map
+    let ctx, gids, tys, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_tys, acc_decls, acc_node_decls_map) ty -> 
+      let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids nname acc_node_decls_map ty in 
+      ctx, gids, acc_tys @ [ty], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], [], node_decls_map) tys in 
+    ctx, gids, GroupType (p, tys), decls, node_decls_map
   | RecordType (p, id, tis) -> 
-    let ctx, tis, decls, node_decls_map = List.fold_left (fun (ctx, acc_tys, acc_decls, acc_node_decls_map) (p, id, ty) -> 
-      let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx nname acc_node_decls_map ty in 
-      ctx, acc_tys @ [(p, id, ty)], decls @ acc_decls, node_decls_map
-    ) (ctx, [], [], node_decls_map) tis in 
-    ctx, RecordType (p, id, tis), decls, node_decls_map
+    let ctx, gids, tis, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_tys, acc_decls, acc_node_decls_map) (p, id, ty) -> 
+      let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids nname acc_node_decls_map ty in 
+      ctx, gids, acc_tys @ [(p, id, ty)], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], [], node_decls_map) tis in 
+    ctx, gids, RecordType (p, id, tis), decls, node_decls_map
   | ArrayType (p, (ty, expr)) -> 
-    let ctx, ty, decls1, node_decls_map = gen_poly_decls_ty ctx nname node_decls_map ty in 
-    let ctx, expr, decls2, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-    ctx, ArrayType (p, (ty, expr)), decls1 @ decls2, node_decls_map
+    let ctx, gids, ty, decls1, node_decls_map = gen_poly_decls_ty ctx gids nname node_decls_map ty in 
+    let ctx, gids, expr, decls2, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+    ctx, gids, ArrayType (p, (ty, expr)), decls1 @ decls2, node_decls_map
   | TArr (p, ty1, ty2) -> 
-    let ctx, ty1, decls1, node_decls_map = gen_poly_decls_ty ctx nname node_decls_map ty1 in 
-    let ctx, ty2, decls2, node_decls_map = gen_poly_decls_ty ctx nname node_decls_map ty2 in 
-    ctx, TArr (p, ty1, ty2), decls1 @ decls2, node_decls_map
+    let ctx, gids, ty1, decls1, node_decls_map = gen_poly_decls_ty ctx gids nname node_decls_map ty1 in 
+    let ctx, gids, ty2, decls2, node_decls_map = gen_poly_decls_ty ctx gids nname node_decls_map ty2 in 
+    ctx, gids, TArr (p, ty1, ty2), decls1 @ decls2, node_decls_map
   | RefinementType (p, (p2, id, ty), expr) -> 
-    let ctx, ty, decls1, node_decls_map = gen_poly_decls_ty ctx nname node_decls_map ty in 
-    let ctx, expr, decls2, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-    ctx, RefinementType (p, (p2, id, ty), expr), decls1 @ decls2, node_decls_map
+    let ctx, gids, ty, decls1, node_decls_map = gen_poly_decls_ty ctx gids nname node_decls_map ty in 
+    let ctx, gids, expr, decls2, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+    ctx, gids, RefinementType (p, (p2, id, ty), expr), decls1 @ decls2, node_decls_map
   | Bool _ | Int _ | UInt8 _ | UInt16 _ | UInt32 _ | UInt64  _ | Int8 _ | Int16 _
   | Int32 _ | Int64 _ | IntRange _ | Real _ | UserType _
-  | AbstractType _ | EnumType _ | History _ -> ctx, ty, [], node_decls_map
+  | AbstractType _ | EnumType _ | History _ -> ctx, gids, ty, [], node_decls_map
 
-and gen_poly_decls_expr: Ctx.tc_context -> HString.t option -> (A.declaration * A.lustre_type list list) HString.HStringMap.t ->
-                             A.expr -> Ctx.tc_context * A.expr *  A.declaration list * (A.declaration * A.lustre_type list list) HString.HStringMap.t
-= fun ctx caller_nname node_decls_map expr -> 
-  let rec_call = gen_poly_decls_expr ctx caller_nname node_decls_map in
+and gen_poly_decls_expr: Ctx.tc_context -> GI.t GI.StringMap.t -> HString.t option -> (A.declaration * A.lustre_type list list) HString.HStringMap.t ->
+                             A.expr -> Ctx.tc_context * GI.t GI.StringMap.t * A.expr *  A.declaration list * (A.declaration * A.lustre_type list list) HString.HStringMap.t
+= fun ctx gids caller_nname node_decls_map expr -> 
+  let rec_call = gen_poly_decls_expr ctx gids caller_nname node_decls_map in
   match expr with 
   | A.Call (pos, ty :: tys, nname, exprs) -> 
-    let ctx, exprs, decls1, node_decls_map = List.fold_left (fun (ctx, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
-      let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx caller_nname acc_node_decls_map expr in 
-      ctx, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
-    ) (ctx, [], [], node_decls_map) exprs in 
-    let ctx, pnname, decls2, node_decls_map  = gen_poly_decl ctx caller_nname node_decls_map  nname (ty :: tys) in
+    let ctx, gids, exprs, decls1, node_decls_map = List.fold_left (fun (ctx, gids, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
+      let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids caller_nname acc_node_decls_map expr in 
+      ctx, gids, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], [], node_decls_map) exprs in 
+    let ctx, gids, pnname, decls2, node_decls_map  = gen_poly_decl ctx gids caller_nname node_decls_map  nname (ty :: tys) in
 
     let ty_args =
       match caller_nname with
@@ -254,309 +294,309 @@ and gen_poly_decls_expr: Ctx.tc_context -> HString.t option -> (A.declaration * 
         |> Ctx.SI.elements
         |> List.map (fun ty_var -> A.UserType (pos, [], ty_var))
     in
-    ctx, Call (pos, ty_args, pnname, exprs), decls1 @ decls2, node_decls_map
+    ctx, gids, Call (pos, ty_args, pnname, exprs), decls1 @ decls2, node_decls_map
   | Ident _ 
   | Call _ 
   | Const _
-  | ModeRef _ -> ctx, expr, [], node_decls_map
+  | ModeRef _ -> ctx, gids, expr, [], node_decls_map
   | RecordProject (p, expr, id) -> 
-    let ctx, expr, decls, node_decls_map = rec_call expr in 
-    ctx, RecordProject (p, expr, id), decls, node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
+    ctx, gids, RecordProject (p, expr, id), decls, node_decls_map
   | TupleProject (p, expr, i) -> 
-    let ctx, expr, decls, node_decls_map = rec_call expr in 
-    ctx, TupleProject (p, expr, i), decls, node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
+    ctx, gids, TupleProject (p, expr, i), decls, node_decls_map
   | ConvOp (p, op, expr) -> 
-    let ctx, expr, decls, node_decls_map = rec_call expr in 
-    ctx, ConvOp (p, op, expr), decls, node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
+    ctx, gids, ConvOp (p, op, expr), decls, node_decls_map
   | When (p, expr, cl) -> 
-    let ctx, expr, decls, node_decls_map = rec_call expr in 
-    ctx, When (p, expr, cl), decls, node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
+    ctx, gids, When (p, expr, cl), decls, node_decls_map
   | Pre (p, expr) -> 
-    let ctx, expr, decls, node_decls_map = rec_call expr in 
-    ctx, Pre (p, expr), decls, node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
+    ctx, gids, Pre (p, expr), decls, node_decls_map
   | UnaryOp (p, op, expr) -> 
-    let ctx, expr, decls, node_decls_map = rec_call expr in 
-    ctx, UnaryOp (p, op, expr), decls, node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
+    ctx, gids, UnaryOp (p, op, expr), decls, node_decls_map
   | BinaryOp (p, op, expr1, expr2) ->
-    let ctx, expr1, decls1, node_decls_map = rec_call expr1 in 
-    let ctx, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr2 in 
-    ctx, BinaryOp (p, op, expr1, expr2), decls1 @ decls2, node_decls_map 
+    let ctx, gids, expr1, decls1, node_decls_map = rec_call expr1 in 
+    let ctx, gids, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr2 in 
+    ctx, gids, BinaryOp (p, op, expr1, expr2), decls1 @ decls2, node_decls_map 
   | CompOp (p, op, expr1, expr2) ->
-    let ctx, expr1, decls1, node_decls_map = rec_call expr1 in 
-    let ctx, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr2 in 
-    ctx, CompOp (p, op, expr1, expr2), decls1 @ decls2, node_decls_map 
+    let ctx, gids, expr1, decls1, node_decls_map = rec_call expr1 in 
+    let ctx, gids, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr2 in 
+    ctx, gids, CompOp (p, op, expr1, expr2), decls1 @ decls2, node_decls_map 
   | ArrayConstr (p, expr1, expr2) ->
-    let ctx, expr1, decls1, node_decls_map = rec_call expr1 in 
-    let ctx, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr2 in 
-    ctx, ArrayConstr (p, expr1, expr2), decls1 @ decls2, node_decls_map 
+    let ctx, gids, expr1, decls1, node_decls_map = rec_call expr1 in 
+    let ctx, gids, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr2 in 
+    ctx, gids, ArrayConstr (p, expr1, expr2), decls1 @ decls2, node_decls_map 
   | Arrow (p, expr1, expr2) ->
-    let ctx, expr1, decls1, node_decls_map = rec_call expr1 in 
-    let ctx, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr2 in 
-    ctx, Arrow (p, expr1, expr2), decls1 @ decls2, node_decls_map 
+    let ctx, gids, expr1, decls1, node_decls_map = rec_call expr1 in 
+    let ctx, gids, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr2 in 
+    ctx, gids, Arrow (p, expr1, expr2), decls1 @ decls2, node_decls_map 
   | StructUpdate (p, expr1, lois, expr2) ->
-    let ctx, expr1, decls1, node_decls_map = rec_call expr1 in 
-    let ctx, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr2 in 
-    ctx, StructUpdate (p, expr1, lois, expr2), decls1 @ decls2, node_decls_map 
+    let ctx, gids, expr1, decls1, node_decls_map = rec_call expr1 in 
+    let ctx, gids, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr2 in 
+    ctx, gids, StructUpdate (p, expr1, lois, expr2), decls1 @ decls2, node_decls_map 
   | ArrayIndex (p, expr1, expr2) ->
-    let ctx, expr1, decls1, node_decls_map = rec_call expr1 in 
-    let ctx, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr2 in 
-    ctx, ArrayIndex (p, expr1, expr2), decls1 @ decls2, node_decls_map 
+    let ctx, gids, expr1, decls1, node_decls_map = rec_call expr1 in 
+    let ctx, gids, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr2 in 
+    ctx, gids, ArrayIndex (p, expr1, expr2), decls1 @ decls2, node_decls_map 
   | TernaryOp (p, op, expr1, expr2, expr3) ->
-    let ctx, expr1, decls1, node_decls_map = rec_call expr1 in 
-    let ctx, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr2 in 
-    let ctx, expr3, decls3, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr3 in
-    ctx, TernaryOp (p, op, expr1, expr2, expr3), decls1 @ decls2 @ decls3, node_decls_map
+    let ctx, gids, expr1, decls1, node_decls_map = rec_call expr1 in 
+    let ctx, gids, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr2 in 
+    let ctx, gids, expr3, decls3, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr3 in
+    ctx, gids, TernaryOp (p, op, expr1, expr2, expr3), decls1 @ decls2 @ decls3, node_decls_map
   | AnyOp (p, (p2, id, ty), expr1, Some expr2) -> 
-    let ctx, expr1, decls1, node_decls_map = rec_call expr1 in 
-    let ctx, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr2 in 
-    let ctx, ty, decls3, node_decls_map = gen_poly_decls_ty ctx caller_nname node_decls_map ty in 
-    ctx, AnyOp (p, (p2, id, ty), expr1, Some expr2), decls1 @ decls2 @ decls3, node_decls_map
+    let ctx, gids, expr1, decls1, node_decls_map = rec_call expr1 in 
+    let ctx, gids, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr2 in 
+    let ctx, gids, ty, decls3, node_decls_map = gen_poly_decls_ty ctx gids caller_nname node_decls_map ty in 
+    ctx, gids, AnyOp (p, (p2, id, ty), expr1, Some expr2), decls1 @ decls2 @ decls3, node_decls_map
   | AnyOp (p, (p2, id, ty), expr, None) ->
-    let ctx, expr, decls1, node_decls_map = rec_call expr in 
-    let ctx, ty, decls2, node_decls_map = gen_poly_decls_ty ctx caller_nname node_decls_map ty in 
-    ctx, AnyOp (p, (p2, id, ty), expr, None), decls1 @ decls2, node_decls_map
+    let ctx, gids, expr, decls1, node_decls_map = rec_call expr in 
+    let ctx, gids, ty, decls2, node_decls_map = gen_poly_decls_ty ctx gids caller_nname node_decls_map ty in 
+    ctx, gids, AnyOp (p, (p2, id, ty), expr, None), decls1 @ decls2, node_decls_map
   | Quantifier (p, q, tis, expr) -> 
-    let ctx, expr, decls1, node_decls_map = rec_call expr in 
-    let ctx, tis, decls2, node_decls_map = List.fold_left (fun (ctx, acc_tis, acc_decls, acc_node_decls_map) (p, id, ty) -> 
-      let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx caller_nname acc_node_decls_map ty in 
-      ctx, acc_tis @ [p, id, ty], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls1, node_decls_map) tis in 
-    ctx, Quantifier (p, q, tis, expr), decls1 @ decls2, node_decls_map
+    let ctx, gids, expr, decls1, node_decls_map = rec_call expr in 
+    let ctx, gids, tis, decls2, node_decls_map = List.fold_left (fun (ctx, gids, acc_tis, acc_decls, acc_node_decls_map) (p, id, ty) -> 
+      let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids caller_nname acc_node_decls_map ty in 
+      ctx, gids, acc_tis @ [p, id, ty], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls1, node_decls_map) tis in 
+    ctx, gids, Quantifier (p, q, tis, expr), decls1 @ decls2, node_decls_map
   | Merge (p, id, id_exprs) ->
-    let ctx, id_exprs, decls, node_decls_map = List.fold_left (fun (ctx, acc_id_exprs, acc_decls, acc_node_decls_map) (id, expr) -> 
-      let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx caller_nname acc_node_decls_map expr in 
-      ctx, acc_id_exprs @ [id, expr], decls @ acc_decls, node_decls_map
-    ) (ctx, [], [], node_decls_map) id_exprs in 
-    ctx, Merge (p, id, id_exprs), decls, node_decls_map
+    let ctx, gids, id_exprs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_id_exprs, acc_decls, acc_node_decls_map) (id, expr) -> 
+      let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids caller_nname acc_node_decls_map expr in 
+      ctx, gids, acc_id_exprs @ [id, expr], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], [], node_decls_map) id_exprs in 
+    ctx, gids, Merge (p, id, id_exprs), decls, node_decls_map
   | RecordExpr (p, id, ps, id_exprs) ->
-    let ctx, id_exprs, decls, node_decls_map = List.fold_left (fun (ctx, acc_id_exprs, acc_decls, acc_node_decls_map) (id, expr) -> 
-      let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx caller_nname acc_node_decls_map expr in 
-      ctx, acc_id_exprs @ [id, expr], decls @ acc_decls, node_decls_map
-    ) (ctx, [], [], node_decls_map) id_exprs in 
-    ctx, RecordExpr (p, id, ps, id_exprs), decls, node_decls_map
+    let ctx, gids, id_exprs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_id_exprs, acc_decls, acc_node_decls_map) (id, expr) -> 
+      let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids caller_nname acc_node_decls_map expr in 
+      ctx, gids, acc_id_exprs @ [id, expr], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], [], node_decls_map) id_exprs in 
+    ctx, gids, RecordExpr (p, id, ps, id_exprs), decls, node_decls_map
   | GroupExpr (p, ge, exprs) ->
-    let ctx, exprs, decls, node_decls_map = List.fold_left (fun (ctx, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
-      let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx caller_nname acc_node_decls_map expr in 
-      ctx, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
-    ) (ctx, [], [], node_decls_map) exprs in 
-    ctx, GroupExpr (p, ge, exprs), decls, node_decls_map
+    let ctx, gids, exprs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
+      let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids caller_nname acc_node_decls_map expr in 
+      ctx, gids, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], [], node_decls_map) exprs in 
+    ctx, gids, GroupExpr (p, ge, exprs), decls, node_decls_map
   | Condact (p, expr1, expr2, id, exprs1, exprs2) ->
-    let ctx, expr1, decls1, node_decls_map = rec_call expr1 in 
-    let ctx, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr2 in 
-    let ctx, exprs1, decls, node_decls_map = List.fold_left (fun (ctx, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
-      let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx caller_nname acc_node_decls_map expr in 
-      ctx, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls1 @ decls2, node_decls_map) exprs1 in 
-    let ctx, exprs2, decls, node_decls_map = List.fold_left (fun (ctx, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
-      let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx caller_nname acc_node_decls_map expr in 
-      ctx, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) exprs2 in 
-    ctx, Condact (p, expr1, expr2, id, exprs1, exprs2), decls, node_decls_map
+    let ctx, gids, expr1, decls1, node_decls_map = rec_call expr1 in 
+    let ctx, gids, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr2 in 
+    let ctx, gids, exprs1, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
+      let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids caller_nname acc_node_decls_map expr in 
+      ctx, gids, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls1 @ decls2, node_decls_map) exprs1 in 
+    let ctx, gids, exprs2, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
+      let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids caller_nname acc_node_decls_map expr in 
+      ctx, gids, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) exprs2 in 
+    ctx, gids, Condact (p, expr1, expr2, id, exprs1, exprs2), decls, node_decls_map
   | Activate (p, id, expr1, expr2, exprs) ->
-    let ctx, expr1, decls1, node_decls_map = rec_call expr1 in 
-    let ctx, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx caller_nname node_decls_map expr2 in 
-    let ctx, exprs, decls, node_decls_map = List.fold_left (fun (ctx, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
-      let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx caller_nname acc_node_decls_map expr in 
-      ctx, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls1 @ decls2, node_decls_map) exprs in 
-    ctx, Activate (p, id, expr1, expr2, exprs), decls, node_decls_map
+    let ctx, gids, expr1, decls1, node_decls_map = rec_call expr1 in 
+    let ctx, gids, expr2, decls2, node_decls_map = gen_poly_decls_expr ctx gids caller_nname node_decls_map expr2 in 
+    let ctx, gids, exprs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
+      let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids caller_nname acc_node_decls_map expr in 
+      ctx, gids, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls1 @ decls2, node_decls_map) exprs in 
+    ctx, gids, Activate (p, id, expr1, expr2, exprs), decls, node_decls_map
   | RestartEvery (p, id, exprs, expr) ->
-    let ctx, expr, decls, node_decls_map = rec_call expr in 
-    let ctx, exprs, decls, node_decls_map = List.fold_left (fun (ctx, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
-      let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx caller_nname acc_node_decls_map expr in 
-      ctx, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) exprs in 
-    ctx, RestartEvery (p, id, exprs, expr), decls, node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
+    let ctx, gids, exprs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
+      let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids caller_nname acc_node_decls_map expr in 
+      ctx, gids, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) exprs in 
+    ctx, gids, RestartEvery (p, id, exprs, expr), decls, node_decls_map
 
 and gen_poly_decls_ni
-= fun ctx nname node_decls_map ni -> match ni with 
+= fun ctx gids nname node_decls_map ni -> match ni with 
   | A.Body (Equation (p, lhs, expr)) -> 
-    let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-    ctx, A.Body (Equation (p, lhs, expr)), decls, node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+    ctx, gids, A.Body (Equation (p, lhs, expr)), decls, node_decls_map
   | Body (Assert (p, expr)) -> 
-    let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-    ctx, Body (Assert (p, expr)), decls, node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+    ctx, gids, Body (Assert (p, expr)), decls, node_decls_map
   | IfBlock (p, expr, nis1, nis2) -> 
-    let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-    let ctx, nis1, decls, node_decls_map = List.fold_left (fun (ctx, acc_nis, acc_decls, acc_node_decls_map) ni -> 
-      let ctx, ni, decls, node_decls_map = gen_poly_decls_ni ctx nname acc_node_decls_map ni in 
-      ctx, acc_nis @ [ni], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) nis1 in 
-    let ctx, nis2, decls, node_decls_map = List.fold_left (fun (ctx, acc_nis, acc_decls, acc_node_decls_map) ni -> 
-      let ctx, ni, decls, node_decls_map = gen_poly_decls_ni ctx nname acc_node_decls_map ni in 
-      ctx, acc_nis @ [ni], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) nis2 in 
-    ctx, IfBlock (p, expr, nis1, nis2), decls, node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+    let ctx, gids, nis1, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_nis, acc_decls, acc_node_decls_map) ni -> 
+      let ctx, gids, ni, decls, node_decls_map = gen_poly_decls_ni ctx gids nname acc_node_decls_map ni in 
+      ctx, gids, acc_nis @ [ni], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) nis1 in 
+    let ctx, gids, nis2, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_nis, acc_decls, acc_node_decls_map) ni -> 
+      let ctx, gids, ni, decls, node_decls_map = gen_poly_decls_ni ctx gids nname acc_node_decls_map ni in 
+      ctx, gids, acc_nis @ [ni], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) nis2 in 
+    ctx, gids, IfBlock (p, expr, nis1, nis2), decls, node_decls_map
   | FrameBlock (p, vars, nes, nis) -> 
-    let ctx, nis, decls, node_decls_map = List.fold_left (fun (ctx, acc_nis, acc_decls, acc_node_decls_map) ni -> 
-      let ctx, ni, decls, node_decls_map = gen_poly_decls_ni ctx nname acc_node_decls_map ni in 
-      ctx, acc_nis @ [ni], decls @ acc_decls, node_decls_map
-    ) (ctx, [], [], node_decls_map) nis in 
-    let ctx, nes, decls, node_decls_map = List.fold_left (fun (ctx, acc_nes, acc_decls, acc_node_decls_map) ne -> 
-      let ctx, ni, decls, node_decls_map = gen_poly_decls_ni ctx nname acc_node_decls_map (A.Body ne) in 
+    let ctx, gids, nis, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_nis, acc_decls, acc_node_decls_map) ni -> 
+      let ctx, gids, ni, decls, node_decls_map = gen_poly_decls_ni ctx gids nname acc_node_decls_map ni in 
+      ctx, gids, acc_nis @ [ni], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], [], node_decls_map) nis in 
+    let ctx, gids, nes, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_nes, acc_decls, acc_node_decls_map) ne -> 
+      let ctx, gids, ni, decls, node_decls_map = gen_poly_decls_ni ctx gids nname acc_node_decls_map (A.Body ne) in 
       let ne = match ni with | Body ne -> ne | _ -> assert false in
-      ctx, acc_nes @ [ne], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) nes in  
-    ctx, FrameBlock (p, vars, nes, nis), decls, node_decls_map
+      ctx, gids, acc_nes @ [ne], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) nes in  
+    ctx, gids, FrameBlock (p, vars, nes, nis), decls, node_decls_map
   | AnnotProperty (p, n, expr, k) -> 
-    let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-    ctx, AnnotProperty (p, n, expr, k), decls, node_decls_map
-  | AnnotMain _ -> ctx, ni, [], node_decls_map
+    let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+    ctx, gids, AnnotProperty (p, n, expr, k), decls, node_decls_map
+  | AnnotMain _ -> ctx, gids, ni, [], node_decls_map
 
 and gen_poly_decls_op
-= fun ctx nname node_decls_map (p, id, ty, cl) -> 
-  let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx nname node_decls_map ty in 
-  ctx, (p, id, ty, cl), decls, node_decls_map
+= fun ctx gids nname node_decls_map (p, id, ty, cl) -> 
+  let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids nname node_decls_map ty in 
+  ctx, gids, (p, id, ty, cl), decls, node_decls_map
 
 and gen_poly_decls_loc
-= fun ctx nname node_decls_map loc -> match loc with 
+= fun ctx gids nname node_decls_map loc -> match loc with 
 | A.NodeConstDecl (p, FreeConst (p2, id, ty)) -> 
-  let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx nname node_decls_map ty in
-  ctx, A.NodeConstDecl (p, FreeConst (p2, id, ty)), decls, node_decls_map
+  let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids nname node_decls_map ty in
+  ctx, gids, A.NodeConstDecl (p, FreeConst (p2, id, ty)), decls, node_decls_map
 | A.NodeConstDecl (p, UntypedConst (p2, id, expr)) -> 
-  let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in
-  ctx, A.NodeConstDecl (p, UntypedConst (p2, id, expr)), decls, node_decls_map
+  let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in
+  ctx, gids, A.NodeConstDecl (p, UntypedConst (p2, id, expr)), decls, node_decls_map
 | A.NodeConstDecl (p, TypedConst (p2, id, expr, ty)) -> 
-  let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx nname node_decls_map ty in 
-  let ctx, expr, decls2, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-  ctx, A.NodeConstDecl (p, TypedConst (p2, id, expr, ty)), decls @ decls2, node_decls_map
+  let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids nname node_decls_map ty in 
+  let ctx, gids, expr, decls2, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+  ctx, gids, A.NodeConstDecl (p, TypedConst (p2, id, expr, ty)), decls @ decls2, node_decls_map
 | NodeVarDecl (p, var_decl) -> 
-  let ctx, var_decl, decls, node_decls_map = gen_poly_decls_op ctx nname node_decls_map var_decl in 
-  ctx, NodeVarDecl (p, var_decl), decls, node_decls_map
+  let ctx, gids, var_decl, decls, node_decls_map = gen_poly_decls_op ctx gids nname node_decls_map var_decl in 
+  ctx, gids, NodeVarDecl (p, var_decl), decls, node_decls_map
 
 and gen_poly_decls_ip
-= fun ctx nname node_decls_map (p, id, ty, cl, is_const) -> 
-  let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx nname node_decls_map ty in 
-  ctx, (p, id, ty, cl, is_const), decls, node_decls_map
+= fun ctx gids nname node_decls_map (p, id, ty, cl, is_const) -> 
+  let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids nname node_decls_map ty in 
+  ctx, gids, (p, id, ty, cl, is_const), decls, node_decls_map
 
 and gen_poly_decls_ci
-= fun ctx nname node_decls_map ci -> match ci with 
+= fun ctx gids nname node_decls_map ci -> match ci with 
 | A.ContractCall (p, cname, ty_arg :: ty_args, ips, ops) -> 
-  let ctx, pcname, decls, node_decls_map = gen_poly_decl ctx nname node_decls_map cname (ty_arg :: ty_args) in 
-  ctx, A.ContractCall (p, pcname, ty_arg :: ty_args, ips, ops), decls, node_decls_map
-| A.ContractCall (_, _, [], _, _) -> ctx, ci, [], node_decls_map
+  let ctx, gids, pcname, decls, node_decls_map = gen_poly_decl ctx gids nname node_decls_map cname (ty_arg :: ty_args) in 
+  ctx, gids, A.ContractCall (p, pcname, ty_arg :: ty_args, ips, ops), decls, node_decls_map
+| A.ContractCall (_, _, [], _, _) -> ctx, gids, ci, [], node_decls_map
 | Assume (p, id, b, expr) -> 
-  let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-  ctx, Assume (p, id, b, expr), decls, node_decls_map 
+  let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+  ctx, gids, Assume (p, id, b, expr), decls, node_decls_map 
 | Guarantee (p, id, b, expr) -> 
-  let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-  ctx, Guarantee (p, id, b, expr), decls, node_decls_map 
+  let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+  ctx, gids, Guarantee (p, id, b, expr), decls, node_decls_map 
 | GhostConst (FreeConst (p, id, ty)) -> 
-  let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx nname node_decls_map ty in 
-  ctx, GhostConst (FreeConst (p, id, ty)), decls, node_decls_map
+  let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids nname node_decls_map ty in 
+  ctx, gids, GhostConst (FreeConst (p, id, ty)), decls, node_decls_map
 | GhostConst (UntypedConst (p, id, expr)) -> 
-  let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in
-  ctx, GhostConst (UntypedConst (p, id, expr)), decls, node_decls_map
+  let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in
+  ctx, gids, GhostConst (UntypedConst (p, id, expr)), decls, node_decls_map
 | GhostConst (TypedConst (p, id, expr, ty)) -> 
-  let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx nname node_decls_map ty in 
-  let ctx, expr, decls2, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-  ctx, GhostConst (TypedConst (p, id, expr, ty)), decls @ decls2, node_decls_map
+  let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids nname node_decls_map ty in 
+  let ctx, gids, expr, decls2, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+  ctx, gids, GhostConst (TypedConst (p, id, expr, ty)), decls @ decls2, node_decls_map
 | GhostVars (p, GhostVarDec (p2, tis), expr) -> 
-  let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname node_decls_map expr in 
-  let ctx, tis, decls, node_decls_map = List.fold_left (fun (ctx, acc_tis, acc_decls, acc_node_decls_map) (p, id, ty) -> 
-    let ctx, ty, decls, node_decls_map = gen_poly_decls_ty ctx nname acc_node_decls_map ty in 
-    ctx, acc_tis @ [p, id, ty], decls @ acc_decls, node_decls_map
-  ) (ctx, [], decls, node_decls_map) tis in 
-  ctx, GhostVars (p, GhostVarDec (p2, tis), expr), decls, node_decls_map
+  let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname node_decls_map expr in 
+  let ctx, gids, tis, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_tis, acc_decls, acc_node_decls_map) (p, id, ty) -> 
+    let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids nname acc_node_decls_map ty in 
+    ctx, gids, acc_tis @ [p, id, ty], decls @ acc_decls, node_decls_map
+  ) (ctx, gids, [], decls, node_decls_map) tis in 
+  ctx, gids, GhostVars (p, GhostVarDec (p2, tis), expr), decls, node_decls_map
 | Mode (p, id, creqs, cens) -> 
-  let ctx, creqs, decls, node_decls_map = List.fold_left (fun (ctx, acc_creqs, acc_decls, acc_node_decls_map) (p, id, expr) -> 
-    let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname acc_node_decls_map expr in 
-    ctx, acc_creqs @ [p, id, expr], decls @ acc_decls, node_decls_map
-  ) (ctx, [], [], node_decls_map) creqs in 
-  let ctx, cens, decls, node_decls_map = List.fold_left (fun (ctx, acc_cens, acc_decls, acc_node_decls_map) (p, id, expr) -> 
-    let ctx, expr, decls, node_decls_map = gen_poly_decls_expr ctx nname acc_node_decls_map expr in 
-    ctx, acc_cens @ [p, id, expr], decls @ acc_decls, node_decls_map
-  ) (ctx, [], decls, node_decls_map) cens in 
-  ctx, Mode (p, id, creqs, cens), decls, node_decls_map
-| AssumptionVars _ -> ctx, ci, [], node_decls_map
+  let ctx, gids, creqs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_creqs, acc_decls, acc_node_decls_map) (p, id, expr) -> 
+    let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname acc_node_decls_map expr in 
+    ctx, gids, acc_creqs @ [p, id, expr], decls @ acc_decls, node_decls_map
+  ) (ctx, gids, [], [], node_decls_map) creqs in 
+  let ctx, gids, cens, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_cens, acc_decls, acc_node_decls_map) (p, id, expr) -> 
+    let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids nname acc_node_decls_map expr in 
+    ctx, gids, acc_cens @ [p, id, expr], decls @ acc_decls, node_decls_map
+  ) (ctx, gids, [], decls, node_decls_map) cens in 
+  ctx, gids, Mode (p, id, creqs, cens), decls, node_decls_map
+| AssumptionVars _ -> ctx, gids, ci, [], node_decls_map
 
 and gen_poly_decls_decls
-= fun ctx node_decls_map decls -> 
-  let ctx, decls, node_decls_map = List.fold_left (fun (ctx, acc_decls, acc_node_decls_map) decl -> match decl with
+= fun ctx gids node_decls_map decls -> 
+  let ctx, gids, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_decls, acc_node_decls_map) decl -> match decl with
   | A.FuncDecl (p, (nname, ext, opac, ps, ips, ops, locs, nis, c)) ->
     let ctx = Chk.add_ty_params_node_ctx ctx nname ps in
-    let ctx, ips, decls, node_decls_map = List.fold_left (fun (ctx, acc_ips, acc_decls, acc_node_decls_map) ip -> 
-      let ctx, ip, decls, node_decls_map = gen_poly_decls_ip ctx (Some nname) acc_node_decls_map ip in 
-      ctx, acc_ips @ [ip], decls @ acc_decls, node_decls_map
-    ) (ctx, [], acc_decls, acc_node_decls_map) ips in 
-    let ctx, ops, decls, node_decls_map = List.fold_left (fun (ctx, acc_ops, acc_decls, acc_node_decls_map) op -> 
-      let ctx, op, decls, node_decls_map = gen_poly_decls_op ctx (Some nname) acc_node_decls_map op in 
-      ctx, acc_ops @ [op], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) ops in
-    let ctx, locs, decls, node_decls_map = List.fold_left (fun (ctx, acc_locs, acc_decls, acc_node_decls_map) loc -> 
-      let ctx, loc, decls, node_decls_map = gen_poly_decls_loc ctx (Some nname) acc_node_decls_map loc in 
-      ctx, acc_locs @ [loc], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) locs in
-    let ctx, nis, decls, node_decls_map = List.fold_left (fun (ctx, acc_nis, acc_decls, acc_node_decls_map) ni -> 
-      let ctx, ni, decls, node_decls_map = gen_poly_decls_ni ctx (Some nname) acc_node_decls_map ni in 
-      ctx, acc_nis @ [ni], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) nis in (
+    let ctx, gids, ips, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ips, acc_decls, acc_node_decls_map) ip -> 
+      let ctx, gids, ip, decls, node_decls_map = gen_poly_decls_ip ctx gids (Some nname) acc_node_decls_map ip in 
+      ctx, gids, acc_ips @ [ip], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], acc_decls, acc_node_decls_map) ips in 
+    let ctx, gids, ops, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ops, acc_decls, acc_node_decls_map) op -> 
+      let ctx, gids, op, decls, node_decls_map = gen_poly_decls_op ctx gids (Some nname) acc_node_decls_map op in 
+      ctx, gids, acc_ops @ [op], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) ops in
+    let ctx, gids, locs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_locs, acc_decls, acc_node_decls_map) loc -> 
+      let ctx, gids, loc, decls, node_decls_map = gen_poly_decls_loc ctx gids (Some nname) acc_node_decls_map loc in 
+      ctx, gids, acc_locs @ [loc], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) locs in
+    let ctx, gids, nis, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_nis, acc_decls, acc_node_decls_map) ni -> 
+      let ctx, gids, ni, decls, node_decls_map = gen_poly_decls_ni ctx gids (Some nname) acc_node_decls_map ni in 
+      ctx, gids, acc_nis @ [ni], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) nis in (
     match c with 
     | None -> 
       let decl =  A.FuncDecl (p, (nname, ext, opac, ps, ips, ops, locs, nis, c)) in
-      ctx, decl :: decls, node_decls_map
+      ctx, gids, decl :: decls, node_decls_map
     | Some (p3, c) ->
-      let ctx, c, decls, node_decls_map = List.fold_left (fun (ctx, acc_cis, acc_decls, acc_node_decls_map) ip -> 
-        let ctx, ci, decls, node_decls_map = gen_poly_decls_ci ctx (Some nname) acc_node_decls_map ip in 
-        ctx, acc_cis @ [ci], decls @ acc_decls, node_decls_map
-      ) (ctx, [], decls, node_decls_map) c in 
+      let ctx, gids, c, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_cis, acc_decls, acc_node_decls_map) ip -> 
+        let ctx, gids, ci, decls, node_decls_map = gen_poly_decls_ci ctx gids (Some nname) acc_node_decls_map ip in 
+        ctx, gids, acc_cis @ [ci], decls @ acc_decls, node_decls_map
+      ) (ctx, gids, [], decls, node_decls_map) c in 
       let decl = A.FuncDecl (p, (nname, ext, opac, ps, ips, ops, locs, nis, Some (p3, c))) in
-      ctx, decl :: decls, node_decls_map
+      ctx, gids, decl :: decls, node_decls_map
     )
   | NodeDecl (p, (nname, ext, opac, ps, ips, ops, locs, nis, c)) ->
     let ctx = Chk.add_ty_params_node_ctx ctx nname ps in
-    let ctx, ips, decls, node_decls_map = List.fold_left (fun (ctx, acc_ips, acc_decls, acc_node_decls_map) ip -> 
-      let ctx, ip, decls, node_decls_map = gen_poly_decls_ip ctx (Some nname) acc_node_decls_map ip in 
-      ctx, acc_ips @ [ip], decls @ acc_decls, node_decls_map
-    ) (ctx, [], acc_decls, acc_node_decls_map) ips in 
-    let ctx, ops, decls, node_decls_map = List.fold_left (fun (ctx, acc_ops, acc_decls, acc_node_decls_map) op -> 
-      let ctx, op, decls, node_decls_map = gen_poly_decls_op ctx (Some nname) acc_node_decls_map op in 
-      ctx, acc_ops @ [op], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) ops in
-    let ctx, locs, decls, node_decls_map = List.fold_left (fun (ctx, acc_locs, acc_decls, acc_node_decls_map) loc -> 
-      let ctx, loc, decls, node_decls_map = gen_poly_decls_loc ctx (Some nname) acc_node_decls_map loc in 
-      ctx, acc_locs @ [loc], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) locs in
-    let ctx, nis, decls, node_decls_map = List.fold_left (fun (ctx, acc_nis, acc_decls, acc_node_decls_map) ni -> 
-      let ctx, ni, decls, node_decls_map = gen_poly_decls_ni ctx (Some nname) acc_node_decls_map ni in 
-      ctx, acc_nis @ [ni], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) nis in (
+    let ctx, gids, ips, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ips, acc_decls, acc_node_decls_map) ip -> 
+      let ctx, gids, ip, decls, node_decls_map = gen_poly_decls_ip ctx gids (Some nname) acc_node_decls_map ip in 
+      ctx, gids, acc_ips @ [ip], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], acc_decls, acc_node_decls_map) ips in 
+    let ctx, gids, ops, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ops, acc_decls, acc_node_decls_map) op -> 
+      let ctx, gids, op, decls, node_decls_map = gen_poly_decls_op ctx gids (Some nname) acc_node_decls_map op in 
+      ctx, gids, acc_ops @ [op], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) ops in
+    let ctx, gids, locs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_locs, acc_decls, acc_node_decls_map) loc -> 
+      let ctx, gids, loc, decls, node_decls_map = gen_poly_decls_loc ctx gids (Some nname) acc_node_decls_map loc in 
+      ctx, gids, acc_locs @ [loc], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) locs in
+    let ctx, gids, nis, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_nis, acc_decls, acc_node_decls_map) ni -> 
+      let ctx, gids, ni, decls, node_decls_map = gen_poly_decls_ni ctx gids (Some nname) acc_node_decls_map ni in 
+      ctx, gids, acc_nis @ [ni], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) nis in (
     match c with 
       | None -> 
         let decl =  A.NodeDecl (p, (nname, ext, opac, ps, ips, ops, locs, nis, c)) in
-        ctx, decl :: decls, node_decls_map
+        ctx, gids, decl :: decls, node_decls_map
       | Some (p3, c) ->
-        let ctx, c, decls, node_decls_map = List.fold_left (fun (ctx, acc_cis, acc_decls, acc_node_decls_map) ip -> 
-          let ctx, ci, decls, node_decls_map = gen_poly_decls_ci ctx (Some nname) acc_node_decls_map ip in 
-          ctx, acc_cis @ [ci], decls @ acc_decls, node_decls_map
-        ) (ctx, [], decls, node_decls_map) c in 
+        let ctx, gids, c, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_cis, acc_decls, acc_node_decls_map) ip -> 
+          let ctx, gids, ci, decls, node_decls_map = gen_poly_decls_ci ctx gids (Some nname) acc_node_decls_map ip in 
+          ctx, gids, acc_cis @ [ci], decls @ acc_decls, node_decls_map
+        ) (ctx, gids, [], decls, node_decls_map) c in 
         let decl = A.NodeDecl (p, (nname, ext, opac, ps, ips, ops, locs, nis, Some (p3, c))) in
-        ctx, decl :: decls, node_decls_map
+        ctx, gids, decl :: decls, node_decls_map
     )
   | ContractNodeDecl (p, (cname, ps, ips, ops, (p3, c))) ->
     let ctx = Chk.add_ty_params_node_ctx ctx cname ps in
-    let ctx, ips, decls, node_decls_map = List.fold_left (fun (ctx, acc_ips, acc_decls, acc_node_decls_map) ip -> 
-      let ctx, ip, decls, node_decls_map = gen_poly_decls_ip ctx (Some cname) acc_node_decls_map ip in 
-      ctx, acc_ips @ [ip], decls @ acc_decls, node_decls_map
-    ) (ctx, [], acc_decls, acc_node_decls_map) ips in 
-    let ctx, ops, decls, node_decls_map = List.fold_left (fun (ctx, acc_ops, acc_decls, acc_node_decls_map) op -> 
-      let ctx, op, decls, node_decls_map = gen_poly_decls_op ctx (Some cname) acc_node_decls_map op in 
-      ctx, acc_ops @ [op], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) ops in
-    let ctx, c, decls, node_decls_map = List.fold_left (fun (ctx, acc_cis, acc_decls, acc_node_decls_map) ip -> 
-      let ctx, ci, decls, node_decls_map = gen_poly_decls_ci ctx (Some cname) acc_node_decls_map ip in 
-      ctx, acc_cis @ [ci], decls @ acc_decls, node_decls_map
-    ) (ctx, [], decls, node_decls_map) c in 
+    let ctx, gids, ips, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ips, acc_decls, acc_node_decls_map) ip -> 
+      let ctx, gids, ip, decls, node_decls_map = gen_poly_decls_ip ctx gids (Some cname) acc_node_decls_map ip in 
+      ctx, gids, acc_ips @ [ip], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], acc_decls, acc_node_decls_map) ips in 
+    let ctx, gids, ops, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ops, acc_decls, acc_node_decls_map) op -> 
+      let ctx, gids, op, decls, node_decls_map = gen_poly_decls_op ctx gids (Some cname) acc_node_decls_map op in 
+      ctx, gids, acc_ops @ [op], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) ops in
+    let ctx, gids, c, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_cis, acc_decls, acc_node_decls_map) ip -> 
+      let ctx, gids, ci, decls, node_decls_map = gen_poly_decls_ci ctx gids (Some cname) acc_node_decls_map ip in 
+      ctx, gids, acc_cis @ [ci], decls @ acc_decls, node_decls_map
+    ) (ctx, gids, [], decls, node_decls_map) c in 
     let decl = A.ContractNodeDecl (p, (cname, ps, ips, ops, (p3, c))) in
-    ctx, decl :: decls, node_decls_map
+    ctx, gids, decl :: decls, node_decls_map
   | TypeDecl _ 
   | ConstDecl _ 
-  | NodeParamInst _ -> ctx, decl :: acc_decls, node_decls_map
-  ) (ctx, [], node_decls_map) decls in
-  ctx, decls, node_decls_map
+  | NodeParamInst _ -> ctx, gids, decl :: acc_decls, node_decls_map
+  ) (ctx, gids, [], node_decls_map) decls in
+  ctx, gids, decls, node_decls_map
 
-let instantiate_polymorphic_nodes: Ctx.tc_context -> A.declaration list -> Ctx.tc_context * A.declaration list 
-= fun ctx decls -> 
+let instantiate_polymorphic_nodes: Ctx.tc_context -> GI.t GI.StringMap.t -> A.declaration list -> Ctx.tc_context * GI.t GI.StringMap.t  * A.declaration list 
+= fun ctx gids decls -> 
   (* Initialize node_decls_map (a map from a node name to its declaration and the list of its polymorphic instantiations 
      created so far) *)
   let node_decls_map = List.fold_left (fun acc decl -> match decl with 
@@ -567,5 +607,5 @@ let instantiate_polymorphic_nodes: Ctx.tc_context -> A.declaration list -> Ctx.t
   ) GI.StringMap.empty decls 
   in
 
-  let ctx, decls, _ = gen_poly_decls_decls ctx node_decls_map decls in 
-  ctx, List.rev decls
+  let ctx, gids, decls, _ = gen_poly_decls_decls ctx gids node_decls_map decls in 
+  ctx, gids, List.rev decls

--- a/src/lustre/lustreInstantiatePolyNodes.mli
+++ b/src/lustre/lustreInstantiatePolyNodes.mli
@@ -19,6 +19,7 @@
 
 module A = LustreAst
 module Ctx = TypeCheckerContext
+module GI = GeneratedIdentifiers
 
 val instantiate_polymorphic_nodes :
-  Ctx.tc_context -> A.declaration list -> Ctx.tc_context * A.declaration list
+  Ctx.tc_context -> GI.t GI.StringMap.t  -> A.declaration list -> Ctx.tc_context * GI.t GI.StringMap.t * A.declaration list 

--- a/tests/regression/falsifiable/polymorphic_gids.lus
+++ b/tests/regression/falsifiable/polymorphic_gids.lus
@@ -1,0 +1,19 @@
+node M<<T>> () returns (y1, y2: T)
+let
+tel
+
+node N<<T>> (c: bool;) returns (y1, y2: T)
+let
+  if c then 
+    y1, y2 = M<<T>>();
+  fi
+tel
+
+node top (c: bool) returns (y1, y2: int; y3, y4: bool)
+let
+  y1, y2 = N<<int>>(c);
+  y3, y4 = N<<bool>>(c);
+
+  check y1 = y2;
+  check y3 = y4;
+tel


### PR DESCRIPTION
At the `lustreInstantiatePolyNodes.ml` step, we create a monomorphization for each concrete instance of each polymorphic node (e.g., instantiating `M<<T>>` with `M<<int>>` and `M<<bool>>`). We need to do the same thing in the generated identifiers data structure, that is, create generated identifiers for each monomorphization.

Most of the diff in this PR is just for passing `gids` throughout the module; the substantive changes are in the `gen_poly_decl` function