### PR TITLE
Support abstract types in map key and value types

### DIFF
--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -2265,7 +2265,7 @@ and check_ref_type_assumptions ctx src nname bound_var e =
 
 and check_map_type pos ctx ty = let r = check_map_type pos ctx in match ty with  
 | LA.Map _ | GroupType _ | ArrayType _ | History _ 
-| TArr _ | AbstractType _ -> type_error pos (UnsupportedMapType ty) 
+| TArr _ -> type_error pos (UnsupportedMapType ty) 
 | RecordType (_, _, tis) -> 
   Res.seq_ (List.map (fun (_, _, ty) -> r ty) tis)
 | RefinementType (_, (_, _, ty), _) -> 
@@ -2275,7 +2275,7 @@ and check_map_type pos ctx ty = let r = check_map_type pos ctx in match ty with
 | UserType _ -> 
   let* ty = expand_type_syn_reftype ctx ty in 
   r ty 
-| Bool _ | Int _ | IntRange _ | EnumType _ | Real _ | SBitVector _ | UBitVector _ -> Res.ok () 
+| AbstractType _ | Bool _ | Int _ | IntRange _ | EnumType _ | Real _ | SBitVector _ | UBitVector _ -> Res.ok () 
 
 and check_type_well_formed: tc_context -> source -> NI.t option -> bool -> tc_type -> ([> warning] list, [> error]) result
   = fun ctx src nname is_const ->

--- a/tests/regression/success/abstract_ty_map.lus
+++ b/tests/regression/success/abstract_ty_map.lus
@@ -1,0 +1,11 @@
+type T;
+
+node N (x1, x2: T) returns (m: map<T, int>;) 
+var counter: int;
+let
+  counter = 0 -> pre counter + 1;
+  m = map[]@<T, int>[x1 := counter; x2 := counter+1] -> (pre m)[x1 := counter; x2 := counter+1];
+
+  check m[x1] >= 0;
+  check m[x2] > 0;
+tel


### PR DESCRIPTION
Running the new test case produces the following invariant generation error:
```
<Error> Caught exception in invariant generator: SMTSolver.Unknown
```
However, replacing type `T` with `int` in the test case and rerunning, the same error is still produced, suggesting that the problem is not with abstract types. 

Still, it seems more investigation is required before merging.

EDIT: The problem seems to be solved when using the latest version of Z3.