### PR TITLE
Type inference for map and set literals

### DIFF
--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -119,8 +119,8 @@ type expr =
   | GroupExpr of position * group_expr * expr list
   (* Update of structured expressions *)
   | StructUpdate of position * expr * label_or_index list * expr option
-  | EmptyMap of position * (lustre_type * lustre_type)
-  | EmptySet of position * lustre_type 
+  | EmptyMap of position * (lustre_type * lustre_type) option
+  | EmptySet of position * lustre_type option
   | ArrayConstr of position * expr * expr  
   | IndexAccess of position * expr * expr * access_kind
   (* Quantified expressions *)
@@ -413,6 +413,19 @@ let rec pp_print_expr ppf =
 
     | GroupExpr (p, ArrayExpr, l) -> Format.fprintf ppf "%a@[<hv 1>[%a]@]" ppos p pl l
 
+    | StructUpdate (_, EmptySet _, i, None) -> 
+
+      Format.fprintf ppf
+        "{ %a }"
+        (pp_print_list pp_print_label_or_index "") i
+
+    | StructUpdate (_, EmptyMap _, i, Some e) -> 
+
+      Format.fprintf ppf
+        "map[%a := %a]"
+        (pp_print_list pp_print_label_or_index "") i
+        pp_print_expr e
+
     | StructUpdate (_, e1, i, Some e2) -> 
 
       Format.fprintf ppf
@@ -428,18 +441,22 @@ let rec pp_print_expr ppf =
         pp_print_expr e1
         (pp_print_list pp_print_label_or_index "") i
 
-    | EmptySet (_, ty) ->
+    | EmptySet (_, Some ty) ->
 
       Format.fprintf ppf
         "set[]@<%a>"
         pp_print_lustre_type ty
 
-    | EmptyMap (_, (key_ty, value_ty)) ->
+    | EmptySet (_, None) -> assert false
+
+    | EmptyMap (_, Some (key_ty, value_ty)) ->
 
       Format.fprintf ppf
         "map[]@<%a,%a>"
         pp_print_lustre_type key_ty
         pp_print_lustre_type value_ty
+
+    | EmptyMap (_, None) -> assert false 
 
     | ArrayConstr (p, e1, e2) -> 
 

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -156,8 +156,8 @@ and expr =
   | GroupExpr of position * group_expr * expr list
   (* Update of structured expressions *)
   | StructUpdate of position * expr * label_or_index list * expr option
-  | EmptyMap of position * (lustre_type * lustre_type)
-  | EmptySet of position * lustre_type
+  | EmptyMap of position * (lustre_type * lustre_type) option
+  | EmptySet of position * lustre_type option
   | ArrayConstr of position * expr * expr 
   | IndexAccess of position * expr * expr * access_kind
   (* Quantified expressions *)

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -338,11 +338,11 @@ and mk_graph_expr ?(only_modes = false)
   | LA.Call (_, _, _, es) ->
      List.fold_left union_dependency_analysis_data empty_dependency_analysis_data
        (List.map (mk_graph_expr ~only_modes) es)
-  | LA.EmptyMap (_, (kt, vt)) -> 
+  | LA.EmptyMap (_, Some (kt, vt)) -> 
     union_dependency_analysis_data
       (mk_graph_type kt)
       (mk_graph_type vt)
-  | LA.EmptySet (_, ty) -> mk_graph_type ty
+  | LA.EmptySet (_, Some ty) -> mk_graph_type ty
   | LA.AnyOp _ -> assert false (* Already desugared in lustreDesugarAnyOps *)
   | LA.Quantifier (_, _, tis, e) -> 
     let tys = List.map (fun (_, _, ty) -> ty) tis in 
@@ -380,9 +380,9 @@ let mk_graph_type_decl: LA.type_decl -> dependency_analysis_data
                             
 let rec get_node_call_from_expr: LA.expr -> (LA.ident * Lib.position) list
   = function
-  | Ident _ -> []
-  | EmptyMap (_, (kt, vt)) -> extract_node_calls_type kt @ extract_node_calls_type vt
-  | EmptySet (_, ty) -> extract_node_calls_type ty
+  | Ident _ | EmptyMap (_, None) | EmptySet (_, None) -> []
+  | EmptyMap (_, Some (kt, vt)) -> extract_node_calls_type kt @ extract_node_calls_type vt
+  | EmptySet (_, Some ty) -> extract_node_calls_type ty
   | ModeRef (pos, ids) ->
     if List.length ids = 1 then []
     else [(HString.concat2 contract_prefix (List.hd ids), pos)]  
@@ -650,9 +650,10 @@ let rec vars_with_flattened_nodes: node_summary -> int -> LA.expr -> LA.SI.t
   let r = vars_with_flattened_nodes m proj in
   match expr with
   | Ident (_ , i) -> SI.singleton i
+  | EmptyMap (_, None) | EmptySet (_, None) 
   | ModeRef _ -> SI.empty
-  | EmptySet (_, ty) -> LH.vars_of_type ty
-  | EmptyMap (_, (kt, vt)) -> SI.union (LH.vars_of_type kt) (LH.vars_of_type vt) 
+  | EmptySet (_, Some ty) -> LH.vars_of_type ty
+  | EmptyMap (_, Some (kt, vt)) -> SI.union (LH.vars_of_type kt) (LH.vars_of_type vt) 
   | RecordProject (_, e, _) -> r e 
   | TupleProject (_, e, _) -> r e
   (* Values *)
@@ -786,10 +787,10 @@ let rec mk_graph_expr2: node_summary -> LA.expr -> (dependency_analysis_data lis
   | LA.Ident (pos, i) -> R.ok [singleton_dependency_analysis_data empty_hs i pos]
   | LA.ModeRef (pos, ids) ->
      R.ok [singleton_dependency_analysis_data mode_prefix (List.nth ids (List.length ids - 1) ) pos] 
-  | LA.EmptySet (_, ty) -> R.ok [mk_graph_type ty]
-  | LA.EmptyMap (_, (kt, vt)) -> 
+  | LA.EmptySet (_, Some ty) -> R.ok [mk_graph_type ty]
+  | LA.EmptyMap (_, Some (kt, vt)) -> 
     R.ok [union_dependency_analysis_data (mk_graph_type kt) (mk_graph_type vt)]
-  | LA.Const _ ->
+  | LA.Const _ | EmptySet (_, None) | EmptyMap (_, None) ->
      R.ok [empty_dependency_analysis_data]
 
   | LA.RecordExpr (pos, i, _, ty_ids) ->

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -121,9 +121,11 @@ let type_arity ty =
 
 let rec expr_contains_call = function
   | Ident (_, _) | ModeRef (_, _) | Const (_, _) -> false 
-  | EmptySet (_, ty) -> 
+  | EmptySet (_, Some ty) -> 
     fold_lustre_ty expr_contains_call false (||) ty
-  | EmptyMap (_, (kt, vt)) ->
+  | EmptySet (_, None)
+  | EmptyMap (_, None) -> false
+  | EmptyMap (_, Some (kt, vt)) ->
     fold_lustre_ty expr_contains_call false (||) kt || 
     fold_lustre_ty expr_contains_call false (||) vt
   | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
@@ -148,11 +150,12 @@ let rec expr_contains_call = function
 
 let rec expr_contains_id id = function
   | Ident (_, id2) -> id = id2
+  | EmptyMap (_, None) | EmptySet (_, None)
   | ModeRef (_, _) | Const (_, _) -> false 
-  | EmptyMap (_, (kt, vt)) -> 
+  | EmptyMap (_, Some (kt, vt)) -> 
     fold_lustre_ty expr_is_id false (||) kt || 
     fold_lustre_ty expr_is_id false (||) vt 
-  | EmptySet (_, ty) -> fold_lustre_ty expr_is_id false (||) ty
+  | EmptySet (_, Some ty) -> fold_lustre_ty expr_is_id false (||) ty
   | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
   | ConvOp (_, _, e) | Quantifier (_, _, _, e) | When (_, e, _) | Pre (_, e) 
   | Extract (_, e, _, _) | StructUpdate (_, e, _, None)

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -184,11 +184,12 @@ let rec expr_contains_id id = function
 (* Substitute t for var. AnyOp is not supported due to introduction of bound variables. *)
 let rec substitute_naive (var:HString.t) t = function
   | Ident (_, i) as e -> if i = var then t else e
+  | EmptyMap (_, None) | EmptySet (_, None)
   | ModeRef (_, _) as e -> e
-  | EmptyMap (p, (kt, vt)) ->
-    EmptyMap (p, (map_lustre_ty (substitute_naive var t) kt, map_lustre_ty (substitute_naive var t) vt))
-  | EmptySet (p, ty) -> 
-    EmptySet (p, map_lustre_ty (substitute_naive var t) ty)
+  | EmptyMap (p, Some (kt, vt)) ->
+    EmptyMap (p, Some (map_lustre_ty (substitute_naive var t) kt, map_lustre_ty (substitute_naive var t) vt))
+  | EmptySet (p, Some ty) -> 
+    EmptySet (p, Some (map_lustre_ty (substitute_naive var t) ty))
   | RecordProject (pos, e, idx) -> RecordProject (pos, substitute_naive var t e, idx)
   | TupleProject (pos, e, idx) -> TupleProject (pos, substitute_naive var t e, idx)
   | Const (_, _) as e -> e
@@ -247,11 +248,12 @@ let rec apply_subst_in_expr sigma = function
       | Some expr -> expr
       | None -> Ident (pos, i)
   )
