### PR TITLE
Fix check for symbolic indices passed to non-inlinable functions

### DIFF
--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -222,7 +222,7 @@ let type_check declarations =
       LUF.inlinable_functions inlined_global_ctx const_inlined_nodes_and_contracts
     in
     let* warnings5 =
-      LS.no_quant_vars_in_calls_to_non_inlinable_funcs inlinable_funcs declarations
+      LS.no_quant_vars_in_calls_to_non_inlinable_funcs inlined_global_ctx inlinable_funcs declarations
     in
 
     (* Step 19. Normalize AST: guard pres, abstract to locals where appropriate *)

--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -23,6 +23,7 @@ module LA = LustreAst
 module LAH = LustreAstHelpers
 module H = HString
 module NI = NodeId
+module Ctx = TypeCheckerContext
 
 exception Cycle (* Exception raised locally when a cycle in contract imports is detected *)
 
@@ -64,10 +65,8 @@ type error_kind = Unknown of string
   | UnsupportedAssignment
   | MultAssignArrayDef
   | AssumptionVariablesInContractNode
-  | ClockMismatchInMerge
   | MisplacedVarInFrameBlock of LustreAst.ident
   | MisplacedAssertInFrameBlock
-  | IllegalClockExprInActivate of LustreAst.expr
   | OpaqueWithoutContract of LustreAst.ident
   | TransparentWithoutBody of LustreAst.ident
   | IllegalHistoryVar of LustreAst.ident
@@ -119,10 +118,8 @@ let error_message kind = match kind with
   | UnsupportedAssignment -> "Assignment not supported"
   | MultAssignArrayDef -> "Inductive array definition within multiple assignment is not supported"
   | AssumptionVariablesInContractNode -> "Assumption variables not supported in contract nodes"
-  | ClockMismatchInMerge -> "Clock mismatch for argument of merge"
   | MisplacedVarInFrameBlock id -> "Variable '" ^ HString.string_of_hstring id ^ "' is defined in the frame block but not declared in the frame block header"
   | MisplacedAssertInFrameBlock -> "Assertion not allowed in frame block initialization"
-  | IllegalClockExprInActivate e -> "Illegal clock expression '" ^ LA.string_of_expr e ^ "' in activate"
   | OpaqueWithoutContract n -> "An opaque annotation found for a node/function without a contract: " ^ HString.string_of_hstring n
   | TransparentWithoutBody n -> "A transparent annotation found for an imported node/function: " ^ HString.string_of_hstring n
   | IllegalHistoryVar id -> "History type constructor uses illegal quantified variable '" ^ HString.string_of_hstring id ^ "'"
@@ -370,20 +367,31 @@ let build_local_ctx ctx locals inputs outputs =
   let ctx = List.fold_left over_inputs ctx inputs in
   List.fold_left over_outputs ctx outputs
 
-let build_equation_ctx ctx = function
+let unwrap = function 
+| Result.Ok r -> r 
+| Error _ -> assert false
+
+let build_equation_ctx ctx tc_ctx = function
   | LA.StructDef (_, items) ->
     let over_items ctx = function
       | LA.ArrayDef (_, i, indices) ->
         let output_type_opt = StringMap.find_opt i ctx.locals |> Lib.join in
         let is_symbolic = match output_type_opt with
-          | Some ty -> (match ty with
-            | ArrayType (_, (_, e)) ->
-              let vars = LAH.vars_without_node_call_ids e in
-              let check_var e = StringMap.mem e ctx.free_consts
-                || StringMap.mem e ctx.locals
-              in
-              LA.SI.exists check_var vars
-            | _ -> false)
+          | Some ty -> 
+            (* Chase type aliases if we have proper type context *)
+            let ty = match tc_ctx with 
+            | Some tc_ctx -> 
+              LustreTypeChecker.expand_type_syn_reftype_history_subrange tc_ctx ty |> unwrap 
+            | None -> ty 
+            in
+            (match ty with
+              | ArrayType (_, (_, e)) ->
+                let vars = LAH.vars_without_node_call_ids e in
+                let check_var e = StringMap.mem e ctx.free_consts
+                  || StringMap.mem e ctx.locals
+                in
+                LA.SI.exists check_var vars
+              | _ -> false)
           | None -> false
         in
         let over_indices acc id =
@@ -797,9 +805,9 @@ and check_contract_node_decl ctx span (id, params, inputs, outputs, contract) =
     let* warnings = (check_contract true ctx common_contract_checks contract) in
     (Ok (warnings, decl))
 
