### PR TITLE
Use short names in SMTLIB function definitions as well

### DIFF
--- a/src/smt/SMTLIBSolver.ml
+++ b/src/smt/SMTLIBSolver.ml
@@ -573,7 +573,8 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
         (pp_print_list
            (fun ppf var -> 
               Format.fprintf ppf "(%s %s)" 
-                (Var.string_of_var var)
+                (UfSymbol.string_of_uf_symbol
+                  (Var.unrolled_uf_of_state_var_instance var))
                 (string_of_sort (Var.type_of_var var)))
            "@ ")
         arg_vars

--- a/src/smt/SMTSolver.ml
+++ b/src/smt/SMTSolver.ml
@@ -237,7 +237,7 @@ let define_fun s uf_symbol vars term =
        (UfSymbol.string_of_uf_symbol uf_symbol)
        vars
        (UfSymbol.res_type_of_uf_symbol uf_symbol)
-       term)
+       (S.Conv.smtexpr_of_term term))
 
 
 

--- a/src/terms/stateVar.ml
+++ b/src/terms/stateVar.ml
@@ -308,7 +308,7 @@ let mk_state_var
     
     try 
       
-      if (Flags.Smt.short_names () && not is_const) then raise Not_found;
+      if (Flags.Smt.short_names ()) then raise Not_found;
 
       let _ = 
         UfSymbol.uf_symbol_of_string 
@@ -328,7 +328,7 @@ let mk_state_var
        (* Create an uninterpreted function symbol for the state variable *)
        let state_var_uf_symbol = 
 
-         (if (Flags.Smt.short_names () && not is_const) then 
+         (if (Flags.Smt.short_names ()) then
             
             gen_uf
               


### PR DESCRIPTION
Use short names in SMTLIB function definitions when passing `--smt_short_names true`. This PR also enables the use of short names for global constants, which was previously disabled in #565. I re-enabled the latter because it seems to work now. I cannot reproduce the issue, and unfortunately, I didn’t save a regression test.

This change enables the MoXI checker to accept quoted symbols for constant and variable names in upcoming PRs.