### PR TITLE
Add support for Arrays in MoXI checker

### DIFF
--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -903,6 +903,7 @@ let run in_sys =
       let msg_setup = KEvent.setup () in
       KEvent.set_module `Supervisor ;
       KEvent.run_im msg_setup [] (on_exit_success `Supervisor);
+      Flags.Arrays.set_smt true ;
 
       let params = ISys.moxi_params in_sys in
       let run_check param =

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -774,6 +774,17 @@ and pp_print_app ?as_type safe pvar ppf = function
             
         | _ -> assert false)
 
+    | `CONST_ARRAY _ ->
+
+      (function
+        | [v] ->
+
+          Format.fprintf ppf
+          "@[<hv 2>%a^?@]"
+          (pp_print_term_node safe pvar) v
+
+        | _ -> assert false)
+
     | `STORE ->
       
       (function 

--- a/src/moxi/moxiInput.ml
+++ b/src/moxi/moxiInput.ml
@@ -90,10 +90,7 @@ let rec mk_subsystem sys = {
 let hstring_of_symbol = snd
 let string_of_symbol symbol = HString.string_of_hstring (snd symbol)
 
-let type_of_sort A.{ id; parameters } =
-  if parameters <> [] then
-    failwith("Parametric identifiers are not supported yet") ;
-
+let rec type_of_sort A.{ id; parameters } =
   let _, symbol, indices = id in
 
   let name = string_of_symbol symbol in
@@ -105,6 +102,11 @@ let type_of_sort A.{ id; parameters } =
     match indices with
     | [NumericIndex (_, n)] -> Type.t_ubv (Numeral.to_int n)
     | _ -> failwith("Unexpected index for BitVec sort")
+  )
+  else if name = "Array" then (
+    match parameters with
+    | [idx_ty; elem_ty] -> Type.mk_array (type_of_sort elem_ty) (type_of_sort idx_ty)
+    | _ -> failwith("Incorrect arity for Array sort")
   )
   else raise (Invalid_argument
     (Format.asprintf "Sort '%s' is not supported" name))
@@ -172,7 +174,7 @@ let rec kind2_term scope = function
       )
     )
   )
-  | A.App (_, (id, is_prime, _), args) -> (
+  | A.App (_, (id, is_prime, sort), args) -> (
     let args = List.map (kind2_term scope) args in
 
     let _, symbol, indices = id in
@@ -184,7 +186,17 @@ let rec kind2_term scope = function
         let symb =
           GenericSMTLIBDriver.symbol_of_smtlib_atom (hstring_of_symbol symbol)
         in
-        Term.mk_app symb args
+        if Symbol.is_const_array symb then (
+          match sort with
+          | Some sort -> (
+            match args with
+            | [v] -> Term.mk_const_array (type_of_sort sort) v
+            | _ -> failwith("Incorrect number of arguments for const function")
+          )
+          | None -> failwith("Couldn't determine sort for const function")
+        )
+        else
+          Term.mk_app symb args
       )
       | [idx1; idx2] -> (
         if (string_of_symbol symbol = "extract") then (

--- a/src/qe/presburger.ml
+++ b/src/qe/presburger.ml
@@ -604,6 +604,7 @@ let to_presburger (v: Var.t list) (gf: Term.t) : cformula =
 
                | `SELECT _, _
                | `STORE, _
+               | `CONST_ARRAY _, _
 
 
                | `BVULT, _

--- a/src/simplify.ml
+++ b/src/simplify.ml
@@ -764,6 +764,7 @@ let rec negate_nnf term = match Term.destruct term with
       | `DIVISIBLE _, _
       | `UF _, _
       | `SELECT _, _
+      | `CONST_ARRAY _, _
       | `STORE, _ -> Term.mk_not term
 
       (* Negate both cases of ite term *)
@@ -1172,6 +1173,12 @@ let store = function
  (* Store is ternary *)
  | _ -> assert false
 
+let const_array ty_array = function
+ | [v] ->
+
+  atom_of_term (Term.mk_const_array ty_array (term_of_nf v))
+
+ | _ -> assert false
 
 let select simplify_term_node model fterm = function
 
@@ -2075,6 +2082,8 @@ let rec simplify_term_node ?(split_eq=false) default_of_var uf_defs model fterm 
 
           (* array store *)
           | `STORE -> store args
+
+          | `CONST_ARRAY ty_array -> const_array ty_array args
 
           | `UF _ when Symbol.is_select s ->
 
@@ -3114,6 +3123,8 @@ let rec remove_ite' fterm args =
 
         (* Selec from an array *)
         | `SELECT _ -> select remove_ite' (Var.VarHashtbl.create 0) fterm args
+
+        | `CONST_ARRAY ty_array -> const_array ty_array args
 
         (* Array store *)
         | `STORE -> store args

--- a/src/smt/genericSMTLIBDriver.ml
+++ b/src/smt/genericSMTLIBDriver.ml
@@ -686,7 +686,10 @@ let smtlib_string_symbol_list =
    (* uninterpreted select *)
    (* ("uselect", Symbol.mk_symbol (`SELECT Type.t_int)); *)
 
