### PR TITLE
Support any operators in functions

### DIFF
--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -50,7 +50,6 @@ type error_kind = Unknown of string
   | QuantifiedVariableInPre of HString.t
   | QuantifiedVariableInNodeArgument of HString.t * HString.t
   | SymbolicArrayIndexInNodeArgument of HString.t * HString.t
-  | AnyOpInFunction
   | NodeCallInFunction of HString.t
   | NodeCallInConstant of HString.t
   | NodeCallInGlobalTypeDecl of HString.t
@@ -102,7 +101,6 @@ let error_message kind = match kind with
   | SymbolicArrayIndexInNodeArgument (idx, node) -> "Symbolic array index '"
     ^ HString.string_of_hstring idx ^ "' is not allowed in an argument of a call to node or non-inlinable function '"
     ^ HString.string_of_hstring node ^ "'"
-  | AnyOpInFunction -> "Illegal any operator in function"
   | NodeCallInFunction node -> "Illegal call to node '"
     ^ HString.string_of_hstring node ^ "', functions and function contracts can only call other functions, not nodes"
   | NodeCallInConstant id -> "Illegal node call or 'any' operator in definition of constant '" ^ HString.string_of_hstring id ^ "'"
@@ -551,7 +549,6 @@ let no_calls_to_node ctx = function
     let check_nodes = StringMap.mem (NI.get_internal_name node_id) ctx.nodes in
     if check_nodes then syntax_error pos (NodeCallInFunction (NI.get_user_name node_id))
     else Ok ()
-  | AnyOp (pos, _, _, _) -> syntax_error pos AnyOpInFunction
   | _ -> Ok ()
 
 let no_temporal_operator decl_ctx expr =

--- a/src/lustre/lustreSyntaxChecks.mli
+++ b/src/lustre/lustreSyntaxChecks.mli
@@ -32,7 +32,6 @@ type error_kind = Unknown of string
   | QuantifiedVariableInPre of HString.t
   | QuantifiedVariableInNodeArgument of HString.t * HString.t
   | SymbolicArrayIndexInNodeArgument of HString.t * HString.t
-  | AnyOpInFunction
   | NodeCallInFunction of HString.t
   | NodeCallInConstant of HString.t
   | NodeCallInGlobalTypeDecl of HString.t

--- a/tests/ounit/lustre/lustreSyntaxChecks/any_op_func.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/any_op_func.lus
@@ -1,0 +1,9 @@
+node n(x: int) returns (y: int);
+let
+tel
+
+function f() returns (y: int);
+let
+  y = any subtype { y: int | n(y) > 0 };
+  check y > 0;
+tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/any_op_func_pre.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/any_op_func_pre.lus
@@ -1,0 +1,5 @@
+function f() returns (y: int);
+let
+  y = any subtype { y: int | (pre y) > 0 };
+  check y > 0;
+tel

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -182,6 +182,14 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
     match load_file "./lustreSyntaxChecks/history_quantified_var_3.lus" with
     | Error (`LustreSyntaxChecksError (_, IllegalHistoryVar _)) -> true
     | _ -> false);
+  mk_test "node call in any op in function" (fun () ->
+    match load_file "./lustreSyntaxChecks/any_op_func.lus" with
+    | Error (`LustreSyntaxChecksError (_, NodeCallInFunction _)) -> true
+    | _ -> false);
+  mk_test "pre in any op in function" (fun () ->
+    match load_file "./lustreSyntaxChecks/any_op_func_pre.lus" with
+    | Error (`LustreSyntaxChecksError (_, IllegalTemporalOperator _)) -> true
+    | _ -> false);
 ])
 
 (* *************************************************************************** *)


### PR DESCRIPTION
Support any operators in functions, as long as they do not contain refinement type predicates with temporal operators or node calls.

The current code already (1) generates imported functions rather than imported nodes whenever possible, and (2) disallows temporal operators and node calls in functions. Because of this, we can remove the restriction of not allowing any operators in functions without adding any new checks (in other words, the restriction was unnecessary).