### PR TITLE
Fix extract bug

### DIFF
--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -2959,9 +2959,9 @@ let mk_bvand expr1 expr2 = mk_binary eval_bvand type_of_bvand expr1 expr2
 let mk_bvconcat expr1 expr2 = mk_binary eval_bvconcat type_of_bvconcat expr1 expr2
 
 (* Bitvector extract *)
-let mk_bvextract (lb: int) (ub: int) expr = 
-  { expr_init = eval_bvextract expr.expr_init (Term.mk_num_of_int lb) (Term.mk_num_of_int ub);
-  expr_step = eval_bvextract expr.expr_step (Term.mk_num_of_int lb) (Term.mk_num_of_int ub);
+let mk_bvextract ub lb expr = 
+  { expr_init = eval_bvextract expr.expr_init (Term.mk_num_of_int ub) (Term.mk_num_of_int lb);
+  expr_step = eval_bvextract expr.expr_step (Term.mk_num_of_int ub) (Term.mk_num_of_int lb);
   expr_type = (type_of_bvextract expr ub lb) } 
 
 

--- a/tests/regression/success/bv_extract_bug.lus
+++ b/tests/regression/success/bv_extract_bug.lus
@@ -1,0 +1,5 @@
+function Concat3(x1: uint<22>; x2: uint<20>; x3: uint<4>) returns (z: uint<46>)
+let
+  z = (x1 ++ x2) ++ x3;
+  check "P1" x3 = z[3:0];
+tel


### PR DESCRIPTION
Caller assumed the order of arguments of `mk_bvextract` was upper bound before lower bound (as in all other bitvector-related functions). Swapped the order to align. 

Funnily enough, this went unnoticed, because a second mistake canceled it out at the term level (passing lb before ub in `eval_bvextract`). However, at the type level, it was passed correctly (the opposite way), leading to the exception.