-   ("store", Symbol.mk_symbol `STORE)
+   ("store", Symbol.mk_symbol `STORE);
+
+   ("const", Symbol.mk_symbol
+      (`CONST_ARRAY (Type.mk_array Type.t_int Type.t_int))); (* placeholder *)
 
   ]
 
@@ -825,6 +828,13 @@ let [@ocaml.warning "-27"] rec pp_print_symbol_node ?arity ppf = function
       )
 
   | `STORE -> Format.pp_print_string ppf "store"
+
+  | `CONST_ARRAY ty_array ->
+    Format.fprintf
+      ppf
+      "(as const %a)"
+      Type.pp_print_type ty_array
+
   | `UF u -> UfSymbol.pp_print_uf_symbol ppf u
                                 
 

--- a/src/smt/yicesDriver.ml
+++ b/src/smt/yicesDriver.ml
@@ -365,6 +365,8 @@ let rec pp_print_symbol_node ?arity ppf = function
 
   | `STORE -> Format.pp_print_string ppf "update"
 
+  | `CONST_ARRAY _ -> Format.pp_print_string ppf ""
+
   | `UF u -> UfSymbol.pp_print_uf_symbol ppf u
 
   | `UINT8_TO_INT -> assert false

--- a/src/smt/yicesNative.ml
+++ b/src/smt/yicesNative.ml
@@ -549,6 +549,7 @@ let ensure_symbol_qf_lira s =
   | `BV2NAT
   | `SBV_TO_INT
   | `SELECT _
+  | `CONST_ARRAY _
   | `STORE ->
     
     let msg = Format.sprintf "Yices was run with set-arith-only, but the \

--- a/src/terms/term.ml
+++ b/src/terms/term.ml
@@ -691,6 +691,11 @@ let rec type_of_term' t = match T.destruct t with
            | a :: _ -> Type.elem_type_of_array (type_of_term' a)
            | _ -> assert false)
 
+        | `CONST_ARRAY _ (* ty_array *) ->
+
+          (match l with
+           | [v] -> (type_of_term' v)
+           | _ -> assert false)
 
         (* Bitvector-valued function *)
         | `BVEXTRACT (i, j) -> 
@@ -1555,6 +1560,7 @@ let mk_select a i = mk_app_of_symbol_node (`SELECT (type_of_term a)) [a; i]
 let mk_store a i v =
   mk_app_of_symbol_node `STORE [a; i; v]
 
+let mk_const_array t v = mk_app_of_symbol_node (`CONST_ARRAY t) [v]
 
 (* Generate a new tag *)
 let newid =

--- a/src/terms/term.mli
+++ b/src/terms/term.mli
@@ -338,6 +338,8 @@ val mk_select : t -> t -> t
 (** Functionally update an array at a given index *)
 val mk_store : t -> t -> t -> t
 
+val mk_const_array : Type.t -> t -> t
+
 (** Uniquely name a term with an integer and return a named term and
     its name *)
 val mk_named : t -> int * t

--- a/src/terms/type.ml
+++ b/src/terms/type.ml
@@ -226,8 +226,8 @@ let rec pp_print_type_node ppf = function
     Format.fprintf
       ppf 
       "(Array %a %a)"
-      pp_print_type s 
       pp_print_type t
+      pp_print_type s
 
   | Abstr s -> Format.pp_print_string ppf s
 
@@ -284,8 +284,8 @@ let rec pp_print_type_node_debug ppf = function
     Format.fprintf
       ppf 
       "(Array %a %a)"
-      pp_print_type s 
       pp_print_type t
+      pp_print_type s
 
   | Abstr s -> Format.pp_print_string ppf s
 

--- a/src/utils/symbol.ml
+++ b/src/utils/symbol.ml
@@ -124,6 +124,8 @@ type interpreted_symbol =
   (* Selection from array (binary) *)
   | `SELECT of Type.t
   | `STORE                (* Update of an array (ternary) *)
+
+  | `CONST_ARRAY of Type.t (** Constant array (unary) *)
   ]
 
 
@@ -240,6 +242,9 @@ module Symbol_node = struct
 
     | `STORE, `STORE -> true
 
+    | `CONST_ARRAY a1, `CONST_ARRAY a2 ->
+      Type.equal_types a1 a2
+
     | `BVEXTRACT (i1, j1), `BVEXTRACT (i2, j2) -> Numeral.equal i1 i2 && Numeral.equal j1 j2
     | `BVSIGNEXT i1, `BVSIGNEXT i2 -> Numeral.equal i1 i2
     | `BVZEROEXT i1, `BVZEROEXT i2 -> Numeral.equal i1 i2
@@ -312,6 +317,7 @@ module Symbol_node = struct
     | `IS_INT, _
     | `SELECT _, _
     | `STORE, _ 
+    | `CONST_ARRAY _, _
     | `BVEXTRACT _, _
     | `BVCONCAT, _
     | `BVSIGNEXT _, _
@@ -531,6 +537,11 @@ let rec pp_print_symbol_node ppf = function
 
   | `SELECT _ -> Format.pp_print_string ppf "select"
   | `STORE -> Format.pp_print_string ppf "store"
+  | `CONST_ARRAY a ->
+      Format.fprintf
+      ppf
+      "(as const %a)"
+      Type.pp_print_type a
   | `UF u -> UfSymbol.pp_print_uf_symbol ppf u
 
 (* Pretty-print a hashconsed symbol *)
@@ -787,11 +798,17 @@ let is_select = function
      with Scanf.Scan_failure _ -> false)
   | _ -> false
 
