### PR TITLE
Disable combo of inductive array definition and multiple assignment

### DIFF
--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -416,7 +416,13 @@ let inline_constants_of_node_equation: TC.tc_context -> LA.node_equation -> LA.n
   function
   | (LA.Assert (pos, e)) -> (Assert (pos, simplify_expr ctx e))
   | (LA.Equation (pos, (StructDef (_, sis) as lhs), e)) ->
-    (* Collect ind_vars, as they shadow global constants. *)
+    (* Collect ind_vars, as they shadow global constants. 
+       In general, this check is too coarse grained. For example, assuming 
+       some global constant i, it erroneously prevents both occurrences of i 
+       from being inlined in the following equation: 
+       A[i], x = (i, i). 
+       However, we currently do not support mixing inductive array definitions with 
+       multiple assignment, so this is not actually (currently) a problem. *)
     let ind_vars = List.fold_left (fun acc si -> match si with
       | LA.ArrayDef (_, _, vars) -> acc @ vars 
       | _ -> acc

--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -62,6 +62,7 @@ type error_kind = Unknown of string
   | UnsupportedWhen of LustreAst.expr
   | UnsupportedParametricDeclaration
   | UnsupportedAssignment
+  | MultAssignArrayDef
   | AssumptionVariablesInContractNode
   | ClockMismatchInMerge
   | MisplacedVarInFrameBlock of LustreAst.ident
@@ -116,6 +117,7 @@ let error_message kind = match kind with
   | UnsupportedWhen e -> "The `when` expression '" ^ LA.string_of_expr e ^ "' can only be the top most expression of a merge case"
   | UnsupportedParametricDeclaration -> "Parametric nodes and functions are not supported"
   | UnsupportedAssignment -> "Assignment not supported"
+  | MultAssignArrayDef -> "Inductive array definition within multiple assignment is not supported"
   | AssumptionVariablesInContractNode -> "Assumption variables not supported in contract nodes"
   | ClockMismatchInMerge -> "Clock mismatch for argument of merge"
   | MisplacedVarInFrameBlock id -> "Variable '" ^ HString.string_of_hstring id ^ "' is defined in the frame block but not declared in the frame block header"
@@ -845,7 +847,9 @@ and check_struct_items ctx items =
   let r items = check_struct_items ctx items in
   match items with
   | [] -> Ok ()
-  | (LA.SingleIdent (pos, id)) :: tail ->
+  | LA.ArrayDef (pos, _, _) :: _ :: _ 
+  | _ :: ArrayDef (pos, _, _) :: _ ->  syntax_error pos MultAssignArrayDef
+  | (SingleIdent (pos, id)) :: tail ->
     no_a_dangling_identifier ctx pos id >> r tail
   | (ArrayDef (pos, id, _)) :: tail ->
     no_a_dangling_identifier ctx pos id >> r tail

--- a/src/lustre/lustreSyntaxChecks.mli
+++ b/src/lustre/lustreSyntaxChecks.mli
@@ -44,6 +44,7 @@ type error_kind = Unknown of string
   | UnsupportedWhen of LustreAst.expr
   | UnsupportedParametricDeclaration
   | UnsupportedAssignment
+  | MultAssignArrayDef
   | AssumptionVariablesInContractNode
   | ClockMismatchInMerge
   | MisplacedVarInFrameBlock of LustreAst.ident

--- a/tests/ounit/lustre/lustreSyntaxChecks/mult_assign_array_def.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/mult_assign_array_def.lus
@@ -1,0 +1,12 @@
+node N(input: int) returns (x, y: int)
+let
+  x = input; 
+  y = input;
+tel
+
+node M() returns (A:int^3; B: int^3; x1, x2: int);
+let
+  --!! Disallow combination of multiple assignment and inductive array definition
+  B[j], x2 = N(j);
+  check x2 = 2;
+tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/mult_assign_array_def.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/mult_assign_array_def.lus
@@ -4,9 +4,8 @@ let
   y = input;
 tel
 
-node M() returns (A:int^3; B: int^3; x1, x2: int);
+node M() returns (B: int^3; x: int);
 let
-  --!! Disallow combination of multiple assignment and inductive array definition
-  B[j], x2 = N(j);
-  check x2 = 2;
+  B[j], x = N(j);
+  check x = 2;
 tel

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -194,6 +194,10 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
     match load_file "./lustreSyntaxChecks/any_op_func_pre.lus" with
     | Error (`LustreSyntaxChecksError (_, IllegalTemporalOperator _)) -> true
     | _ -> false);
+  mk_test "inductive array definition in multiple assignment" (fun () ->
+    match load_file "./lustreSyntaxChecks/mult_assign_array_def.lus" with
+    | Error (`LustreSyntaxChecksError (_, MultAssignArrayDef)) -> true
+    | _ -> false);
 ])
 
 (* *************************************************************************** *)