+  | EmptyMap (_, None) | EmptySet (_, None)
   | ModeRef (_, _) as e -> e
-  | EmptyMap (p, (kt, vt)) -> 
-    EmptyMap (p, (map_lustre_ty (apply_subst_in_expr sigma) kt, map_lustre_ty (apply_subst_in_expr sigma) vt))
-  | EmptySet (p, ty) -> 
-    EmptySet (p, map_lustre_ty (apply_subst_in_expr sigma) ty)
+  | EmptyMap (p, Some (kt, vt)) -> 
+    EmptyMap (p, Some (map_lustre_ty (apply_subst_in_expr sigma) kt, map_lustre_ty (apply_subst_in_expr sigma) vt))
+  | EmptySet (p, Some ty) -> 
+    EmptySet (p, Some (map_lustre_ty (apply_subst_in_expr sigma) ty))
   | RecordProject (pos, e, idx) -> RecordProject (pos, apply_subst_in_expr sigma e, idx)
   | TupleProject (pos, e, idx) -> TupleProject (pos, apply_subst_in_expr sigma e, idx)
   | Const (_, _) as e -> e
@@ -306,13 +308,14 @@ let rec apply_type_subst_in_expr
   | Call (pos, ty_args, id, expr_list) ->
     let ty_args = List.map (apply_type_subst_in_type sigma) ty_args in
     Call (pos, ty_args, id, List.map (apply_type_subst_in_expr sigma) expr_list)
-  | EmptyMap (pos, (kt, vt)) ->
+  | EmptyMap (_, None) | EmptySet (_, None) -> expr
+  | EmptyMap (pos, Some (kt, vt)) ->
     let kt = apply_type_subst_in_type sigma kt in
     let vt = apply_type_subst_in_type sigma vt in
-    EmptyMap (pos, (kt, vt))
-  | EmptySet (pos, ty) ->
+    EmptyMap (pos, Some (kt, vt))
+  | EmptySet (pos, Some ty) ->
     let ty = apply_type_subst_in_type sigma ty in