+let is_const_array = function
+  | { Hashcons.node = `CONST_ARRAY _ } -> true
+  | _ -> false
+
 let is_divisible = function
   | { Hashcons.node = `DIVISIBLE _ } -> true
   | _ -> false
 
 let s_store = mk_symbol `STORE
+
+let s_const_array ta = mk_symbol (`CONST_ARRAY ta)
 
 (* Bit-vector extract operator *)
 let s_extract i j = mk_symbol (`BVEXTRACT (i,j))

--- a/src/utils/symbol.mli
+++ b/src/utils/symbol.mli
@@ -85,6 +85,7 @@
     {- [`BVZEROEXT i] unary: extend bitvectors with zeros}
     {- [`SELECT] binary: selection from array}
     {- [`STORE] ternary: update of an array}
+    {- [`CONST_ARRAY] unary: constant array}
     }
 
     A chainable symbol is to be read as the conjunction of successive
@@ -200,6 +201,8 @@ type interpreted_symbol =
 
   | `STORE                (** Update of an array (ternary) *)
 
+  | `CONST_ARRAY of Type.t (** Constant array (unary) *)
+
   ]
 
 (** Adding uninterpreted function symbols separately for conversions
@@ -304,6 +307,8 @@ val s_select : Type.t -> t
 (** array store symbol *)
 val s_store : t
 
+val s_const_array : Type.t -> t
+
 (**  Bit-vector extract operator *)
 val s_extract : Numeral.t -> Numeral.t -> t
 
@@ -391,6 +396,9 @@ val is_to_int64 : t -> bool
 
 (** Return true if the symbol is select from array  *)
 val is_select : t -> bool
+
+(** Return true if the symbol is a constant array  *)
+  val is_const_array : t -> bool
 
 (** Return true if the symbol is the divisible function *)
 val is_divisible : t -> bool


### PR DESCRIPTION
This update also adds support for constant arrays in the backend. Retrieving and displaying counterexamples remains pending.