### PR TITLE
Do not use SoFar(/\ assume_i) to guard function guarantees

### DIFF
--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -1100,7 +1100,11 @@ let prefix_system (type s) (input_system : s t) prefix : s t = match input_syste
     let rename_contract (contract : LustreContract.t) : LustreContract.t =
       {
         assumes = List.map rename_svar contract.assumes;
-        sofar_assump = rename_state_var contract.sofar_assump;
+        sofar_assump = (
+          match contract.sofar_assump with
+          | None -> None
+          | Some v -> Some (rename_state_var v)
+        );
         guarantees = List.map (fun (sv, candidate) -> (rename_svar sv, candidate)) contract.guarantees;
         modes = List.map rename_mode contract.modes;
       }

--- a/src/lustre/contractChecker.ml
+++ b/src/lustre/contractChecker.ml
@@ -40,15 +40,22 @@ let get_assumption_vars in_sys sys =
   match ISys.get_lustre_node in_sys scope with
   | Some { LN.contract } -> (
     match contract with
-    | Some { LC.sofar_assump } -> (
+    | Some { LC.assumes; LC.sofar_assump } -> (
       let svar_deps =
         match Scope.Map.find_opt scope (ISys.state_var_dependencies in_sys) with
         | Some deps -> deps
         | None -> assert false
       in
       try (
-        SVM.find sofar_assump svar_deps
-        |> SVS.add sofar_assump
+        match sofar_assump with
+        | Some v -> SVM.find v svar_deps |> SVS.add v
+        | None -> (
+          let vars = List.map (fun {LC.svar} -> svar) assumes in
+          List.fold_left
+            (fun acc v -> SVS.union acc (SVM.find v svar_deps))
+            (SVS.of_list vars)
+            vars
+        )
       ) with Not_found -> assert false
     )
     | None -> SVS.empty

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1705,7 +1705,7 @@ let add_node_sofar_assumption ctx =
 
     | { node = None } -> raise (Invalid_argument "add_node_sofar_assumption")
 
-    | { node = Some ({ N.is_function; N.locals ; N.equations; N.contract } as n) } ->
+    | { node = Some ({ N.locals ; N.equations; N.contract } as n) } ->
 
       match contract with
 

--- a/src/lustre/lustreContext.ml
+++ b/src/lustre/lustreContext.ml
@@ -1622,6 +1622,12 @@ let trace_svars_of ctx expr = match ctx with
   )
 )
 
+let mk_sofar_svar ctx is_function =
+  if is_function then
+    let svar, ctx = mk_fresh_local ctx Type.t_bool in
+    Some svar, ctx
+  else
+    None, ctx
 
 (* Add node assumes to context *)
 let add_node_ass ctx assumes = 
@@ -1630,10 +1636,10 @@ let add_node_ass ctx assumes =
 
     | { node = None } -> raise (Invalid_argument "add_node_global_contract")
 
-    | { node = Some ({ N.contract } as node) } ->
+    | { node = Some ({ N.is_function; N.contract } as node) } ->
       let contract, ctx = match contract with
         | None -> (
-          let svar, ctx = mk_fresh_local ctx Type.t_bool in
+          let svar, ctx = mk_sofar_svar ctx is_function in
           C.mk assumes svar [] [], ctx
         )
         | Some contract -> C.add_ass contract assumes, ctx
@@ -1648,10 +1654,10 @@ let add_node_gua ctx guarantees =
 
     | { node = None } -> raise (Invalid_argument "add_node_global_contract")
 
-    | { node = Some ({ N.contract } as node) } ->
+    | { node = Some ({ N.is_function; N.contract } as node) } ->
       let contract, ctx = match contract with
         | None -> (
-          let svar, ctx = mk_fresh_local ctx Type.t_bool in
+          let svar, ctx = mk_sofar_svar ctx is_function in
           C.mk [] svar guarantees [], ctx
         )
         | Some contract -> C.add_gua contract guarantees, ctx
@@ -1667,10 +1673,10 @@ let add_node_mode ctx mode =
 
     | { node = None } -> raise (Invalid_argument "add_node_mode_contract")
 
