### PR TITLE
Add short-circuiting versions of 'and', 'or', and '=>'

### DIFF
--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -63,8 +63,8 @@ type unary_operator =
   | BVNot
 
 type binary_operator =
-  | And | Or | Xor | Impl | In
-  | Mod | Minus | Plus | Div | Times | IntDiv
+  | And | AndThen | Or | OrElse | Xor | Impl | LazyImpl
+  | In | Mod | Minus | Plus | Div | Times | IntDiv
   | BVAnd | BVOr | BVShiftL | BVShiftR | BVConcat 
 
 type ternary_operator =
@@ -475,9 +475,12 @@ let rec pp_print_expr ppf =
 
     | UnaryOp (p, Not, e) -> p1 p "not" e
     | BinaryOp (p, And, e1, e2) -> p2 p "and" e1 e2
+    | BinaryOp (p, AndThen, e1, e2) -> p2 p "and then" e1 e2
     | BinaryOp (p, Or, e1, e2) -> p2 p "or" e1 e2
+    | BinaryOp (p, OrElse, e1, e2) -> p2 p "or else" e1 e2
     | BinaryOp (p, Xor, e1, e2) -> p2 p "xor" e1 e2
     | BinaryOp (p, Impl, e1, e2) -> p2 p "=>" e1 e2
+    | BinaryOp (p, LazyImpl, e1, e2) -> p2 p "==>" e1 e2
     | BinaryOp (p, In, e1, e2) -> p2 p "in" e1 e2
     
     | Quantifier (_, Forall, vars, e) -> 

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -79,8 +79,8 @@ type unary_operator =
   | BVNot
 
 type binary_operator =
-  | And | Or | Xor | Impl | In
-  | Mod | Minus | Plus | Div | Times | IntDiv
+  | And | AndThen | Or | OrElse | Xor | Impl | LazyImpl
+  | In | Mod | Minus | Plus | Div | Times | IntDiv
   | BVAnd | BVOr | BVShiftL | BVShiftR | BVConcat
 
 type ternary_operator =

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2157,6 +2157,23 @@ and normalize_expr ?guard info node_id map =
   | Extract (pos, expr, ub, lb) ->
     let nexpr, gids, warnings = normalize_expr ?guard info node_id map expr in
     Extract (pos, nexpr, ub, lb), gids, warnings
+  | BinaryOp (pos, AndThen, expr1, expr2) ->
+    let e =
+      let not_e1 = A.UnaryOp (pos, Not, expr1) in
+      A.TernaryOp (pos, LazyIte, not_e1, A.Const (pos, A.False), expr2)
+    in
+    normalize_expr ?guard info node_id map e
+  | BinaryOp (pos, OrElse, expr1, expr2) ->
+    let e =
+      A.TernaryOp (pos, LazyIte, expr1, A.Const (pos, A.True), expr2)
+    in
+    normalize_expr ?guard info node_id map e
+  | BinaryOp (pos, LazyImpl, expr1, expr2) ->
+    let e =
+      let not_e1 = A.UnaryOp (pos, Not, expr1) in
+      A.BinaryOp (pos, OrElse, not_e1, expr2)
+    in
+    normalize_expr ?guard info node_id map e
   | BinaryOp (pos, op, expr1, expr2) ->
     let nexpr1, gids1, warnings1 = normalize_expr ?guard info node_id map expr1 in
     let nexpr2, gids2, warnings2 = normalize_expr ?guard info node_id map expr2 in

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -471,6 +471,7 @@ rule token = parse
   | '{' { LCURLYBRACKET }
   | '}' { RCURLYBRACKET }
   | ".%" { DOTPERCENT }
+  | "==>" { LAZY_IMPL }
   | "=>" { IMPL }
   | '#' { HASH }
   | "<=" { LTE }
@@ -500,6 +501,18 @@ rule token = parse
   | hex_num as p { NUMERAL (HString.mk_hstring p) }
   | hex_dec1 as p { DECIMAL (HString.mk_hstring p) }
   | hex_dec2 as p { DECIMAL (HString.mk_hstring p) }
