### PR TITLE
Cone of influence based slicing

### DIFF
--- a/src/flags.ml
+++ b/src/flags.ml
@@ -3397,20 +3397,34 @@ module Global = struct
     )
   let modular () = !modular
 
-
-  let slice_nodes_default = true
+  type slice_nodes = [`On | `Off | `Experimental]
+  let slice_nodes_of_string = function
+    | "on" -> `On
+    | "off" -> `Off
+    | "experimental" -> `Experimental
+    | unexpected -> Arg.Bad (
+      Format.sprintf "Unexpected value \"%s\" for flag --slice_nodes" unexpected
+    ) |> raise
+  let string_of_slice_nodes = function
+    | `On -> "on"
+    | `Off -> "off"
+    | `Experimental -> "experimental"
+  let slice_nodes_default = `On
   let slice_nodes = ref slice_nodes_default
   let _ = add_spec
     "--slice_nodes"
-    (bool_arg slice_nodes)
+    (Arg.String
+      (fun str -> slice_nodes := slice_nodes_of_string str)
+    )
     (fun fmt ->
       Format.fprintf fmt
         "\
+          where <string> can be on, off, or experimental@ \
           Only equations that are relevant for checking the contract and@ \
           properties of a node are considered during the analysis@ \
-          Default: %a\
+          Default: %s\
         "
-        fmt_bool slice_nodes_default
+        (string_of_slice_nodes slice_nodes_default)
     )
   let slice_nodes () = !slice_nodes
 
@@ -3687,6 +3701,7 @@ type enable = Global.enable
 type input_format = Global.input_format
 type real_precision = Global.real_precision
 type exit_code_convention = Global.exit_code_convention
+type slice_nodes = Global.slice_nodes
 
 
 (* ********************************************************************** *)

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -229,7 +229,8 @@ val disable : Lib.kind_module -> unit
 val modular : unit -> bool
 
 (** Node slicing *)
-val slice_nodes : unit -> bool
+type slice_nodes = [`On | `Off | `Experimental ]
+val slice_nodes : unit -> slice_nodes
 
 (** Check reachability properties *)
 val check_reach : unit -> bool

--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -939,7 +939,7 @@ let main fwd slice_to_prop prop in_sys param sys =
   let param = Analysis.param_clone param in
 
   let sys =
-    if Flags.slice_nodes () && slice_to_prop then (
+    if Flags.slice_nodes () == `On && slice_to_prop then (
       (* Only slice if the property was already present in the original input system.
          The current slicing procedure works on the input system, not the transition system *)
       match prop.Property.prop_source with

--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -731,7 +731,7 @@ let slice_to_abstraction
     let subsystem' =
       let sub = S.find_subsystem_of_list main_subs scope in
         LustreSlicing.slice_to_abstraction
-          (Flags.slice_nodes ()) analysis sub
+          (Flags.slice_nodes () == `On) analysis sub
     in
 
     Lustre ([subsystem'], globals, ast)
@@ -857,7 +857,7 @@ let slice_to_abstraction_and_property
         let sub = S.find_subsystem_of_list main_subs scope in
         if is_prop'_instantiated then
           LustreSlicing.slice_to_abstraction
-            (Flags.slice_nodes ()) analysis' sub
+            (Flags.slice_nodes () == `On) analysis' sub
         else
           LustreSlicing.slice_to_abstraction_and_property
             analysis' vars sub

--- a/src/inputSystem.mli
+++ b/src/inputSystem.mli
@@ -78,7 +78,7 @@ val moxi_params : 'a t -> Analysis.param list
 (** Return a transition system for an analysis run *)
 val trans_sys_of_analysis:
   ?preserve_sig:bool ->
-  ?slice_nodes:bool ->
+  ?slice_nodes:Flags.slice_nodes ->
   ?add_functional_constraints: bool ->
   ?slice_to_prop:Property.t ->
   'a t -> Analysis.param -> TransSys.t * 'a t

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -692,7 +692,7 @@ let run in_sys =
       (* Build trans sys and slicing info. *)
       let sys, _ =
         ISys.trans_sys_of_analysis
-          ~preserve_sig:true ~slice_nodes:false in_sys param
+          ~preserve_sig:true ~slice_nodes:`Off in_sys param
       in
       (* Run interpreter. *)
       Interpreter.main (

--- a/src/lustre/dependencyGraph.ml
+++ b/src/lustre/dependencyGraph.ml
@@ -1,0 +1,227 @@
+module SVM = StateVar.StateVarMap
+module SVS = StateVar.StateVarSet
+
+module Vertex = struct
+  type t = StateVar.t
+
+  let compare = StateVar.compare_state_vars
+  let pp_print_t = StateVar.pp_print_state_var
+end
+
+module VarGraph = Graph.Make (Vertex)
+
+let args term = try Term.node_args_of_term term with _ -> [term]
+
+(** [get_vars term] is a sequence containing the state vars of [term]*)
+let get_vars (term : Term.t) =
+  Term.vars_of_term term |> Var.VarSet.to_seq
+  |> Seq.filter_map (fun var ->
+         try Some (Var.state_var_of_state_var_instance var) with _ -> None)
+
+(** [subgraph_of_term definition_set term] builds a dependency_graph for the
+    individual term. If the term is a definition, for example `(= a b)`, then an
+    edge is drawn from the lhs to every state variable of the rhs. For any other
+    term an edge is drawn between every state variable in the term. *)
+let subgraph_of_term (definition_set : Term.TermSet.t) (term : Term.t) =
+  if Term.is_node term && Term.node_symbol_of_term term |> Symbol.is_uf then
+    let vars = get_vars term in
+    Seq.fold_left VarGraph.add_vertex VarGraph.empty vars
+  else
+    match Term.TermSet.mem term definition_set with
+    | false ->
+        let vars = get_vars term |> List.of_seq in
+        let graph = List.fold_left VarGraph.add_vertex VarGraph.empty vars in
+        List.fold_left VarGraph.connect graph vars
+    | true -> (
+        match args term with
+        | [ dependant; dependencies ] ->
+            let dependants = get_vars dependant |> List.of_seq in
+            let dependencies = get_vars dependencies in
+            let graph =
+              Seq.fold_left VarGraph.add_vertex VarGraph.empty dependencies
+            in
+            let graph = List.fold_left VarGraph.add_vertex graph dependants in
+            List.fold_left VarGraph.connect graph dependants
+        | _ -> VarGraph.empty)
+
+(** [dependency_graph definition_set term] builds a dependency_graph for the
+    individual term. If the term is a definition, for example `(= a b)`, then an
+    edge is drawn from the lhs to every state variable of the rhs. For any other
+    term an edge is drawn between every state variable in the term. *)
+let dependency_graph (definition_set : Term.TermSet.t) (term : Term.t) =
+  args term |> List.to_seq
+  |> Seq.map (subgraph_of_term definition_set)
+  |> Seq.fold_left VarGraph.union VarGraph.empty
+
+let graph_of_instances (definition_set : Term.TermSet.t)
+    (trans_sys : TransSys.t) (instances : (TransSys.t * TransSys.instance) list)
+    (subgraphs : VarGraph.t list) =
+  (* 1. Merge all the subgraphs *)
+  let result = List.fold_left VarGraph.union VarGraph.empty subgraphs in
+
+  (* 2. Construct the graph of the given transition system *)
+  let transition_term =
+    TransSys.trans_of_bound None trans_sys TransSys.trans_base
+  in
+  let initial_term = TransSys.init_of_bound None trans_sys TransSys.init_base in
+
+  let result = TransSys.get_properties trans_sys
+        |> List.to_seq
+        |> Seq.map Property.get_prop_term
+        |> Seq.map (dependency_graph definition_set)
+        |> Seq.fold_left VarGraph.union result
+  in
+
+  let result =
+    initial_term |> dependency_graph definition_set |> VarGraph.union result
+  in
+  let result =
+    transition_term |> dependency_graph definition_set |> VarGraph.union result
+  in
+
+  (* 3. Connect edges along node calls *)
+  List.to_seq instances
+  |> Seq.map (fun (_, instance) -> instance)
+  |> Seq.flat_map (fun { TransSys.map_up } -> SVM.to_seq map_up)
+  |> Seq.fold_left
+       (fun graph (sv1, sv2) ->
+         let open VarGraph in
+         let graph = add_vertex graph sv1 in
+         let graph = add_vertex graph sv2 in
+         let graph = add_edge graph (mk_edge sv1 sv2) in
+         add_edge graph (mk_edge sv2 sv1))
+       result
+
+(*
+  When slicing we draw an arrow `a -> b` if `b` is used in the definition of
+  `a`. Constraints need a biderectional arrow. That is `guarantee x > y` should
+  add both arrows `x -> y` and `y -> x`. However constraints need to be viral.
+  For example in the following case:
+    ```
+     b = x > y;
+     guarantee b;
+    ```
+  we need to add all the edges `b <-> x`, `b <-> y`, and `x <-> y`. To do this
+  we remove `b = x > y` from
+  the definition set. We prune the definition set as follows:
+
+   1. mark variables which are present in guarantees
+   2. for each marked variable:
+     1. remove their definitions from the definition set
+     2. mark all variables on the rhs of their defintion
+   3. repeat until there are no more variables to mark
+*)
+let prune_definitions trans_sys definition_set =
+
+  (* look up table mapping variables -> defintions *)
+  let definition_map =
+    Term.TermSet.to_seq definition_set
+    |> Seq.filter_map (fun term ->
+           let args = Term.node_args_of_term term in
+           match args with
+           | lhs :: _ -> Some (Term.state_vars_of_term lhs |> SVS.choose, term)
+           | [] -> None)
+    |> Seq.fold_left
+         (fun map (var, term) ->
+           let set =
+             SVM.find_opt var map
+             |> Option.value ~default:Term.TermSet.empty
+             |> Term.TermSet.add term
+           in
+           SVM.add var set map)
+         SVM.empty
+  in
+
+  let rec remove_definitions (definition_map : Term.TermSet.t SVM.t)
+      (state_vars : StateVar.t List.t) =
+    match state_vars with
+    | [] -> definition_map
+    | state_var :: state_vars ->
+        let new_vars =
+          SVM.find_opt state_var definition_map
+          |> Option.to_seq
+          |> Seq.flat_map Term.TermSet.to_seq
+          |> Seq.map Term.state_vars_of_term
+          |> Seq.flat_map SVS.to_seq
+          |> Seq.filter (fun sv -> SVM.mem sv definition_map)
+          |> List.of_seq
+        in
+        let definition_map = SVM.remove state_var definition_map in
+        remove_definitions definition_map (state_vars @ new_vars)
+  in
+
+  (* a constraint is any non-definition *)
+  let get_constraints trans_sys =
+    let init_term = TransSys.init_of_bound None trans_sys TransSys.init_base in
+    let trans_term = TransSys.trans_of_bound None trans_sys TransSys.trans_base in
+    [init_term ; trans_term]
+    |> List.to_seq
+    |> Seq.flat_map (fun t -> try Term.node_args_of_term t |> List.to_seq with _ -> Seq.return t)
+    |> Seq.filter (fun t -> Term.TermSet.mem t definition_set |> not)
+    |> Seq.map Term.state_vars_of_term
+    |> Seq.flat_map SVS.to_seq
+  in
+
+  let constraints =
+    TransSys.fold_subsystems
+      (fun constraints trans_sys ->
+        constraints @ (get_constraints trans_sys |> List.of_seq))
+      [] trans_sys
+  in
+
+  remove_definitions definition_map constraints
+  |> SVM.to_seq
+  |> Seq.flat_map (fun (_, term) -> Term.TermSet.to_seq term)
+  |> Term.TermSet.of_seq
+
+let dependency_graph_of_system definition_set trans_sys =
+  let definition_set = prune_definitions trans_sys definition_set in
+  TransSys.fold_subsystem_instances
+    (graph_of_instances definition_set)
+    trans_sys
+
+let cone_of_influence dependency_graph roots =
+  let memo = ref VarGraph.VMap.empty in
+
+  let reachable var =
+    VarGraph.memoized_reachable memo dependency_graph var
+    |> VarGraph.to_vertex_list |> SVS.of_list
+  in
+  SVS.to_seq roots |> Seq.map reachable |> Seq.fold_left SVS.union SVS.empty
+
+let pp_print_dot ?(cone_of_influence = SVS.empty) ppf graph =
+  let background = "whitesmoke" in
+  let foreground = "black" in
+  let highlight = "plum" in
+
+  (* Formatting rules for the graph *)
+  Format.fprintf ppf "@[<v 2>digraph G {";
+  Format.fprintf ppf "@;bgcolor=\"%s\";" background;
+  Format.fprintf ppf "@;fontcolor=\"%s\";" foreground;
+  Format.fprintf ppf "@;node[fontcolor=\"%s\", color=\"%s\"];" foreground
+    foreground;
+  Format.fprintf ppf "@;edge[fontcolor=\"%s\", color=\"%s\"];" foreground
+    foreground;
+  Format.fprintf ppf "@;overlap=scale;";
+  Format.fprintf ppf "@;concentrate=true;";
+
+  (* All the Vertices *)
+  VarGraph.get_vertices graph
+  |> VarGraph.to_vertex_list
+  |> List.iter (fun vertex ->
+         if SVS.mem vertex cone_of_influence then
+           Format.fprintf ppf "@;\"%s\" [color=\"%s\" style=filled];"
+             (StateVar.string_of_state_var vertex)
+             highlight
+         else
+           Format.fprintf ppf "@;\"%s\";" (StateVar.string_of_state_var vertex));
+
+  (* All the edges *)
+  VarGraph.get_edges graph |> VarGraph.to_edge_list |> List.to_seq
+  |> Seq.filter (fun (sv1, sv2) -> sv1 != sv2)
+  |> Seq.iter (fun (sv1, sv2) ->
+         Format.fprintf ppf "@;\"%s\" -> \"%s\";"
+           (StateVar.string_of_state_var sv1)
+           (StateVar.string_of_state_var sv2));
+
+  Format.fprintf ppf "@]@.}@;"

--- a/src/lustre/dependencyGraph.mli
+++ b/src/lustre/dependencyGraph.mli
@@ -1,0 +1,57 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2025 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+
+*)
+
+(** Create a dependency graph from a transition system *)
+
+module Vertex : Graph.OrderedType with type t = StateVar.t
+module VarGraph : Graph.S with type vertex = Vertex.t
+
+val dependency_graph_of_system : Term.TermSet.t -> TransSys.t -> VarGraph.t
+(** [dependency_graph_of_system definition_set trans_sys] constructs a
+    dependency graph representing the dependencies between state variables in
+    the given transition system.
+
+    @param definition_set A set of terms which are to be treated as dependencies
+    @param trans_sys
+      The transition system from which dependencies are extracted.
+    @return
+      A graph representing variable dependencies. The state variable `sv1`
+      depends on `sv2` if there is the edge `sv1 -> sv2` *)
+
+val cone_of_influence :
+  VarGraph.t -> StateVar.StateVarSet.t -> StateVar.StateVarSet.t
+(** [cone_of_influence properties dependency_graph] constructs the set of state
+    variables which are depended upon by [properties]
+
+    @param dependency_graph The dependency graph for the system
+    @param roots Where the cone of influence starts
+    @return The set of variables upon which [properties] depend *)
+
+val pp_print_dot :
+  ?cone_of_influence:StateVar.StateVarSet.t ->
+  Format.formatter ->
+  VarGraph.t ->
+  unit
+(** [pp_print_dot ?cone_of_influence ppf graph] prints a graphviz DOT
+    representation of the given variable graph [graph] to the formatter [ppf].
+
+    @param cone_of_influence
+      (optional) A set of state variables that should be highlighted in the
+      output. If omitted, no special highlighting is applied.
+    @param ppf The formatter to which the DOT representation is printed.
+    @param graph The dependency_graph graph to be printed. *)

--- a/src/lustre/dependencyGraph.mli
+++ b/src/lustre/dependencyGraph.mli
@@ -40,7 +40,7 @@ val cone_of_influence :
 
     @param dependency_graph The dependency graph for the system
     @param roots Where the cone of influence starts
-    @return The set of variables upon which [properties] depend *)
+    @return The set of variables upon which [properties] depend according to [dependency_graph]*)
 
 val pp_print_dot :
   ?cone_of_influence:StateVar.StateVarSet.t ->

--- a/src/lustre/dependencyGraph.mli
+++ b/src/lustre/dependencyGraph.mli
@@ -35,7 +35,7 @@ val dependency_graph_of_system : Term.TermSet.t -> TransSys.t -> VarGraph.t
 
 val cone_of_influence :
   VarGraph.t -> StateVar.StateVarSet.t -> StateVar.StateVarSet.t
-(** [cone_of_influence properties dependency_graph] constructs the set of state
+(** [cone_of_influence dependency_graph properties] constructs the set of state
     variables which are depended upon by [properties]
 
     @param dependency_graph The dependency graph for the system

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -1365,7 +1365,7 @@ let stateful_vars_of_node
       oracles; 
       outputs; 
       locals;
-      equations; 
+      equations;
       calls; 
       asserts; 
       props; 
@@ -1383,103 +1383,113 @@ let stateful_vars_of_node
        @ oracles)
   in
 
-  (* Add stateful variables from properties *)
-  let stateful_vars = 
-    add_to_svs
+  (*
+    We disable the let binding optimization when using the experimental
+    slicing algorithm. In this case we have to manually add these back in
+  *)
+  let stateful_vars =
+    if Flags.slice_nodes () == `Experimental
+    then
+      List.map D.values locals |>
+        List.flatten |>
+        add_to_svs stateful_vars
+    else
+
+      (* Add stateful variables from properties *)
+      let stateful_vars = 
+        add_to_svs
+          stateful_vars
+          (List.map (fun (sv, _, _, _) -> sv) props) 
+      in
+
+      (* Add stateful variables from contracts *)
+      let stateful_vars = match contract with
+        | None -> stateful_vars
+        | Some contract ->
+          (* Sofar variable should only be added if the corresponding equation is present,
+             which is detected below since its definition refers to itself:
+             sofar = [...] and pre sofar
+          *)
+          C.svars_of ~with_sofar_var:false contract |> SVS.union stateful_vars
+      in
+
+      (* Add stateful variables from equations *)
+      let stateful_vars =
+        List.fold_left
+          (fun  accum (_, expr) ->
+             SVS.union accum (stateful_vars_of_expr expr))
+          stateful_vars
+          equations
+      in
+
+      (* TODO: this can be removed if we forbid undefined local variables.
+         Unconstrained local state variables must be stateful *)
+      let stateful_vars =
+        List.fold_left
+          (fun a l ->
+             D.fold
+               (fun _ sv a ->
+                  if
+                    (* Arrays are global TODO maybe this is not necessary *)
+                    not (Type.is_array (StateVar.type_of_state_var sv)) &&
+                    (* Local state variable is defined by an equation? *)
+                    List.exists
+                      (fun ((sv', _), _) -> StateVar.equal_state_vars sv sv')
+                      equations 
+                  then a
+                  else
+                    (* State variable without equation must be stateful *)
+                    SVS.add sv a)
+               l
+               a)
+          stateful_vars
+          locals
+      in
+
+      (* Add stateful variables from assertions *)
+      let stateful_vars = 
+        add_to_svs
+          stateful_vars
+          (List.map (fun (_, sv) -> sv) asserts) 
+      in
+
+      (* Add variables from node calls *)
+      let stateful_vars =
+        List.fold_left
+          (fun
+            accum
+            { call_cond;
+              call_inputs;
+              call_oracles;
+              call_outputs;
+              call_defaults } ->
+
+            (* Input and output variables are always stateful *)
+            ((D.values call_inputs) @
+             call_oracles @
+             (D.values call_outputs))
+            |> SVS.of_list
+            (* Add stateful variables from initial defaults *)
+            |> SVS.union
+               (match call_defaults with
+                 | None -> accum
+                 | Some d ->
+                   List.fold_left
+                     (fun accum expr ->
+                        SVS.union accum (stateful_vars_of_expr expr))
+                     accum
+                     (D.values d))
+
+            (* Variables in activation and restart conditions are always
+               stateful *)
+            |> SVS.union
+              (List.map (function | CActivate v | CRestart v -> v) call_cond
+               |> SVS.of_list)
+
+          ) stateful_vars calls
+      in
       stateful_vars
-      (List.map (fun (sv, _, _, _) -> sv) props) 
   in
-
-  (* Add stateful variables from contracts *)
-  let stateful_vars = match contract with
-    | None -> stateful_vars
-    | Some contract ->
-      (* Sofar variable should only be added if the corresponding equation is present,
-         which is detected below since its definition refers to itself:
-         sofar = [...] and pre sofar
-      *)
-      C.svars_of ~with_sofar_var:false contract |> SVS.union stateful_vars
-  in
-
-  (* Add stateful variables from equations *)
-  let stateful_vars = 
-    List.fold_left
-      (fun  accum (_, expr) -> 
-         SVS.union accum (stateful_vars_of_expr expr))
-      stateful_vars
-      equations
-  in
-
-  (* TODO: this can be removed if we forbid undefined local variables.
-     Unconstrained local state variables must be stateful *)
-  let stateful_vars = 
-    List.fold_left
-      (fun a l -> 
-         D.fold
-           (fun _ sv a ->
-              if 
-                (* Arrays are global TODO maybe this is not necessary *)
-                not (Type.is_array (StateVar.type_of_state_var sv)) &&
-                (* Local state variable is defined by an equation? *)
-                List.exists
-                  (fun ((sv', _), _) -> StateVar.equal_state_vars sv sv') 
-                  equations 
-              then a
-              else 
-
-                (* State variable without equation must be stateful *)
-                SVS.add sv a)
-           l
-           a)
-      stateful_vars
-      locals
-  in
-
-  (* Add stateful variables from assertions *)
-  let stateful_vars = 
-    add_to_svs
-      stateful_vars
-      (List.map (fun (_, sv) -> sv) asserts) 
-  in
-
-  (* Add variables from node calls *)
-  let stateful_vars = 
-    List.fold_left
-      (fun
-        accum
-        { call_cond;
-          call_inputs; 
-          call_oracles;
-          call_outputs; 
-          call_defaults } -> 
-
-        (* Input and output variables are always stateful *)
-        ((D.values call_inputs) @ 
-         call_oracles @
-         (D.values call_outputs))
-        
-        |> SVS.of_list
-        
-        (* Add stateful variables from initial defaults *)
-        |> SVS.union 
-           (match call_defaults with 
-             | None -> accum
-             | Some d ->
-               List.fold_left 
-                 (fun accum expr -> 
-                    SVS.union accum (stateful_vars_of_expr expr))
-                 accum
-                 (D.values d))
-
-        (* Variables in activation and restart conditions are always
-           stateful *)
-        |> SVS.union
-          (List.map (function | CActivate v | CRestart v -> v) call_cond
-           |> SVS.of_list)
-       
-      ) stateful_vars calls
-  in
-
   stateful_vars
 
 (* ********************************************************************** *)

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -39,7 +39,7 @@ module TM = Type.TypeMap
 
 type settings = {
   preserve_sig: bool;
-  slice_nodes: bool;
+  slice_nodes: Flags.slice_nodes;
   add_functional_constraints: bool;
   slice_to_prop: P.t option
 }
@@ -2336,12 +2336,13 @@ let rec trans_sys_of_node'
             )
           in
 
-          if not (Flags.slice_nodes ()) then
+          if (Flags.slice_nodes () != `On) then
             all_state_vars |> List.iter (fun state_var ->
               let state_var_type = StateVar.type_of_state_var state_var in
               if Type.is_array state_var_type then (
                 (* Enforce creation of 'select' functions required to retrieve models, even if
-                   the array variable is not used in the input, when slice_nodes=false *)
+                   the array variable is not used in the input. Legacy slicing algorithm
+                   handles this case for us *)
                 StateVar.encode_select state_var |> ignore
               )
             )
@@ -2872,22 +2873,28 @@ let trans_sys_of_nodes
   );
 
   let subsystem' = SubSystem.find_subsystem_of_list subsystems top in
-  
+
   let { SubSystem.source = { N.node_id = top_name; } } as subsystem' =
+
+  if options.slice_nodes != `Experimental then
     let preserve_sig, slice_nodes =
       options.preserve_sig, options.slice_nodes
     in
     match options.slice_to_prop with
     | None -> 
       S.slice_to_abstraction
-        ~preserve_sig slice_nodes analysis_param subsystem'
+        ~preserve_sig (slice_nodes == `On) analysis_param subsystem'
     | Some prop ->
       let vars =
         Term.state_vars_of_term prop.P.prop_term
       in
       S.slice_to_abstraction_and_property
         ~preserve_sig analysis_param vars subsystem'
+  else
+    subsystem'
   in
+
+  let top_name = subsystem'.source.N.node_id in
 
   let nodes = N.nodes_of_subsystem subsystem' in
 

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2898,13 +2898,11 @@ let trans_sys_of_nodes
     subsystem'
   in
 
-  let top_name = subsystem'.source.N.node_id in
-
   let nodes = N.nodes_of_subsystem subsystem' in
 
   let { trans_sys; definition_set} =
 
-    try 
+    try
 
       (* Create a transition system for each node *)
       trans_sys_of_node'
@@ -2958,6 +2956,29 @@ let trans_sys_of_nodes
 
   (* Reset garbage collector to its initial settings *)
   Lib.reset_gc_params ();
+
+  let trans_sys =
+    if options.slice_nodes == `Experimental then (
+      let graph =
+        DependencyGraph.dependency_graph_of_system definition_set trans_sys
+      in
+
+      let roots = TransSys.get_properties trans_sys
+        |> List.to_seq
+        |> Seq.map Property.get_prop_term
+        |> Seq.map Term.state_vars_of_term
+        |> Seq.fold_left SVS.union SVS.empty
+      in
+
+      let coi =
+        DependencyGraph.cone_of_influence
+          graph
+          roots
+      in
+
+      TransSys.slice_system trans_sys coi)
+    else trans_sys
+  in
 
   trans_sys, subsystem'
 

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -95,6 +95,9 @@ type node_def = {
   history_svars: (StateVar.t list) SVM.t TM.t;
 
   ctr_svars: StateVar.t list ;
+
+  definition_set : Term.TermSet.t;
+  (* Terms which occur as part of a definition *)
 }
 
 
@@ -1729,9 +1732,9 @@ module MBounds = Map.Make (struct
 (* Add constraints from equations to initial state constraint and
    transition relation *)
 let rec constraints_of_equations_wo_arrays transfer_defs node
-    eq_bounds init stateful_vars terms (lets, lets_dependencies) = function
+    eq_bounds init stateful_vars terms (lets, lets_dependencies) definition_set = function
   (* Constraints for all equations generated *)
-  | [] -> terms, lets, eq_bounds
+  | [] -> terms, lets, eq_bounds, definition_set
 
   (* Stateful variable must have an equational constraint *)
   (* If we are doing experimental slicing the let binding optimization is
@@ -1758,7 +1761,7 @@ let rec constraints_of_equations_wo_arrays transfer_defs node
 
     (* Add terms of equation *)
     constraints_of_equations_wo_arrays transfer_defs node
-      eq_bounds init stateful_vars (def :: terms) (lets, lets_dependencies) tl
+      eq_bounds init stateful_vars (def :: terms) (lets, lets_dependencies) (Term.TermSet.add def definition_set) tl
 
   (* Can define state variable with a let binding *)
   (* Let binding optimization is not performed when experimental slicing is
@@ -1847,7 +1850,7 @@ let rec constraints_of_equations_wo_arrays transfer_defs node
 
     (* Start with singleton lists of let-bound terms *)
     constraints_of_equations_wo_arrays transfer_defs node
-      eq_bounds init stateful_vars terms (let_closure :: lets, lets_dependencies) tl
+      eq_bounds init stateful_vars terms (let_closure :: lets, lets_dependencies) definition_set tl
 
   (* Array state variable *)
   | (((_, bounds), _) as eq) :: tl -> 
@@ -1856,9 +1859,9 @@ let rec constraints_of_equations_wo_arrays transfer_defs node
 
     (* map equation to its bounds for future treatment and continue *)
     let eq_bounds = MBounds.add bounds (eq :: other_eqs) eq_bounds in
-    
+
     constraints_of_equations_wo_arrays transfer_defs node
-      eq_bounds init stateful_vars terms (lets, lets_dependencies) tl
+      eq_bounds init stateful_vars terms (lets, lets_dependencies) definition_set tl
 
 
 (* create quantified (or no) constraints for recursive arrays definitions *)
@@ -1916,9 +1919,7 @@ let constraints_of_arrays init terms eq_bounds =
     | _ -> Term.mk_forall ~fundef:(Flags.Arrays.recdef ()) quant_v term
 
     in
-  
-  
-  MBounds.fold (fun bounds eqs terms ->
+  MBounds.fold (fun bounds eqs (terms, definition_set) ->
       let cstrs_eqs =
         List.map (function
             | (state_var, bounds), { E.expr_init; E.expr_step } ->
@@ -1956,53 +1957,47 @@ let constraints_of_arrays init terms eq_bounds =
               ) eqs
       in
 
+      let definition_set = Term.TermSet.(of_list cstrs_eqs |> union definition_set) in
+
       (* group constraints under same quantifier when not using recursive
          encoding *)
       let cstrs =
         if Flags.Arrays.recdef () then cstrs_eqs
         else [Term.mk_and cstrs_eqs] in
-      
+
       (* Wrap equations in let binding and/or quantifiers for indexes and add
-         definitions to terms *)        
-      List.fold_left (fun terms cstr ->
+         definitions to terms *)
+      (List.fold_left (fun terms cstr ->
             add_bounds cstr bounds :: terms
-        ) terms cstrs
-           
-    ) eq_bounds terms              
-           
-           
-let constraints_of_equations node init stateful_vars terms equations =
-        
+        ) terms cstrs, definition_set)
+
+    ) eq_bounds terms
+
+let constraints_of_equations node init stateful_vars terms equations definition_set =
+
   (* make constraints for equations which do not redefine arrays first *)
-  let terms, lets, eq_bounds =
+  let terms, lets, eq_bounds, definition_set =
     let transfer_defs =
       Flags.IVC.compute_ivc () || List.mem `MCS (Flags.enabled ())
     in
     constraints_of_equations_wo_arrays transfer_defs node
-      MBounds.empty init stateful_vars terms ([], SVM.empty) equations
+      MBounds.empty init stateful_vars terms ([], SVM.empty) definition_set equations
     in
 
   (* then make constraints for recursive arrays so as to merge quantifiers as
      much as possible *)
-  let terms = constraints_of_arrays init terms eq_bounds in
+  let terms, definition_set = constraints_of_arrays init (terms, definition_set) eq_bounds in
 
-  if lets = [] then terms
+  if lets = [] then terms, definition_set
   else
     (* Apply let bindings *)
     [List.fold_left (fun t let_bind -> let_bind t)
        (Term.mk_and terms) (List.rev lets)
-     |> Term.convert_select]
+     |> Term.convert_select], definition_set
 
 
-let rec trans_sys_of_node'
-  options
-  globals
-  top_name
-  analysis_param
-  trans_sys_defs
-  output_input_dep
-  nodes
-= function
+let rec trans_sys_of_node' options globals top_name analysis_param
+  trans_sys_defs output_input_dep nodes definition_set = function
 
   (* Transition system for all nodes created *)
   | [] -> trans_sys_defs
@@ -2016,14 +2011,8 @@ let rec trans_sys_of_node'
 
       (* Continue with next transition systems *)
       trans_sys_of_node'
-        options
-        globals
-        top_name
-        analysis_param
-        trans_sys_defs 
-        output_input_dep
-        nodes
-        tl
+        options globals top_name analysis_param trans_sys_defs output_input_dep
+        nodes definition_set tl
 
     (* Transition system has not been created *)
     else
@@ -2153,6 +2142,7 @@ let rec trans_sys_of_node'
             trans_sys_defs
             output_input_dep
             nodes
+            definition_set
             (tl' @ node_id :: tl)
 
         (* All transitions systems of called nodes have been
@@ -2378,14 +2368,14 @@ let rec trans_sys_of_node'
             List.rev_append subrange_state_vars enum_state_vars
           in
 
-          let init_terms = 
+          let init_terms =
             List.fold_left
               (add_constraints_of_type true)
               init_terms
               subrange_and_enum_state_vars
           in
 
-          let trans_terms = 
+          let trans_terms =
             List.fold_left
               (add_constraints_of_type false)
               trans_terms
@@ -2551,20 +2541,26 @@ let rec trans_sys_of_node'
 
           (* Order initial state equations by dependency and
              generate terms *)
-          let init_terms, svar_dep_init, node_output_input_dep_init =
+          let (init_terms, definition_set), svar_dep_init, node_output_input_dep_init =
             S.order_equations true output_input_dep node
               |> (fun (e, sv_d, io_d) ->
-               constraints_of_equations node
-                    true stateful_vars init_terms (List.rev e), sv_d, io_d)
+               constraints_of_equations
+                node
+                true
+                stateful_vars
+                init_terms
+                (List.rev e)
+                definition_set
+                , sv_d, io_d)
           in
 
           (* Order transition relation equations by dependency and
              generate terms *)
-          let trans_terms, svar_dep_trans, node_output_input_dep_trans =
+          let (trans_terms, definition_set ), svar_dep_trans, node_output_input_dep_trans =
             S.order_equations false output_input_dep node
               |> (fun (e, sv_d, io_d) ->
                constraints_of_equations node
-                    false stateful_vars trans_terms (List.rev e), sv_d, io_d)
+                    false stateful_vars trans_terms (List.rev e) definition_set, sv_d, io_d)
           in
 
           (* We compute an overapproximation of the set of variables
@@ -2844,14 +2840,16 @@ let rec trans_sys_of_node'
                  init_flags;
                  properties;
                  history_svars;
-                 ctr_svars }
+                 ctr_svars;
+                 definition_set;
+              }
                trans_sys_defs)
             ((node_id, 
               (node_output_input_dep_init, node_output_input_dep_trans))
              :: output_input_dep)
             nodes
+            definition_set
             tl
-          
 
 let trans_sys_of_nodes
     ?(options=default_settings)
@@ -2904,7 +2902,7 @@ let trans_sys_of_nodes
 
   let nodes = N.nodes_of_subsystem subsystem' in
 
-  let { trans_sys } =   
+  let { trans_sys; definition_set} =
 
     try 
 
@@ -2917,6 +2915,7 @@ let trans_sys_of_nodes
         I.Map.empty
         [] 
         nodes
+        Term.TermSet.empty
         [top_name]
 
       (* Return the transition system of the top node *)
@@ -2926,7 +2925,7 @@ let trans_sys_of_nodes
     with Not_found -> assert false
 
   in
-  
+
   ( match analysis_param with
     | A.Refinement (_,result) ->
       (* The analysis that's going to run is a refinement. *)

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -1734,8 +1734,12 @@ let rec constraints_of_equations_wo_arrays transfer_defs node
   | [] -> terms, lets, eq_bounds
 
   (* Stateful variable must have an equational constraint *)
+  (* If we are doing experimental slicing the let binding optimization is
+     skipped and this is not relevant *)
   | ((state_var, []), { E.expr_init; E.expr_step }) :: tl 
-    when List.exists (StateVar.equal_state_vars state_var) stateful_vars -> 
+    when
+      (Flags.slice_nodes () != `Experimental) &&
+      (List.exists (StateVar.equal_state_vars state_var) stateful_vars) ->
 
     (* Equation for stateful variable *)
     let def = 
@@ -1756,9 +1760,12 @@ let rec constraints_of_equations_wo_arrays transfer_defs node
     constraints_of_equations_wo_arrays transfer_defs node
       eq_bounds init stateful_vars (def :: terms) (lets, lets_dependencies) tl
 
-
   (* Can define state variable with a let binding *)
-  | ((state_var, []), ({ E.expr_init; E.expr_step } as expr)) :: tl ->
+  (* Let binding optimization is not performed when experimental slicing is
+     performed *)
+  | ((state_var, []), ({ E.expr_init; E.expr_step } as expr)) :: tl
+    when ( Flags.slice_nodes () != `Experimental )
+    ->
 
     if transfer_defs then (
     (* TODO: Factor out and optimize this code *)
@@ -1805,33 +1812,32 @@ let rec constraints_of_equations_wo_arrays transfer_defs node
 
     (* Let binding for stateless variable, in closure form *)
     let let_closure =
-      Term.mk_let 
-        (if init then 
+      Term.mk_let
+        (if init then
             (* Binding for the variable at the base instant only *)
-            [(E.base_var_of_state_var TransSys.init_base state_var, 
-              E.base_term_of_expr TransSys.init_base expr_init)] 
+            [(E.base_var_of_state_var TransSys.init_base state_var,
+              E.base_term_of_expr TransSys.init_base expr_init)]
           else
             (* Binding for the variable at the current instant *)
-            (E.cur_var_of_state_var TransSys.trans_base state_var, 
-            E.cur_term_of_expr TransSys.trans_base expr_step) :: 
-            (if 
+            (E.cur_var_of_state_var TransSys.trans_base state_var,
+            E.cur_term_of_expr TransSys.trans_base expr_step) ::
+            (if
               (* Does the state variable occur at the previous
                 instant? *)
               try
-              Term.state_vars_at_offset_of_term 
-                Numeral.(TransSys.trans_base |> pred) 
+              Term.state_vars_at_offset_of_term
+                Numeral.(TransSys.trans_base |> pred)
                 (Term.mk_and terms)
-              |> SVS.mem state_var  
+              |> SVS.mem state_var
               with Invalid_argument _ -> true
 
-              
             then
               ((* Definition must not contain a [pre] operator, otherwise we'd
                   have a double [pre]. The state variable is not stateless in
                   this case, and we should not be here. *)
                 assert (not (E.has_pre_var E.base_offset expr));
                 (* Binding for the variable at the previous instant *)
-                [(E.pre_var_of_state_var TransSys.trans_base state_var, 
+                [(E.pre_var_of_state_var TransSys.trans_base state_var,
                   E.pre_term_of_expr TransSys.trans_base expr_step)])
             else (* No binding for the variable at the previous instant
                     necessary *)

--- a/src/lustre/lustreTransSys.mli
+++ b/src/lustre/lustreTransSys.mli
@@ -18,7 +18,7 @@
 
 type settings = {
   preserve_sig: bool;
-  slice_nodes: bool;
+  slice_nodes: Flags.slice_nodes;
   add_functional_constraints: bool;
   slice_to_prop: Property.t option;
 }

--- a/src/postAnalysis.ml
+++ b/src/postAnalysis.ml
@@ -467,7 +467,7 @@ module RunContractGen: PostAnalysis = struct
     (* Building transition system and slicing info. *)
     let sys, in_sys_sliced =
       ISys.trans_sys_of_analysis
-        ~preserve_sig:true ~slice_nodes:false in_sys param
+        ~preserve_sig:true ~slice_nodes:`Off in_sys param
     in
     let target = Flags.subdir_for top in
     (* Create directories if they don't exist. *)

--- a/src/property.ml
+++ b/src/property.ml
@@ -307,6 +307,9 @@ let set_prop_unknown p =
 (* Get property status *)
 let get_prop_status { prop_status } = prop_status
 
+(* Get property term *)
+let get_prop_term { prop_term } = prop_term
+
 let rec get_prop_original_source { prop_source } =
   match prop_source with
   | Instantiated (_, p) -> get_prop_original_source p

--- a/src/property.mli
+++ b/src/property.mli
@@ -131,6 +131,8 @@ val get_prop_status : t -> prop_status
 
 val get_prop_original_source : t -> prop_source
 
+val get_prop_term : t -> Term.t
+
 (* 
    Local Variables:
    compile-command: "make -C .. -k"

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -2124,8 +2124,11 @@ let slice_term (cone_of_influence : SVS.t) (term : Term.t) =
     |> Seq.find (fun x -> StateVar.StateVarSet.mem x cone_of_influence)
     |> is_some
   in
-  try Term.node_args_of_term term |> List.filter keep_term |> Term.mk_and
-  with _ -> Term.mk_true ()
+  try
+    assert ((Term.node_symbol_of_term term |> Symbol.node_of_symbol) == `AND);
+    Term.node_args_of_term term |> List.filter keep_term |> Term.mk_and
+  with _ ->
+    if keep_term term then term else Term.mk_true ()
 
 let rec slice_system sys cone_of_influence =
 

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -20,7 +20,7 @@ open Lib
 
 module P = Property
 module SVM = StateVar.StateVarMap
-(* module SVS = StateVar.StateVarSet *)
+module SVS = StateVar.StateVarSet
 
 exception PropertyNotFound of string
 
@@ -2112,6 +2112,47 @@ let enforce_constantness_via_equations sys =
 
 let global_const_state_vars { global_consts } = 
   List.map Var.state_var_of_state_var_instance global_consts
+
+let slice_term (cone_of_influence : SVS.t) (term : Term.t) =
+  let state_var_of_state_var_instance_opt var =
+    try Some (Var.state_var_of_state_var_instance var) with _ -> None
+  in
+
+  let keep_term t =
+    Term.vars_of_term t |> Var.VarSet.to_seq
+    |> Seq.filter_map state_var_of_state_var_instance_opt
+    |> Seq.find (fun x -> StateVar.StateVarSet.mem x cone_of_influence)
+    |> is_some
+  in
+  try Term.node_args_of_term term |> List.filter keep_term |> Term.mk_and
+  with _ -> Term.mk_true ()
+
+let rec slice_system sys cone_of_influence =
+
+  let initial_term = init_of_bound None sys init_base |> slice_term cone_of_influence in
+  let transition_term = trans_of_bound None sys trans_base |> slice_term cone_of_influence in
+
+  let sys =
+    set_subsystem_equations sys (scope_of_trans_sys sys) initial_term
+      transition_term
+  in
+  {
+    sys with
+    subsystems =
+      List.map
+        (fun (system, instances) ->
+          (slice_system system cone_of_influence, instances))
+        sys.subsystems;
+    properties =
+      List.filter
+        (fun property ->
+          property.Property.prop_term |> Term.vars_of_term |> Var.VarSet.to_seq
+          |> Seq.filter_map (fun var ->
+                 try Some (Var.state_var_of_state_var_instance var)
+                 with _ -> None)
+          |> Seq.exists (fun sv -> SVS.mem sv cone_of_influence))
+        sys.properties;
+  }
 
 (* 
    Local Variables:

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -699,6 +699,16 @@ val enforce_constantness_via_equations : t -> (t * StateVar.t list)
 (** Return the global constant state variables of the transition system *)
 val global_const_state_vars : t -> StateVar.t list
 
+(** [slice_system sys vars] returns a new system obtained by restricting
+    [sys] to only the state variables in [vars].
+
+    @param sys The original system.
+    @param vars The set of state variables to retain in the sliced system.
+    @return A new system containing only the specified state variables.
+*)
+val slice_system : t -> StateVar.StateVarSet.t -> t
+
+
 (* 
    Local Variables:
    compile-command: "make -C .. -k"

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -700,11 +700,15 @@ val enforce_constantness_via_equations : t -> (t * StateVar.t list)
 val global_const_state_vars : t -> StateVar.t list
 
 (** [slice_system sys vars] returns a new system obtained by restricting
-    [sys] to only the state variables in [vars].
+    [sys] to only the state variables in [vars]. Technically the state
+    variables not in [vars] are retained in the system but terms referencing
+    them are removed. That is if `x` and `y` are both not in [vars] then the
+    declaration of `x` and `y` remain in the system however a term of the form
+    `x and y` will be removed.
 
     @param sys The original system.
     @param vars The set of state variables to retain in the sliced system.
-    @return A new system containing only the specified state variables.
+    @return A new system where terms wich do not refer to variables in the sliced system are removed.
 *)
 val slice_system : t -> StateVar.StateVarSet.t -> t
 

--- a/src/utils/graph.ml
+++ b/src/utils/graph.ml
@@ -84,6 +84,12 @@ module type S = sig
   val to_vertex_list: vertices -> vertex list
   (** Returns a list of vertex  *)
 
+  val get_edges: t -> edges
+  (** get all edges in the graph *)
+
+  val to_edge_list: edges -> (vertex * vertex) list
+  (** Returns a list of edge *)
+
   val add_edge: t ->  edge ->  t
   (** Add an [edge] to a graph  *)
 
@@ -429,4 +435,8 @@ module Make (Ord: OrderedType) = struct
 
   let to_vertex_list: vertices -> vertex list = VSet.elements
   (** returns a list of vertex *)
+
+  let to_edge_list = fun edge -> List.map (fun element -> (fst element, snd element))  (ESet.elements edge)
+  (** returns a list of vertex *)
+
 end

--- a/src/utils/graph.ml
+++ b/src/utils/graph.ml
@@ -436,7 +436,7 @@ module Make (Ord: OrderedType) = struct
   let to_vertex_list: vertices -> vertex list = VSet.elements
   (** returns a list of vertex *)
 
-  let to_edge_list = fun edge -> List.map (fun element -> (fst element, snd element))  (ESet.elements edge)
+  let to_edge_list = ESet.elements
   (** returns a list of vertex *)
 
 end

--- a/src/utils/graph.mli
+++ b/src/utils/graph.mli
@@ -85,6 +85,12 @@ module type S = sig
   val to_vertex_list: vertices -> vertex list
   (** Returns a list of vertex  *)
 
+  val get_edges: t -> edges
+  (** get all edges in the graph *)
+
+  val to_edge_list: edges -> (vertex * vertex) list
+  (** Returns a list of edges  in the form (source, target) *)
+
   val add_edge: t ->  edge ->  t
   (** Add an [edge] to a graph  *)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 
 # The default arguments we want set for every run
 common_args = {
-    "--timeout": "42",
+    "--timeout": "84",
     "--color": "false",
     "--check_subproperties": "true",
     "--check_sat_assume": "false",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,9 @@ common_args = {
 # All the different test conditions, will override common_args if there is a
 # disagreement
 test_cases = {
-    "slice_true": {"--slice_nodes": "true"},
-    "slice_false": {"--slice_nodes": "false"},
+    "slice_on": {"--slice_nodes": "on"},
+    "slice_off": {"--slice_nodes": "off"},
+    "slice_experimental": {"--slice_nodes": "experimental"},
 }
 
 # Where to find the regression tests

--- a/tests/regression/success/assert-not-sliced.lus
+++ b/tests/regression/success/assert-not-sliced.lus
@@ -1,0 +1,7 @@
+node N(x: int) returns (y: int; b: bool);
+let
+  b = x >= 0;
+  assert b;
+  y =  x + 1;
+  check y > 0;
+tel


### PR DESCRIPTION
The current slicing algorithm is applied at the lustre level. This pull request adds a slicing algorithm which operates at the transition system level.

A new module, `src/lustre/dependencyGraph.ml`, is added for computing the dependence between terms in the transition system.

This module is used to compute the cone of influence of all the properties of the system. Any terms in the transition system not present in the cone of influence are removed.

This changes the flag `--slice_nodes` from a boolean to a flag with three options: `off`, `on`, `experimental`. `off` corresponds to the previous choice false, `on` to the previous choice true, and `experimental` to the slicing algorithm in this pr. Currently the default is left as `on`.