### PR TITLE
Fix map refinement type bugs

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2268,14 +2268,18 @@ and normalize_expr ?guard info node_id map =
         quantified_variables = info.quantified_variables @ vars }
     in
     let nexpr, gids, warnings = normalize_expr ?guard info node_id map expr in
-    List.fold_left (fun acc var ->
+    List.fold_left (fun acc ((p, id, ty) as var) ->
       (* Assume constraints are constant expressions, and thus,
            no normalization is required *)
       let c = mk_enum_subrange_reftype_constraints (Some node_id) info [var] in 
       match c, kind with
       | None, _ -> A.Quantifier (pos, kind, [var], acc)
-      | Some c, A.Exists -> A.Quantifier (pos, kind, [var], A.BinaryOp (pos, A.And, c, acc))
-      | Some c, A.Forall -> A.Quantifier (pos, kind, [var], A.BinaryOp (pos, A.Impl, c, acc))
+      | Some c, A.Exists -> 
+        let ty = Chk.expand_type_syn_reftype_history_subrange ctx ty |> unwrap in 
+        A.Quantifier (pos, kind, [p, id, ty], A.BinaryOp (pos, A.And, c, acc))
+      | Some c, A.Forall -> 
+        let ty = Chk.expand_type_syn_reftype_history_subrange ctx ty |> unwrap in 
+        A.Quantifier (pos, kind, [p, id, ty], A.BinaryOp (pos, A.Impl, c, acc))
     ) nexpr (List.rev vars), gids, warnings
   | When (pos, expr, clock_expr) ->
     let nexpr, gids, warnings = normalize_expr ?guard info node_id map expr in

--- a/src/lustre/lustreFlattenRefinementTypes.ml
+++ b/src/lustre/lustreFlattenRefinementTypes.ml
@@ -57,14 +57,28 @@ let rec flatten_ref_type ctx ty = match ty with
       ) tys |> List.flatten
     | Map (pos, ty1, ty2) ->
       let dummy_index = AN.mk_fresh_dummy_index () in
-      let exprs = chase_refinements ty2 in
-      List.map (fun expr ->
+      let exprs1 = chase_refinements ty1 in
+      let exprs1 = List.map (fun expr ->
+        let idx = A.Ident(pos, dummy_index) in
+        let expr = AH.substitute_naive id idx expr in
+        let expr = 
+          A.BinaryOp(pos, A.Impl, A.BinaryOp(pos, In, Ident(pos, dummy_index), Ident(pos, id)), expr) 
+        in
+        let ty1 = LustreTypeChecker.expand_type_syn_reftype_history_subrange ctx ty1 |> Result.get_ok in 
+        A.Quantifier(pos, Forall, [pos, dummy_index, ty1], expr)
+      ) exprs1 in 
+      let exprs2 = chase_refinements ty2 in
+      let exprs2 = List.map (fun expr ->
         let idx =
           A.IndexAccess(pos, Ident(pos, id), Ident(pos, dummy_index), Map)
         in
         let expr = AH.substitute_naive id idx expr in
+        let expr = 
+          A.BinaryOp(pos, A.Impl, A.BinaryOp(pos, In, Ident(pos, dummy_index), Ident(pos, id)), expr) 
+        in
         A.Quantifier(pos, Forall, [pos, dummy_index, ty1], expr)
-      ) exprs
+      ) exprs2 in 
+      exprs1 @ exprs2
     | ArrayType (pos, (ty, len)) ->
       let dummy_index = AN.mk_fresh_dummy_index () in
       let exprs = chase_refinements ty in

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1510,6 +1510,7 @@ and infer_type_binary_op: tc_context -> NI.t option -> Lib.position
         (type_error pos (ExpectedType ((LA.Bool pos), ty2))))
       (type_error pos (ExpectedType ((LA.Bool pos), ty1)))
   | LA.In -> (
+    let* ty2 = expand_type_syn_reftype_history_subrange ctx ty2 in
     match ty2 with
     | LA.Map (_, given_index_type, _) -> (
       R.ifM (eq_lustre_type ctx ty1 given_index_type)

--- a/tests/regression/success/map_ref_bugs.lus
+++ b/tests/regression/success/map_ref_bugs.lus
@@ -1,0 +1,10 @@
+type Nat = subtype {x: int | x >= 0};
+type Pos = subtype {x: int | x > 0};
+type R = subtype {m: map<Nat, Pos> | 0 in m};
+
+node N (m: R) returns () 
+let
+  check 0 in m;
+  check not (-1 in m);
+  check forall (i: int) (i in m => m[i] > 0);
+tel


### PR DESCRIPTION
Refinements of map types (as in `type R = subtype {m: map<Nat, Pos> | 0 in m};`) were buggy in two places, (i) type checking and (ii) refinement type flattening. For (i), in type checking the `In` membership operator, we need to chase base types for the second operand. For (ii), we were neglecting to flatten the key type.

Before this PR, all testing was concentrated on map key and value refinement types (ie `type M = map<Nat, Pos>`) without wrapping the outer map in a refinement type.