### PR TITLE
X.MapIndex -> X.SetMapIndex

### DIFF
--- a/src/inputParser.ml
+++ b/src/inputParser.ml
@@ -222,7 +222,7 @@ let rec read_val scope name indexes arr_indexes json =
         (function 
           | LustreIndex.ArrayVarIndex _ 
           | LustreIndex.ArrayIntIndex _
-          | LustreIndex.MapIndex _ -> false
+          | LustreIndex.SetMapIndex _ -> false
           | LustreIndex.RecordIndex _
           | LustreIndex.TupleIndex _
           | LustreIndex.ListIndex _

--- a/src/lustre/lustreIndex.ml
+++ b/src/lustre/lustreIndex.ml
@@ -43,7 +43,7 @@ type one_index =
   (* Array field indexed by variable *)
   | ArrayVarIndex of E.expr
 
-  | MapIndex of E.expr 
+  | SetMapIndex of E.expr 
 
   (* Index to the representation field of an abstract type *)
   | AbstractTypeIndex of string
@@ -60,7 +60,7 @@ let pp_print_one_index' db = function
        | ListIndex i -> Format.fprintf ppf "{%d}" i
        | ArrayIntIndex i -> Format.fprintf ppf "[%d]" i
        | ArrayVarIndex _ -> () (* Format.fprintf ppf "[X%d(%a)]" db (E.pp_print_expr false) v ) *)
-       | MapIndex _ -> ()
+       | SetMapIndex _ -> ()
        | AbstractTypeIndex _ -> ())
 
   | true ->
@@ -71,7 +71,7 @@ let pp_print_one_index' db = function
        | ListIndex i -> Format.fprintf ppf "_%d" i
        | ArrayIntIndex i -> Format.fprintf ppf "_%d" i
        | ArrayVarIndex _ ->  Format.fprintf ppf "_X%d" db
-       | MapIndex _ ->  Format.fprintf ppf "_Y%d" db 
+       | SetMapIndex _ ->  Format.fprintf ppf "_Y%d" db 
        | AbstractTypeIndex i -> Format.fprintf ppf ".%s" i)
 
 
@@ -123,7 +123,7 @@ let compare_one_index a b = match a, b with
 
   (* Variable indexes are equal regardless of the bound expression *)
   | ArrayVarIndex _, ArrayVarIndex _ -> 0
-  | MapIndex _, MapIndex _ -> 0
+  | SetMapIndex _, SetMapIndex _ -> 0
 
   (* Record indexes are greatest *)
   | RecordIndex _, TupleIndex _
@@ -131,7 +131,7 @@ let compare_one_index a b = match a, b with
   | RecordIndex _, ArrayIntIndex _
   | RecordIndex _, ArrayVarIndex _
   | RecordIndex _, AbstractTypeIndex _
-  | RecordIndex _, MapIndex _ -> 1 
+  | RecordIndex _, SetMapIndex _ -> 1 
 
   (* Tuple indexes are only smaller than record indexes *)
   | TupleIndex _, RecordIndex _ -> -1 
@@ -139,7 +139,7 @@ let compare_one_index a b = match a, b with
   | TupleIndex _, ArrayIntIndex _
   | TupleIndex _, ArrayVarIndex _
   | TupleIndex _, AbstractTypeIndex _
-  | TupleIndex _, MapIndex _ -> 1 
+  | TupleIndex _, SetMapIndex _ -> 1 
 
   (* List indexes are smaller than tuple and record indexes *)
   | ListIndex _, RecordIndex _
@@ -147,7 +147,7 @@ let compare_one_index a b = match a, b with
   | ListIndex _, ArrayIntIndex _
   | ListIndex _, ArrayVarIndex _
   | ListIndex _, AbstractTypeIndex _
-  | ListIndex _, MapIndex _ -> 1 
+  | ListIndex _, SetMapIndex _ -> 1 
 
   (* Intger array indexes are greater than array variables
    * and abstract type indexes *)
@@ -155,7 +155,7 @@ let compare_one_index a b = match a, b with
   | ArrayIntIndex _, TupleIndex _
   | ArrayIntIndex _, ListIndex _ -> -1
   | ArrayIntIndex _, ArrayVarIndex _
-  | ArrayIntIndex _, MapIndex _
+  | ArrayIntIndex _, SetMapIndex _
   | ArrayIntIndex _, AbstractTypeIndex _ -> 1
 
   (* Array variable indexes are greater than map indexes and abstract type indexes *)
@@ -163,16 +163,16 @@ let compare_one_index a b = match a, b with
   | ArrayVarIndex _, ArrayIntIndex _
   | ArrayVarIndex _, ListIndex _
   | ArrayVarIndex _, TupleIndex _ -> -1
-  | ArrayVarIndex _, MapIndex _
+  | ArrayVarIndex _, SetMapIndex _
   | ArrayVarIndex _, AbstractTypeIndex _ -> 1
 
   (* Map indexes are only greater than abstract types indexes *)
