### PR TITLE
Enforce abstract functions behave as mathematical functions

### DIFF
--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -794,30 +794,20 @@ Functions
 
 Kind 2 supports the ``function`` keyword which is used just like the ``node`` one
 but has slightly different semantics. Like the name suggests, the output(s) of
-a ``function`` should be a *non-temporal* combination of its inputs. That is, a
+a ``function`` must be a *non-temporal* combination of its inputs. That is, a
 function cannot depend on the ``->``\ , ``pre``\ , ``merge``\ , ``when``\ ,
 ``condact``\ , or ``activate`` operators.
 A function is also not allowed to call a node, only other functions.
 In Lustre terms, functions are stateless.
 
-In Kind 2, these restrictions extend to the contract attached to the function,
-if any. Note that besides the ones mentioned above, no additional restrictions
-are enforced on functions compared to nodes.
-In particular, functional congruence is not enforced on
-partially defined functions, imported functions, and
-functions abstracted by their contracts. That is,
-Kind 2 might return a counterexample where two calls to an abstract function
-with the same input values provide different output values.
-To prevent this kind of counterexamples from happening, Kind 2 offers an option
-called ``--enforce_func_congruence`` which enforces
-abstract functions to behave as mathematical functions.
-The downside of using this option is that the IC3QE engine and
-IC3IA engine with the Z3qe or cvc5qe options are forced to
-shut down because its current implementation cannot reason about
-the resulting system.
+In Kind 2, these restrictions also apply to the contract attached to a function,
+if any. Moreover, Kind 2 enforces that partially defined functions,
+imported functions, and functions abstracted by their contracts
+behave as mathematical functions. That is, given the same inputs,
+the functions always produce the same outputs.
 
-Benefits
-^^^^^^^^
+Benefits and limitations
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Functions are interesting in the model-checking context of Kind 2 mainly as
 a mean to make an abstraction more precise. A realistic use-case is when one
@@ -846,6 +836,11 @@ a linear one.
 Using a function instead of a node simply results in a better abstraction. Kind
 2 will encode, at SMT-level, that the outputs of this component depend on the
 *current* version of its inputs only, not on its previous values.
+
+The downside of using functions in your model is that the IC3QE engine and
+the IC3IA engine with the Z3qe or cvc5qe options must shut down,
+since their current implementation cannot reason about the resulting system.
+
 
 If statements and frame conditions
 ----------------------------------

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -1352,24 +1352,6 @@ module Contracts = struct
     )
   let refinement () = !refinement
 
-  let enforce_func_congruence_default = false
-  let enforce_func_congruence = ref enforce_func_congruence_default
-  let _ = add_spec
-    "--enforce_func_congruence"
-    (bool_arg enforce_func_congruence)
-    (fun fmt ->
-      Format.fprintf fmt
-      "@[<v>\
-        Add constraints to ensure imported functions,@ \
-        partially defined functions, and functions abstracted by@ \
-        their contracts behave as mathematical functions:@ \
-        given the same inputs the functions provide the same outputs@ \
-        Default: %a\
-      @]"
-      fmt_bool enforce_func_congruence_default
-    )
-  let enforce_func_congruence () = !enforce_func_congruence
-
   let print_deadlock_default = true
   let print_deadlock = ref print_deadlock_default
   let _ = add_spec

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -522,9 +522,6 @@ module Contracts : sig
   (** Activate refinement. *)
   val refinement : unit -> bool
 
-  (** Enforce functional congruence on abstract functions *)
-  val enforce_func_congruence : unit -> bool
-
   (** Print deadlocking trace and a conflict *)
   val print_deadlock : unit -> bool
 

--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -494,7 +494,7 @@ let lustre_source_ast (type s) (input_system : s t) =
 let trans_sys_of_analysis (type s)
 ?(preserve_sig = false)
 ?(slice_nodes = Flags.slice_nodes ())
-?(add_functional_constraints = Flags.Contracts.enforce_func_congruence ())
+?(add_functional_constraints = true)
 ?slice_to_prop
 : s t -> A.param -> TransSys.t * s t = function
 

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -47,7 +47,7 @@ type settings = {
 let default_settings = {
   preserve_sig = false ;
   slice_nodes = Flags.slice_nodes () ;
-  add_functional_constraints = Flags.Contracts.enforce_func_congruence () ;
+  add_functional_constraints = true ;
   slice_to_prop = None
 }
 

--- a/src/realizability.ml
+++ b/src/realizability.ml
@@ -638,7 +638,7 @@ let compute_deadlocking_trace_and_conflict
     match InputSystem.get_lustre_node in_sys scope with
     | None -> sys, false
     | Some { LustreNode.is_function } ->
-      if is_function && Flags.Contracts.enforce_func_congruence () then (
+      if is_function then (
         (* Recompute transition system adding functional constraints *)
         let sys, _ =
           InputSystem.trans_sys_of_analysis

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ common_args = {
     "--color": "false",
     "--check_subproperties": "true",
     "--check_sat_assume": "false",
-    "--enforce_func_congruence": "true",
 }
 
 # All the different test conditions, will override common_args if there is a


### PR DESCRIPTION
In Kind 2 v1.6.0, we modified the semantics of abstract functions so that they were no longer required to behave as mathematical functions by default. In other words, functions were not constrained to produce the same outputs for identical inputs. The previous semantics could still be recovered by passing the option `--enforce_func_congruence true` to Kind 2. Under this modification, all functions were treated as just *stateless* nodes, and abstract functions could be interpreted as *non-deterministic*.

At the time, only the k-induction engine supported the strict semantics. Consequently, enforcing functional congruence prevented some users from proving properties with other engines. The situation has since improved, as the IC3IA engine now also supports strict semantics. Furthermore, our future development plans involve increased reliance on mathematical functions. Therefore, this PR restores the default requirement that abstract functions behave as mathematical functions and removes the option to override this behavior.