+
+  | "and" ((whitespace | newline) as gap)+ "then" {
+    (* update line counter for every newline in the gap *)
+    String.iter (fun c -> if c = '\n' then Lexing.new_line lexbuf) gap;
+    AND_THEN
+  }
+
+  | "or" ((whitespace | newline) as gap)+ "else" {
+    (* update line counter for every newline in the gap *)
+    String.iter (fun c -> if c = '\n' then Lexing.new_line lexbuf) gap;
+    OR_ELSE
+  }
 
   (* Keyword *)
   | id as p {

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1172,12 +1172,15 @@ and compile_ast_expr
   (* ****************************************************************** *)
   | A.BinaryOp (_, A.And, expr1, expr2) ->
     compile_binary bounds E.mk_and expr1 expr2
+  | A.BinaryOp (_, A.AndThen, _, _) -> assert false
   | A.BinaryOp (_, A.Or, expr1, expr2) ->
     compile_binary bounds E.mk_or expr1 expr2 
+  | A.BinaryOp (_, A.OrElse, _, _) -> assert false
   | A.BinaryOp (_, A.Xor, expr1, expr2) ->
     compile_binary bounds E.mk_xor expr1 expr2 
   | A.BinaryOp (_, A.Impl, expr1, expr2) ->
     compile_binary bounds E.mk_impl expr1 expr2
+  | A.BinaryOp (_, A.LazyImpl, _, _) -> assert false
   | A.BinaryOp (_, A.In, k, map_expr) ->
     let map_expr = compile_map_index bounds map_expr k in
     X.find_prefix [(X.TupleIndex 0)] map_expr

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -150,10 +150,10 @@ let mk_span start_pos end_pos =
 %token TRUE
 %token FALSE
 %token NOT
-%token AND
+%token AND AND_THEN
 %token XOR
-%token OR
-%token IMPL
+%token OR OR_ELSE
+%token IMPL LAZY_IMPL
 %token FORALL
 %token EXISTS
 %token IN
@@ -220,9 +220,9 @@ let mk_span start_pos end_pos =
 %nonassoc ELSE OTHERWISE
 %right ARROW
 %nonassoc prec_forall prec_exists
-%right IMPL
-%left OR XOR
-%left AND
+%right IMPL LAZY_IMPL
+%left OR OR_ELSE XOR
+%left AND AND_THEN
 %left IN
 %left LT LTE EQUALS NEQ GTE GT
 %left PLUS MINUS
@@ -990,9 +990,12 @@ pexpr(Q):
   (* A Boolean operation *)
   | NOT; e = pexpr(Q) { A.UnaryOp (mk_pos $startpos, A.Not, e) } 
   | e1 = pexpr(Q); AND; e2 = pexpr(Q) { A.BinaryOp (mk_pos $startpos, A.And, e1, e2) }
+  | e1 = pexpr(Q); AND_THEN; e2 = pexpr(Q) { A.BinaryOp (mk_pos $startpos, A.AndThen, e1, e2) }
   | e1 = pexpr(Q); OR; e2 = pexpr(Q) { A.BinaryOp (mk_pos $startpos, A.Or, e1, e2) }
+  | e1 = pexpr(Q); OR_ELSE; e2 = pexpr(Q) { A.BinaryOp (mk_pos $startpos, A.OrElse, e1, e2) }
   | e1 = pexpr(Q); XOR; e2 = pexpr(Q) { A.BinaryOp (mk_pos $startpos, A.Xor, e1, e2) }
   | e1 = pexpr(Q); IMPL; e2 = pexpr(Q) { A.BinaryOp (mk_pos $startpos, A.Impl, e1, e2) }
+  | e1 = pexpr(Q); LAZY_IMPL; e2 = pexpr(Q) { A.BinaryOp (mk_pos $startpos, A.LazyImpl, e1, e2) }
   | e1 = pexpr(Q); IN; e2 = pexpr(Q) { A.BinaryOp (mk_pos $startpos, A.In, e1, e2) }
   | HASH; LPAREN; pexpr_list(Q); RPAREN { 
     let pos = mk_pos $startpos in

--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -961,6 +961,11 @@ and check_expr: context -> (context -> LA.expr -> ([> warning] list, ([> error] 
     >> (no_temporal_operator "branches of an if-then-otherwise" e)
     >> (f ctx e)
   in
+  let lazy_bool_op op ctx e =
+    (no_calls_to_node ("the argument of " ^ op)  ctx e)
+    >> (no_temporal_operator ("arguments of " ^ op) e)
+    >> (f ctx e)
+  in
   let res = f ctx expr in
   let check = function
     | LA.RecordProject (_, e, _)
@@ -979,6 +984,18 @@ and check_expr: context -> (context -> LA.expr -> ([> warning] list, ([> error] 
       let* _ = check_quantified_vars ctx vars in
       let* warnings2 = check_expr ctx f e in 
       Res.ok (warnings @ warnings2)
+    | BinaryOp (_, AndThen, e1, e2) ->
+      let* warnings1 = (check_expr ctx (lazy_bool_op "'and then'") e1) in 
+      let* warnings2 = (check_expr ctx (lazy_bool_op "'and then'") e2) in 
+      Ok (warnings1 @ warnings2)
+    | BinaryOp (_, OrElse, e1, e2) ->
+      let* warnings1 = (check_expr ctx (lazy_bool_op "'or else'") e1) in 
+      let* warnings2 = (check_expr ctx (lazy_bool_op "'or else'") e2) in 
+      Ok (warnings1 @ warnings2)
+    | BinaryOp (_, LazyImpl, e1, e2) ->
+      let* warnings1 = (check_expr ctx (lazy_bool_op "==>") e1) in 
+      let* warnings2 = (check_expr ctx (lazy_bool_op "==>") e2) in 
+      Ok (warnings1 @ warnings2)
     | BinaryOp (_, _, e1, e2)
     | CompOp (_, _, e1, e2)
     | IndexAccess (_, e1, e2, _)

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1465,7 +1465,7 @@ and infer_type_binary_op: tc_context -> NI.t option -> Lib.position
   let* ty1, warnings1 = infer_type_expr ctx nname e1 in
   let* ty2, warnings2 = infer_type_expr ctx nname e2 in
   match op with
-  | LA.And | LA.Or | LA.Xor | LA.Impl ->
+  | LA.And | LA.AndThen | LA.Or | LA.OrElse | LA.Xor | LA.Impl | LA.LazyImpl ->
     R.ifM (eq_lustre_type ctx ty1 (Bool pos))
       (R.ifM (eq_lustre_type ctx ty2 (Bool pos))
         (R.ok (LA.Bool pos, warnings1 @ warnings2))

--- a/tests/regression/success/lazy_implication.lus
+++ b/tests/regression/success/lazy_implication.lus
@@ -1,0 +1,15 @@
+
+function F(x:int) returns (y:int);
+(*@contract
+  assume "A" x >=0;
+  guarantee "G" y>0;
+*)
+let
+  y = x + 1;
+tel
+
+node N(x:int) returns (y:bool);
+let
+  y = x>=0 ==> F(x)>0;
+  check "P" y;
+tel


### PR DESCRIPTION
This PR introduces three new boolean operators: `and then`, `or else`, and `==>`. They behave like `and`, `or`, and `=>` but evaluate the right-hand side only when necessary. Specifically, assumption checks of functions called in the second argument respect short-circuiting semantics. Node calls and temporal operators are not allowed in the arguments of these operators.