### PR TITLE
Do not letify var if def contains access to unbounded array

### DIFF
--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -1073,6 +1073,13 @@ let vars_of_expr { expr_init; expr_step } =
   (* Join sets of state variables *)
   Var.VarSet.union vars_init vars_step
 
+let select_terms { expr_init; expr_step } =
+  let terms_init = Term.select_terms expr_init in
+
+  let terms_step = Term.select_terms expr_step in
+
+  Term.TermSet.union terms_init terms_step
+
 
 (* Return all state variables at the current instant in the initial
    state expression *)

--- a/src/lustre/lustreExpr.mli
+++ b/src/lustre/lustreExpr.mli
@@ -284,6 +284,9 @@ val state_vars_of_expr : t -> StateVar.StateVarSet.t
 
 val vars_of_expr : t -> Var.VarSet.t
 
+(** Return the terms of the form (select ...) that appear in a expression *)
+val select_terms : t -> Term.TermSet.t
+
 (** Return all state variables of the initial state expression at the
     base instant *)
 val base_state_vars_of_init_expr : t -> StateVar.StateVarSet.t

--- a/src/lustre/lustreGlobals.ml
+++ b/src/lustre/lustreGlobals.ml
@@ -19,6 +19,9 @@
 (* Abbreviations *)
 module E = LustreExpr
 
+type state_var_bounds = (E.expr E.bound_or_fixed list) StateVar.StateVarHashtbl.t
+
+
 type t = 
 
   { 
@@ -27,7 +30,7 @@ type t =
     free_constants : (LustreIdent.t * Var.t LustreIndex.t) list;
     
     (* register bounds of state variables for later use *)
-    state_var_bounds : (E.expr E.bound_or_fixed list) StateVar.StateVarHashtbl.t;
+    state_var_bounds : state_var_bounds;
 
     (* Constraints on free constants *)
     global_constraints: E.t list;

--- a/src/lustre/lustreGlobals.mli
+++ b/src/lustre/lustreGlobals.mli
@@ -21,14 +21,16 @@
     @author Christoph Sticksel *)
 
 (** *)
+
+type state_var_bounds = (LustreExpr.expr LustreExpr.bound_or_fixed list)
+        StateVar.StateVarHashtbl.t
+
 type t = 
   { 
     free_constants : (LustreIdent.t * Var.t LustreIndex.t) list;
     (** Free constants *)
 
-    state_var_bounds :
-      (LustreExpr.expr LustreExpr.bound_or_fixed list)
-        StateVar.StateVarHashtbl.t;
+    state_var_bounds : state_var_bounds;
     (** Register bounds of state variables for later use *)
 
     global_constraints: LustreExpr.t list;

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -50,6 +50,7 @@ module D = LustreIndex
 module E = LustreExpr
 module C = LustreContract
 module NI = NodeId
+module LG = LustreGlobals
 
 module SVS = StateVar.StateVarSet
 module SVM = StateVar.StateVarMap
@@ -1364,6 +1365,7 @@ let stateful_vars_of_expr { E.expr_step } =
 
 (* Return all stateful variables from expressions in a node *)
 let stateful_vars_of_node
+    (svar_bounds: LG.state_var_bounds)
     { inputs; 
       oracles; 
       outputs; 
@@ -1373,6 +1375,11 @@ let stateful_vars_of_node
       asserts; 
       props; 
       contract } =
+
+  let is_unbounded_array svar =
+    let bounds = SVT.find svar_bounds svar in
+    List.exists (function E.Unbound _ -> true | _ -> false) bounds
+  in
 
   (* Input, oracle, and output variables are always stateful
 
@@ -1435,10 +1442,26 @@ let stateful_vars_of_node
                   if
                     (* Arrays are global TODO maybe this is not necessary *)
                     not (Type.is_array (StateVar.type_of_state_var sv)) &&
-                    (* Local state variable is defined by an equation? *)
-                    List.exists
-                      (fun ((sv', _), _) -> StateVar.equal_state_vars sv sv')
-                      equations 
+                    (* Local state variable is defined by an equation and
+                       the definition does not access an unbounded array *)
+                    let eq =
+                      List.find_opt
+                        (fun ((sv', _), _) -> StateVar.equal_state_vars sv sv')
+                        equations
+                    in
+                    match eq with
+                    | Some (_, def) -> (
+                      let select_terms = E.select_terms def in
+                      Term.TermSet.for_all
+                        (fun t ->
+                          let svar =
+                            Var.state_var_of_state_var_instance (Term.var_of_select_store t)
+                          in
+                          not (is_unbounded_array svar)
+                        )
+                        select_terms
+                    )
+                    | None -> false
                   then a
                   else
                     (* State variable without equation must be stateful *)

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -48,6 +48,7 @@
 open Lib
 
 module NI = NodeId
+module LG = LustreGlobals
 
 (** {1 Types} *)
 
@@ -334,7 +335,7 @@ val subsystem_of_nodes : NI.t -> t list -> t SubSystem.t
 val nodes_of_subsystem : t SubSystem.t -> t list
 
 (** Return all stateful variables from expressions in a node *)
-val stateful_vars_of_node : t -> StateVar.StateVarSet.t
+val stateful_vars_of_node : LG.state_var_bounds -> t -> StateVar.StateVarSet.t
 
 (** Return the name of the node *)
 val node_id_of_node : t -> NI.t

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2531,7 +2531,8 @@ let rec trans_sys_of_node' options globals top_name analysis_param
              variables for node instance, first tick flag, and state
              variables capturing outputs of node calls *)
           let stateful_vars_of_node =
-            N.stateful_vars_of_node node |> SVS.elements
+            N.stateful_vars_of_node globals.state_var_bounds node
+            |> SVS.elements
           in
           let stateful_vars = 
             init_flag :: stateful_vars_of_node

--- a/tests/regression/falsifiable/map_set_cex.lus
+++ b/tests/regression/falsifiable/map_set_cex.lus
@@ -1,0 +1,16 @@
+node N(m: map<int,int>; x: int; A:int^2) returns (y: int);
+var l: int;
+    r: bool;
+    s: set<int>;
+    k: int;
+let
+  s = {}@<int>;
+  l = m[0];
+  r = 0 in m;
+  y = x;
+  k = A[0];
+  check "P1" l>0;
+  check "P2" r => l>0;
+  check "P3" y in s;
+  check "P4" k>0;
+tel


### PR DESCRIPTION
Currently, only sets and maps produce unbounded arrays. This enforces the evaluation of set and map accesses included in the definition of stateless local variables when a counterexample is generated.