-    EmptySet (pos, ty)
+    EmptySet (pos, Some ty)
   | Quantifier (pos, q, tis, expr) -> 
     let tis = List.map (fun (p, id, ty) -> 
       p, id, apply_type_subst_in_type sigma ty
@@ -428,12 +431,12 @@ let rec apply_subst_in_type sigma = function
   | ty -> ty
     
 let rec has_unguarded_pre ung = function
-  | Const _ | Ident _ | ModeRef _  -> false 
+  | Const _ | Ident _ | ModeRef _  | EmptyMap (_, None) | EmptySet (_, None) -> false 
 
-  | EmptyMap (_, (kt, vt)) ->  
+  | EmptyMap (_, Some (kt, vt)) ->  
     fold_lustre_ty (has_unguarded_pre ung) false (||) kt || 
     fold_lustre_ty (has_unguarded_pre ung) false (||) vt
-  | EmptySet (_, ty) -> 
+  | EmptySet (_, Some ty) -> 
     fold_lustre_ty (has_unguarded_pre ung) false (||) ty
   | RecordProject (_, e, _) | ConvOp (_, _, e)
   | UnaryOp (_, _, e) | When (_, e, _)
@@ -529,12 +532,12 @@ let has_unguarded_pre e =
   then raise Parser_error; u
 
 let rec has_unguarded_pre_no_warn ung = function
-  | Const _ | Ident _ | ModeRef _  -> false 
+  | Const _ | Ident _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> false 
 
-  | EmptyMap (_, (kt, vt)) -> 
+  | EmptyMap (_, Some (kt, vt)) -> 
     fold_lustre_ty (has_unguarded_pre_no_warn ung) false (||) kt || 
     fold_lustre_ty (has_unguarded_pre_no_warn ung) false (||) vt
-  | EmptySet (_, ty) -> 
+  | EmptySet (_, Some ty) -> 
     fold_lustre_ty (has_unguarded_pre_no_warn ung) false (||) ty
   | RecordProject (_, e, _) | ConvOp (_, _, e)
   | UnaryOp (_, _, e) | When (_, e, _)
@@ -630,14 +633,14 @@ let some_of_list = List.fold_left (
 
 (** Checks whether an expression has a `pre` or a `->`. *)
 let rec has_pre_or_arrow = function
-  | Const _ | Ident _ | ModeRef _ -> None 
+  | Const _ | Ident _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> None 
 
-  | EmptyMap (_, (kt, vt)) -> (
+  | EmptyMap (_, Some (kt, vt)) -> (
     match (fold_lustre_ty has_pre_or_arrow None (fun x1 x2 -> some_of_list [x1; x2]) kt) with 
     | None -> fold_lustre_ty has_pre_or_arrow None (fun x1 x2 -> some_of_list [x1; x2]) vt 
     | res -> res
     )
-  | EmptySet (_, ty) -> 
+  | EmptySet (_, Some ty) -> 
     fold_lustre_ty has_pre_or_arrow None (fun x1 x2 -> some_of_list [x1; x2]) ty
   | RecordProject (_, e, _) | ConvOp (_, _, e)
   | UnaryOp (_, _, e) | When (_, e, _)
@@ -894,10 +897,11 @@ let rec vars_of_node_calls_h obs =
   | ModeRef (_, is) -> if obs then SI.singleton (mk_mode_ref_id is) else SI.empty
   | RecordProject (_, e, _) -> vars obs e 
   | TupleProject (_, e, _) -> vars obs e
-  | EmptyMap (_, (kt, vt)) -> 
+  | EmptyMap (_, None) | EmptySet (_, None) -> SI.empty   
+  | EmptyMap (_, Some (kt, vt)) -> 
     SI.union (fold_lustre_ty (vars obs) SI.empty SI.union kt)
              (fold_lustre_ty (vars obs) SI.empty SI.union vt)
-  | EmptySet (_, ty) ->
+  | EmptySet (_, Some ty) ->
     fold_lustre_ty (vars obs) SI.empty SI.union ty
   (* Values *)
   | Const _ -> SI.empty
@@ -942,10 +946,11 @@ let rec vars_without_node_call_ids: expr -> iset =
   | ModeRef (_, is) -> SI.singleton (mk_mode_ref_id is)
   | RecordProject (_, e, _) -> vars e 
   | TupleProject (_, e, _) -> vars e
-  | EmptyMap (_, (kt, vt)) -> 
+  | EmptyMap (_, None) | EmptySet (_, None) -> SI.empty
+  | EmptyMap (_, Some (kt, vt)) -> 
     SI.union (fold_lustre_ty vars SI.empty SI.union kt) 
              (fold_lustre_ty vars SI.empty SI.union vt)
-  | EmptySet (_, ty) ->
+  | EmptySet (_, Some ty) ->
     fold_lustre_ty vars SI.empty SI.union ty
   (* Values *)
   | Const _ -> SI.empty
@@ -1011,10 +1016,11 @@ let rec calls_of_expr: expr -> NI.Set.t =
   | StructUpdate (_, e1, _, Some e2) -> NI.Set.union (calls_of_expr e1) (calls_of_expr e2)
   | StructUpdate (_, e1, _, None) -> calls_of_expr e1
   | ArrayConstr (_, e1, e2) -> NI.Set.union (calls_of_expr e1) (calls_of_expr e2)
-  | EmptyMap (_, (kt, vt)) -> 
+  | EmptyMap (_, None) | EmptySet (_, None) -> NI.Set.empty
+  | EmptyMap (_, Some (kt, vt)) -> 
     NI.Set.union (fold_lustre_ty calls_of_expr NI.Set.empty NI.Set.union kt)
                  (fold_lustre_ty calls_of_expr NI.Set.empty NI.Set.union vt)
-  | EmptySet (_, ty) -> 
+  | EmptySet (_, Some ty) -> 
     fold_lustre_ty calls_of_expr NI.Set.empty NI.Set.union ty
   | IndexAccess (_, e1, e2, _) -> NI.Set.union (calls_of_expr e1) (calls_of_expr e2)
   | Quantifier (_, _, _, e) -> calls_of_expr e
@@ -1032,10 +1038,11 @@ let rec vars_without_node_call_ids_current: expr -> iset =
   | ModeRef (_, is) -> SI.singleton (mk_mode_ref_id is)
   | RecordProject (_, e, _) -> vars e 
   | TupleProject (_, e, _) -> vars e
-  | EmptyMap (_, (kt, vt)) -> 
+  | EmptyMap (_, None) | EmptySet (_, None) -> SI.empty
+  | EmptyMap (_, Some (kt, vt)) -> 
     SI.union (fold_lustre_ty vars SI.empty SI.union kt) 
              (fold_lustre_ty vars SI.empty SI.union vt)
-  | EmptySet (_, ty) -> 
+  | EmptySet (_, Some ty) -> 
     fold_lustre_ty vars SI.empty SI.union ty
   (* Values *)
   | Const _ -> SI.empty
@@ -1168,13 +1175,14 @@ let rec replace_with_constants: expr -> expr =
   let c p = Const(p, Num (HString.mk_hstring "42")) in
   function
   | Ident(p, _) -> c p 
+    | EmptySet (_, None) | EmptyMap (_, None)
     | ModeRef _ as e -> e 
   | RecordProject (p, e, i) -> RecordProject (p, replace_with_constants e, i)  
   | TupleProject (p, e, i) -> TupleProject (p, replace_with_constants e, i)
-  | EmptyMap (p, (kt, vt)) -> 
-    EmptyMap (p, (map_lustre_ty replace_with_constants kt, map_lustre_ty replace_with_constants vt))
-  | EmptySet (p, ty) -> 
-    EmptySet (p, map_lustre_ty replace_with_constants ty)
+  | EmptyMap (p, Some (kt, vt)) -> 
+    EmptyMap (p, Some (map_lustre_ty replace_with_constants kt, map_lustre_ty replace_with_constants vt))
+  | EmptySet (p, Some ty) -> 
+    EmptySet (p, Some (map_lustre_ty replace_with_constants ty))
   (* Values *)
   | Const _ as e -> e
 
@@ -1256,11 +1264,12 @@ and is used inside abstract_pre_subexpressions *)
   
 let rec abstract_pre_subexpressions: expr -> expr = function
   | Ident _ 
+  | EmptySet (_, None) | EmptyMap (_, None)
   | ModeRef _ as e -> e 
-  | EmptyMap (p, (kt, vt)) -> 
-    EmptyMap (p, (map_lustre_ty abstract_pre_subexpressions kt, map_lustre_ty abstract_pre_subexpressions vt))
-  | EmptySet (p, ty) -> 
-    EmptySet (p, map_lustre_ty abstract_pre_subexpressions ty)
+  | EmptyMap (p, Some (kt, vt)) -> 
+    EmptyMap (p, Some (map_lustre_ty abstract_pre_subexpressions kt, map_lustre_ty abstract_pre_subexpressions vt))
+  | EmptySet (p, Some ty) -> 
+    EmptySet (p, Some (map_lustre_ty abstract_pre_subexpressions ty))
   | RecordProject (p, e, i) -> RecordProject (p, abstract_pre_subexpressions e, i)  
   | TupleProject (p, e, i) -> TupleProject (p, abstract_pre_subexpressions e, i)
   (* Values *)
@@ -1367,11 +1376,11 @@ let rec replace_idents locals1 locals2 expr =
   
   | GroupExpr (a, b, l) -> GroupExpr (a, b, List.map r l)
   | Call (a, b, c, l) -> Call (a, b, c, List.map r l)
-
-  | EmptyMap (p, (kt, vt)) ->
-    EmptyMap (p, (map_lustre_ty r kt, map_lustre_ty r vt))
-  | EmptySet (p, t) ->
-    EmptySet (p, map_lustre_ty r t)
+  | EmptyMap (_, None) | EmptySet (_, None) -> expr
+  | EmptyMap (p, Some (kt, vt)) ->
+    EmptyMap (p, Some (map_lustre_ty r kt, map_lustre_ty r vt))
+  | EmptySet (p, Some t) ->
+    EmptySet (p, Some (map_lustre_ty r t))
 
   | AnyOp _ -> assert false (* desugared in lustreDesugarAnyOps *)
   | Quantifier (a, b, tis, e) -> 
@@ -1839,11 +1848,12 @@ let rec rename_contract_vars = function
         Ident (p, id)
       else e
     with _ -> e)
+  | EmptySet (_, None) | EmptyMap (_, None)
   | ModeRef (_, _) as e -> e
-  | EmptyMap (p, (kt, vt)) ->
-    EmptyMap (p, (map_lustre_ty rename_contract_vars kt, map_lustre_ty rename_contract_vars vt))
-  | EmptySet (p, ty) ->
-    EmptySet (p, map_lustre_ty rename_contract_vars ty)
+  | EmptyMap (p, Some (kt, vt)) ->
+    EmptyMap (p, Some (map_lustre_ty rename_contract_vars kt, map_lustre_ty rename_contract_vars vt))
+  | EmptySet (p, Some ty) ->
+    EmptySet (p, Some (map_lustre_ty rename_contract_vars ty))
   | RecordProject (pos, e, idx) -> RecordProject (pos, rename_contract_vars e, idx)
   | TupleProject (pos, e, idx) -> TupleProject (pos, rename_contract_vars e, idx)
   | Const (_, _) as e -> e

--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -372,10 +372,10 @@ and simplify_expr ?(is_guarded = false) ?(ind_vars = []) ctx =
     ) (ctx, []) tis in
     let e' = simplify_expr ~ind_vars ~is_guarded:false ctx e in
     Quantifier (pos, q, tis, e')
-  | EmptySet (pos, ty) -> 
-    EmptySet (pos, inline_constants_of_lustre_type ~ind_vars ctx ty)
-  | EmptyMap (pos, (kt, vt)) -> 
-    EmptyMap (pos, (inline_constants_of_lustre_type ~ind_vars ctx kt, 
+  | EmptySet (pos, Some ty) -> 
+    EmptySet (pos, Some (inline_constants_of_lustre_type ~ind_vars ctx ty))
+  | EmptyMap (pos, Some (kt, vt)) -> 
+    EmptyMap (pos, Some (inline_constants_of_lustre_type ~ind_vars ctx kt, 
                     inline_constants_of_lustre_type ~ind_vars ctx vt))
   | e -> e
 (** Assumptions: These constants are arranged in dependency order, 

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2173,8 +2173,9 @@ and normalize_expr ?guard info node_id map =
   (* ************************************************************************ *)
   (* The remaining expr kinds are all just structurally recursive             *)
   (* ************************************************************************ *)
-  | ModeRef _ as expr -> expr, empty (), []
-  | EmptySet (pos, ty) -> 
+  | ModeRef _ 
+  | EmptyMap (_, None) | EmptySet (_, None) as expr -> expr, empty (), []
+  | EmptySet (pos, Some ty) -> 
     i := !i + 1;
     let prefix = HString.mk_hstring (string_of_int !i) in
     let name = HString.concat2 prefix (HString.mk_hstring "_empty_set") in
@@ -2184,7 +2185,7 @@ and normalize_expr ?guard info node_id map =
     } in
     let nexpr = A.Ident (pos, name) in 
     nexpr, gids, []
-  | EmptyMap (pos, (kt, vt)) -> 
+  | EmptyMap (pos, Some (kt, vt)) -> 
     i := !i + 1;
     let prefix = HString.mk_hstring (string_of_int !i) in
     let name = HString.concat2 prefix (HString.mk_hstring "_empty_map") in

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2173,8 +2173,17 @@ and normalize_expr ?guard info node_id map =
   (* ************************************************************************ *)
   (* The remaining expr kinds are all just structurally recursive             *)
   (* ************************************************************************ *)
-  | ModeRef _ 
-  | EmptyMap (_, None) | EmptySet (_, None) as expr -> expr, empty (), []
+  | ModeRef _ as expr -> expr, empty (), []
+  | StructUpdate (p1, EmptyMap (p2, None), [A.MapIndex (p3, e1)], Some e2) -> 
+    let kt, _ = Chk.infer_type_expr info.context (Some node_id) e1 |> Result.get_ok in 
+    let vt, _ = Chk.infer_type_expr info.context (Some node_id) e2 |> Result.get_ok in 
+    let expr = A.StructUpdate (p1, EmptyMap (p2, Some (kt, vt)), [A.MapIndex (p3, e1)], Some e2) in 
+    normalize_expr info node_id map expr
+  | StructUpdate (p1, EmptySet (p2, None), [A.SetIndex (p3, e)], None) ->
+    let ty, _ = Chk.infer_type_expr info.context (Some node_id) e |> Result.get_ok in 
+    let expr = A.StructUpdate (p1, EmptySet (p2, Some ty), [A.SetIndex (p3, e)], None) in 
+    normalize_expr info node_id map expr
+  | EmptyMap (_, None) | EmptySet (_, None) -> assert false 
   | EmptySet (pos, Some ty) -> 
     i := !i + 1;
     let prefix = HString.mk_hstring (string_of_int !i) in

--- a/src/lustre/lustreFlattenRefinementTypes.ml
+++ b/src/lustre/lustreFlattenRefinementTypes.ml
@@ -166,12 +166,12 @@ let rec flatten_ref_types_expr: TypeCheckerContext.tc_context -> A.expr -> A.exp
   | Quantifier (p, q, tis, e) ->
     let tis = List.map (fun (p, id, ty) -> p, id, flatten_ref_type ctx ty) tis in
     Quantifier (p, q, tis, rec_call e)
-  | EmptySet (p, ty) -> 
-    EmptySet (p, flatten_ref_type ctx ty)
-  | EmptyMap (p, (kt, vt)) ->
-    EmptyMap (p, (flatten_ref_type ctx kt, flatten_ref_type ctx vt))
+  | EmptySet (p, Some ty) -> 
+    EmptySet (p, Some (flatten_ref_type ctx ty))
+  | EmptyMap (p, Some (kt, vt)) ->
+    EmptyMap (p, Some (flatten_ref_type ctx kt, flatten_ref_type ctx vt))
   (* Everything else *)
-  | Ident _ 
+  | Ident _ | EmptyMap (_, None) | EmptySet (_, None)
   | ModeRef _ as e -> e 
   | RecordProject (p, e, i) -> RecordProject (p, rec_call e, i)  
   | TupleProject (p, e, i) -> TupleProject (p, rec_call e, i)

--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -334,7 +334,7 @@ and gen_poly_decls_expr: Ctx.tc_context -> GI.t NI.Map.t -> NI.t option -> (A.de
       ctx, gids, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
     ) (ctx, gids, [], [], node_decls_map) exprs in 
     ctx, gids, Call (pos, [], node_id, exprs), decls, node_decls_map
-  | Ident _ 
+  | Ident _ | EmptyMap (_, None) | EmptySet (_, None)
   | Const _
   | ModeRef _ -> ctx, gids, expr, [], node_decls_map
   | RecordProject (p, expr, id) -> 
@@ -394,13 +394,13 @@ and gen_poly_decls_expr: Ctx.tc_context -> GI.t NI.Map.t -> NI.t option -> (A.de
     let ctx, gids, expr, decls1, node_decls_map = rec_call expr in 
     let ctx, gids, ty, decls2, node_decls_map = gen_poly_decls_ty ctx gids caller_nname node_decls_map ty in 
     ctx, gids, AnyOp (p, (p2, id, ty), expr), decls1 @ decls2, node_decls_map
-  | EmptySet (p, ty) ->
+  | EmptySet (p, Some ty) ->
     let ctx, gids, ty, decls, node_decls_map = gen_poly_decls_ty ctx gids caller_nname node_decls_map ty in 
-    ctx, gids, EmptySet (p, ty), decls, node_decls_map
-  | EmptyMap (p, (kt, vt)) ->
+    ctx, gids, EmptySet (p, Some ty), decls, node_decls_map
+  | EmptyMap (p, Some (kt, vt)) ->
     let ctx, gids, kt, decls1, node_decls_map = gen_poly_decls_ty ctx gids caller_nname node_decls_map kt in 
     let ctx, gids, vt, decls2, node_decls_map = gen_poly_decls_ty ctx gids caller_nname node_decls_map vt in 
-    ctx, gids, EmptyMap (p, (kt, vt)), decls1 @ decls2, node_decls_map
+    ctx, gids, EmptyMap (p, Some (kt, vt)), decls1 @ decls2, node_decls_map
   | Quantifier (p, q, tis, expr) -> 
     let ctx, gids, expr, decls1, node_decls_map = rec_call expr in 
     let ctx, gids, tis, decls2, node_decls_map = List.fold_left (fun (ctx, gids, acc_tis, acc_decls, acc_node_decls_map) (p, id, ty) -> 

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -931,6 +931,7 @@ pexpr(Q):
   (* An array constructor (not quantified) *)
   | e1 = pexpr(Q); CARET; e2 = expr { A.ArrayConstr (mk_pos $startpos, e1, e2) }
 
+  (* Map literals *)
   | MAP LSQBRACKET 
     updates = separated_list(SEMICOLON, assign); 
     RSQBRACKET ATSIGN
@@ -938,9 +939,20 @@ pexpr(Q):
   {
     List.fold_left (fun acc (e2, e3) -> 
       A.StructUpdate (mk_pos $startpos, acc, [A.GenericIndex (mk_pos $startpos, e2)], Some e3) 
-    )  (A.EmptyMap (mk_pos $startpos, (key_ty, value_ty))) updates 
+    )  (A.EmptyMap (mk_pos $startpos, Some (key_ty, value_ty))) updates 
   }
 
+  (* Type annotation can be omitted if there is at least one update *)
+  | MAP LSQBRACKET 
+    updates = separated_nonempty_list(SEMICOLON, assign); 
+    RSQBRACKET ATSIGN
+  {
+    List.fold_left (fun acc (e2, e3) -> 
+      A.StructUpdate (mk_pos $startpos, acc, [A.GenericIndex (mk_pos $startpos, e2)], Some e3) 
+    )  (A.EmptyMap (mk_pos $startpos, None)) updates 
+  }
+
+  (* Set literals *)
   | LCURLYBRACKET 
     elements = separated_list(COMMA, pexpr(Q));
     RCURLYBRACKET ATSIGN
@@ -950,6 +962,16 @@ pexpr(Q):
       A.StructUpdate (mk_pos $startpos, acc, [A.SetIndex (mk_pos $startpos, e)], None) 
     ) (A.EmptySet (mk_pos $startpos, value_ty)) elements
   }
+
+  (* Type annotation can be omitted if there is at least one element *)
+  (*| LCURLYBRACKET 
+    elements = separated_nonempty_list(COMMA, pexpr(Q));
+    RCURLYBRACKET ATSIGN
+  {
+    List.fold_left (fun acc e -> 
+      A.StructUpdate (mk_pos $startpos, acc, [A.SetIndex (mk_pos $startpos, e)], None) 
+    ) (A.EmptySet (mk_pos $startpos, value_ty)) elements
+  }*)
 
   | e1 = pexpr(Q); 
     LSQBRACKET; 

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -878,6 +878,14 @@ any_expr:
 assign:
   | e2 = expr; ASSIGN; e3 = expr { e2, e3 }
 
+map_type_annotation: 
+  | ATSIGN; LT key_ty=lustre_type; comma_or_semicolon; value_ty=lustre_type; GT
+  { key_ty, value_ty } 
+
+type_annotation: 
+  | ATSIGN; LT ty=lustre_type; GT
+  { ty }
+
 (* An possibly quantified expression *)
 pexpr(Q): 
   
@@ -934,43 +942,33 @@ pexpr(Q):
   (* Map literals *)
   | MAP LSQBRACKET 
     updates = separated_list(SEMICOLON, assign); 
-    RSQBRACKET ATSIGN
-    LT key_ty=lustre_type; comma_or_semicolon; value_ty=lustre_type; GT
+    RSQBRACKET 
+    ta = option(map_type_annotation)
   {
-    List.fold_left (fun acc (e2, e3) -> 
-      A.StructUpdate (mk_pos $startpos, acc, [A.GenericIndex (mk_pos $startpos, e2)], Some e3) 
-    )  (A.EmptyMap (mk_pos $startpos, Some (key_ty, value_ty))) updates 
-  }
-
-  (* Type annotation can be omitted if there is at least one update *)
-  | MAP LSQBRACKET 
-    updates = separated_nonempty_list(SEMICOLON, assign); 
-    RSQBRACKET ATSIGN
-  {
-    List.fold_left (fun acc (e2, e3) -> 
-      A.StructUpdate (mk_pos $startpos, acc, [A.GenericIndex (mk_pos $startpos, e2)], Some e3) 
-    )  (A.EmptyMap (mk_pos $startpos, None)) updates 
+    match ta, updates with 
+    | None, [] -> 
+      let pos = mk_pos $startpos in 
+      fail_at_position pos "Empty map must have a type annotation"
+    | ta, updates -> 
+      List.fold_left (fun acc (e2, e3) -> 
+        A.StructUpdate (mk_pos $startpos, acc, [A.MapIndex (mk_pos $startpos, e2)], Some e3) 
+      )  (A.EmptyMap (mk_pos $startpos, ta)) updates 
   }
 
   (* Set literals *)
   | LCURLYBRACKET 
-    elements = separated_list(COMMA, pexpr(Q));
-    RCURLYBRACKET ATSIGN
-    LT value_ty=lustre_type GT
-  {
-    List.fold_left (fun acc e -> 
-      A.StructUpdate (mk_pos $startpos, acc, [A.SetIndex (mk_pos $startpos, e)], None) 
-    ) (A.EmptySet (mk_pos $startpos, Some value_ty)) elements
-  }
-
-  (* Type annotation can be omitted if there is at least one element *)
-  | LCURLYBRACKET 
-    elements = separated_nonempty_list(COMMA, pexpr(Q));
+    elements = separated_list(COMMA, expr);
     RCURLYBRACKET 
+    ta = option(type_annotation); 
   {
-    List.fold_left (fun acc e -> 
-      A.StructUpdate (mk_pos $startpos, acc, [A.SetIndex (mk_pos $startpos, e)], None) 
-    ) (A.EmptySet (mk_pos $startpos, None)) elements
+    match ta, elements with 
+    | None, [] -> 
+      let pos = mk_pos $startpos in 
+      fail_at_position pos "Empty set must have a type annotation"
+    | ta, elements -> 
+      List.fold_left (fun acc e -> 
+        A.StructUpdate (mk_pos $startpos, acc, [A.SetIndex (mk_pos $startpos, e)], None) 
+      ) (A.EmptySet (mk_pos $startpos, ta)) elements
   }
 
   | e1 = pexpr(Q); 

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -960,18 +960,18 @@ pexpr(Q):
   {
     List.fold_left (fun acc e -> 
       A.StructUpdate (mk_pos $startpos, acc, [A.SetIndex (mk_pos $startpos, e)], None) 
-    ) (A.EmptySet (mk_pos $startpos, value_ty)) elements
+    ) (A.EmptySet (mk_pos $startpos, Some value_ty)) elements
   }
 
   (* Type annotation can be omitted if there is at least one element *)
-  (*| LCURLYBRACKET 
+  | LCURLYBRACKET 
     elements = separated_nonempty_list(COMMA, pexpr(Q));
-    RCURLYBRACKET ATSIGN
+    RCURLYBRACKET 
   {
     List.fold_left (fun acc e -> 
       A.StructUpdate (mk_pos $startpos, acc, [A.SetIndex (mk_pos $startpos, e)], None) 
-    ) (A.EmptySet (mk_pos $startpos, value_ty)) elements
-  }*)
+    ) (A.EmptySet (mk_pos $startpos, None)) elements
+  }
 
   | e1 = pexpr(Q); 
     LSQBRACKET; 

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -854,11 +854,11 @@ let rec infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * [> w
                 | Some ty -> R.ok ty in
     let* ty = lookup_mode_ty ctx ids in 
     R.ok (ty, [])
-  | LA.StructUpdate (pos, EmptyMap _, [MapIndex (_, e1)], Some e2) ->
+  | LA.StructUpdate (pos, EmptyMap (_, None), [MapIndex (_, e1)], Some e2) ->
     let* ty1, warnings1 = infer_type_expr ctx nname e1 in 
     let* ty2, warnings2 = infer_type_expr ctx nname e2 in 
     R.ok (LA.Map (pos, ty1, ty2), warnings1 @ warnings2)
-  | LA.StructUpdate (pos, EmptySet _, [SetIndex (_, e)], None) ->
+  | LA.StructUpdate (pos, EmptySet (_, None), [SetIndex (_, e)], None) ->
     let* ty, warnings = infer_type_expr ctx nname e in 
     R.ok (LA.Set (pos, ty), warnings)
   (* only reachable through previous 2 cases *)

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -16,7 +16,6 @@
 
  *)
 
