### PR TITLE
Fix bug w/ symbolic subranges

### DIFF
--- a/src/lustre/lustreFlattenRefinementTypes.ml
+++ b/src/lustre/lustreFlattenRefinementTypes.ml
@@ -19,6 +19,8 @@
 module A = LustreAst
 module AH = LustreAstHelpers
 module AN = LustreAstNormalizer
+module GI = GeneratedIdentifiers
+module NI = NodeId
 
 let rec flatten_ref_type ctx ty = match ty with
   | A.UserType (pos, ty_args, str) -> 
@@ -268,8 +270,8 @@ let flatten_ref_types_contract_opt ctx = function
 | Some c -> Some (flatten_ref_types_contract ctx c)
 | None -> None
 
-let flatten_ref_types ctx sorted_node_contract_decls = 
-  List.map (fun decl -> match decl with
+let flatten_ref_types ctx (gids : GI.t NI.Map.t) decls = 
+  let decls = List.map (fun decl -> match decl with
     | A.TypeDecl (pos, AliasType (pos2, id, ps, ty)) -> 
       A.TypeDecl (pos, AliasType (pos2, id, ps, flatten_ref_type ctx ty))
     | NodeDecl (pos, (id, imported, opac, params, ips, ops, locals, items, contract)) ->
@@ -321,4 +323,11 @@ let flatten_ref_types ctx sorted_node_contract_decls =
     | ConstDecl (pos, cd) -> ConstDecl (pos, flatten_ref_types_const_decl ctx cd)
     | A.TypeDecl (_, FreeType _) -> decl
     
-  ) sorted_node_contract_decls
+  ) decls in 
+  let gids = NI.Map.map (fun gids -> 
+    { gids with 
+      GI.ib_oracles = List.map (fun (id, ty) -> id, flatten_ref_type ctx ty) gids.GI.ib_oracles; 
+      GI.locals = GI.StringMap.map (fun ty -> flatten_ref_type ctx ty) gids.GI.locals;
+    } 
+  ) gids in 
+  decls, gids

--- a/src/lustre/lustreFlattenRefinementTypes.mli
+++ b/src/lustre/lustreFlattenRefinementTypes.mli
@@ -17,5 +17,8 @@
  *)
 
 (** @author Rob Lorch *)
-                    
-val flatten_ref_types: TypeCheckerContext.tc_context -> LustreAst.declaration list -> LustreAst.declaration list
+module GI = GeneratedIdentifiers 
+module NI = NodeId
+module A = LustreAst 
+
+val flatten_ref_types: TypeCheckerContext.tc_context -> GI.t NI.Map.t -> A.declaration list -> A.declaration list * GI.t NI.Map.t

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -216,8 +216,8 @@ let type_check declarations =
     let inlined_global_ctx, gids, const_inlined_nodes_and_contracts = LIP.instantiate_polymorphic_nodes inlined_global_ctx gids const_inlined_nodes_and_contracts in
 
     (* Step 17. Flatten refinement types *)
-    let const_inlined_type_and_consts = LFR.flatten_ref_types inlined_global_ctx const_inlined_type_and_consts in
-    let const_inlined_nodes_and_contracts = LFR.flatten_ref_types inlined_global_ctx const_inlined_nodes_and_contracts in
+    let const_inlined_type_and_consts, gids = LFR.flatten_ref_types inlined_global_ctx gids const_inlined_type_and_consts in
+    let const_inlined_nodes_and_contracts, gids = LFR.flatten_ref_types inlined_global_ctx gids const_inlined_nodes_and_contracts in
 
     (* Step 18. Check no quantified variable in argument of non-inlinable function *)
     let inlinable_funcs =

--- a/tests/regression/falsifiable/sym_subrange_bug.lus
+++ b/tests/regression/falsifiable/sym_subrange_bug.lus
@@ -1,0 +1,12 @@
+type Pos = subrange [1,*] of int;
+
+const N: Pos;
+
+type R = subrange [0,N-1] of int;
+
+node N(c: bool; r: R) returns (s: set<R>);
+let
+  if c then
+    s = {r} + {r};
+  fi
+tel


### PR DESCRIPTION
The pipeline step for flattening refinement types (which also handles desugaring of symbolic subranges to refinement types) also needs to be applied to the generated identifiers collected so far (this was previously neglected) 