### PR TITLE
Support element updates in empty map constructor

### DIFF
--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -927,10 +927,14 @@ pexpr(Q):
   (* An array constructor (not quantified) *)
   | e1 = pexpr(Q); CARET; e2 = expr { A.ArrayConstr (mk_pos $startpos, e1, e2) }
 
-  | MAP LSQBRACKET RSQBRACKET ATSIGN
+  | MAP LSQBRACKET 
+    updates = separated_list(SEMICOLON, assign); 
+    RSQBRACKET ATSIGN
     LT key_ty=lustre_type; comma_or_semicolon; value_ty=lustre_type; GT
   {
-    A.EmptyMap (mk_pos $startpos, (key_ty, value_ty))
+    List.fold_left (fun acc (e2, e3) -> 
+      A.StructUpdate (mk_pos $startpos, acc, [A.GenericIndex (mk_pos $startpos, e2)], e3) 
+    )  (A.EmptyMap (mk_pos $startpos, (key_ty, value_ty))) updates 
   }
 
   | e1 = pexpr(Q); 
@@ -938,13 +942,9 @@ pexpr(Q):
     updates = separated_nonempty_list(SEMICOLON, assign); 
     RSQBRACKET;
     { 
-      match updates with 
-      | [] -> assert false 
-      | (e2, e3) :: tl -> 
-        List.fold_left (fun acc (e2, e3) -> 
-          A.StructUpdate (mk_pos $startpos, acc, [A.GenericIndex (mk_pos $startpos, e2)], e3) 
-        ) (A.StructUpdate (mk_pos $startpos, e1, [A.GenericIndex (mk_pos $startpos, e2)], e3)) 
-          tl 
+      List.fold_left (fun acc (e2, e3) -> 
+        A.StructUpdate (mk_pos $startpos, acc, [A.GenericIndex (mk_pos $startpos, e2)], e3) 
+      ) e1 updates 
     }
 
   (* Tuple projection (not quantified) *)

--- a/tests/regression/success/empty_map_update_test.lus
+++ b/tests/regression/success/empty_map_update_test.lus
@@ -1,0 +1,7 @@
+node N () returns (out: map<int, int>) 
+let
+  out = map[1 := 2; 3 := 4]@<int, int>;
+  check 1 in out;
+  check 3 in out;
+  check forall (i: int) i <> 1 and i <> 3 => not (i in out);
+tel


### PR DESCRIPTION
The update to the map element update case in the parser is purely cosmetic; the pattern matching on `updates` was unnecessary