-(*!! Node calls, set literals, map literals, any operators(?) *) 
 
 (** Type checking the surface syntax of Lustre programs
   
@@ -1158,7 +1157,7 @@ let rec infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * [> w
       (type_error pos (IlltypedArrow (ty1, ty2)))
     
   (* Node calls *)
-  | LA.Call (pos, ty_args, node_id, arg_exprs) -> 
+  | LA.Call (pos, ty_args, node_id, arg_exprs) -> (
     Debug.parse "Inferring type for node call %a" NI.pp_print_node_id_user_name node_id ;
     (* Values 'Input' and 'true' passed to check_type_well_formed are conservative 
        guesses in the case that ty_args contains refinement types. This rules out 
@@ -1192,6 +1191,7 @@ let rec infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * [> w
     )
     | _, Some ty -> type_error pos (ExpectedFunctionType ty)
     | _, None -> type_error pos (UnboundNodeName (NI.get_user_name node_id))
+  )
 (** Infer the type of a [LA.expr] with the types of free variables given in [tc_context] *)
 
 and check_array_dimensions pos ctx base_e idxs =
@@ -1468,12 +1468,21 @@ and check_type_expr: tc_context -> NI.t option -> LA.expr -> tc_type -> ([> warn
     R.ok (warnings1 @ warnings2)
 
   (* Node calls *)
-  | Call (pos, _, _, _) as e -> 
-    let* inf_ty, warnings = infer_type_expr ctx nname e in 
-    R.ifM (eq_lustre_type ctx exp_ty inf_ty)
-      (R.ok warnings)
-      (type_error pos (ExpectedType (exp_ty, inf_ty)))
-
+  | Call (pos, ty_args, node_id, args) ->
+    let* arg_tys_warns = R.seq (List.map (infer_type_expr ctx nname) args) in
+    let arg_tys, warnings = List.split arg_tys_warns in
+    let arg_ty = if List.length arg_tys = 1 then List.hd arg_tys
+                else GroupType (pos, arg_tys) in
+    (match (lookup_node_ty ctx node_id), (lookup_node_param_ids ctx node_id) with
+    | None, _ 
+    | _, None -> type_error pos (UnboundNodeName (NI.get_user_name node_id))
+    | Some ty, Some call_params -> 
+      (* Express ty in terms of the current context *)
+      let ty = update_ty_with_ctx ty call_params ctx args in
+      let* ty = instantiate_type_variables ctx pos node_id ty ty_args in
+      let* b = (eq_lustre_type ctx ty (LA.TArr (pos, arg_ty, exp_ty))) in
+      if b then R.ok (List.flatten warnings)
+      else (type_error pos (MismatchedNodeType ((NI.get_user_name node_id), (TArr (pos, arg_ty, exp_ty)), ty))))
 
 (** Type checks an expression and returns [ok] 
  * if the expected type is the given type [tc_type]  

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1158,36 +1158,6 @@ let rec infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * [> w
       (type_error pos (IlltypedArrow (ty1, ty2)))
     
   (* Node calls *)
-  (*| LA.Call (pos, [], node_id, arg_exprs) -> (
-    Debug.parse "Inferring type for node call %a" NI.pp_print_node_id_user_name node_id ;
-    let infer_type_node_args: tc_context -> LA.expr list -> (tc_type list * [> warning] list, [> error]) result =
-    fun ctx args ->
-      let* r = R.seq (List.map (infer_type_expr ctx nname) args) in  
-      let arg_tys, warnings = List.split r in
-      R.ok (arg_tys, List.flatten warnings)
-    in
-    match (lookup_node_param_ids ctx node_id), (lookup_node_ty ctx node_id) with
-    | Some call_params, Some node_ty -> (
-      (* Express exp_arg_tys and exp_ret_tys in terms of the current context *)
-      let node_ty = update_ty_with_ctx node_ty call_params ctx arg_exprs in
-      let* given_arg_tys, warnings = infer_type_node_args ctx arg_exprs in
-      let given_arg_tys = List.map (expand_type_syn ctx) given_arg_tys in
-      (*!! given_arg_tys will be types of the args, and not necessarily the type variables. 
-           E.g. for call param x:T^n called with type int^n, the given_arg_ty will be int^n 
-           but we really need just the T spot, here int *)
-      let* node_ty = instantiate_type_variables ctx pos node_id node_ty given_arg_tys in
-      let exp_ret_tys = match node_ty with 
-        | LA.TArr (_, _, exp_ret_tys) ->
-          (*!! Check for uninstantiated type variables in exp_ret_tys *)
-          expand_type_syn ctx exp_ret_tys
-        | _ -> assert false 
-      in
-      R.ok (exp_ret_tys, warnings)
-    )
-    | _, Some ty -> type_error pos (ExpectedFunctionType ty)
-    | _, None -> type_error pos (UnboundNodeName (NI.get_user_name node_id))
-  )*)
-  (*!! Use old code here because ty_args are actually supplied *)
   | LA.Call (pos, ty_args, node_id, arg_exprs) -> 
     Debug.parse "Inferring type for node call %a" NI.pp_print_node_id_user_name node_id ;
     (* Values 'Input' and 'true' passed to check_type_well_formed are conservative 

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1158,7 +1158,7 @@ let rec infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * [> w
       (type_error pos (IlltypedArrow (ty1, ty2)))
     
   (* Node calls *)
-  | LA.Call (pos, [], node_id, arg_exprs) -> (
+  (*| LA.Call (pos, [], node_id, arg_exprs) -> (
     Debug.parse "Inferring type for node call %a" NI.pp_print_node_id_user_name node_id ;
     let infer_type_node_args: tc_context -> LA.expr list -> (tc_type list * [> warning] list, [> error]) result =
     fun ctx args ->
@@ -1186,9 +1186,42 @@ let rec infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * [> w
     )
     | _, Some ty -> type_error pos (ExpectedFunctionType ty)
     | _, None -> type_error pos (UnboundNodeName (NI.get_user_name node_id))
-  )
+  )*)
   (*!! Use old code here because ty_args are actually supplied *)
-  | LA.Call (pos, ty_args, node_id, arg_exprs) -> assert false
+  | LA.Call (pos, ty_args, node_id, arg_exprs) -> 
+    Debug.parse "Inferring type for node call %a" NI.pp_print_node_id_user_name node_id ;
+    (* Values 'Input' and 'true' passed to check_type_well_formed are conservative 
+       guesses in the case that ty_args contains refinement types. This rules out 
+       instantiated polymorphic nodes having ill-formed refinement types (with e.g., assumptions on 
+       current values of output variables).  *)
+    let* warnings1 = R.seq (List.map (check_type_well_formed ctx Input nname true) ty_args) in
+    let infer_type_node_args: tc_context -> LA.expr list -> (tc_type * [> warning] list, [> error]) result =
+    fun ctx args ->
+      let* arg_tys_warns = R.seq (List.map (infer_type_expr ctx nname) args) in
+      let arg_tys, warnings = List.split arg_tys_warns in
+      if List.length arg_tys = 1 then R.ok ((List.hd arg_tys), List.flatten warnings)
+      else R.ok (LA.GroupType (pos, arg_tys), List.flatten warnings)
+    in
+    match (lookup_node_param_ids ctx node_id), (lookup_node_ty ctx node_id) with
+    | Some call_params, Some node_ty -> (
+      (* Express exp_arg_tys and exp_ret_tys in terms of the current context *)
+      let node_ty = update_ty_with_ctx node_ty call_params ctx arg_exprs in
+      let* node_ty = instantiate_type_variables ctx pos node_id node_ty ty_args in
+      let exp_arg_tys, exp_ret_tys = match node_ty with 
+        | LA.TArr (_, exp_arg_tys, exp_ret_tys) ->
+          expand_type_syn ctx exp_arg_tys, expand_type_syn ctx exp_ret_tys
+        | _ -> assert false 
+      in
+      let* given_arg_tys, warnings2 = infer_type_node_args ctx arg_exprs in
+      let given_arg_tys = expand_type_syn ctx given_arg_tys in
+      let* are_equal = eq_lustre_type ctx exp_arg_tys given_arg_tys in
+      if are_equal then
+        (check_constant_args ctx node_id arg_exprs >> (R.ok (exp_ret_tys, List.flatten warnings1 @ warnings2)))
+      else
+        (type_error pos (IlltypedCall (exp_arg_tys, given_arg_tys)))
+    )
+    | _, Some ty -> type_error pos (ExpectedFunctionType ty)
+    | _, None -> type_error pos (UnboundNodeName (NI.get_user_name node_id))
 (** Infer the type of a [LA.expr] with the types of free variables given in [tc_context] *)
 
 and check_array_dimensions pos ctx base_e idxs =

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -319,11 +319,11 @@ let no_mismatched_clock is_bool e =
         | _ -> type_error pos (IllegalClockExprInActivate c)
       in
       clocks_match_result pos clk_exp clock
-    | Ident _ | Const _ | ModeRef _ -> Ok ()
-    | EmptyMap (_, (kt, vt)) ->
+    | Ident _ | Const _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> Ok ()
+    | EmptyMap (_, Some (kt, vt)) ->
       (LH.fold_lustre_ty (check_clocks clock) (R.ok ()) (>>) kt) >>
       (LH.fold_lustre_ty (check_clocks clock) (R.ok ()) (>>) vt) 
-    | EmptySet (_, ty) -> 
+    | EmptySet (_, Some ty) -> 
       LH.fold_lustre_ty (check_clocks clock) (R.ok ()) (>>) ty
     | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
     | ConvOp (_, _, e) | Pre (_, e) | Extract (_, e, _, _) | Quantifier (_, _, _, e) 
@@ -361,11 +361,11 @@ let no_mismatched_clock is_bool e =
           let* _ = check_clocks (ClockPos clock) e1 in
           check_clocks (ClockNeg clock) e2
         | _ -> Ok ())
-    | Ident _ | Const _ | ModeRef _ -> Ok ()
-    | EmptyMap (_, (kt, vt)) -> 
+    | Ident _ | Const _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> Ok ()
+    | EmptyMap (_, Some (kt, vt)) -> 
       (LH.fold_lustre_ty check_merge (R.ok ()) (>>) kt) >> 
       (LH.fold_lustre_ty check_merge (R.ok ()) (>>) vt)
-    | EmptySet (_, ty) -> 
+    | EmptySet (_, Some ty) -> 
       LH.fold_lustre_ty check_merge (R.ok ()) (>>) ty
     | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
     | ConvOp (_, _, e) | Pre (_, e) | Extract (_, e, _, _) | Quantifier (_, _, _, e) 
@@ -490,11 +490,11 @@ let rec infer_const_attr ctx exp =
   | RecordProject (_, e, _) -> r e
   | TupleProject (_, e, _) -> r e
   (* Values *)
-  | Const _ -> [R.ok ()]
-  | EmptyMap (_, (kt, vt)) -> 
+  | Const _ | EmptyMap (_, None) | EmptySet (_, None) -> [R.ok ()]
+  | EmptyMap (_, Some (kt, vt)) -> 
     combine (LH.fold_lustre_ty r [R.ok ()] combine kt)
             (LH.fold_lustre_ty r [R.ok ()] combine vt)
-  | EmptySet (_, ty) ->
+  | EmptySet (_, Some ty) ->
     LH.fold_lustre_ty r [R.ok ()] combine ty
   (* Operators *)
   | Extract (_, e, _, _)
@@ -678,13 +678,13 @@ let rec instantiate_type_variables_expr: tc_context -> NI.t -> tc_type list -> L
     ) old_ty_args) in
     let* es = R.seq (List.map call es) in
     Ok (LA.Call (pos, ty_args, id, es))
-  | EmptyMap (pos, (kt, vt)) ->
+  | EmptyMap (pos, Some (kt, vt)) ->
     let* kt = instantiate_type_variables ctx pos nname kt ty_args in
     let* vt = instantiate_type_variables ctx pos nname vt ty_args in
-    Ok (LA.EmptyMap (pos, (kt, vt)))
-  | EmptySet (pos, ty) -> 
+    Ok (LA.EmptyMap (pos, Some (kt, vt)))
+  | EmptySet (pos, Some ty) -> 
     let* ty = instantiate_type_variables ctx pos nname ty ty_args in 
-    Ok (LA.EmptySet (pos, ty))
+    Ok (LA.EmptySet (pos, Some ty))
   | Quantifier (pos, q, tis, e) -> 
     let* tis = R.seq (List.map (fun (p, id, ty) -> 
       let* ty = instantiate_type_variables ctx pos nname ty ty_args in 
@@ -692,7 +692,7 @@ let rec instantiate_type_variables_expr: tc_context -> NI.t -> tc_type list -> L
     ) tis) in 
     let* e = call e in 
     R.ok (LA.Quantifier (pos, q, tis, e))
-  | Ident _ 
+  | Ident _ | EmptyMap (_, None) | EmptySet (_, None) 
   | ModeRef _ -> R.ok expr
   | RecordProject (pos, e, idx) -> 
     let* e = call e in 
@@ -855,9 +855,18 @@ let rec infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * [> w
                 | Some ty -> R.ok ty in
     let* ty = lookup_mode_ty ctx ids in 
     R.ok (ty, [])
-  | LA.EmptyMap (pos, (kt, vt)) ->
+  | LA.StructUpdate (pos, EmptyMap _, [MapIndex (_, e1)], Some e2) ->
+    let* ty1, warnings1 = infer_type_expr ctx nname e1 in 
+    let* ty2, warnings2 = infer_type_expr ctx nname e2 in 
+    R.ok (LA.Map (pos, ty1, ty2), warnings1 @ warnings2)
+  | LA.StructUpdate (pos, EmptySet _, [SetIndex (_, e)], None) ->
+    let* ty, warnings = infer_type_expr ctx nname e in 
+    R.ok (LA.Set (pos, ty), warnings)
+  (* only reachable through previous 2 cases *)
+  | LA.EmptyMap (_, None) | LA.EmptySet (_, None) -> assert false 
+  | LA.EmptyMap (pos, Some (kt, vt)) ->
     R.ok (LA.Map (pos, kt, vt), [])
-  | LA.EmptySet (pos, ty) -> 
+  | LA.EmptySet (pos, Some ty) -> 
     R.ok (LA.Set (pos, ty), [])
   | LA.RecordProject (pos, e, fld) ->
     let* rec_ty, warnings = infer_type_expr ctx nname e in

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -16,6 +16,7 @@
 
  *)
 
+(*!! Node calls, set literals, map literals, any operators(?) *) 
 
 (** Type checking the surface syntax of Lustre programs
   
@@ -1146,43 +1147,39 @@ let rec infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * [> w
     R.ifM (eq_lustre_type ctx ty1 ty2)
       (R.ok (ty1, warnings1 @ warnings2))
       (type_error pos (IlltypedArrow (ty1, ty2)))
-     
+    
   (* Node calls *)
-  | LA.Call (pos, ty_args, node_id, arg_exprs) -> (
+  | LA.Call (pos, [], node_id, arg_exprs) -> (
     Debug.parse "Inferring type for node call %a" NI.pp_print_node_id_user_name node_id ;
-    (* Values 'Input' and 'true' passed to check_type_well_formed are conservative 
-       guesses in the case that ty_args contains refinement types. This rules out 
-       instantiated polymorphic nodes having ill-formed refinement types (with e.g., assumptions on 
-       current values of output variables).  *)
-    let* warnings1 = R.seq (List.map (check_type_well_formed ctx Input nname true) ty_args) in
-    let infer_type_node_args: tc_context -> LA.expr list -> (tc_type * [> warning] list, [> error]) result =
+    let infer_type_node_args: tc_context -> LA.expr list -> (tc_type list * [> warning] list, [> error]) result =
     fun ctx args ->
-      let* arg_tys_warns = R.seq (List.map (infer_type_expr ctx nname) args) in
-      let arg_tys, warnings = List.split arg_tys_warns in
-      if List.length arg_tys = 1 then R.ok ((List.hd arg_tys), List.flatten warnings)
-      else R.ok (LA.GroupType (pos, arg_tys), List.flatten warnings)
+      let* r = R.seq (List.map (infer_type_expr ctx nname) args) in  
+      let arg_tys, warnings = List.split r in
+      R.ok (arg_tys, List.flatten warnings)
     in
     match (lookup_node_param_ids ctx node_id), (lookup_node_ty ctx node_id) with
     | Some call_params, Some node_ty -> (
       (* Express exp_arg_tys and exp_ret_tys in terms of the current context *)
       let node_ty = update_ty_with_ctx node_ty call_params ctx arg_exprs in
-      let* node_ty = instantiate_type_variables ctx pos node_id node_ty ty_args in
-      let exp_arg_tys, exp_ret_tys = match node_ty with 
-        | LA.TArr (_, exp_arg_tys, exp_ret_tys) ->
-          expand_type_syn ctx exp_arg_tys, expand_type_syn ctx exp_ret_tys
+      let* given_arg_tys, warnings = infer_type_node_args ctx arg_exprs in
+      let given_arg_tys = List.map (expand_type_syn ctx) given_arg_tys in
+      (*!! given_arg_tys will be types of the args, and not necessarily the type variables. 
+           E.g. for call param x:T^n called with type int^n, the given_arg_ty will be int^n 
+           but we really need just the T spot, here int *)
+      let* node_ty = instantiate_type_variables ctx pos node_id node_ty given_arg_tys in
+      let exp_ret_tys = match node_ty with 
+        | LA.TArr (_, _, exp_ret_tys) ->
+          (*!! Check for uninstantiated type variables in exp_ret_tys *)
+          expand_type_syn ctx exp_ret_tys
         | _ -> assert false 
       in
-      let* given_arg_tys, warnings2 = infer_type_node_args ctx arg_exprs in
-      let given_arg_tys = expand_type_syn ctx given_arg_tys in
-      let* are_equal = eq_lustre_type ctx exp_arg_tys given_arg_tys in
-      if are_equal then
-        (check_constant_args ctx node_id arg_exprs >> (R.ok (exp_ret_tys, List.flatten warnings1 @ warnings2)))
-      else
-        (type_error pos (IlltypedCall (exp_arg_tys, given_arg_tys)))
+      R.ok (exp_ret_tys, warnings)
     )
     | _, Some ty -> type_error pos (ExpectedFunctionType ty)
     | _, None -> type_error pos (UnboundNodeName (NI.get_user_name node_id))
   )
+  (*!! Use old code here because ty_args are actually supplied *)
+  | LA.Call (pos, ty_args, node_id, arg_exprs) -> assert false
 (** Infer the type of a [LA.expr] with the types of free variables given in [tc_context] *)
 
 and check_array_dimensions pos ctx base_e idxs =
@@ -1459,21 +1456,13 @@ and check_type_expr: tc_context -> NI.t option -> LA.expr -> tc_type -> ([> warn
     R.ok (warnings1 @ warnings2)
 
   (* Node calls *)
-  | Call (pos, ty_args, node_id, args) ->
-    let* arg_tys_warns = R.seq (List.map (infer_type_expr ctx nname) args) in
-    let arg_tys, warnings = List.split arg_tys_warns in
-    let arg_ty = if List.length arg_tys = 1 then List.hd arg_tys
-                else GroupType (pos, arg_tys) in
-    (match (lookup_node_ty ctx node_id), (lookup_node_param_ids ctx node_id) with
-    | None, _ 
-    | _, None -> type_error pos (UnboundNodeName (NI.get_user_name node_id))
-    | Some ty, Some call_params -> 
-      (* Express ty in terms of the current context *)
-      let ty = update_ty_with_ctx ty call_params ctx args in
-      let* ty = instantiate_type_variables ctx pos node_id ty ty_args in
-      let* b = (eq_lustre_type ctx ty (LA.TArr (pos, arg_ty, exp_ty))) in
-      if b then R.ok (List.flatten warnings)
-      else (type_error pos (MismatchedNodeType ((NI.get_user_name node_id), (TArr (pos, arg_ty, exp_ty)), ty))))
+  | Call (pos, _, _, _) as e -> 
+    let* inf_ty, warnings = infer_type_expr ctx nname e in 
+    R.ifM (eq_lustre_type ctx exp_ty inf_ty)
+      (R.ok warnings)
+      (type_error pos (ExpectedType (exp_ty, inf_ty)))
+
+
 (** Type checks an expression and returns [ok] 
  * if the expected type is the given type [tc_type]  
  * returns an [Error of string] otherwise *)

--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -842,9 +842,9 @@ let rec ty_vars_of_expr ctx node_name expr =
   | LA.Call (_, tys, _, es) -> 
     SI.union (SI.flatten (List.map (ty_vars_of_type ctx node_name) tys))
               (SI.flatten (List.map call es))
-  | LA.EmptyMap (_, (kt, vt)) ->
+  | LA.EmptyMap (_, Some (kt, vt)) ->
     SI.union (ty_vars_of_type ctx node_name kt) (ty_vars_of_type ctx node_name vt)
-  | LA.EmptySet (_, ty) ->
+  | LA.EmptySet (_, Some ty) ->
     ty_vars_of_type ctx node_name ty 
   | AnyOp (_, (_, _, ty), e) -> 
     SI.union (call e) (ty_vars_of_type ctx node_name ty)
@@ -856,6 +856,7 @@ let rec ty_vars_of_expr ctx node_name expr =
     | None -> SI.empty (* e.g. any bound variable *)
     | Some ty -> ty_vars_of_type ctx node_name ty
   )
+  | EmptyMap (_, None) | EmptySet (_, None) 
   | ModeRef _ -> SI.empty
   | RecordProject (_, e, _) -> call e 
   | TupleProject (_, e, _) -> call e

--- a/tests/ounit/lustre/lustreTypeChecker/bad_ty_annot.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/bad_ty_annot.lus
@@ -1,0 +1,5 @@
+node N(x: int) returns (y: set<int>);
+let
+  y = { x }@<bool>;
+  check x in y;
+tel

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -423,6 +423,10 @@ let _ = run_test_tt_main ("frontend LustreTypeChecker error tests" >::: [
     match load_file "./lustreTypeChecker/poly_fail.lus" with
     | Error (`LustreTypeCheckerError (_, ExpectedType _)) -> true
     | _ -> false);
+  mk_test "test bad type annotation" (fun () ->
+    match load_file "./lustreTypeChecker/bad_ty_annot.lus" with
+    | Error (`LustreTypeCheckerError (_, ExpectedType _)) -> true
+    | _ -> false);
   mk_test "test polymorphism 2" (fun () ->
     match load_file "./lustreTypeChecker/poly_fail2.lus" with
     | Error (`LustreTypeCheckerError (_, ExpectedNumberOrSetTypes _)) -> true

--- a/tests/regression/success/map_set_literals_type_inference.lus
+++ b/tests/regression/success/map_set_literals_type_inference.lus
@@ -1,0 +1,9 @@
+node N(x: int; m: map<int, int>) returns (y: set<int>; y2: map<int, int>; y3: map<int, int>);
+let
+  y = { x };
+  y2 = map[x := x];
+  y3 = m[x := x];
+  check x in y;
+  check x in y2;
+  check x in y3;
+tel


### PR DESCRIPTION
Make type annotations optional for non-empty map and set literals.

(This PR is less general than the branch name suggests. Other work on type inference, e.g. for node calls, will be in separate PRs.)