-    | { node = Some ({ N.contract } as node) } ->
+    | { node = Some ({ N.is_function; N.contract } as node) } ->
       let contract, ctx = match contract with
         | None -> (
-          let svar, ctx = mk_fresh_local ctx Type.t_bool in
+          let svar, ctx = mk_sofar_svar ctx is_function in
           C.mk [] svar [] [ mode ], ctx
         )
         | Some contract -> C.add_modes contract [ mode ], ctx
@@ -1699,7 +1705,7 @@ let add_node_sofar_assumption ctx =
 
     | { node = None } -> raise (Invalid_argument "add_node_sofar_assumption")
 
-    | { node = Some ({ N.locals ; N.equations; N.contract } as n) } ->
+    | { node = Some ({ N.is_function; N.locals ; N.equations; N.contract } as n) } ->
 
       match contract with
 
@@ -1707,33 +1713,37 @@ let add_node_sofar_assumption ctx =
 
        | Some contract -> (
 
-         let sofar_svar = contract.C.sofar_assump in
+        let sofar_svar = contract.C.sofar_assump in
 
-         let conj_of_assumes = contract.C.assumes |>
-           List.map (fun { C.svar } -> E.mk_var svar) |> E.mk_and_n
-         in
+        match sofar_svar with
+        | None -> ctx
+        | Some sofar_svar ->
 
-         let pre_sofar, _ = (* Context should not be modified *)
-           assert (not (guard_flag ctx));
-           E.mk_pre_with_context
-             (* No abstraction should be necessary, see [mk_pre] *)
-             (fun _ _ -> assert false) (fun _ -> assert false)
-             ctx false (E.mk_var sofar_svar)
-         in
+          let conj_of_assumes = contract.C.assumes |>
+            List.map (fun { C.svar } -> E.mk_var svar) |> E.mk_and_n
+          in
 
-         let expr =
-           E.mk_arrow conj_of_assumes (E.mk_and conj_of_assumes pre_sofar)
-         in
+          let pre_sofar, _ = (* Context should not be modified *)
+            assert (not (guard_flag ctx));
+            E.mk_pre_with_context
+              (* No abstraction should be necessary, see [mk_pre] *)
+              (fun _ _ -> assert false) (fun _ -> assert false)
+              ctx false (E.mk_var sofar_svar)
+          in
 
-         let equations' = ((sofar_svar, []), expr) :: equations in
+          let expr =
+            E.mk_arrow conj_of_assumes (E.mk_and conj_of_assumes pre_sofar)
+          in
 
-         (* Return node with equation and local variable added *)
-         { ctx with
-             node = Some { n with
-               N.equations = equations' ;
-               N.locals = D.singleton D.empty_index sofar_svar :: locals
-             }
-         }
+          let equations' = ((sofar_svar, []), expr) :: equations in
+
+          (* Return node with equation and local variable added *)
+          { ctx with
+              node = Some { n with
+                N.equations = equations' ;
+                N.locals = D.singleton D.empty_index sofar_svar :: locals
+              }
+          }
 
        )
 

