### PR TITLE
Fix name clash bug

### DIFF
--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -42,6 +42,15 @@ let poly_gen_node_tag = ".poly_"
 
 type node_type = Environment | Contract | Type | User
 
+(* Module state for fresh identifiers *)
+let i = ref 0
+
+let mk_fresh_id id = 
+  i := !i + 1;
+  let prefix = HString.concat2 (HString.mk_hstring (string_of_int !i)) (HString.mk_hstring "_") in
+  HString.concat2 prefix id
+
+
 let get_node_type_and_name: string -> node_type * string 
 = fun name ->
   let inputs_tag_len = String.length inputs_tag in
@@ -236,6 +245,8 @@ let type_to_contract: Lib.position -> HString.t -> A.lustre_type -> HString.t li
   let gen_node_id = HString.concat2 (HString.mk_hstring type_tag) id in
   (* To prevent slicing, we mark generated imported nodes as main nodes *)
   let node_items = [A.AnnotMain(pos, true)] in 
+  (* Avoid name clashes (e.g., with enum constants) *)
+  let id = mk_fresh_id id in
   Some (NodeDecl (span, (gen_node_id, true, A.Opaque, ps, [], [(pos, id, ty, A.ClockTrue)], [], node_items, None)))
 
 let gen_imp_nodes: Ctx.tc_context -> A.declaration list -> (A.declaration list * Ctx.tc_context * GI.t HString.HStringMap.t, [> error]) result


### PR DESCRIPTION
Fix a name clash bug with type realizability checking. Example test case previously failing with `--enable CONTRACTCK`
```
type HostId = subtype { i: int | i < 10 };

type VoteMsg = struct {
  sender: HostId;
  vote: int;
};

type MsgVariant = enum {VoteReqMsg, VoteMsg};
```