### PR TITLE
Fix array bug

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2200,12 +2200,25 @@ and normalize_expr ?guard info node_id map =
         in
         StringMap.singleton name expr_type
       in
-      let index = HString.mk_hstring "i" in
-      let eq_lhs = A.StructDef (dpos, [A.ArrayDef (dpos, name, [index])]) in
-      let equations =
-        [(info.quantified_variables, info.contract_scope, eq_lhs, base_expr, None)]
-      in
-      { (empty ()) with locals; equations }
+      let indices = info.inductive_variables |> StringMap.bindings |> List.map fst |> List.rev in
+      match List.length indices with 
+      | 1 ->
+        let eq_lhs = A.StructDef (dpos, [A.ArrayDef (dpos, name, indices)]) in
+        let equations =
+          [(info.quantified_variables, info.contract_scope, eq_lhs, base_expr, None)]
+        in
+        { (empty ()) with locals; equations }
+      (* Array constructors containing inductive variables in definitions of multi-dimensional 
+         arrays are rejected in lustreSyntaxChecks. So if there is not exactly one index 
+         variable, then the generated name does not matter. *)
+      | _ -> 
+        let eq_lhs = 
+            A.StructDef (dpos, [A.ArrayDef (dpos, name, [HString.mk_hstring "i"])]) 
+        in
+        let equations =
+          [(info.quantified_variables, info.contract_scope, eq_lhs, base_expr, None)]
+        in
+        { (empty ()) with locals; equations }
     in
     let nexpr = A.Ident (pos, name) in
     nexpr, union gids1 gids2, warnings

--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -70,6 +70,7 @@ type error_kind = Unknown of string
   | OpaqueWithoutContract of LustreAst.ident
   | TransparentWithoutBody of LustreAst.ident
   | IllegalHistoryVar of LustreAst.ident
+  | InductiveVarsWithArrayConstr of LustreAst.expr
 
 type error = [
   | `LustreSyntaxChecksError of Lib.position * error_kind
@@ -123,6 +124,7 @@ let error_message kind = match kind with
   | OpaqueWithoutContract n -> "An opaque annotation found for a node/function without a contract: " ^ HString.string_of_hstring n
   | TransparentWithoutBody n -> "A transparent annotation found for an imported node/function: " ^ HString.string_of_hstring n
   | IllegalHistoryVar id -> "History type constructor uses illegal quantified variable '" ^ HString.string_of_hstring id ^ "'"
+  | InductiveVarsWithArrayConstr e -> "Array constructor expression '" ^ LA.string_of_expr e ^ "' not supported within multi-dimensional inductive array equation"
 
 let syntax_error pos kind = Error (`LustreSyntaxChecksError (pos, kind))
 
@@ -972,12 +974,26 @@ and check_expr: context -> (context -> LA.expr -> ([> warning] list, ([> error] 
       Res.ok (warnings @ warnings2)
     | BinaryOp (_, _, e1, e2)
     | CompOp (_, _, e1, e2)
-    | ArrayConstr (_, e1, e2)
     | IndexAccess (_, e1, e2, _)
     | Arrow (_, e1, e2) ->
       let* warnings1 = (check_expr ctx f e1) in 
       let* warnings2 = (check_expr ctx f e2) in 
       Ok (warnings1 @ warnings2)
+    | ArrayConstr (p, e1, e2) as e -> 
+      let* warnings1 = (check_expr ctx f e1) in 
+      let* warnings2 = (check_expr ctx f e2) in 
+      let ivars = 
+        StringMap.bindings ctx.array_indices @ StringMap.bindings ctx.symbolic_array_indices 
+        |> List.map fst |> LA.SI.of_list
+      in
+      let num_ivars = LA.SI.cardinal ivars in
+      let evars = LustreAstHelpers.vars_without_node_call_ids e1 in 
+      let ie_vars = LA.SI.inter ivars evars in 
+      let num_ie_vars = LA.SI.cardinal ie_vars in
+      (* Disallow inductive variables in ArrayConstrs if the array is multidimensional *)
+      if num_ivars >= 2 && num_ie_vars >= 1 
+      then syntax_error p (InductiveVarsWithArrayConstr e) 
+      else Ok (warnings1 @ warnings2)
     | TernaryOp (_, _, e1, e2, e3) -> 
       let* warnings1 = (check_expr ctx f e1) in
       let* warnings2 = (check_expr ctx f e2) in 

--- a/src/lustre/lustreSyntaxChecks.mli
+++ b/src/lustre/lustreSyntaxChecks.mli
@@ -51,6 +51,7 @@ type error_kind = Unknown of string
   | OpaqueWithoutContract of LustreAst.ident
   | TransparentWithoutBody of LustreAst.ident
   | IllegalHistoryVar of LustreAst.ident
+  | InductiveVarsWithArrayConstr of LustreAst.expr
 
 type error = [
   | `LustreSyntaxChecksError of Lib.position * error_kind

--- a/tests/ounit/lustre/lustreSyntaxChecks/arraydef_bug_2.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/arraydef_bug_2.lus
@@ -1,0 +1,5 @@
+node N() returns (A: int^4^4;)
+let
+  A[i][j] = ((i+j)^4)[i][j];
+tel
+

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -66,6 +66,10 @@ let _ = run_test_tt_main ("frontend LustreAstInlineConstants error tests" >::: [
 (*                           Lustre Syntax Checks                              *)
 (* *************************************************************************** *)
 let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
+  mk_test "test unsupported arraydef" (fun () ->
+    match load_file "./lustreSyntaxChecks/arraydef_bug_2.lus" with
+    | Error (`LustreSyntaxChecksError (_, InductiveVarsWithArrayConstr _)) -> true
+    | _ -> false);
   mk_test "test undefined local" (fun () ->
     match load_file "./lustreSyntaxChecks/undefined_local.lus" with
     | Error (`LustreSyntaxChecksError (_, UndefinedLocal _)) -> true

--- a/tests/regression/success/arraydef_bug.lus
+++ b/tests/regression/success/arraydef_bug.lus
@@ -1,0 +1,6 @@
+node N() returns (A: int^4;)
+let
+  A[j] = (j^4)[j];
+  check forall (j: subrange [0, 3] of int) A[j] = j; 
+tel
+


### PR DESCRIPTION
Fix bug that involves the combination of inductive array definitions and array constructors (of the form `expr1^expr2`. For cases when the inductive array definition has exactly 1 inductive variable, the bug is fixed. For multi-dimensional inductive array definitions and `ArrayConstr` expressions with at least one inductive variable, the input is rejected as unsupported. 

For context, I have pasted below some of my thoughts from a Zulip conversation with Daniel. 

...

Neither the new frontend or old frontend can generalize to the multidimensional case. Consider `A2[i][j] = ((i+j)^4^4)[i][j];`. Conceptually, we want something like 
```
T[i][j] = i+j
A2[i][j] = T[i][j]
```
However, the normalizer recursively processes one `ArrayConstr` at a time, creating a new equation `T[i] = ...` for each dimension of the array separately. But, since we need an equation with a right-hand side of `i+j`, we need multiple indices on the left-hand side. It is tricky because the multiple `ArrayConstr` expressions may not be directly nested, there could be ITEs in between and so on. Further, we will recursively process the inner-most `ArrayConstr` first, which is also a bit tricky, since we will need to generate an `n_array_ctor` with a type of greater dimensionality than fits directly within the original expression