### PR TITLE
Fix lus_main and lus_main_type flag bugs

### DIFF
--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -358,12 +358,16 @@ let of_channel old_frontend only_parse in_ch =
                     (2) the main node's enviornment, if environment checking is enabled *)
               let main_nodes = 
                 if (not main_lustre_node.is_extern) && List.mem `CONTRACTCK (Flags.enabled ()) then 
-                  [NI.mk_node_id ~node_type:Contract (HString.mk_hstring s)]
+                  let node_id = NI.mk_node_id ~node_type:Contract (HString.mk_hstring s) in 
+                  let _ = LN.node_of_node_id node_id nodes in
+                  [node_id]
                 else [NI.mk_node_id (HString.mk_hstring s)] 
               in
               let main_nodes = 
                 if (Flags.Contracts.check_environment ()) && List.mem `CONTRACTCK (Flags.enabled ()) then
-                  (NI.mk_node_id ~node_type:Environment (HString.mk_hstring s)) :: main_nodes 
+                  let node_id = NI.mk_node_id ~node_type:Environment (HString.mk_hstring s) in 
+                  let _ = LN.node_of_node_id node_id nodes in
+                  node_id :: main_nodes 
                 else 
                   main_nodes 
                 in 
@@ -395,11 +399,11 @@ let of_channel old_frontend only_parse in_ch =
               raise (MainTypeWithoutRealizability msg)
             else (
               try 
-                (* let s_ident = LustreIdent.mk_string_ident (LGI.type_tag ^ s) in *)
-                let _ = LN.node_of_input_name s_ident nodes in  
+                let node_id = NI.mk_node_id ~node_type:Type (HString.mk_hstring s) in
+                let _ = LN.node_of_node_id node_id nodes in  
                 match Flags.lus_main () with 
-                | Some _ -> (NI.mk_node_id ~node_type:Type (HString.mk_hstring s)) :: main_nodes
-                | None -> [NI.mk_node_id (HString.mk_hstring s)]
+                | Some _ -> node_id :: main_nodes
+                | None -> [node_id]
               (* User-specified type alias in command-line input might not exist *)
               with Not_found -> 
                 let msg =

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -1072,10 +1072,6 @@ let rec subsystem_of_nodes' nodes accum = function
 
         try 
 
-          Format.fprintf Format.std_formatter "Node names: %a\n looking for: %a\n"
-            (Lib.pp_print_list (fun ppf node -> HString.pp_print_hstring ppf (NI.get_internal_name node.node_id)) ", ") nodes
-            HString.pp_print_hstring (NI.get_internal_name top); 
-
           (* Get node by name *)
           node_of_node_id top nodes 
 

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -1072,6 +1072,10 @@ let rec subsystem_of_nodes' nodes accum = function
 
         try 
 
+          Format.fprintf Format.std_formatter "Node names: %a\n looking for: %a\n"
+            (Lib.pp_print_list (fun ppf node -> HString.pp_print_hstring ppf (NI.get_internal_name node.node_id)) ", ") nodes
+            HString.pp_print_hstring (NI.get_internal_name top); 
+
           (* Get node by name *)
           node_of_node_id top nodes 
 


### PR DESCRIPTION
After the changes to node IDs, `--lus_main` and `--lus_main_type` (before this PR) exhibited some buggy behaviors. 

1. Line 402 (before changes) accidentally omitted `~node_type:Type`, so in this case, the constructed node ID could not be found in the list of lustre nodes, throwing an error. 
2. Say you have a refinement type `T` but pass `--lus_main T` (rather than `--lus_main_type T`) to Kind 2. Previously, an internal error was thrown in `subsystem_of_nodes` rather than a nice error message. This is because the check on line 354 (calling `node_of_input_name`) only looks to see if there is some component with a matching name, and not whether the component type (node or type declaration) is correct. To address this, I insert calls to `node_of_node_id` to trigger the `Not_found` exception in all necessary cases. 

You can compare the behavior of calling `--lus_main T`, `--lus_main_type T`, `--lus_main N`, and `--lus_main_type N` before and after changes in the following example: 

```
type T = int;

node N (x: T) returns (y: T)
let
    y = x;
    check x = y;
tel
```