### PR TITLE
Fix index access type checking bug

### DIFF
--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1382,18 +1382,13 @@ and check_type_expr: tc_context -> NI.t option -> LA.expr -> tc_type -> ([> warn
     R.ifM (eq_lustre_type ctx exp_ty arr_ty)
       (R.ok (warnings1 @ warnings2))
       (type_error pos (ExpectedType (exp_ty, arr_ty)))
-  | IndexAccess (pos, e, idx, _) ->
-    let* index_type, warnings1 = infer_type_expr ctx nname idx in
-    if is_expr_int_type ctx nname idx
-    then 
-      let* inf_arr_ty, warnings2 = infer_type_expr ctx nname e in
-      (match inf_arr_ty with
-        | ArrayType (_, (arr_b_ty, _)) ->
-          R.ifM (eq_lustre_type ctx arr_b_ty exp_ty)
-            (R.ok (warnings1 @ warnings2))
-            (type_error pos (ExpectedType (exp_ty, arr_b_ty)))
-        | _ -> type_error pos (ExpectedArrayType inf_arr_ty))
-    else type_error pos (ExpectedIntegerTypeForArrayIndex index_type)
+
+  | IndexAccess (pos, _, _, _) as e ->
+    let* inf_ty, warnings = infer_type_expr ctx nname e in 
+    R.ifM    
+      (eq_lustre_type ctx inf_ty exp_ty) 
+      (R.ok warnings)
+      (type_error pos (UnificationFailed (exp_ty, inf_ty)))
 
   (* Quantified expressions *)
   | Quantifier (_, _, qs, e) -> (

--- a/tests/regression/success/index_access_bug.lus
+++ b/tests/regression/success/index_access_bug.lus
@@ -1,0 +1,5 @@
+node N(m1: map<int,int>; m2: map<int,bool>) returns (r: bool); 
+(*@contract assume "A" m2[m1[0]]; *) 
+let 
+  check true;
+tel


### PR DESCRIPTION
The given test case was (previously) incorrectly rejected by the type checker. 

The bug was caused by the catch-all on line 1395 of the old version, which misses the `Map` case.

Analogous checks are already performed in `infer_type_expr`. So, I replaced the code with general logic (infer the type of the expression and compare with the expected type). I believe a similar simplification can be performed for many, if not all, of the cases in `check_type_expr`.