### PR TITLE
Global assumptions

### DIFF
--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -30,6 +30,8 @@ let mk_span start_pos end_pos =
   { A.start_pos = mk_pos start_pos;
     A.end_pos = mk_pos end_pos }
 
+let i = ref 0
+
 %}
 
 (* Special characters *)
@@ -289,6 +291,14 @@ decl:
   }
   | d = contract_decl { [A.ContractNodeDecl (mk_span $startpos $endpos, d)] }
   | d = node_param_inst { [A.NodeParamInst (mk_span $startpos $endpos, d)] }
+  | ASSUME; e = qexpr; SEMICOLON; {
+    (* A global assumption desugars to a global constant refinement type predicate *)
+    let pos = mk_pos $startpos in 
+    let id = HString.mk_hstring ((string_of_int !i) ^ "_gassume") in 
+    i := !i + 1;
+    let ty = A.RefinementType (pos, (pos, id, A.Bool pos), e) in
+    [A.ConstDecl (mk_span $startpos $endpos, FreeConst (pos, id, ty))] 
+  }
 
 
 (* ********************************************************************** *)
@@ -1289,7 +1299,7 @@ merge_case :
 ident:
   (* Contract tokens are not keywords. *)
   | MODE { HString.mk_hstring "mode" }
-  | ASSUME { HString.mk_hstring "assume" }
+  (*| ASSUME { HString.mk_hstring "assume" }*)
   | GUARANTEE { HString.mk_hstring "guarantee" }
   | REQUIRE { HString.mk_hstring "require" }
   | ENSURE { HString.mk_hstring "ensure" }


### PR DESCRIPTION
Partial support for global assumptions with the `assume` keyword. 

For full support, we need to (at least)
1. Make sure no generated names appear in counterexamples
2. Make sure we aren't breaking other features, e.g. inductive validity cores 

For the above, it may be necessary to introduce a new `declaration` constructor in the Lustre AST.

Note -- to avoid shift/reduce conflicts, I had to promote `assume` to a proper keyword (it can't be used as a variable/constant/function/node name). We have not yet determined whether the same treatment should be applied to the other contract "keywords"