--- a/tests/regression/success/frame_block_mult_assign2.lus
+++ b/tests/regression/success/frame_block_mult_assign2.lus
@@ -28,14 +28,16 @@ let
   tel
   
   frame ( y3, y4 )
-  (y3, y4[i]) = (4, if i = 0 then 0 else y4[i-1] + 1);
+  y3 = 4; 
+  y4[i] = if i = 0 then 0 else y4[i-1] + 1;
   let
     y3 = 4;
     y4[i] = if i = 0 then 0 else y4[i-1] + 1;
   tel
 
   frame ( y5, y6 )
-  (y5, y6[i]) = (4, if i = 0 then 0 else y6[i-1] + 1);
+  y5 = 4;
+  y6[i] = if i = 0 then 0 else y6[i-1] + 1;
   let
     if (oscillate())
     then

--- a/tests/regression/success/frame_block_mult_assign3.lus
+++ b/tests/regression/success/frame_block_mult_assign3.lus
@@ -23,7 +23,8 @@ let
 
 
    frame ( y1, y2, x1 )
-   y1, y2[i][j] = (7, if i=0 or j=0 then 0 else y2[i-1][j-1] + 1);
+   y1 = 7;
+   y2[i][j] = if i=0 or j=0 then 0 else y2[i-1][j-1] + 1;
    let
       if oscillate()
       then
@@ -42,19 +43,22 @@ let
       then
          x2 = 0;
       else
-         y3, y4[i][j] = (8, if (i=0 or j=0) then 0 else y4[i-1][j-1] + 2);
+         y3 = 8;
+         y4[i][j] = if (i=0 or j=0) then 0 else y4[i-1][j-1] + 2;
       fi
    tel
    
 
    frame ( y5, y6, x3 )
-   y5, y6[i][j] = (7, if (i=0 or j=0) then 0 else y6[i-1][j-1] + 1);
+   y5 = 7;
+   y6[i][j] = if (i=0 or j=0) then 0 else y6[i-1][j-1] + 1;
    let
       if oscillate()
       then
          x3 = 0;
       else
-         y5, y6[i][j] = (8, if (i=0 or j=0) then 0 else y6[i-1][j-1] + 2);
+         y5 = 8; 
+         y6[i][j] = if (i=0 or j=0) then 0 else y6[i-1][j-1] + 2;
       fi
    tel   
       


### PR DESCRIPTION
In the current state of `develop` (before this PR), the following example is a crash bug somewhere in normalization. We "address" this crash bug by disallowing inductive array definitions within multiple assignments (below, `B[j], x2 = N(j);` becomes disallowed). 

```
node N(input: int) returns (x, y: int)
let
  x = input; 
  y = input;
tel

node M() returns (A:int^3; B: int^3; x1, x2: int);
let
  B[j], x2 = N(j);
  check x2 = 2;
tel
```

Additionally, this simplifies the logic regarding shadowing and inductive array definitions. See the comment in this PR starting with "Collect ind_vars, ..." 