### PR TITLE
Add if-then-otherwise expressions

### DIFF
--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -46,6 +46,7 @@ type t = {
     * HString.t (* abstracted output *)
     * LustreAst.expr (* condition expression *)
     * LustreAst.expr (* restart expression *)
+    * HString.t option (* boolean variable representing call context *)
     * NodeId.t (* node name *)
     * (LustreAst.expr list) (* node arguments *)
     * (LustreAst.expr list option) (* node argument defaults *)

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -46,6 +46,7 @@ type t = {
     * HString.t (* abstracted output *)
     * LustreAst.expr (* condition expression *)
     * LustreAst.expr (* restart expression *)
+    * HString.t option (* boolean variable representing call context *)
     * NodeId.t (* node name *)
     * (LustreAst.expr list) (* node arguments *)
     * (LustreAst.expr list option) (* node argument defaults *)

--- a/src/lustre/lustreAbstractInterpretation.ml
+++ b/src/lustre/lustreAbstractInterpretation.ml
@@ -511,7 +511,8 @@ and interpret_int_expr node_id ctx ty_ctx proj expr =
     interpret_int_unary_expr node_id ctx ty_ctx op proj e
   | BinaryOp (_, op, e1, e2) ->
     interpret_int_binary_expr node_id ctx ty_ctx proj op e1 e2
-  | TernaryOp (_, Ite, _, e1, e2) ->
+  | TernaryOp (_, Ite, _, e1, e2)
+  | TernaryOp (_, LazyIte, _, e1, e2) ->
     interpret_int_branch_expr node_id ctx ty_ctx proj e1 e2
   | ConvOp (_, _, e) -> interpret_int_expr node_id ctx ty_ctx proj e
   | CompOp _-> assert false

--- a/src/lustre/lustreArrayDependencies.ml
+++ b/src/lustre/lustreArrayDependencies.ml
@@ -160,7 +160,7 @@ and process_expr ind_vars ctx ns proj indices expr =
   | Extract (_, e, _, _)
   | UnaryOp (_, _, e) -> r e
   | BinaryOp (_, _, e1, e2) -> union_ (r e1) (r e2)
-  | TernaryOp (_, Ite, e1, e2, e3) ->
+  | TernaryOp (_, _, e1, e2, e3) ->
     let r_e1 = process_expr ind_vars ctx ns 0 indices e1 in
     union_ (union_ (r_e1) (r e2)) (r e3)
   | ConvOp (_, _, e) -> r e

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -69,6 +69,7 @@ type binary_operator =
 
 type ternary_operator =
   | Ite
+  | LazyIte
 
 type comparison_operator =
   | Eq | Neq  | Lte  | Lt  | Gte | Gt
@@ -504,6 +505,8 @@ let rec pp_print_expr ppf =
     | BinaryOp (p, BVConcat, e1, e2) -> p2 p "++" e1 e2
 
     | TernaryOp (p, Ite, e1, e2, e3) -> p3 p "if" "then" "else" e1 e2 e3
+
+    | TernaryOp (p, LazyIte, e1, e2, e3) -> p3 p "if" "then" "otherwise" e1 e2 e3
 
     | CompOp (p, Eq, e1, e2) -> p2 p "=" e1 e2
     | CompOp (p, Neq, e1, e2) -> p2 p "<>" e1 e2

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -85,6 +85,7 @@ type binary_operator =
 
 type ternary_operator =
   | Ite
+  | LazyIte
 
 type comparison_operator =
   | Eq | Neq  | Lte  | Lt  | Gte | Gt

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -44,6 +44,10 @@ let expr_is_false = function
   | Const (_, False) -> true
   | _ -> false
 
+let id_of_expr = function
+  | Ident (_, id) -> Some id
+  | _ -> None
+
 let pos_of_expr = function
   | Ident (pos , _) | ModeRef (pos , _ ) | RecordProject (pos , _ , _)
   | TupleProject (pos , _ , _) | StructUpdate (pos , _ , _ , _) | Const (pos, _)

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -37,6 +37,9 @@ val expr_is_false : expr -> bool
 val pos_of_expr : expr -> Lib.position
 (** Returns the position of an expression *)
 
+val id_of_expr : expr -> HString.t option
+(** Return a lustre id if the expression is an Ident variant or None otherwise *)
+
 val expr_contains_call : expr -> bool
 (** Checks if the expression contains a call to a node *)
 

--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -187,14 +187,14 @@ and eval_bool_ternary_op: TC.tc_context -> Lib.position -> LA.ternary_operator
   eval_bool_expr ctx e1 >>= fun v1 ->
   eval_bool_expr ctx e2 >>= fun v2 ->
   match top with
-  | LA.Ite -> if c then R.ok v1 else R.ok v2
+  | LA.Ite | LA.LazyIte -> if c then R.ok v1 else R.ok v2
 (** try and evalutate ternary op expression to bool, return error otherwise *)
 
 and eval_int_ternary_op: TC.tc_context -> Lib.position -> LA.ternary_operator
                      -> LA.expr -> LA.expr -> LA.expr -> (int, [> error]) result
   = fun ctx _ top b1 e1 e2 ->
   match top with
-  | LA.Ite ->
+  | LA.Ite | LA.LazyIte ->
      eval_bool_expr ctx b1 >>= fun c ->
      if c
      then eval_int_expr ctx e1
@@ -257,6 +257,7 @@ and push_pre is_guarded pos =
   | UnaryOp (p, op, e) -> UnaryOp (p, op, r e)
   | BinaryOp (p, op, e1, e2) -> BinaryOp (p, op, r e1, r e2)
   | TernaryOp (p, Ite, e1, e2, e3) -> TernaryOp (p, Ite, e1, r e2, r e3)
+  | TernaryOp (p, LazyIte, e1, e2, e3) -> TernaryOp (p, LazyIte, e1, e2, e3)
   | ConvOp (p, op, e) -> ConvOp (p, op, r e)
   | CompOp (p, op, e1, e2) -> CompOp (p, op, r e1, r e2)
   | Extract (pos, e, idx1, idx2) -> LA.Extract (pos, r e, idx1, idx2)
@@ -325,7 +326,7 @@ and simplify_expr ?(is_guarded = false) ?(ind_vars = []) ctx =
       | Error _ -> e')
   | LA.TernaryOp (pos, top, cond, e1, e2) ->
      (match top with
-     | Ite -> 
+     | Ite | LazyIte -> 
         (match eval_bool_expr ctx cond with
         | Ok v -> if v then simplify_expr ~ind_vars ~is_guarded ctx e1
           else simplify_expr ~ind_vars ~is_guarded ctx e2 

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -163,6 +163,7 @@ type info = {
   interpretation : HString.t StringMap.t;
   local_group_projection : int;
   inlinable_funcs : LustreAst.node_decl NI.Map.t;
+  call_context : LustreAst.expr list;
 }
 
 let pp_print_generated_identifiers ppf gids =
@@ -185,12 +186,17 @@ let pp_print_generated_identifiers ppf gids =
     LustreAst.pp_print_lustre_type ty
     LustreAst.pp_print_expr e
   in
-  let pp_print_call = (fun ppf (pos, output, cond, restart, node_id, args, defaults, inlined) ->
+  let pp_print_context ppf = function
+    | Some ctx -> Format.fprintf ppf "%a" HString.pp_print_hstring ctx
+    | None -> ()
+  in
+  let pp_print_call = (fun ppf (pos, output, cond, restart, ctx, node_id, args, defaults, inlined) ->
     Format.fprintf ppf 
-      "%a: %a = call(%a,(restart %a every %a)(%a),%a)%s"
+      "%a: %a = call(%a,%a,(restart %a every %a)(%a),%a)%s"
       pp_print_position pos
       HString.pp_print_hstring output
       A.pp_print_expr cond
+      pp_print_context ctx
       NI.pp_print_node_id_user_name node_id
       A.pp_print_expr restart
       (pp_print_list A.pp_print_expr ",@ ") args
@@ -680,20 +686,6 @@ let mk_fresh_refinement_type_constraint source info pos node_id id expr_type =
   in
   List.fold_left union (empty ()) gids
 
-let mk_fresh_call ?(inlined=false) info id pos cond restart args defaults =
-  i := !i + 1;
-  let prefix = HString.mk_hstring (string_of_int !i) in
-  let name = HString.concat2 prefix  (HString.mk_hstring "_call") in
-  let proj = if info.local_group_projection < 0 then (HString.mk_hstring "")
-    else HString.concat2
-      (HString.mk_hstring (string_of_int info.local_group_projection))
-      (HString.mk_hstring "proj_")
-  in
-  let nexpr = A.Ident (pos, HString.concat2 proj name) in
-  let call = (pos, name, cond, restart, id, args, defaults, inlined) in
-  let gids = { (empty ()) with calls = [call] } in
-  nexpr, gids
-
 let add_step_counter info =
   let dpos = Lib.dummy_pos in
   let eq_lhs = A.StructDef (dpos, [SingleIdent (dpos, ctr_id)]) in
@@ -1025,7 +1017,8 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
     contract_scope = [];
     interpretation = StringMap.empty;
     local_group_projection = -1;
-    inlinable_funcs = get_inlinable_func_decls inlinable_funcs decls }
+    inlinable_funcs = get_inlinable_func_decls inlinable_funcs decls;
+    call_context = [] }
   in 
   let over_declarations (nitems, accum, warnings_accum) item =
     clear_cache ();
@@ -1780,6 +1773,35 @@ and abstract_expr ?guard force info node_id map expr =
     let iexpr, gids2 = mk_fresh_local force info pos ivars ty nexpr in
     iexpr, union gids1 gids2, warnings
 
+and mk_fresh_call ?(inlined=false) info id map pos cond restart args defaults =
+  let call_ctx, gids1 =
+    match info.call_context with
+    | [] -> None, empty ()
+    | c :: cs -> (
+      let conj =
+        List.fold_left
+          (fun acc c' -> A.BinaryOp (dpos, A.And, c', acc)) c cs
+      in
+      let nexpr, gids, warnings = abstract_expr false info id map conj in
+      assert (warnings = []);
+      match AH.id_of_expr nexpr with
+      | None -> assert false
+      | Some id -> Some id, gids
+    )
+  in
+  i := !i + 1;
+  let prefix = HString.mk_hstring (string_of_int !i) in
+  let name = HString.concat2 prefix  (HString.mk_hstring "_call") in
+  let proj = if info.local_group_projection < 0 then (HString.mk_hstring "")
+    else HString.concat2
+      (HString.mk_hstring (string_of_int info.local_group_projection))
+      (HString.mk_hstring "proj_")
+  in
+  let nexpr = A.Ident (pos, HString.concat2 proj name) in
+  let call = (pos, name, cond, restart, call_ctx, id, args, defaults, inlined) in
+  let gids2 = { (empty ()) with calls = [call] } in
+  nexpr, union gids1 gids2
+
 and expand_node_call info node_id expr var count =
   let ty = Chk.infer_type_expr info.context (Some node_id) expr |> unwrap |> fst in
   let mk_index i = A.Const (dpos, Num (HString.mk_hstring (string_of_int i))) in
@@ -1896,7 +1918,7 @@ and normalize_expr ?guard info node_id map =
         (combine_args_with_const info args flags)
       in
       let nexpr, gids2 =
-        mk_fresh_call ~inlined info id pos cond restart nargs None
+        mk_fresh_call ~inlined info id map pos cond restart nargs None
       in
       nexpr, union gids1 gids2, warnings
     in
@@ -1931,7 +1953,7 @@ and normalize_expr ?guard info node_id map =
       (combine_args_with_const info args flags)
     in
     let ndefaults, gids4, warnings4 = normalize_list (normalize_expr ?guard info node_id map) defaults in
-    let nexpr, gids5 = mk_fresh_call info id pos ncond nrestart nargs (Some ndefaults) in
+    let nexpr, gids5 = mk_fresh_call info id map pos ncond nrestart nargs (Some ndefaults) in
     let gids = union_list [gids1; gids2; gids3; gids4; gids5] in
     let warnings = warnings1 @ warnings2 @ warnings3 @ warnings4 in
     nexpr, gids, warnings
@@ -1944,7 +1966,7 @@ and normalize_expr ?guard info node_id map =
       (fun (arg, is_const) -> abstract_node_arg ?guard:None false is_const info map arg)
       (combine_args_with_const info args flags)
     in
-    let nexpr, gids3 = mk_fresh_call info id pos cond nrestart nargs None in
+    let nexpr, gids3 = mk_fresh_call info id map pos cond nrestart nargs None in
     let gids = union_list [gids1; gids2; gids3] in
     nexpr, gids, warnings1 @ warnings2
   | Merge (pos, clock_id, cases) ->
@@ -1959,7 +1981,7 @@ and normalize_expr ?guard info node_id map =
           (fun (arg, is_const) -> abstract_node_arg ?guard:None false is_const info map arg)
           (combine_args_with_const info args flags)
         in
-        let nexpr, gids4 = mk_fresh_call info id pos ncond nrestart nargs None in
+        let nexpr, gids4 = mk_fresh_call info id map pos ncond nrestart nargs None in
         let gids = union_list [gids1; gids2; gids3; gids4] in
         let warnings = warnings1 @ warnings2 @ warnings3 in
         (clock_value, nexpr), gids, warnings
@@ -1975,7 +1997,7 @@ and normalize_expr ?guard info node_id map =
           (fun (arg, is_const) -> abstract_node_arg ?guard:None false is_const info map arg)
           (combine_args_with_const info args flags)
         in
-        let nexpr, gids3 = mk_fresh_call info id pos ncond restart nargs None in
+        let nexpr, gids3 = mk_fresh_call info id map pos ncond restart nargs None in
         let gids = union_list [gids1; gids2; gids3] in
         let warnings = warnings1 @ warnings2 in
         (clock_value, nexpr), gids, warnings
@@ -2139,13 +2161,24 @@ and normalize_expr ?guard info node_id map =
     let nexpr1, gids1, warnings1 = normalize_expr ?guard info node_id map expr1 in
     let nexpr2, gids2, warnings2 = normalize_expr ?guard info node_id map expr2 in
     BinaryOp (pos, op, nexpr1, nexpr2), union gids1 gids2, warnings1 @ warnings2
-  | TernaryOp (pos, op, expr1, expr2, expr3) ->
+  | TernaryOp (pos, Ite, expr1, expr2, expr3) ->
     let nexpr1, gids1, warnings1= normalize_expr ?guard info node_id map expr1 in
     let nexpr2, gids2, warnings2 = normalize_expr ?guard info node_id map expr2 in
     let nexpr3, gids3, warnings3 = normalize_expr ?guard info node_id map expr3 in
     let gids = union (union gids1 gids2) gids3 in
     let warnings = warnings1 @ warnings2 @ warnings3 in
-    TernaryOp (pos, op, nexpr1, nexpr2, nexpr3), gids, warnings
+    TernaryOp (pos, Ite, nexpr1, nexpr2, nexpr3), gids, warnings
+  | TernaryOp (pos, LazyIte, expr1, expr2, expr3) ->
+    let nexpr1, gids1, warnings1= normalize_expr ?guard info node_id map expr1 in
+    let info2 = { info with call_context = nexpr1 :: info.call_context } in
+    let nexpr2, gids2, warnings2 = normalize_expr ?guard info2 node_id map expr2 in
+    let info3 = { info with call_context =
+      A.UnaryOp (AH.pos_of_expr expr1, Not, nexpr1) :: info.call_context }
+    in
+    let nexpr3, gids3, warnings3 = normalize_expr ?guard info3 node_id map expr3 in
+    let gids = union (union gids1 gids2) gids3 in
+    let warnings = warnings1 @ warnings2 @ warnings3 in
+    TernaryOp (pos, LazyIte, nexpr1, nexpr2, nexpr3), gids, warnings
   | ConvOp (pos, op, expr) ->
     let nexpr, gids, warnings = normalize_expr ?guard info node_id map expr in
     ConvOp (pos, op, nexpr), gids, warnings

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -291,6 +291,7 @@ let keyword_table = mk_hashtbl [
   "if", IF ;
   "then", THEN ;
   "else", ELSE ;
+  "otherwise", OTHERWISE;
   "elsif", ELSIF ;
   "fi", FI ;
   "frame", FRAME ;

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -108,6 +108,9 @@ type node_call = {
   (* Boolean activation and/or restart conditions if any *)
   call_cond : call_cond list;
  
+  (* Boolean variable representing the condition of a function call if any *)
+  call_context : StateVar.t option;
+
   (* Variables for input parameters *)
   call_inputs : StateVar.t D.t;
 
@@ -1459,6 +1462,7 @@ let stateful_vars_of_node
           (fun
             accum
             { call_cond;
+              call_context;
               call_inputs;
               call_oracles;
               call_outputs;
@@ -1469,6 +1473,9 @@ let stateful_vars_of_node
              call_oracles @
              (D.values call_outputs))
             |> SVS.of_list
+
+            |> SVS.union (match call_context with | None -> SVS.empty | Some sv -> SVS.singleton sv)
+
             (* Add stateful variables from initial defaults *)
             |> SVS.union
                (match call_defaults with

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -75,6 +75,9 @@ type node_call = {
   call_cond : call_cond list;
   (** Boolean activation and/or restart conditions if any *)
 
+  call_context : StateVar.t option;
+  (** Boolean variable representing the condition of a function call if any *)
+
   call_inputs : StateVar.t LustreIndex.t;
   (** Variables for actual input parameters 
 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1228,7 +1228,8 @@ and compile_ast_expr
     compile_equality bounds true expr1 expr2
   | A.CompOp (_, A.Neq, expr1, expr2) ->
     compile_equality bounds false expr1 expr2
-  | A.TernaryOp (_, A.Ite, expr1, expr2, expr3) ->
+  | A.TernaryOp (_, A.Ite, expr1, expr2, expr3)
+  | A.TernaryOp (_, A.LazyIte, expr1, expr2, expr3) ->
     compile_ite bounds expr1 expr2 expr3
   | A.Pre (_, expr) -> compile_pre bounds expr
   | A.Merge (_, clock_ident, merge_cases) ->
@@ -1290,7 +1291,7 @@ and compile_ast_expr
   | A.When _ -> assert false
   | A.Activate _ -> assert false
 
-and compile_node node_scope pos ctx cstate map outputs cond restart node_id args defaults inlined =
+and compile_node node_scope pos ctx cstate map outputs cond restart call_ctx node_id args defaults inlined =
   let called_node = N.node_of_node_id node_id cstate.nodes in
   let ident = NI.get_internal_name node_id |> I.of_hstring in
   let po_ct = !map.poracle_count in
@@ -1365,6 +1366,11 @@ and compile_node node_scope pos ctx cstate map outputs cond restart node_id args
     | None, Some r -> [N.CRestart r]
     | Some c, Some r -> [N.CActivate c; N.CRestart r]
   in
+  let call_ctx =
+    match call_ctx with
+    | Some id -> Some (mk_ident id |> H.find !map.state_var)
+    | None -> None
+  in
   let call_id = !map.call_count in
   map := {!map with call_count = call_id + 1 };
   let node_call = {
@@ -1372,6 +1378,7 @@ and compile_node node_scope pos ctx cstate map outputs cond restart node_id args
     N.call_pos = pos;
     N.call_node_id = called_node.node_id;
     N.call_cond = cond_state_var;
+    N.call_context = call_ctx;
     N.call_inputs = input_state_vars;
     N.call_oracles = oracles;
     N.call_outputs = outputs;
@@ -1822,7 +1829,7 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
   (* ****************************************************************** *)
   in
   let () =
-    let over_calls = fun () ((_, var, _, _, node_id, _, _, _)) ->
+    let over_calls = fun () ((_, var, _, _, _, node_id, _, _, _)) ->
       let called_node = N.node_of_node_id node_id cstate.nodes in
       let _outputs =
         let over_vars = fun index sv compiled_vars ->
@@ -1921,7 +1928,7 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
   let (calls, glocals) =
     let seen_calls = ref SVS.empty in
     let over_calls =
-      fun (calls, glocals) (pos, var, cond, restart, node_id, args, defaults, inlined)
+      fun (calls, glocals) (pos, var, cond, restart, call_ctx, node_id, args, defaults, inlined)
     ->
       (* let internal_node_name_hstring = NI.get_internal_name node_id |> HString.mk_hstring in *)
       let internal_node_name = NI.get_internal_name node_id |> I.of_hstring in
@@ -1964,7 +1971,7 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
         X.fold over_vars called_node.outputs X.empty
       in
       let node_call = compile_node
-        node_scope pos ctx cstate map outputs cond restart node_id args defaults inlined
+        node_scope pos ctx cstate map outputs cond restart call_ctx node_id args defaults inlined
       in
       let glocals' = H.fold (fun _ v a -> (X.singleton X.empty_index v) :: a) local_map [] in 
       node_call :: calls, glocals' @ glocals

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -163,6 +163,7 @@ let mk_span start_pos end_pos =
 %token THEN
 %token ELSE
 %token ELSIF
+%token OTHERWISE
 %token FI
 %token FRAME
 
@@ -216,7 +217,7 @@ let mk_span start_pos end_pos =
 (* Priorities and associativity of operators, lowest first *)
 %nonassoc UINT8 UINT16 UINT32 UINT64 INT8 INT16 INT32 INT64 
 %nonassoc WHEN CURRENT BAR
-%nonassoc ELSE
+%nonassoc ELSE OTHERWISE
 %right ARROW
 %nonassoc prec_forall prec_exists
 %right IMPL
@@ -1033,6 +1034,9 @@ pexpr(Q):
   (* An if operation *)
   | IF; e1 = pexpr(Q); THEN; e2 = pexpr(Q); ELSE; e3 = pexpr(Q) 
     { A.TernaryOp (mk_pos $startpos, A.Ite, e1, e2, e3) }
+
+  | IF; e1 = pexpr(Q); THEN; e2 = pexpr(Q); OTHERWISE; e3 = pexpr(Q)
+    { A.TernaryOp (mk_pos $startpos, A.LazyIte, e1, e2, e3) }
 
   (* Recursive node call *)
   | WITH; pexpr(Q); THEN; pexpr(Q); ELSE; pexpr(Q) 

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -590,6 +590,7 @@ let slice_all_of_node
 let add_roots_of_node_call 
     roots
     { N.call_cond;
+      N.call_context;
       N.call_inputs; 
       N.call_oracles; 
       N.call_defaults } =
@@ -605,6 +606,12 @@ let add_roots_of_node_call
              (E.state_vars_of_expr e |> SVS.elements) @ a) 
           d
           roots
+  in
+
+  let roots' =
+    match call_context with
+    | None -> roots'
+    | Some sv -> sv :: roots'
   in
 
   (* Add inputs, oracles and clock as roots *)

--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -51,7 +51,7 @@ type error_kind = Unknown of string
   | QuantifiedVariableInPre of HString.t
   | QuantifiedVariableInNodeArgument of HString.t * HString.t
   | SymbolicArrayIndexInNodeArgument of HString.t * HString.t
-  | NodeCallInFunction of HString.t
+  | IllegalNodeCall of (HString.t * string)
   | NodeCallInConstant of HString.t
   | NodeCallInGlobalTypeDecl of HString.t
   | IllegalTemporalOperator of string * string
@@ -102,12 +102,11 @@ let error_message kind = match kind with
   | SymbolicArrayIndexInNodeArgument (idx, node) -> "Symbolic array index '"
     ^ HString.string_of_hstring idx ^ "' is not allowed in an argument of a call to node or non-inlinable function '"
     ^ HString.string_of_hstring node ^ "'"
-  | NodeCallInFunction node -> "Illegal call to node '"
-    ^ HString.string_of_hstring node ^ "', functions and function contracts can only call other functions, not nodes"
+  | IllegalNodeCall (node, variant) -> "Illegal call to node '"
+    ^ HString.string_of_hstring node ^ "', " ^ variant ^ " can only include calls to other functions, not nodes"
   | NodeCallInConstant id -> "Illegal node call or 'any' operator in definition of constant '" ^ HString.string_of_hstring id ^ "'"
   | NodeCallInGlobalTypeDecl id -> "Illegal node call or 'any' operator in definition of global type '" ^ HString.string_of_hstring id ^ "'"
-  | IllegalTemporalOperator (kind, variant) -> "Illegal " ^ kind ^ " in " ^ variant ^ " definition, "
-    ^ variant ^ "s cannot have state"
+  | IllegalTemporalOperator (kind, variant) -> "Illegal " ^ kind ^ " in expression, " ^ variant ^ " cannot have state"
   | IllegalImportOfStatefulContract contract -> "Illegal import of stateful contract '"
     ^ HString.string_of_hstring contract ^ "'. Functions can only be specified by stateless contracts"
   | UnsupportedClockedInputOrOutput -> "Clocked inputs or outputs are not supported"
@@ -558,13 +557,15 @@ let no_quant_var_or_symbolic_index_in_node_call ctx = function
     List.fold_left (>>) (Ok ()) check
   | _ -> Ok ()
 
-let no_calls_to_node ctx = function
+let no_calls_to_node scope ctx = function
   | LA.Condact (pos, _, _, node_id, _, _)
   | Activate (pos, node_id, _, _, _)
   | RestartEvery (pos, node_id, _, _) 
   | Call (pos, _, node_id, _) ->
     let check_nodes = StringMap.mem (NI.get_internal_name node_id) ctx.nodes in
-    if check_nodes then syntax_error pos (NodeCallInFunction (NI.get_user_name node_id))
+    if check_nodes then
+      syntax_error pos 
+        (IllegalNodeCall (NI.get_user_name node_id, scope))
     else Ok ()
   | _ -> Ok ()
 
@@ -775,14 +776,14 @@ and check_func_decl ctx span (node_id, ext, opac, params, inputs, outputs, local
     (span, (node_id, ext, opac, params, inputs, outputs, locals, items, contract))
   in
   let composed_items_checks ctx e =
-    (no_calls_to_node ctx e)
-    >> (no_temporal_operator "function" e)
+    (no_calls_to_node "functions" ctx e)
+    >> (no_temporal_operator "functions" e)
     >> (common_node_equations_checks ctx e)
   in
   let function_contract_checks ctx e =
-    (no_calls_to_node ctx e) >> 
+    (no_calls_to_node "function contracts" ctx e) >> 
     let* warnings1 =  (common_contract_checks ctx e) in
-    let* warnings2 = (no_temporal_operator "function contract" e) in 
+    let* warnings2 = (no_temporal_operator "function contracts" e) in 
     Ok (warnings1 @ warnings2)
   in
   check_opacity span.start_pos (NI.get_internal_name node_id) contract ext opac
@@ -844,7 +845,7 @@ and check_items: context -> ?tc_ctx:Ctx.tc_context option -> (context -> LA.expr
       (*  Make sure 'nes' and 'nis' LHS vars are in 'vars_ids' *)
       (Res.seq_ (List.map (check_frame_vars pos var_ids) nis)) >>
       (Res.seq_ (List.map (check_frame_vars pos var_ids) nes)) >> 
-      let* warnings1 = check_items ctx ~tc_ctx (fun _ e -> no_temporal_operator "frame block initialization" e) nes in
+      let* warnings1 = check_items ctx ~tc_ctx (fun _ e -> no_temporal_operator "frame block initializations" e) nes in
       let* warnings2 = check_items ctx ~tc_ctx f nes in 
       let* warnings3 = (check_items ctx ~tc_ctx f nis) in
       Ok (warnings1 @ warnings2 @ warnings3)
@@ -955,6 +956,11 @@ and check_ty_quantified_var ctx f = function
 
 and check_expr: context -> (context -> LA.expr -> ([> warning] list, ([> error] as 'a)) result) ->
   LA.expr -> ([> warning] list, 'a) result = fun ctx f (expr:LustreAst.expr) ->
+  let lazy_ite ctx e =
+    (no_calls_to_node "a branch of an if-then-otherwise" ctx e)
+    >> (no_temporal_operator "branches of an if-then-otherwise" e)
+    >> (f ctx e)
+  in
   let res = f ctx expr in
   let check = function
     | LA.RecordProject (_, e, _)
@@ -995,10 +1001,15 @@ and check_expr: context -> (context -> LA.expr -> ([> warning] list, ([> error] 
       if num_ivars >= 2 && num_ie_vars >= 1 
       then syntax_error p (InductiveVarsWithArrayConstr e) 
       else Ok (warnings1 @ warnings2)
-    | TernaryOp (_, _, e1, e2, e3) -> 
+    | TernaryOp (_, Ite, e1, e2, e3) -> 
       let* warnings1 = (check_expr ctx f e1) in
       let* warnings2 = (check_expr ctx f e2) in 
       let* warnings3 = (check_expr ctx f e3) in 
+      Ok (warnings1 @ warnings2 @ warnings3)
+    | TernaryOp (_, LazyIte, e1, e2, e3) -> 
+      let* warnings1 = (check_expr ctx f e1) in
+      let* warnings2 = (check_expr ctx lazy_ite e2) in
+      let* warnings3 = (check_expr ctx lazy_ite e3) in
       Ok (warnings1 @ warnings2 @ warnings3)
     | GroupExpr (_, _, e)
     | Call (_, _, _, e)

--- a/src/lustre/lustreSyntaxChecks.mli
+++ b/src/lustre/lustreSyntaxChecks.mli
@@ -32,7 +32,7 @@ type error_kind = Unknown of string
   | QuantifiedVariableInPre of HString.t
   | QuantifiedVariableInNodeArgument of HString.t * HString.t
   | SymbolicArrayIndexInNodeArgument of HString.t * HString.t
-  | NodeCallInFunction of HString.t
+  | IllegalNodeCall of (HString.t * string)
   | NodeCallInConstant of HString.t
   | NodeCallInGlobalTypeDecl of HString.t
   | IllegalTemporalOperator of string * string

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -646,6 +646,7 @@ let call_terms_of_node_call mk_fresh_state_var globals
     { N.call_node_id ;
       N.call_id        ;
       N.call_pos       ;
+      N.call_context   ;
       N.call_inputs    ;
       N.call_oracles   ;
       N.call_outputs   ;}
@@ -833,6 +834,18 @@ let call_terms_of_node_call mk_fresh_state_var globals
 
   let node_props = node_assume_props @ node_props in
 
+  let node_props =
+    match call_context with
+    | None -> node_props
+    | Some sv -> (
+      let v = Var.mk_state_var_instance sv TransSys.prop_base in
+      node_props |> List.map (fun p ->
+        let prop_term = Term.mk_implies [Term.mk_var v; p.P.prop_term] in
+        { p with prop_term }
+      )
+    )
+  in
+
   let node_assumes =
     if node_assume_props = [] then None
     else (
@@ -942,6 +955,16 @@ let call_terms_of_node_call mk_fresh_state_var globals
   trans_call_term
   
 
+let add_call_context call_context init_term trans_term =
+  match call_context with
+  | None -> init_term, trans_term
+  | Some sv -> (
+    let v_i = Var.mk_state_var_instance sv TransSys.init_base in
+    let v_t = Var.mk_state_var_instance sv TransSys.trans_base in
+    Term.mk_implies [Term.mk_var v_i; init_term],
+    Term.mk_implies [Term.mk_var v_t; trans_term]
+  )
+
 (* Add constraints from node calls to initial state constraint and
    transition relation *)
 let rec constraints_of_node_calls 
@@ -971,7 +994,7 @@ let rec constraints_of_node_calls
   )
 
   (* Node call without an activation condition or restart *)
-  | { N.call_id; N.call_pos; N.call_node_id; N.call_cond = [] }
+  | { N.call_id; N.call_pos; N.call_context; N.call_node_id; N.call_cond = [] }
     as node_call :: tl ->
 
     (* Get generated transition system of callee *)
@@ -1022,6 +1045,10 @@ let rec constraints_of_node_calls
         subsystems
     in
 
+    let init_term, trans_term =
+      add_call_context call_context init_term trans_term
+    in
+
     (* Continue with next node calls *)
     constraints_of_node_calls 
       mk_fresh_state_var
@@ -1038,8 +1065,10 @@ let rec constraints_of_node_calls
       tl
 
   (* Node call with restart condition *)
-  | { N.call_id; N.call_pos; N.call_node_id; N.call_cond = [N.CRestart restart] }
-    as node_call :: tl ->
+  | { N.call_id; N.call_pos; N.call_context; N.call_node_id;
+      N.call_cond = [N.CRestart restart] } as node_call :: tl ->
+
+    assert (call_context = None);
 
     (* Get generated transition system of callee *)
     let { trans_sys } as node_def =
@@ -1114,11 +1143,14 @@ let rec constraints_of_node_calls
   (* Node call with activation condition *)
   | { N.call_id;
       N.call_pos;
+      N.call_context;
       N.call_node_id; 
       N.call_cond = N.CActivate clock :: other_conds;
       N.call_inputs;
       N.call_outputs; 
       N.call_defaults } as node_call :: tl -> 
+
+    assert (call_context = None);
 
     (* Get generated transition system of callee *)
     let { node = { N.inputs; }; trans_sys; init_flags } as node_def =

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -451,7 +451,8 @@ let rec infer_const_attr ctx exp =
   | Extract (_, e, _, _)
   | UnaryOp (_, _, e) -> r e
   | BinaryOp (_, _, e1, e2) -> combine (r e1) (r e2)
-  | TernaryOp (_, Ite, e1, e2, e3) -> (
+  | TernaryOp (_, Ite, e1, e2, e3)
+  | TernaryOp (_, LazyIte, e1, e2, e3) -> (
     let r_e2 = r e2 in
     match r e1 with
     | [Ok _] -> combine r_e2 (r e3)
@@ -846,7 +847,7 @@ let rec infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * [> w
     | _ -> type_error pos (ExpectedMachineIntegerType inf_ty)) 
   | LA.TernaryOp (pos, top, con, e1, e2) ->
     (match top with
-    | Ite -> 
+    | Ite | LazyIte -> 
       let* inf_ty, warnings1 = infer_type_expr ctx nname con in
       let* inf_ty = expand_type_syn_reftype_history ctx inf_ty in
       (match inf_ty with
@@ -1167,7 +1168,8 @@ and check_type_expr: tc_context -> NI.t option -> LA.expr -> tc_type -> ([> warn
     R.ifM (eq_lustre_type ctx inf_ty exp_ty) 
       (R.ok warnings)
       (type_error pos (UnificationFailed (exp_ty, inf_ty)))
-  | LA.TernaryOp (pos, _, con, e1, e2) ->
+  | LA.TernaryOp (pos, Ite, con, e1, e2)
+  | LA.TernaryOp (pos, LazyIte, con, e1, e2) ->
     infer_type_expr ctx nname con
     >>= (function 
         | Bool _, warnings1 ->

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -108,7 +108,7 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
     | _ -> false);
   mk_test "test function with node call in body" (fun () ->
     match load_file "./lustreSyntaxChecks/function_no_node_call.lus" with
-    | Error (`LustreSyntaxChecksError (_, NodeCallInFunction _)) -> true
+    | Error (`LustreSyntaxChecksError (_, IllegalNodeCall _)) -> true
     | _ -> false);
   mk_test "test function with pre in body" (fun () ->
     match load_file "./lustreSyntaxChecks/function_no_pre_in_body.lus" with
@@ -140,7 +140,7 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
     | _ -> false);  
   mk_test "test node call in function contract" (fun () ->
     match load_file "./lustreSyntaxChecks/function_no_stateful_contract_2.lus" with
-    | Error (`LustreSyntaxChecksError (_, NodeCallInFunction _)) -> true
+    | Error (`LustreSyntaxChecksError (_, IllegalNodeCall _)) -> true
     | _ -> false);
   mk_test "test defining a variable more than once 1" (fun () ->
     match load_file "./lustreSyntaxChecks/var_redefinition.lus" with
@@ -184,7 +184,7 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
     | _ -> false);
   mk_test "node call in any op in function" (fun () ->
     match load_file "./lustreSyntaxChecks/any_op_func.lus" with
-    | Error (`LustreSyntaxChecksError (_, NodeCallInFunction _)) -> true
+    | Error (`LustreSyntaxChecksError (_, IllegalNodeCall _)) -> true
     | _ -> false);
   mk_test "pre in any op in function" (fun () ->
     match load_file "./lustreSyntaxChecks/any_op_func_pre.lus" with

--- a/tests/regression/success/if_then_otherwise.lus
+++ b/tests/regression/success/if_then_otherwise.lus
@@ -1,0 +1,14 @@
+function F(x:int) returns (y:int);
+(*@contract
+  assume "A" x >=0;
+  guarantee "G" y>0;
+*)
+let
+  y = x + 1;
+tel
+
+node N(x:int) returns (z: int)
+let
+  z = if x>=0 then F(x) otherwise 1;
+  check "P" z>0;
+tel 


### PR DESCRIPTION
The assumptions and guarantees of functions called within a branch of an `if-then-otherwise` expression are checked and applied under that branch's condition. Node calls and temporal operators are not allowed inside such branches.