-and check_items: context -> (context -> LA.expr -> ([> warning] list, ([> error] as 'a)) result) ->
+and check_items: context -> ?tc_ctx:Ctx.tc_context option -> (context -> LA.expr -> ([> warning] list, ([> error] as 'a)) result) ->
   LA.node_item list -> ([> warning] list, 'a) result 
-= fun ctx f items ->
+= fun ctx ?(tc_ctx=None) f items ->
   (* Record duplicate properties if we find them *)
   let over_props props = function
     | LA.AnnotProperty (pos, name, _, kind) ->
@@ -809,18 +817,18 @@ and check_items: context -> (context -> LA.expr -> ([> warning] list, ([> error]
       else Ok (StringSet.add name props)
     | _ -> Ok props
   in
-  let check_item: context -> (context -> LA.expr -> ([> warning] list, ([> error] as 'a)) result) ->
-    LA.node_item -> ([> warning] list, 'a) result = fun ctx f -> function
+  let check_item: context -> Ctx.tc_context option -> (context -> LA.expr -> ([> warning] list, ([> error] as 'a)) result) ->
+    LA.node_item -> ([> warning] list, 'a) result = fun ctx tc_ctx f -> function
     | LA.Body (Equation (_, lhs, e)) ->
-      let ctx' = build_equation_ctx ctx lhs in
+      let ctx' = build_equation_ctx ctx tc_ctx lhs in
       let StructDef (_, struct_items) = lhs in
       check_struct_items ctx struct_items
         >> (expr_only_supported_in_merge false e)
         >> check_expr ctx' f e
     | LA.IfBlock (_, e, l1, l2) -> 
       let* warnings1 = check_expr ctx f e in 
-      let* warnings2 = (check_items ctx f l1) in 
-      let* warnings3 = (check_items ctx f l2) in 
+      let* warnings2 = (check_items ctx ~tc_ctx f l1) in 
+      let* warnings3 = (check_items ctx ~tc_ctx f l2) in 
       Ok (warnings1 @ warnings2 @ warnings3)
     | LA.FrameBlock (pos, vars, nes, nis) ->
       let var_ids = List.map snd vars in
@@ -830,9 +838,9 @@ and check_items: context -> (context -> LA.expr -> ([> warning] list, ([> error]
       (*  Make sure 'nes' and 'nis' LHS vars are in 'vars_ids' *)
       (Res.seq_ (List.map (check_frame_vars pos var_ids) nis)) >>
       (Res.seq_ (List.map (check_frame_vars pos var_ids) nes)) >> 
-      let* warnings1 = check_items ctx (fun _ e -> no_temporal_operator "frame block initialization" e) nes in
-      let* warnings2 = check_items ctx f nes in 
-      let* warnings3 = (check_items ctx f nis) in
+      let* warnings1 = check_items ctx ~tc_ctx (fun _ e -> no_temporal_operator "frame block initialization" e) nes in
+      let* warnings2 = check_items ctx ~tc_ctx f nes in 
+      let* warnings3 = (check_items ctx ~tc_ctx f nis) in
       Ok (warnings1 @ warnings2 @ warnings3)
     | Body (Assert (_, e)) 
     | AnnotProperty (_, _, e, _) -> (check_expr ctx f e)
@@ -840,7 +848,7 @@ and check_items: context -> (context -> LA.expr -> ([> warning] list, ([> error]
   in
   (* Check for duplicate properties *)
   Res.seq_chain (fun props -> over_props props) StringSet.empty items >> 
-  let* warnings = Res.seq (List.map (check_item ctx f) items) in 
+  let* warnings = Res.seq (List.map (check_item ctx tc_ctx f) items) in 
   Ok (List.flatten warnings)
 
 and check_struct_items ctx items =
@@ -1035,58 +1043,6 @@ and check_expr_list ctx f l =
   let* warnings = Res.seq (List.map (check_expr ctx f) l) in 
   Ok(List.flatten warnings)
 
-let no_mismatched_clock is_bool e =
-  let ctx = empty_ctx () in
-  let clocks_match c1 c2 =
-    match c1, c2 with
-    | LA.ClockTrue, LA.ClockTrue -> true
-    | ClockPos i, ClockPos j -> HString.equal i j
-    | ClockNeg i, ClockNeg j -> HString.equal i j
-    | ClockConstr (i1, i2), ClockConstr (j1, j2) ->
-      HString.equal i1 j1 && HString.equal i2 j2
-    | _ -> false
-  in
-  let clocks_match_result pos c1 c2 =
-    if clocks_match c1 c2 then Ok []
-    else syntax_error pos ClockMismatchInMerge
-  in
-  let check_clocks clock = function
-    | LA.When (pos, _, c) -> clocks_match_result pos c clock
-    | LA.Activate (pos, _, c, _, _) ->
-      let* clk_exp =
-        match c with
-        | LA.Ident (_, i) -> Ok (LA.ClockPos i)
-        | LA.UnaryOp (_, LA.Not, LA.Ident (_, i)) -> Ok (LA.ClockNeg i)
-        | LA.CompOp (_, LA.Eq, LA.Ident (_, c), LA.Ident (_, cv)) ->
-          Ok (LA.ClockConstr (cv, c))
-        | _ -> syntax_error pos (IllegalClockExprInActivate c)
-      in
-      clocks_match_result pos clk_exp clock
-    | _ -> Ok []
-  in
-  let check_merge: LA.expr -> ( [> warning] list, [> error])
-    result = function
-    | LA.Merge (_, clock, exprs) ->
-      if not is_bool then
-        let case (i, e) = check_expr ctx
-          (fun _ -> check_clocks (ClockConstr (i, clock))) e
-        in
-        let* warnings = Res.seq (List.map case exprs) in 
-        Ok (List.flatten warnings)
-      else
-        let true_variant = List.nth_opt exprs 0 in
-        let false_variant = List.nth_opt exprs 1 in
-        (match true_variant, false_variant with
-        | Some (_, e1), Some (_, e2) ->
-          let* warnings1 = check_clocks (ClockPos clock) e1 in
-          let* warnings2 = check_clocks (ClockNeg clock) e2 in 
-          Ok (warnings1 @ warnings2)
-        | _ -> Ok [])
-    | _ -> Ok ([])
-  in
-  check_expr ctx (fun _ -> check_merge) e
-
-
 let ovq_check_expr inlinable_funcs ctx = function
 | LA.Call (pos, _, node_id, args) ->
   let inlinable_funcs = 
@@ -1116,7 +1072,7 @@ let ovq_check_expr inlinable_funcs ctx = function
   List.fold_left (>>) (Ok []) check
 | _ -> Ok []
 
-let oqv_check_node_decl inlinable_funcs ctx (_, _, _, _, inputs, outputs, locals, items, contract) =
+let oqv_check_node_decl inlinable_funcs ctx tc_ctx (_, _, _, _, inputs, outputs, locals, items, contract) =
   let* warnings1 =
     match contract with
     | Some c ->
@@ -1131,6 +1087,7 @@ let oqv_check_node_decl inlinable_funcs ctx (_, _, _, _, inputs, outputs, locals
   let* warnings2 =
     check_items
       (build_local_ctx ctx locals [] []) (* Add locals to ctx *)
+      ~tc_ctx
       (ovq_check_expr inlinable_funcs)
       items
   in
@@ -1143,17 +1100,17 @@ let oqv_check_contract_node_decl inlinable_funcs ctx (_, _, inputs, outputs, con
   in
   Ok warnings
 
-let oqv_check_decl: NI.Set.t -> context -> LA.declaration -> ([> warning] list, [> error]) result
-= fun inlinable_funcs ctx -> function
+let oqv_check_decl: NI.Set.t -> context -> Ctx.tc_context -> LA.declaration -> ([> warning] list, [> error]) result
+= fun inlinable_funcs ctx tc_ctx -> function
   | NodeDecl (_, decl) ->
-    oqv_check_node_decl inlinable_funcs ctx decl
+    oqv_check_node_decl inlinable_funcs ctx (Some tc_ctx) decl
   | FuncDecl (_, decl) ->
-    oqv_check_node_decl inlinable_funcs ctx decl
+    oqv_check_node_decl inlinable_funcs ctx (Some tc_ctx) decl
   | ContractNodeDecl (_, decl) ->
     oqv_check_contract_node_decl inlinable_funcs ctx decl
   | _ -> Ok []
 
-let no_quant_vars_in_calls_to_non_inlinable_funcs inlinable_funcs ast =
+let no_quant_vars_in_calls_to_non_inlinable_funcs tc_ctx inlinable_funcs ast =
   let ctx = build_global_ctx ast in
-  let* warnings = Res.seq (List.map (oqv_check_decl inlinable_funcs ctx) ast) in
+  let* warnings = Res.seq (List.map (oqv_check_decl inlinable_funcs ctx tc_ctx) ast) in
   Ok (List.flatten warnings)

--- a/src/lustre/lustreSyntaxChecks.mli
+++ b/src/lustre/lustreSyntaxChecks.mli
@@ -46,10 +46,8 @@ type error_kind = Unknown of string
   | UnsupportedAssignment
   | MultAssignArrayDef
   | AssumptionVariablesInContractNode
-  | ClockMismatchInMerge
   | MisplacedVarInFrameBlock of LustreAst.ident
   | MisplacedAssertInFrameBlock
-  | IllegalClockExprInActivate of LustreAst.expr
   | OpaqueWithoutContract of LustreAst.ident
   | TransparentWithoutBody of LustreAst.ident
   | IllegalHistoryVar of LustreAst.ident
@@ -71,12 +69,5 @@ val warning_message : warning_kind -> string
 
 val syntax_check : LA.t -> (([> warning] list * LA.t), [> error]) result
 
-val no_mismatched_clock : bool -> LA.expr -> ([> warning ] list, [> error]) result
-(** Conservative syntactic check of clock arguments for merge expressions.
-  To eventually be replaced with more general clock inference/checking.
-
-  Note: type information is needed for this check, causing this check to
-  be called in the lustreTypeChecker *)
-
 val no_quant_vars_in_calls_to_non_inlinable_funcs :
-  NodeId.Set.t -> LA.t -> ([> warning ] list, [> error]) result
+  TypeCheckerContext.tc_context -> NodeId.Set.t -> LA.t -> ([> warning ] list, [> error]) result

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -28,7 +28,6 @@ module R = Res
 module LA = LustreAst
 module LH = LustreAstHelpers
 module IC = LustreAstInlineConstants
-module LSC = LustreSyntaxChecks
 open TypeCheckerContext
 
 type tc_type  = LA.lustre_type
@@ -109,10 +108,11 @@ type error_kind = Unknown of string
   | InvalidExtractLowerBound of int * int
   | UnsupportedMapType of tc_type
   | ExpectedMapType of tc_type
+  | ClockMismatchInMerge
+  | IllegalClockExprInActivate of LustreAst.expr
 
 type error = [
   | `LustreTypeCheckerError of Lib.position * error_kind
-  | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
 ]
 
@@ -216,6 +216,8 @@ let error_message kind = match kind with
   | InvalidExtractLowerBound (ub, lb) -> "Extraction has lower bound " ^ (string_of_int lb) ^ " greater than upper bound " ^ (string_of_int ub) 
   | UnsupportedMapType ty -> "Unsupported map key type " ^ (string_of_tc_type ty) ^ "; only primitive types, record types, and tuples are supported"
   | ExpectedMapType ty -> "Expected map type but found " ^ string_of_tc_type ty
+  | ClockMismatchInMerge -> "Clock mismatch for argument of merge"
+  | IllegalClockExprInActivate e -> "Illegal clock expression '" ^ LA.string_of_expr e ^ "' in activate"
 
 type warning_kind = 
   | UnusedBoundVariableWarning of HString.t
@@ -283,10 +285,81 @@ let add_full_node_ctx ctx nname params inputs outputs locals =
   | _ -> Bool pos
 (** Infers type of constants *)
 
+(* Conservative syntactic check of clock arguments for merge expressions.
+  To eventually be replaced with more general clock inference/checking. *)
+let no_mismatched_clock is_bool e =
+  let clocks_match c1 c2 =
+    match c1, c2 with
+    | LA.ClockTrue, LA.ClockTrue -> true
+    | ClockPos i, ClockPos j -> HString.equal i j
+    | ClockNeg i, ClockNeg j -> HString.equal i j
+    | ClockConstr (i1, i2), ClockConstr (j1, j2) ->
+      HString.equal i1 j1 && HString.equal i2 j2
+    | _ -> false
+  in
+  let clocks_match_result pos c1 c2 =
+    if clocks_match c1 c2 then Ok ()
+    else type_error pos ClockMismatchInMerge
+  in
+  let check_clocks clock = function
+    | LA.When (pos, _, c) -> clocks_match_result pos c clock
+    | LA.Activate (pos, _, c, _, _) ->
+      let* clk_exp =
+        match c with
+        | LA.Ident (_, i) -> Ok (LA.ClockPos i)
+        | LA.UnaryOp (_, LA.Not, LA.Ident (_, i)) -> Ok (LA.ClockNeg i)
+        | LA.CompOp (_, LA.Eq, LA.Ident (_, c), LA.Ident (_, cv)) ->
+          Ok (LA.ClockConstr (cv, c))
+        | _ -> type_error pos (IllegalClockExprInActivate c)
+      in
+      clocks_match_result pos clk_exp clock
+    | _ -> Ok ()
+  in
+  let rec check_merge: LA.expr -> ( unit, [> error])
+    result = function
+    | Ident _ | Const _ | ModeRef _ -> Ok ()
+    | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
+    | ConvOp (_, _, e) | Pre (_, e) | Extract (_, e, _, _) | Quantifier (_, _, _, e) 
+    | AnyOp (_, _, e, None) -> check_merge e
+    | AnyOp (_, _, e1, Some e2) | BinaryOp (_, _, e1, e2) | StructUpdate (_, e1, _, e2)
+    | CompOp (_, _, e1, e2) | Arrow (_, e1, e2) | IndexAccess (_, e1, e2, _)
+    | ArrayConstr (_, e1, e2) -> check_merge e1 >> check_merge e2
+    | TernaryOp (_, _, e1, e2, e3) -> 
+      check_merge e1 >> check_merge e2 >> check_merge e3
+    | GroupExpr (_, _, es)
+    | Call (_, _, _, es) -> Res.seq_ (List.map check_merge es)
+    | RecordExpr (_, _, _, es) -> 
+      Res.seq_ (List.map check_merge (List.map (fun (_, x) -> x) es))
+    | Condact (_, e1, e2, _, es1, es2 ) -> 
+      check_merge e1 >> check_merge e2 >> 
+      Res.seq_ (List.map check_merge es1) >>  Res.seq_ (List.map check_merge es2)
+    | Activate (_, _, e1, e2, es) -> 
+      check_merge e1 >> check_merge e2 >> Res.seq_ (List.map check_merge es)
+    | RestartEvery (_, _, es, e) -> 
+      Res.seq_ (List.map check_merge es) >> check_merge e
+    | LA.Merge (_, clock, exprs) ->
+      if not is_bool then
+        let case (i, e) = check_clocks (ClockConstr (i, clock)) e in
+        let* _ = Res.seq (List.map case exprs) in 
+        Ok ()
+      else
+        let true_variant = List.nth_opt exprs 0 in
+        let false_variant = List.nth_opt exprs 1 in
+        (match true_variant, false_variant with
+        | Some (_, e1), Some (_, e2) ->
+          let* _ = check_merge e1 in 
+          let* _ = check_merge e2 in
+          let* _ = check_clocks (ClockPos clock) e1 in
+          check_clocks (ClockNeg clock) e2
+        | _ -> Ok ())
+    | _ -> Ok (())
+  in
+  check_merge e
+
 let check_merge_clock: LA.expr -> LA.lustre_type -> (unit, [> error]) result = fun e ty ->
   match ty with
-  | EnumType _ -> LSC.no_mismatched_clock false e >> Ok ()
-  | Bool _ -> LSC.no_mismatched_clock true e >> Ok ()
+  | EnumType _ -> no_mismatched_clock false e >> Ok ()
+  | Bool _ -> no_mismatched_clock true e >> Ok ()
   | _ -> Ok ()
 
 let check_merge_exhaustive: tc_context -> Lib.position -> LA.lustre_type -> HString.t list -> (unit, [> error]) result

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -301,9 +301,9 @@ let no_mismatched_clock is_bool e =
     if clocks_match c1 c2 then Ok ()
     else type_error pos ClockMismatchInMerge
   in
-  let rec check_clocks clock = let r = check_clocks clock in function
+  let rec check_clocks clock = function
     | LA.Activate (pos, _, c, e, es) ->
-      r e >> Res.seq_ (List.map r es) >>
+      check_clocks clock e >> Res.seq_ (List.map (check_clocks clock) es) >>
       let* clk_exp =
         match c with
         | LA.Ident (_, i) -> Ok (LA.ClockPos i)
@@ -316,25 +316,25 @@ let no_mismatched_clock is_bool e =
     | Ident _ | Const _ | ModeRef _ -> Ok ()
     | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
     | ConvOp (_, _, e) | Pre (_, e) | Extract (_, e, _, _) | Quantifier (_, _, _, e) 
-    | AnyOp (_, _, e, None) -> r e
+    | AnyOp (_, _, e, None) -> check_clocks clock e
     | AnyOp (_, _, e1, Some e2) | BinaryOp (_, _, e1, e2) | StructUpdate (_, e1, _, e2)
     | CompOp (_, _, e1, e2) | Arrow (_, e1, e2) | IndexAccess (_, e1, e2, _)
-    | ArrayConstr (_, e1, e2) -> r e1 >> r e2
+    | ArrayConstr (_, e1, e2) -> check_clocks clock e1 >> check_clocks clock e2
     | TernaryOp (_, _, e1, e2, e3) -> 
-      r e1 >> r e2 >> r e3
-    | GroupExpr (_, _, es) | Call (_, _, _, es) -> Res.seq_ (List.map r es)
+      check_clocks clock e1 >> check_clocks clock e2 >> check_clocks clock e3
+    | GroupExpr (_, _, es) | Call (_, _, _, es) -> Res.seq_ (List.map (check_clocks clock) es)
     | RecordExpr (_, _, _, es) | Merge (_, _, es) -> 
-      Res.seq_ (List.map r (List.map (fun (_, x) -> x) es))
+      Res.seq_ (List.map (check_clocks clock) (List.map (fun (_, x) -> x) es))
     | Condact (_, e1, e2, _, es1, es2 ) -> 
-      r e1 >> r e2 >> 
-      Res.seq_ (List.map r es1) >>  Res.seq_ (List.map r es2)
+      check_clocks clock e1 >> check_clocks clock e2 >> 
+      Res.seq_ (List.map (check_clocks clock) es1) >>  Res.seq_ (List.map (check_clocks clock) es2)
     | RestartEvery (_, _, es, e) -> 
-      Res.seq_ (List.map r es) >> r e
+      Res.seq_ (List.map (check_clocks clock) es) >> check_clocks clock e
     | When (pos, e, c) -> 
-      r e >> clocks_match_result pos c clock
+      check_clocks clock e >> clocks_match_result pos c clock
   in
   let rec check_merge: LA.expr -> ( unit, [> error])
-    result = let r = check_merge in function
+    result = function
     | Merge (_, clock, exprs) ->
       if not is_bool then
         let case (i, e) = check_clocks (ClockConstr (i, clock)) e in
@@ -345,31 +345,31 @@ let no_mismatched_clock is_bool e =
         let false_variant = List.nth_opt exprs 1 in
         (match true_variant, false_variant with
         | Some (_, e1), Some (_, e2) ->
-          let* _ = r e1 in 
-          let* _ = r e2 in
+          let* _ = check_merge e1 in 
+          let* _ = check_merge e2 in
           let* _ = check_clocks (ClockPos clock) e1 in
           check_clocks (ClockNeg clock) e2
         | _ -> Ok ())
     | Ident _ | Const _ | ModeRef _ -> Ok ()
     | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
     | ConvOp (_, _, e) | Pre (_, e) | Extract (_, e, _, _) | Quantifier (_, _, _, e) 
-    | AnyOp (_, _, e, None) | When (_, e, _) -> r e
+    | AnyOp (_, _, e, None) | When (_, e, _) -> check_merge e
     | AnyOp (_, _, e1, Some e2) | BinaryOp (_, _, e1, e2) | StructUpdate (_, e1, _, e2)
     | CompOp (_, _, e1, e2) | Arrow (_, e1, e2) | IndexAccess (_, e1, e2, _)
-    | ArrayConstr (_, e1, e2) -> r e1 >> r e2
+    | ArrayConstr (_, e1, e2) -> check_merge e1 >> check_merge e2
     | TernaryOp (_, _, e1, e2, e3) -> 
-      r e1 >> r e2 >> r e3
+      check_merge e1 >> check_merge e2 >> check_merge e3
     | GroupExpr (_, _, es)
-    | Call (_, _, _, es) -> Res.seq_ (List.map r es)
+    | Call (_, _, _, es) -> Res.seq_ (List.map check_merge es)
     | RecordExpr (_, _, _, es) -> 
-      Res.seq_ (List.map r (List.map (fun (_, x) -> x) es))
+      Res.seq_ (List.map check_merge (List.map (fun (_, x) -> x) es))
     | Condact (_, e1, e2, _, es1, es2 ) -> 
-      r e1 >> r e2 >> 
-      Res.seq_ (List.map r es1) >>  Res.seq_ (List.map r es2)
+      check_merge e1 >> check_merge e2 >> 
+      Res.seq_ (List.map check_merge es1) >>  Res.seq_ (List.map check_merge es2)
     | Activate (_, _, e1, e2, es) -> 
-      r e1 >> r e2 >> Res.seq_ (List.map r es)
+      check_merge e1 >> check_merge e2 >> Res.seq_ (List.map check_merge es)
     | RestartEvery (_, _, es, e) -> 
-      Res.seq_ (List.map r es) >> r e
+      Res.seq_ (List.map check_merge es) >> check_merge e
   in
   check_merge e
 

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -301,9 +301,9 @@ let no_mismatched_clock is_bool e =
     if clocks_match c1 c2 then Ok ()
     else type_error pos ClockMismatchInMerge
   in
-  let check_clocks clock = function
-    | LA.When (pos, _, c) -> clocks_match_result pos c clock
-    | LA.Activate (pos, _, c, _, _) ->
+  let rec check_clocks clock = let r = check_clocks clock in function
+    | LA.Activate (pos, _, c, e, es) ->
+      r e >> Res.seq_ (List.map r es) >>
       let* clk_exp =
         match c with
         | LA.Ident (_, i) -> Ok (LA.ClockPos i)
@@ -313,31 +313,29 @@ let no_mismatched_clock is_bool e =
         | _ -> type_error pos (IllegalClockExprInActivate c)
       in
       clocks_match_result pos clk_exp clock
-    | _ -> Ok ()
-  in
-  let rec check_merge: LA.expr -> ( unit, [> error])
-    result = function
     | Ident _ | Const _ | ModeRef _ -> Ok ()
     | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
     | ConvOp (_, _, e) | Pre (_, e) | Extract (_, e, _, _) | Quantifier (_, _, _, e) 
-    | AnyOp (_, _, e, None) -> check_merge e
+    | AnyOp (_, _, e, None) -> r e
     | AnyOp (_, _, e1, Some e2) | BinaryOp (_, _, e1, e2) | StructUpdate (_, e1, _, e2)
     | CompOp (_, _, e1, e2) | Arrow (_, e1, e2) | IndexAccess (_, e1, e2, _)
-    | ArrayConstr (_, e1, e2) -> check_merge e1 >> check_merge e2
+    | ArrayConstr (_, e1, e2) -> r e1 >> r e2
     | TernaryOp (_, _, e1, e2, e3) -> 
-      check_merge e1 >> check_merge e2 >> check_merge e3
-    | GroupExpr (_, _, es)
-    | Call (_, _, _, es) -> Res.seq_ (List.map check_merge es)
-    | RecordExpr (_, _, _, es) -> 
-      Res.seq_ (List.map check_merge (List.map (fun (_, x) -> x) es))
+      r e1 >> r e2 >> r e3
+    | GroupExpr (_, _, es) | Call (_, _, _, es) -> Res.seq_ (List.map r es)
+    | RecordExpr (_, _, _, es) | Merge (_, _, es) -> 
+      Res.seq_ (List.map r (List.map (fun (_, x) -> x) es))
     | Condact (_, e1, e2, _, es1, es2 ) -> 
-      check_merge e1 >> check_merge e2 >> 
-      Res.seq_ (List.map check_merge es1) >>  Res.seq_ (List.map check_merge es2)
-    | Activate (_, _, e1, e2, es) -> 
-      check_merge e1 >> check_merge e2 >> Res.seq_ (List.map check_merge es)
+      r e1 >> r e2 >> 
+      Res.seq_ (List.map r es1) >>  Res.seq_ (List.map r es2)
     | RestartEvery (_, _, es, e) -> 
-      Res.seq_ (List.map check_merge es) >> check_merge e
-    | LA.Merge (_, clock, exprs) ->
+      Res.seq_ (List.map r es) >> r e
+    | When (pos, e, c) -> 
+      r e >> clocks_match_result pos c clock
+  in
+  let rec check_merge: LA.expr -> ( unit, [> error])
+    result = let r = check_merge in function
+    | Merge (_, clock, exprs) ->
       if not is_bool then
         let case (i, e) = check_clocks (ClockConstr (i, clock)) e in
         let* _ = Res.seq (List.map case exprs) in 
@@ -347,12 +345,31 @@ let no_mismatched_clock is_bool e =
         let false_variant = List.nth_opt exprs 1 in
         (match true_variant, false_variant with
         | Some (_, e1), Some (_, e2) ->
-          let* _ = check_merge e1 in 
-          let* _ = check_merge e2 in
+          let* _ = r e1 in 
+          let* _ = r e2 in
           let* _ = check_clocks (ClockPos clock) e1 in
           check_clocks (ClockNeg clock) e2
         | _ -> Ok ())
-    | _ -> Ok (())
+    | Ident _ | Const _ | ModeRef _ -> Ok ()
+    | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
+    | ConvOp (_, _, e) | Pre (_, e) | Extract (_, e, _, _) | Quantifier (_, _, _, e) 
+    | AnyOp (_, _, e, None) | When (_, e, _) -> r e
+    | AnyOp (_, _, e1, Some e2) | BinaryOp (_, _, e1, e2) | StructUpdate (_, e1, _, e2)
+    | CompOp (_, _, e1, e2) | Arrow (_, e1, e2) | IndexAccess (_, e1, e2, _)
+    | ArrayConstr (_, e1, e2) -> r e1 >> r e2
+    | TernaryOp (_, _, e1, e2, e3) -> 
+      r e1 >> r e2 >> r e3
+    | GroupExpr (_, _, es)
+    | Call (_, _, _, es) -> Res.seq_ (List.map r es)
+    | RecordExpr (_, _, _, es) -> 
+      Res.seq_ (List.map r (List.map (fun (_, x) -> x) es))
+    | Condact (_, e1, e2, _, es1, es2 ) -> 
+      r e1 >> r e2 >> 
+      Res.seq_ (List.map r es1) >>  Res.seq_ (List.map r es2)
+    | Activate (_, _, e1, e2, es) -> 
+      r e1 >> r e2 >> Res.seq_ (List.map r es)
+    | RestartEvery (_, _, es, e) -> 
+      Res.seq_ (List.map r es) >> r e
   in
   check_merge e
 

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -94,10 +94,11 @@ type error_kind = Unknown of string
   | InvalidExtractLowerBound of int * int
   | UnsupportedMapType of tc_type
   | ExpectedMapType of tc_type
+  | ClockMismatchInMerge
+  | IllegalClockExprInActivate of LustreAst.expr
 
 type error = [
   | `LustreTypeCheckerError of Lib.position * error_kind
-  | `LustreSyntaxChecksError of Lib.position * LustreSyntaxChecks.error_kind
   | `LustreAstInlineConstantsError of Lib.position * LustreAstInlineConstants.error_kind
 ]
 

--- a/tests/ounit/lustre/lustreSyntaxChecks/array_index.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/array_index.lus
@@ -1,0 +1,18 @@
+const Num_Leaders: int;
+const Num_Values: int;
+
+type ValBal = { v: int; b: int };
+
+function imported AcceptorIdSet_Add(set: int; id: int)
+returns (new_set: int);
+
+type ReceivedAccepts = int^Num_Values^Num_Leaders;
+
+function ReceivedAccepts_Add(ra: ReceivedAccepts; vb: ValBal; id: int)
+returns (new_ra: ReceivedAccepts)
+let
+  new_ra[b][v] =
+    if (vb.v = v and vb.b = b)
+    then AcceptorIdSet_Add(ra[b][v], id)
+    else ra[b][v];
+tel

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -118,14 +118,6 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
     match load_file "./lustreSyntaxChecks/function_stateful_contract_import_2.lus" with
     | Error (`LustreSyntaxChecksError (_, IllegalImportOfStatefulContract _)) -> true
     | _ -> false);
-  mk_test "test merge clock mismatch" (fun () ->
-    match load_file "./lustreSyntaxChecks/merge_enum2.lus" with
-    | Error (`LustreSyntaxChecksError (_, ClockMismatchInMerge)) -> true
-    | _ -> false);
-  mk_test "test activate clock mismatch" (fun () ->
-    match load_file "./lustreSyntaxChecks/test_activate_clock_mismatch.lus" with
-    | Error (`LustreSyntaxChecksError (_, ClockMismatchInMerge)) -> true
-    | _ -> false);
   mk_test "test dangling identifier 2" (fun () ->
     match load_file "./lustreSyntaxChecks/test_eqn_lhs_not_defined.lus" with
     | Error (`LustreSyntaxChecksError (_, DanglingIdentifier _)) -> true
@@ -738,6 +730,14 @@ let _ = run_test_tt_main ("frontend LustreTypeChecker error tests" >::: [
   mk_test "test bound variable with refinement type 3" (fun () ->
     match load_file "./lustreTypeChecker/ref_type_const_expr.lus" with
     | Error (`LustreTypeCheckerError (_, ExpectedConstant _)) -> true
+    | _ -> false);
+  mk_test "test merge clock mismatch" (fun () ->
+    match load_file "./lustreSyntaxChecks/merge_enum2.lus" with
+    | Error (`LustreTypeCheckerError (_, ClockMismatchInMerge)) -> true
+    | _ -> false);
+  mk_test "test activate clock mismatch" (fun () ->
+    match load_file "./lustreSyntaxChecks/test_activate_clock_mismatch.lus" with
+    | Error (`LustreTypeCheckerError (_, ClockMismatchInMerge)) -> true
     | _ -> false);
 ])
 

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -190,6 +190,10 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
     match load_file "./lustreSyntaxChecks/mult_assign_array_def.lus" with
     | Error (`LustreSyntaxChecksError (_, MultAssignArrayDef)) -> true
     | _ -> false);
+  mk_test "symbolic array index passed to non-inlinable function" (fun () ->
+    match load_file "./lustreSyntaxChecks/array_index.lus" with
+    | Error (`LustreSyntaxChecksError (_, SymbolicArrayIndexInNodeArgument _)) -> true
+    | _ -> false);
 ])
 
 (* *************************************************************************** *)


### PR DESCRIPTION
Fixes kind2-mc/kind2-dev#154

We do not allow symbolic array indices to be passed to non-inlinable functions. However, the previous code (before this PR) failed to enforce this syntactic constraint in all cases because it failed to chase type aliases. To chase type aliases, we need to pass and use the type checker context. However, passing the context to `lustreSyntaxChecks` created a cyclic dependency, since the type checker references `lustreSyntaxChecks` for a clock check. To address this cyclic dependency, I moved the clock check to the type checker. (So now the type checker has no dependency on `lustreSyntaxChecks`).
