### PR TITLE
Fix spurious unguarded pre warning

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2325,8 +2325,8 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
       BinaryOp (pos, op, nexpr1, nexpr2), union gids1 gids2, warnings1 @ warnings2
     )
   | BinaryOp (pos, ((Union | Intersection) as op), expr1, expr2) -> 
-    let nexpr1, gids1, warnings1 = normalize_expr info node_id map expr1 in 
-    let nexpr2, gids2, warnings2 = normalize_expr info node_id map expr2 in 
+    let nexpr1, gids1, warnings1 = normalize_expr ?guard info node_id map expr1 in 
+    let nexpr2, gids2, warnings2 = normalize_expr ?guard info node_id map expr2 in 
     i := !i + 1; 
     let prefix = HString.mk_hstring (string_of_int !i) in 
     let name1 = HString.concat2 prefix (HString.mk_hstring "_set_union") in 


### PR DESCRIPTION
The following example raised a spurious unguarded `pre` warning before this PR

```
node N(x: int) returns (s:set<int>);
let
  s = {}@<int> -> pre s + { x };
tel
```