### PR TITLE
fix: handle unknown error code in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,11 @@ class LustreItem(pytest.Item):
 
     def repr_failure(self, excinfo, style=None):
         if isinstance(excinfo.value, LustreException):
-            actual = code_to_expected[self.res.returncode]
+            return_code = self.res.returncode
+            actual = code_to_expected.get(
+                return_code,
+                f"Unknown return code: {return_code}",
+            )
             return "\n".join(
                 [
                     f"Expected: {self.expected}, got {actual}",


### PR DESCRIPTION
The test runner crashes if it gets a return code it was not expecting from kind2. For example [this run](
https://github.com/kind2-mc/kind2/actions/runs/16499859899/job/46658094226) got a return code of 1 which is not one of the known ones

```py
return_codes = (
    ("success", 0),
    ("falsifiable", 40),
    ("error", 3),
    ("timeout", 30),
)
```

This PR more gracefully handles this case by not crashing and reporting the received code.