### PR TITLE
Symbolic subranges

### DIFF
--- a/src/lustre/lustreAbstractInterpretation.ml
+++ b/src/lustre/lustreAbstractInterpretation.ml
@@ -37,7 +37,7 @@ type error = [
 let error_message kind = match kind with
   | Unknown s -> s
   | ConstantOutOfSubrange i -> "Constant " ^ (HString.string_of_hstring i) ^ 
-  " is assigned a value outside of its subrange type"
+  " is assigned a value possibly outside of its subrange type"
 
 let inline_error pos kind = Error (`LustreAbstractInterpretationError (pos, kind))
 
@@ -610,29 +610,23 @@ and interpret_int_branch_expr node_id ctx ty_ctx proj e1 e2 =
   in
   l, r
 
+(* Returns None if comparing symbolic bounds *)
 let expr_opt_lte e1 e2 =
-  match e1 with 
-    | None -> true
-    | Some (LA.Const (_, Num l1)) -> (
-      match e2 with 
-        | None -> false
-        | Some (LA.Const (_, Num l2)) -> 
-          int_of_string (HString.string_of_hstring l1) <= int_of_string (HString.string_of_hstring l2)
-        | _ -> true 
-      )
-    | _ -> true 
+  match e1, e2 with 
+  | None, _ -> Some true 
+  | _, None -> Some false 
+  | Some (LA.Const (_, Num l1)), Some (LA.Const (_, Num l2)) -> 
+    Some (int_of_string (HString.string_of_hstring l1) <= int_of_string (HString.string_of_hstring l2))
+  | _ -> None
 
+(* Returns None if comparing symbolic bounds *)
 let expr_opt_gte e1 e2 =
-  match e1 with 
-    | None -> true
-    | Some (LA.Const (_, Num l1)) -> (
-      match e2 with 
-        | None -> false
-        | Some (LA.Const (_, Num l2)) -> 
-          int_of_string (HString.string_of_hstring l1) >= int_of_string (HString.string_of_hstring l2)
-        | _ -> true 
-      )
-    | _ -> true 
+  match e1, e2 with 
+  | None, _ -> Some true 
+  | _, None -> Some false 
+  | Some (LA.Const (_, Num l1)), Some (LA.Const (_, Num l2)) -> 
+    Some (int_of_string (HString.string_of_hstring l1) >= int_of_string (HString.string_of_hstring l2))
+  | _ -> None 
 
 (* Compare a constant's actual range to its inferred range to see if assignment is legal *)
 let rec compare_ranges id pos_map actual_ty inferred_range =
@@ -643,10 +637,11 @@ let rec compare_ranges id pos_map actual_ty inferred_range =
   match inferred_range with 
   | LA.IntRange (_, e1, e2) ->
     (match actual_ty with 
-      | LA.IntRange (_, e3, e4) -> 
-        if expr_opt_lte e3 e1 && expr_opt_gte e4 e2 && expr_opt_lte e1 e2
-        then R.ok () 
-        else error ()
+      | LA.IntRange (_, e3, e4) -> (
+        match expr_opt_lte e3 e1, expr_opt_gte e4 e2, expr_opt_lte e1 e2 with 
+        | Some true, Some true, Some true -> R.ok () 
+        | _ -> error () 
+      )
       | _ -> R.ok ())
   | Int _ ->
     (match actual_ty with 

--- a/src/lustre/lustreAbstractInterpretation.ml
+++ b/src/lustre/lustreAbstractInterpretation.ml
@@ -618,9 +618,9 @@ let expr_opt_lte e1 e2 =
         | None -> false
         | Some (LA.Const (_, Num l2)) -> 
           int_of_string (HString.string_of_hstring l1) <= int_of_string (HString.string_of_hstring l2)
-        | _ -> assert false (* Not possible as we require subranges to have concrete bounds *)
+        | _ -> true 
       )
-    | _ -> assert false (* Not possible as we require subranges to have concrete bounds *)
+    | _ -> true 
 
 let expr_opt_gte e1 e2 =
   match e1 with 
@@ -630,9 +630,9 @@ let expr_opt_gte e1 e2 =
         | None -> false
         | Some (LA.Const (_, Num l2)) -> 
           int_of_string (HString.string_of_hstring l1) >= int_of_string (HString.string_of_hstring l2)
-        | _ -> assert false (* Not possible as we require subranges to have concrete bounds *)
+        | _ -> true 
       )
-    | _ -> assert false (* Not possible as we require subranges to have concrete bounds *)
+    | _ -> true 
 
 (* Compare a constant's actual range to its inferred range to see if assignment is legal *)
 let rec compare_ranges id pos_map actual_ty inferred_range =

--- a/src/lustre/lustreFlattenRefinementTypes.ml
+++ b/src/lustre/lustreFlattenRefinementTypes.ml
@@ -80,7 +80,9 @@ let rec flatten_ref_type ctx ty = match ty with
         let expr = A.BinaryOp(pos, Impl, A.BinaryOp(pos, And, bound1, bound2), expr) in
         A.Quantifier(pos, Forall, [pos, dummy_index, A.Int pos], expr)
       ) exprs
-    | Int _ | Bool _ | IntRange _ | Real _ | AbstractType _ | EnumType _ 
+    | IntRange _
+    | Int _ | Bool _ 
+    | Real _ | AbstractType _ | EnumType _ 
     | History _ | TArr _ | UserType _ | SBitVector _ | UBitVector _ -> []
     in
     let constraints = chase_refinements ty in 
@@ -90,6 +92,31 @@ let rec flatten_ref_type ctx ty = match ty with
     (match LustreTypeChecker.expand_type_syn_reftype_history ctx ty with 
       | Ok ty -> RefinementType (pos, (pos2, id, ty), expr)
       | _ -> assert false)
+  | IntRange (pos, Some lb, None) -> ( 
+    match LustreAstInlineConstants.eval_int_expr ctx lb with 
+    | Ok _ -> ty
+    | Error _ -> 
+      let id = HString.mk_hstring "x" in 
+      let bound_var = A.Ident (pos, id) in  
+      RefinementType (pos, (pos, id, A.Int pos), A.CompOp (pos, A.Lte, lb, bound_var))
+    )
+  | IntRange (pos, None, Some ub) -> ( 
+    match LustreAstInlineConstants.eval_int_expr ctx ub with 
+    | Ok _ -> ty
+    | Error _ -> 
+      let id = HString.mk_hstring "x" in 
+      let bound_var = A.Ident (pos, id) in  
+      RefinementType (pos, (pos, id, A.Int pos), A.CompOp (pos, A.Lte, bound_var, ub))
+    )
+  | IntRange (pos, Some lb, Some ub) -> ( 
+    match LustreAstInlineConstants.eval_int_expr ctx lb,
+          LustreAstInlineConstants.eval_int_expr ctx ub with  
+    | Ok _, Ok _ -> ty
+    | Error _, _ | _, Error _ -> 
+      let id = HString.mk_hstring "x" in 
+      let bound_var = A.Ident (pos, id) in  
+      RefinementType (pos, (pos, id, A.Int pos), 
+        A.BinaryOp (pos, A.And, A.CompOp (pos, A.Lte, lb, bound_var), A.CompOp (pos, A.Lte, bound_var, ub))))
   | Int _ | Bool _ | IntRange _ | Real _ | AbstractType _ | EnumType _ 
   | History _ | TArr _ | SBitVector _ | UBitVector _ -> ty
 

--- a/src/lustre/lustreFlattenRefinementTypes.ml
+++ b/src/lustre/lustreFlattenRefinementTypes.ml
@@ -80,9 +80,7 @@ let rec flatten_ref_type ctx ty = match ty with
         let expr = A.BinaryOp(pos, Impl, A.BinaryOp(pos, And, bound1, bound2), expr) in
         A.Quantifier(pos, Forall, [pos, dummy_index, A.Int pos], expr)
       ) exprs
-    | IntRange _
-    | Int _ | Bool _ 
-    | Real _ | AbstractType _ | EnumType _ 
+    | Int _ | Bool _ | IntRange _ | Real _ | AbstractType _ | EnumType _ 
     | History _ | TArr _ | UserType _ | SBitVector _ | UBitVector _ -> []
     in
     let constraints = chase_refinements ty in 
@@ -92,6 +90,7 @@ let rec flatten_ref_type ctx ty = match ty with
     (match LustreTypeChecker.expand_type_syn_reftype_history ctx ty with 
       | Ok ty -> RefinementType (pos, (pos2, id, ty), expr)
       | _ -> assert false)
+  (* Desugar subranges with symbolic bounds to refinement types *)
   | IntRange (pos, Some lb, None) -> ( 
     match LustreAstInlineConstants.eval_int_expr ctx lb with 
     | Ok _ -> ty

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -2163,9 +2163,6 @@ and check_const_integer_expr: tc_context -> NI.t option -> string -> LA.expr -> 
 and check_array_size_expr ctx nname e =
   check_const_integer_expr ctx nname "array size expression" e
 
-and check_range_bound ctx nname e =
-  check_const_integer_expr ctx nname "subrange bound" e
-
 (* Disallow assumptions on current values of output variables.
    'nname' is optional because the refinement type may not be in the 
    context of a node (e.g., a global type declaration). *)
@@ -2274,16 +2271,32 @@ and check_type_well_formed: tc_context -> source -> NI.t option -> bool -> tc_ty
         | None, None -> 
           type_error pos (UndeclaredType i)
     )
+  (* Allow subranges with symbolic bounds; they will be desugared in lustreFlattenRefinementTypes *) 
   | LA.IntRange (pos, e1, e2) -> (
     match e1, e2 with
     | None, None -> type_error pos IntervalMustHaveBound
-    | Some e, None | None, Some e -> 
-      check_range_bound ctx nname e >> IC.eval_int_expr ctx e >> Ok ([])
+    | Some e, None | None, Some e -> (
+      let* inf_ty, warnings = infer_type_expr ctx nname e in
+      let* inf_ty = expand_type_syn_reftype_history_subrange ctx inf_ty in
+      match inf_ty with 
+      | LA.Int _ -> R.ok warnings 
+      | _ -> type_error (LH.pos_of_expr e) (ExpectedIntegerExpression inf_ty)
+    )
     | Some e1, Some e2 ->
-      check_range_bound ctx nname e1 >> check_range_bound ctx nname e2 >>
-      let* v1 = IC.eval_int_expr ctx e1 in
-      let* v2 = IC.eval_int_expr ctx e2 in
-      if v1 > v2 then type_error pos (EmptySubrange (v1, v2)) else Ok ([])
+      let* inf_ty1, warnings1 = infer_type_expr ctx nname e1 in 
+      let* inf_ty2, warnings2 = infer_type_expr ctx nname e2 in 
+      let* inf_ty1 = expand_type_syn_reftype_history_subrange ctx inf_ty1 in
+      let* inf_ty2 = expand_type_syn_reftype_history_subrange ctx inf_ty2 in
+      match inf_ty1, inf_ty2 with 
+      | LA.Int _, Int _ -> (
+        match IC.eval_int_expr ctx e1, IC.eval_int_expr ctx e2 with 
+        | Ok v1, Ok v2 -> if v1 > v2 then type_error pos (EmptySubrange (v1, v2)) else Ok (warnings1 @ warnings2)
+        | _ -> R.ok (warnings1 @ warnings2)
+      )
+      | LA.Int _, inf_ty -> 
+        type_error (LH.pos_of_expr e2) (ExpectedIntegerExpression inf_ty)
+      | inf_ty, _ -> 
+        type_error (LH.pos_of_expr e1) (ExpectedIntegerExpression inf_ty)
     )
   | Bool _ | Int _ | Real _
   | AbstractType _ | EnumType _ | History _ | SBitVector _ | UBitVector _ -> R.ok ([])

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -54,8 +54,8 @@ let _ = run_test_tt_main ("frontend LustreAstInlineConstants error tests" >::: [
     | _ -> false);
   mk_test "test symbolic subrange bound 1" (fun () ->
     match load_file "./lustreTypeChecker/symbolic_subrange_bound.lus" with
-    | Ok _ -> true
-    | _ -> false);
+    | Ok _ -> false 
+    | _ -> true);
   mk_test "test symbolic subrange bound 2" (fun () ->
     match load_file "./lustreTypeChecker/symbolic_subrange_bound_2.lus" with
     | Ok _ -> true

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -54,11 +54,11 @@ let _ = run_test_tt_main ("frontend LustreAstInlineConstants error tests" >::: [
     | _ -> false);
   mk_test "test symbolic subrange bound 1" (fun () ->
     match load_file "./lustreTypeChecker/symbolic_subrange_bound.lus" with
-    | Error (`LustreAstInlineConstantsError (_, FreeIntIdentifier _)) -> true
+    | Ok _ -> true
     | _ -> false);
   mk_test "test symbolic subrange bound 2" (fun () ->
     match load_file "./lustreTypeChecker/symbolic_subrange_bound_2.lus" with
-    | Error (`LustreAstInlineConstantsError (_, FreeIntIdentifier _)) -> true
+    | Ok _ -> true
     | _ -> false);
 ])
 
@@ -701,7 +701,7 @@ let _ = run_test_tt_main ("frontend LustreTypeChecker error tests" >::: [
     | _ -> false);
   mk_test "test illegal node call in subrange bound" (fun () ->
     match load_file "./lustreTypeChecker/bad_subrange_bound_1.lus" with
-    | Error (`LustreTypeCheckerError (_, ExpectedConstant _)) -> true
+    | Error (`LustreTypeCheckerError (_, UnboundNodeName _)) -> true
     | _ -> false);
   mk_test "test illegal array definition without enough indices" (fun () ->
     match load_file "./lustreTypeChecker/array_frame.lus" with

--- a/tests/regression/success/symbolic_subranges.lus
+++ b/tests/regression/success/symbolic_subranges.lus
@@ -1,0 +1,12 @@
+const N: subtype { x: int | x >= 3 } ; 
+
+node N(x: subrange [0, N] of int; x2: subrange [0, 3] of int) returns (n: int; y: subrange [0, n] of int; y2: subrange [0, 3] of int) 
+var l: subrange [0, n] of int;
+var l2: subrange [0, 3] of int;
+let
+  n = N;
+  l = x;
+  y = l;
+  l2 = x2; 
+  y2 = l2;
+tel


### PR DESCRIPTION
Support subranges with symbolic bounds. The desugaring occurs in `lustreFlattenRefinementTypes.ml`. Additionally, to support this, I relaxed some checks during type checking, and I updated the abstract interpretation code to reject cases where a global constant with a subrange type with a symbolic bound is assigned a value (we are statically determining whether the value is in range before analysis time, but this is not possible with symbolic bounds). 