### PR TITLE
Quantified variable shadowing fix

### DIFF
--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -279,21 +279,22 @@ and push_pre is_guarded pos =
   | Arrow _ as e -> LA.Pre (pos, e)
   | Call _ as e -> LA.Pre (pos, e)
 
-and simplify_expr ?(is_guarded = false) ctx =
+and simplify_expr ?(is_guarded = false) ?(ind_vars = []) ctx =
   function
   | LA.Const _ as c -> c
   | LA.Ident (_, i) as ident ->
+     if List.mem i ind_vars then ident else
      (match (TC.lookup_const ctx i) with
       | Some (const_expr, _, _) ->
          (match const_expr with
           | LA.Ident (_, i') as ident' ->
              if HString.compare i i' = 0 (* If This is a free constant *)
              then ident
-             else simplify_expr ~is_guarded ctx ident'
-          | _ -> simplify_expr ~is_guarded ctx const_expr)
+             else simplify_expr ~ind_vars ~is_guarded ctx ident'
+          | _ -> simplify_expr ~ind_vars ~is_guarded ctx const_expr)
       | None -> ident)
   | LA.UnaryOp (pos, op, e1) ->
-    let e1' = simplify_expr ~is_guarded ctx e1 in
+    let e1' = simplify_expr ~ind_vars ~is_guarded ctx e1 in
     let e' = LA.UnaryOp (pos, op, e1') in
     (match op with
     | LA.Uminus -> (match eval_int_unary_op ctx pos op e1' with
@@ -304,19 +305,19 @@ and simplify_expr ?(is_guarded = false) ctx =
       | Error _ -> e')
     | _ -> e')
   | LA.Pre (pos, e) ->
-    let e' = simplify_expr ~is_guarded:false ctx e in
+    let e' = simplify_expr ~ind_vars ~is_guarded:false ctx e in
     if is_guarded && LH.expr_is_const e' then e'
     else
       if Flags.lus_push_pre ()
       then push_pre is_guarded pos e'
       else Pre (pos, e')
   | Arrow (pos, e1, e2) ->
-    let e1' = simplify_expr ~is_guarded ctx e1 in
-    let e2' = simplify_expr ~is_guarded:true ctx e2 in
+    let e1' = simplify_expr ~ind_vars ~is_guarded ctx e1 in
+    let e2' = simplify_expr ~ind_vars ~is_guarded:true ctx e2 in
     Arrow (pos, e1', e2')
   | LA.BinaryOp (pos, bop, e1, e2) ->
-     let e1' = simplify_expr ~is_guarded ctx e1 in
-     let e2' = simplify_expr ~is_guarded ctx e2 in
+     let e1' = simplify_expr ~ind_vars ~is_guarded ctx e1 in
+     let e2' = simplify_expr ~ind_vars ~is_guarded ctx e2 in
      let e' = LA.BinaryOp (pos, bop, e1', e2') in
      (match (eval_int_binary_op ctx pos bop e1' e2') with
       | Ok v -> LA.Const (pos, Num (v |> string_of_int |> HString.mk_hstring))
@@ -325,29 +326,29 @@ and simplify_expr ?(is_guarded = false) ctx =
      (match top with
      | Ite -> 
         (match eval_bool_expr ctx cond with
-        | Ok v -> if v then simplify_expr ~is_guarded ctx e1
-          else simplify_expr ~is_guarded ctx e2 
+        | Ok v -> if v then simplify_expr ~ind_vars ~is_guarded ctx e1
+          else simplify_expr ~ind_vars ~is_guarded ctx e2 
         | Error _ ->
-          let cond' = simplify_expr ~is_guarded ctx cond in
-          let e1' = simplify_expr ~is_guarded ctx e1 in
-          let e2' = simplify_expr ~is_guarded ctx e2 in
+          let cond' = simplify_expr ~ind_vars ~is_guarded ctx cond in
+          let e1' = simplify_expr ~ind_vars ~is_guarded ctx e1 in
+          let e2' = simplify_expr ~ind_vars ~is_guarded ctx e2 in
             TernaryOp (pos, top, cond', e1', e2')))
   | LA.CompOp (pos, cop, e1, e2) ->
-     let e1' = simplify_expr ~is_guarded ctx e1 in
-     let e2' = simplify_expr ~is_guarded ctx e2 in
+     let e1' = simplify_expr ~ind_vars ~is_guarded ctx e1 in
+     let e2' = simplify_expr ~ind_vars ~is_guarded ctx e2 in
      let e' = LA.CompOp (pos, cop, e1', e2') in
      (match (eval_comp_op ctx cop e1' e2') with
       | Ok v -> LA.Const (pos, lift_bool v)
       | Error _ -> e')
   | LA.GroupExpr (pos, g, es) ->
-     let es' = List.map (fun e -> simplify_expr ~is_guarded ctx e) es in 
+     let es' = List.map (fun e -> simplify_expr ~ind_vars ~is_guarded ctx e) es in 
      LA.GroupExpr (pos, g, es')
   | LA.RecordExpr (pos, i, ps, fields) ->
-     let fields' = List.map (fun (f, e) -> (f, simplify_expr ~is_guarded ctx e)) fields in
+     let fields' = List.map (fun (f, e) -> (f, simplify_expr ~ind_vars ~is_guarded ctx e)) fields in
      LA.RecordExpr (pos, i, ps, fields')
   | LA.ArrayConstr (pos, e1, e2) ->
-     let e1' = simplify_expr ~is_guarded ctx e1 in
-     let e2' = simplify_expr ~is_guarded ctx e2 in
+     let e1' = simplify_expr ~ind_vars ~is_guarded ctx e1 in
+     let e2' = simplify_expr ~ind_vars ~is_guarded ctx e2 in
      let e' = LA.ArrayConstr (pos, e1', e2') in e'
      (*(match (eval_int_expr ctx e2) with
       | Ok size -> LA.GroupExpr (pos, LA.ArrayExpr, List.init size (fun _ -> e1'))
@@ -355,30 +356,30 @@ and simplify_expr ?(is_guarded = false) ctx =
   | LA.ArrayIndex (pos, e1, e2, kind) -> simplify_array_index ctx pos e1 e2 kind
   | LA.TupleProject (pos, e1, e2) -> simplify_tuple_proj ctx pos e1 e2  
   | Call (pos, ty_args, i, es) ->
-    let es' = List.map (fun e -> simplify_expr ~is_guarded:false ctx e) es in
+    let es' = List.map (fun e -> simplify_expr ~ind_vars ~is_guarded:false ctx e) es in
     Call (pos, ty_args, i, es')
   | Quantifier (pos, q, tis, e) -> 
     (* 1. Don't inline constants that are shadowed by quantified vars (by removing these constants from the ctx)
        2. Perform inlining within tis *)
     let ctx, tis = List.fold_left (fun (acc_ctx, acc_tis) (p, id, ty) -> 
       let acc_ctx = TC.remove_const acc_ctx id in 
-      let acc_ti  = (p, id, inline_constants_of_lustre_type acc_ctx ty) in 
+      let acc_ti  = (p, id, inline_constants_of_lustre_type ~ind_vars acc_ctx ty) in 
       acc_ctx, acc_tis @ [acc_ti] 
     ) (ctx, []) tis in
-    let e' = simplify_expr ~is_guarded:false ctx e in
+    let e' = simplify_expr ~ind_vars ~is_guarded:false ctx e in
     Quantifier (pos, q, tis, e')
   | e -> e
 (** Assumptions: These constants are arranged in dependency order, 
    all of the constants have been type checked *)
 
-and inline_constants_of_lustre_type ctx ty = match ty with
+and inline_constants_of_lustre_type ?(ind_vars = []) ctx ty = match ty with
   | LA.IntRange (pos, lbound, ubound) ->
     let lbound' = match lbound with 
       | None -> None
-      | Some lbound -> Some (simplify_expr ctx lbound) in
+      | Some lbound -> Some (simplify_expr ~ind_vars ctx lbound) in
     let ubound' = match ubound with
       | None -> None
-      | Some ubound -> Some (simplify_expr ctx ubound) in
+      | Some ubound -> Some (simplify_expr ~ind_vars ctx ubound) in
     LA.IntRange (pos, lbound', ubound')
   | LA.TupleType (pos, types) ->
     let types' = List.map (fun t -> inline_constants_of_lustre_type ctx t) types in
@@ -391,7 +392,7 @@ and inline_constants_of_lustre_type ctx ty = match ty with
     LA.RecordType (pos, name, types')
   | ArrayType (pos, (ty, expr)) ->
     let ty' = inline_constants_of_lustre_type ctx ty in
-    let expr' = simplify_expr ctx expr in
+    let expr' = simplify_expr ~ind_vars ctx expr in
     ArrayType (pos, (ty', expr'))
   | Map (pos, ty1, ty2) ->
     let ty1' = inline_constants_of_lustre_type ctx ty1 in
@@ -403,7 +404,7 @@ and inline_constants_of_lustre_type ctx ty = match ty with
     TArr (pos, ty1', ty2')
   | RefinementType (pos, (pos2, id, ty), expr) ->
     let ty' = inline_constants_of_lustre_type ctx ty in 
-    let expr' = simplify_expr ctx expr in
+    let expr' = simplify_expr ~ind_vars ctx expr in
     RefinementType (pos, (pos2, id, ty'), expr')
     
   | History _ | Int _ | Bool _ | Real _
@@ -414,8 +415,13 @@ let inline_constants_of_node_equation: TC.tc_context -> LA.node_equation -> LA.n
   = fun ctx ->
   function
   | (LA.Assert (pos, e)) -> (Assert (pos, simplify_expr ctx e))
-  | (LA.Equation (pos, lhs, e)) ->
-    (LA.Equation (pos, lhs, simplify_expr ctx e))
+  | (LA.Equation (pos, (StructDef (_, sis) as lhs), e)) ->
+    (* Collect ind_vars, as they shadow global constants. *)
+    let ind_vars = List.fold_left (fun acc si -> match si with
+      | LA.ArrayDef (_, _, vars) -> acc @ vars 
+      | _ -> acc
+    ) [] sis in
+    (LA.Equation (pos, lhs, simplify_expr ~ind_vars ctx e))
 
 let rec inline_constants_of_const_clocked_type_decl ctx = function
   | [] -> []

--- a/src/lustre/lustreAstInlineConstants.mli
+++ b/src/lustre/lustreAstInlineConstants.mli
@@ -47,11 +47,8 @@ val error_message: error_kind -> string
 val inline_constants: TC.tc_context -> LA.t -> ((TC.tc_context * LA.t), [> error]) result
 (** Best effort at inlining constants *)
 
-val inline_constants_of_lustre_type: TC.tc_context -> LA.lustre_type -> LA.lustre_type
+val inline_constants_of_lustre_type: ?ind_vars:HString.t list -> TC.tc_context -> LA.lustre_type -> LA.lustre_type
 (** Best effort at inlining constants in a lustre type *)
 
 val eval_int_expr: TC.tc_context -> LA.expr -> (int, [> error]) result
 (** try to evaluate an expression to an int *)
-
-val simplify_expr: ?is_guarded:bool -> TC.tc_context -> LA.expr -> LA.expr
-(** Best effort at inlining constants in a lustre expr *)

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -737,6 +737,9 @@ and compile_ast_expr
   let rec compile_id_string bounds id_str =
     let ident = mk_ident id_str in
     try
+      H.find !map.quant_vars ident
+    with Not_found ->
+    try
       let (_, _, var) = List.find (fun (n, i, _) -> match (n, !map.node_name) with
         | Some n, Some n' -> n = n' && i = id_str
         | None, _ -> i = id_str
@@ -753,9 +756,6 @@ and compile_ast_expr
       let id_str = HString.string_of_hstring id_str in
       let ty = Type.enum_of_constr id_str in
       X.singleton X.empty_index (E.mk_constr id_str ty)
-    with Not_found ->
-    try
-      H.find !map.quant_vars ident
     with Not_found ->
     try
       H.find !map.array_index ident

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -740,6 +740,9 @@ and compile_ast_expr
       H.find !map.quant_vars ident
     with Not_found ->
     try
+      H.find !map.array_index ident
+    with Not_found ->
+    try
       let (_, _, var) = List.find (fun (n, i, _) -> match (n, !map.node_name) with
         | Some n, Some n' -> n = n' && i = id_str
         | None, _ -> i = id_str
@@ -756,9 +759,6 @@ and compile_ast_expr
       let id_str = HString.string_of_hstring id_str in
       let ty = Type.enum_of_constr id_str in
       X.singleton X.empty_index (E.mk_constr id_str ty)
-    with Not_found ->
-    try
-      H.find !map.array_index ident
     with Not_found ->
       let id_str = HString.string_of_hstring id_str in
       (match String.split_on_char '_' id_str with

--- a/tests/regression/falsifiable/quantifier_shadowing_global_const.lus
+++ b/tests/regression/falsifiable/quantifier_shadowing_global_const.lus
@@ -1,0 +1,7 @@
+const N: int = 3;
+const j: int = 2; 
+
+node M() returns ();
+let
+  check forall (i,j:int) (0 <= i and i < N and 0 <= j and j < N) => i <= j;
+tel

--- a/tests/regression/success/ind_var_shadowing.lus
+++ b/tests/regression/success/ind_var_shadowing.lus
@@ -1,6 +1,6 @@
 const j: int = 2;
 
-node M() returns (A:int^3; B: int^3; x: int);
+node M() returns (A:int^3;);
 let
   A[j] = j;
   check A[0] = 0;

--- a/tests/regression/success/ind_var_shadowing.lus
+++ b/tests/regression/success/ind_var_shadowing.lus
@@ -1,0 +1,7 @@
+const j: int = 2;
+
+node M() returns (A:int^3; B: int^3; x: int);
+let
+  A[j] = j;
+  check A[0] = 0;
+tel


### PR DESCRIPTION
Fix bug where quantified variables did not shadow global constants with the same name. 

In `lustreNodeGen`, the shadowing did not work because when compiling identifiers, the context of global constants was checked before the context of bound variables. Rearranged to check context of bound variables first.

See attached test case.