-  | MapIndex _, RecordIndex _
-  | MapIndex _, ArrayIntIndex _
-  | MapIndex _, ListIndex _
-  | MapIndex _, TupleIndex _ 
-  | MapIndex _, ArrayVarIndex _ -> -1
-  | MapIndex _, AbstractTypeIndex _ -> 1
+  | SetMapIndex _, RecordIndex _
+  | SetMapIndex _, ArrayIntIndex _
+  | SetMapIndex _, ListIndex _
+  | SetMapIndex _, TupleIndex _ 
+  | SetMapIndex _, ArrayVarIndex _ -> -1
+  | SetMapIndex _, AbstractTypeIndex _ -> 1
 
   (* Abstract type indexes are the smallest *)
   | AbstractTypeIndex _, RecordIndex _
@@ -180,7 +180,7 @@ let compare_one_index a b = match a, b with
   | AbstractTypeIndex _, ListIndex _
   | AbstractTypeIndex _, TupleIndex _
   | AbstractTypeIndex _, ArrayVarIndex _ 
-  | AbstractTypeIndex _, MapIndex _ -> -1
+  | AbstractTypeIndex _, SetMapIndex _ -> -1
 
 (* Equality of indexes *)
 let equal_one_index a b = match a,b with 
@@ -289,7 +289,7 @@ let filter_array_indices index = List.filter (
   function
   | ArrayVarIndex _
   | ArrayIntIndex _ 
-  | MapIndex _ -> false 
+  | SetMapIndex _ -> false 
   | RecordIndex _
   | TupleIndex _
   | ListIndex _

--- a/src/lustre/lustreIndex.mli
+++ b/src/lustre/lustreIndex.mli
@@ -57,7 +57,7 @@ type one_index =
   | ArrayVarIndex of LustreExpr.expr
     (** Variable as index of an array of given size *)
 
-  | MapIndex of LustreExpr.expr 
+  | SetMapIndex of LustreExpr.expr 
 
   | AbstractTypeIndex of string
     (* Index to the representation field of an abstract type *)

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -186,7 +186,7 @@ let mk_state_var_name ident index = Format.asprintf "%a%a"
 let bounds_of_index index =
   List.fold_left (fun acc -> function
       | X.ArrayVarIndex b -> E.Bound b :: acc
-      | X.MapIndex b -> E.Unbound (Some b) :: acc
+      | X.SetMapIndex b -> E.Unbound (Some b) :: acc
       | X.ArrayIntIndex i ->
         E.Fixed (E.mk_int_expr (Numeral.of_int (i + 1))) :: acc
       | _ -> acc
@@ -380,7 +380,7 @@ let rec expand_tuple' pos accum bounds lhs rhs =
     expand_tuple' pos accum (E.Bound b :: bounds)
       ((lhs_index_tl, state_var) :: lhs_tl)
       (([], expr) :: rhs_tl)
-  | (X.MapIndex b :: lhs_index_tl, state_var) :: lhs_tl,
+  | (X.SetMapIndex b :: lhs_index_tl, state_var) :: lhs_tl,
     ([], expr) :: rhs_tl ->
     expand_tuple' pos accum (E.Unbound (Some b) :: bounds)
       ((lhs_index_tl, state_var) :: lhs_tl)
@@ -465,15 +465,15 @@ let rec expand_tuple' pos accum bounds lhs rhs =
       ((lhs_index_tl, state_var) :: lhs_tl)
       ((rhs_index_tl, expr) :: rhs_tl)
   (* Map index on right and left side *)
-  | (X.MapIndex _ :: lhs_index_tl, state_var) :: lhs_tl,
-    (X.MapIndex b :: rhs_index_tl, expr) :: rhs_tl -> 
+  | (X.SetMapIndex _ :: lhs_index_tl, state_var) :: lhs_tl,
+    (X.SetMapIndex b :: rhs_index_tl, expr) :: rhs_tl -> 
     let expr_type = expr.E.expr_type in
     let array_index_types = Type.all_index_types_of_array expr_type in
     let over_index_types (e, i, j) _ =
       let ty = 
-        let idx = List.nth (List.rev (X.MapIndex b :: rhs_index_tl)) j in 
+        let idx = List.nth (List.rev (X.SetMapIndex b :: rhs_index_tl)) j in 
         match idx with 
-        | X.MapIndex b -> 
+        | X.SetMapIndex b -> 
           E.type_of_expr b 
         | _ -> assert false 
       in
@@ -554,47 +554,47 @@ let rec expand_tuple' pos accum bounds lhs rhs =
   | (X.RecordIndex _ :: _, _) :: _, (X.ArrayIntIndex _ :: _, _) :: _
   | (X.RecordIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
   | (X.RecordIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
-  | (X.RecordIndex _ :: _, _) :: _, (X.MapIndex _ :: _, _) :: _
+  | (X.RecordIndex _ :: _, _) :: _, (X.SetMapIndex _ :: _, _) :: _
 
   | (X.TupleIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
   | (X.TupleIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
   | (X.TupleIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
   | (X.TupleIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
-  | (X.TupleIndex _ :: _, _) :: _, (X.MapIndex _ :: _, _) :: _
+  | (X.TupleIndex _ :: _, _) :: _, (X.SetMapIndex _ :: _, _) :: _
 
   | (X.ListIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
   | (X.ListIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
   | (X.ListIndex _ :: _, _) :: _, (X.ArrayIntIndex _ :: _, _) :: _
   | (X.ListIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
   | (X.ListIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
-  | (X.ListIndex _ :: _, _) :: _, (X.MapIndex _ :: _, _) :: _
+  | (X.ListIndex _ :: _, _) :: _, (X.SetMapIndex _ :: _, _) :: _
 
   | (X.ArrayIntIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
   | (X.ArrayIntIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
   | (X.ArrayIntIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
   | (X.ArrayIntIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
   | (X.ArrayIntIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
-  | (X.ArrayIntIndex _ :: _, _) :: _, (X.MapIndex _ :: _, _) :: _
+  | (X.ArrayIntIndex _ :: _, _) :: _, (X.SetMapIndex _ :: _, _) :: _
 
   | (X.ArrayVarIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
   | (X.ArrayVarIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
   | (X.ArrayVarIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
   | (X.ArrayVarIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
-  | (X.ArrayVarIndex _::_, _)::_, (MapIndex _ :: _, _)::_
+  | (X.ArrayVarIndex _::_, _)::_, (SetMapIndex _ :: _, _)::_
 
   | (X.AbstractTypeIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
   | (X.AbstractTypeIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
   | (X.AbstractTypeIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
   | (X.AbstractTypeIndex _ :: _, _) :: _, (X.ArrayIntIndex _ :: _, _) :: _
   | (X.AbstractTypeIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
-  | (X.AbstractTypeIndex _ :: _, _) :: _, (X.MapIndex _ :: _, _) :: _
+  | (X.AbstractTypeIndex _ :: _, _) :: _, (X.SetMapIndex _ :: _, _) :: _
 
-  | (X.MapIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
-  | (X.MapIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
-  | (X.MapIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
-  | (X.MapIndex _ :: _, _) :: _, (X.ArrayIntIndex _ :: _, _) :: _
-  | (X.MapIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
-  | (X.MapIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
+  | (X.SetMapIndex _ :: _, _) :: _, (X.RecordIndex _ :: _, _) :: _
+  | (X.SetMapIndex _ :: _, _) :: _, (X.TupleIndex _ :: _, _) :: _
+  | (X.SetMapIndex _ :: _, _) :: _, (X.ListIndex _ :: _, _) :: _
+  | (X.SetMapIndex _ :: _, _) :: _, (X.ArrayIntIndex _ :: _, _) :: _
+  | (X.SetMapIndex _ :: _, _) :: _, (X.ArrayVarIndex _ :: _, _) :: _
+  | (X.SetMapIndex _ :: _, _) :: _, (X.AbstractTypeIndex _ :: _, _) :: _
 
   | (_ :: _, _) :: _, ([], _) :: _ 
   | ([], _) :: _, (_ :: _, _) :: _ ->
@@ -701,7 +701,7 @@ and compile_ast_type
     let over_element_type ty j t a = 
       let dummy = (E.mk_free_var (Var.mk_fresh_var ty)).E.expr_init in
       X.add
-      (j @ [X.MapIndex dummy])
+      (j @ [X.SetMapIndex dummy])
       (Type.mk_array t ty)
       a
     in
@@ -725,7 +725,7 @@ and compile_ast_type
     let over_element_type ty j t a = 
       let dummy = (E.mk_free_var (Var.mk_fresh_var ty)).E.expr_init in
       X.add
-      (j @ [X.MapIndex dummy])
+      (j @ [X.SetMapIndex dummy])
       (Type.mk_array t ty)
       a
     in
@@ -1121,11 +1121,11 @@ and compile_ast_expr
 
   and compile_array_index' compiled_expr index =
     let rec push expr = match X.choose expr with
-      | X.MapIndex _ :: _, v
+      | X.SetMapIndex _ :: _, v
       | X.ArrayVarIndex _ :: _, v
       | X.ArrayIntIndex _ :: _, v ->
         let over_expr = fun e -> match e with
-          | X.MapIndex _ :: tl
+          | X.SetMapIndex _ :: tl
           | X.ArrayVarIndex _ :: tl
           | X.ArrayIntIndex _ :: tl -> X.add tl
           | _ -> assert false
@@ -2096,7 +2096,7 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
       let kt = X.fold (fun k _ acc -> 
         List.fold_left (fun (acc, acc_is, acc_i) idx -> 
         match idx with 
-        | X.MapIndex b -> 
+        | X.SetMapIndex b -> 
           if is_set then 
             X.add acc_is (E.type_of_expr b) acc, acc_is, acc_i + 1
           else 
@@ -2164,7 +2164,7 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
         | X.ArrayVarIndex b -> if cpt < indexes
           then E.Bound b :: acc, succ cpt
           else acc, cpt
-        | X.MapIndex b -> if cpt < indexes 
+        | X.SetMapIndex b -> if cpt < indexes 
           then E.Unbound (Some b) :: acc, succ cpt
           else acc, cpt
         | X.ArrayIntIndex x -> 


### PR DESCRIPTION
Since `LustreIndex.MapIndex` was used for both maps and sets, we rename for clarity