--- a/src/lustre/lustreContract.ml
+++ b/src/lustre/lustreContract.ml
@@ -74,7 +74,7 @@ let mk_mode name pos path requires ensures candidate = {
 
 type t = {
   assumes: svar list ;
-  sofar_assump: StateVar.t ;
+  sofar_assump: StateVar.t option;
   guarantees: (svar * bool) list ;
   modes: mode list ;
 }
@@ -118,7 +118,9 @@ let svars_of_modes modes set = modes |> List.fold_left (
 let svars_of ?(with_sofar_var=true) { assumes ; sofar_assump ; guarantees ; modes } =
   let initial_set =
     if with_sofar_var then
-      SVarSet.singleton sofar_assump
+      match sofar_assump with
+      | None -> SVarSet.empty
+      | Some v -> SVarSet.singleton v
     else
       SVarSet.empty
   in
@@ -193,8 +195,12 @@ let pp_print_contract safe fmt { assumes ; guarantees ; modes } =
     ) modes
 
 let pp_print_contract_debug safe fmt { sofar_assump; assumes; guarantees; modes } =
-  Format.fprintf fmt "@[<v 2>(*@contract@ %a@ %a@ %a@ %a@]@ *)"
-  StateVar.pp_print_state_var_debug sofar_assump
+  Format.fprintf fmt "@[<v 2>(*@contract@ %t%a@ %a@ %a@]@ *)"
+  (fun fmt ->
+     match sofar_assump with
+     | None -> ()
+     | Some sv -> Format.fprintf fmt "%a@ " StateVar.pp_print_state_var_debug sv
+  )
   (pp_print_list (
       fun fmt ass ->
         Format.fprintf fmt "  assume%a" pp_print_svar_debug ass

--- a/src/lustre/lustreContract.mli
+++ b/src/lustre/lustreContract.mli
@@ -81,8 +81,8 @@ type t = {
   assumes: svar list ;
   (** Assumptions of the contract. *)
 
-  sofar_assump: StateVar.t ;
-  (** State variable to model Sofar(/\ assumes) *)
+  sofar_assump: StateVar.t option;
+  (** State variable to model Sofar(/\ assumes), if any *)
 
   guarantees: (svar * bool) list ;
   (** Guarantees of the contract (boolean is the [candidate] flag). *)
@@ -93,7 +93,7 @@ type t = {
 
 (** Creates a new contract from a set of assumes, a set of guarantess, and a
 list of modes. *)
-val mk: svar list -> StateVar.t -> (svar * bool) list -> mode list -> t
+val mk: svar list -> StateVar.t option -> (svar * bool) list -> mode list -> t
 
 (** Adds assumes to a contract. *)
 val add_ass: t -> svar list -> t

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -2440,37 +2440,41 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
   (* ****************************************************************** *)
   in let (contract, sofar_local, sofar_equation) =
     if assumes != [] || guarantees != [] || modes != [] then
-      let sofar_assumption = get (mk_state_var
-        ~is_input:false
-        map
-        (node_scope @ I.reserved_scope)
-        (mk_ident (HString.mk_hstring "sofar"))
-        X.empty_index
-        Type.t_bool
-        None)
-      in
       let assumes = List.sort
-        (fun a b -> compare_pos (C.pos_of_svar a) (C.pos_of_svar b))
-        assumes
+          (fun a b -> compare_pos (C.pos_of_svar a) (C.pos_of_svar b))
+          assumes
+        in
+        let guarantees = List.sort
+          (fun (a, _) (b, _) -> compare_pos (C.pos_of_svar a) (C.pos_of_svar b))
+          guarantees
+        in
+        let modes = List.sort
+          (fun {C.pos = a} {C.pos = b} -> compare_pos a b)
+          modes
       in
-      let guarantees = List.sort
-        (fun (a, _) (b, _) -> compare_pos (C.pos_of_svar a) (C.pos_of_svar b))
-        guarantees
-      in
-      let modes = List.sort
-        (fun {C.pos = a} {C.pos = b} -> compare_pos a b)
-        modes
-      in
-      let sofar_local = X.singleton X.empty_index sofar_assumption in
-      let conj_of_assumes = assumes
-        |> List.map (fun { C.svar } -> E.mk_var svar)
-        |> E.mk_and_n
-      in
-      let pre_sofar = E.mk_pre (E.mk_var sofar_assumption) in
-      let expr = E.mk_arrow conj_of_assumes (E.mk_and conj_of_assumes pre_sofar) in
-      let equation = (sofar_assumption, []), expr in
-      let contract = C.mk assumes sofar_assumption guarantees modes in
-      Some (contract), [sofar_local], [equation]
+      if is_function then
+        let contract = C.mk assumes None guarantees modes in
+        Some (contract), [], []
+      else
+        let sofar_assumption = get (mk_state_var
+          ~is_input:false
+          map
+          (node_scope @ I.reserved_scope)
+          (mk_ident (HString.mk_hstring "sofar"))
+          X.empty_index
+          Type.t_bool
+          None)
+        in
+        let sofar_local = X.singleton X.empty_index sofar_assumption in
+        let conj_of_assumes = assumes
+          |> List.map (fun { C.svar } -> E.mk_var svar)
+          |> E.mk_and_n
+        in
+        let pre_sofar = E.mk_pre (E.mk_var sofar_assumption) in
+        let expr = E.mk_arrow conj_of_assumes (E.mk_and conj_of_assumes pre_sofar) in
+        let equation = (sofar_assumption, []), expr in
+        let contract = C.mk assumes (Some sofar_assumption) guarantees modes in
+        Some (contract), [sofar_local], [equation]
     else None, [], []
   in
   (* ****************************************************************** *)

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -374,7 +374,9 @@ let abstraction_of_contract assumption_assumed
   (* LHS of the implication. *)
   let lhs =
     if (assumes <> [] && not assumption_assumed) then
-      E.mk_var sofar_assump
+      match sofar_assump with
+      | None -> conj_of assumes
+      | Some v -> E.mk_var v
     else
       E.t_true
   in
@@ -834,19 +836,22 @@ let call_terms_of_node_call mk_fresh_state_var globals
   let node_assumes =
     if node_assume_props = [] then None
     else (
-      let assume_terms =
-        List.map (fun { P.prop_term } -> prop_term) node_assume_props
-      in
-      let sofar_term =
-        match contract with
-        | None -> assert false
-        | Some {C.sofar_assump} -> (
-          Var.mk_state_var_instance sofar_assump TransSys.prop_base
-          |> Term.mk_var
-          |> lift_term state_var_map_up
-        )
-      in
-      Some (assume_terms, sofar_term)
+      match contract with
+      | None -> assert false
+      | Some {C.sofar_assump} -> (
+        match sofar_assump with
+        | None -> None
+        | Some sofar_assump ->
+          let assume_terms =
+            List.map (fun { P.prop_term } -> prop_term) node_assume_props
+          in
+          let sofar_term =
+            Var.mk_state_var_instance sofar_assump TransSys.prop_base
+            |> Term.mk_var
+            |> lift_term state_var_map_up
+          in
+          Some (assume_terms, sofar_term)
+      )
     )
   in
 
@@ -2579,7 +2584,10 @@ let rec trans_sys_of_node' options globals top_name analysis_param
               |> fun roots' -> (
                 match contract with
                 | None -> roots'
-                | Some { C.sofar_assump } -> SVS.add sofar_assump roots'
+                | Some { C.assumes; C.sofar_assump } ->
+                  match sofar_assump with
+                  | None -> SVS.of_list (List.map (fun { C.svar } -> svar) assumes)
+                  | Some sofar_assump -> SVS.add sofar_assump roots'
               )
             in
             List.rev_append svar_dep_init svar_dep_trans |>
@@ -2663,11 +2671,17 @@ let rec trans_sys_of_node' options globals top_name analysis_param
             then
               match contract with
               | Some contract when contract.C.assumes <> [] -> (
-                let sofar_assump offset =
-                  Term.mk_var
-                    (Var.mk_state_var_instance contract.C.sofar_assump offset)
+                let mk_var v offset =
+                  Term.mk_var (Var.mk_state_var_instance v offset)
                 in
-                [sofar_assump TransSys.prop_base]
+                match contract.C.sofar_assump with
+                | None ->
+                  let conj =
+                    List.map (fun {C.svar} -> mk_var svar TransSys.prop_base) contract.C.assumes
+                  in
+                  [Term.mk_and conj]
+                | Some v ->
+                  [mk_var v TransSys.prop_base]
               )
               | _ -> []
             else []

--- a/tests/regression/falsifiable/function_assumption.lus
+++ b/tests/regression/falsifiable/function_assumption.lus
@@ -1,0 +1,13 @@
+function imported F1(x:int) returns (z:int);
+(*@contract
+  assume x>=0;
+  guarantee z>0;
+*)
+
+node F2(x:int) returns (z:int);
+(*@contract
+  guarantee "P1" z>0;
+*)
+let
+  z = if x>=0 then F1(x) else 1;
+tel


### PR DESCRIPTION
Use `/\ assume_i` instead. After this change, Kind 2 will take a function's guarantees into account for time steps where the assumptions are satisfied at the call site, even if they were not satisfied at some point in the past. In the included example, `P1` is proven valid even though the assumptions of the abstract combinational circuit `F1` are not always satisfied.