### PR TITLE
Update tuple indexing syntax

### DIFF
--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -1125,7 +1125,7 @@ returns the corresponding swapped pair tuple as output.
 
    node PairSwap<T; U>(x: [T, U]) returns (y: [U, T]);
    let
-   y = {x.%1, x.%0};
+   y = {x[1], x[0]};
    tel
 
 For a polymorphic node to be well-typed, it must be meaningful for *any* type instantiation

--- a/doc/usr/source/2_input/9_tuples.rst
+++ b/doc/usr/source/2_input/9_tuples.rst
@@ -1,4 +1,4 @@
-Enumeration types
+Tuple types
 ==================
 
 Tuples are constructed with the syntax ``'(x1, ..., xn)`` and destructed with the syntax ``t[idx]``, 

--- a/doc/usr/source/2_input/9_tuples.rst
+++ b/doc/usr/source/2_input/9_tuples.rst
@@ -1,0 +1,14 @@
+Enumeration types
+==================
+
+Tuples are constructed with the syntax ``'(x1, ..., xn)`` and destructed with the syntax ``t[idx]``, 
+where ``idx`` is some concrete natural number that is in range (with ``0``-based indexing).
+
+.. code-block:: none
+
+   type my_tuple = [int, bool, real];
+   node n (x : my_tuple) returns (y1 : my_tuple) 
+   let
+     y1 = '(0, false, x[2]);
+   tel
+

--- a/doc/usr/source/2_input/9_tuples.rst
+++ b/doc/usr/source/2_input/9_tuples.rst
@@ -7,8 +7,8 @@ where ``idx`` is some concrete natural number that is in range (with ``0``-based
 .. code-block:: none
 
    type my_tuple = [int, bool, real];
-   node n (x : my_tuple) returns (y1 : my_tuple) 
+   node n (x : my_tuple) returns (y : my_tuple) 
    let
-     y1 = '(0, false, x[2]);
+     y = '(0, false, x[2]);
    tel
 

--- a/doc/usr/source/index.rst
+++ b/doc/usr/source/index.rst
@@ -29,6 +29,7 @@ Table of Contents
     2_input/6_history_type
     2_input/7_abstract_types
     2_input/8_polymorphic_types
+    2_input/9_tuples
     3_output/2_machine_readable
     3_output/3_exit_codes
 

--- a/src/ivcMcs.ml
+++ b/src/ivcMcs.ml
@@ -230,7 +230,7 @@ let nodes_input_types = Hashtbl.create 10
 let rec minimize_node_call_args ue lst expr =
   let minimize_arg ident i arg =
     match arg with
-    | A.Ident _ | A.ModeRef _ | A.RecordProject _ | A.TupleProject _ -> arg
+    | A.Ident _ | A.ModeRef _ | A.RecordProject _ -> arg
     | _ ->
       let t = Hashtbl.find nodes_input_types ident |> (fun lst -> List.nth lst i) in
       let (_, expr) = minimize_expr ue lst [t] arg in
@@ -243,7 +243,6 @@ let rec minimize_node_call_args ue lst expr =
     | A.Call (pos, ty_args, ident, args) ->
       A.Call (pos, ty_args, ident, List.mapi (minimize_arg ident) args)
     | A.RecordProject (p,e,i) -> A.RecordProject (p,aux e,i)
-    | A.TupleProject (p,e1,e2) -> A.TupleProject (p,aux e1, e2)
     | A.StructUpdate (p,e1,ls,Some e2) -> A.StructUpdate (p,aux e1,ls,Some (aux e2))
     | A.StructUpdate (p,e1,ls,None) -> A.StructUpdate (p,aux e1,ls,None)
     | A.ConvOp (p,op,e) -> A.ConvOp (p,op,aux e)
@@ -281,7 +280,7 @@ and ast_contains p ast =
       List.map aux args
       |> List.exists (fun x -> x)
     | A.ConvOp (_,_,e) | A.UnaryOp (_,_,e) | A.RecordProject (_,e,_)
-      | A.TupleProject (_,e,_) | A.Quantifier (_,_,_,e)
+      | A.Quantifier (_,_,_,e)
       | A.When (_,e,_) | A.Pre (_,e) | A.StructUpdate (_, e, _, None) | A.AnyOp (_,_,e) | A.Extract (_,e,_,_) ->
       aux e
     | A.StructUpdate (_,e1,_,Some e2) | A.ArrayConstr (_,e1,e2)

--- a/src/lustre/lustreAbstractInterpretation.ml
+++ b/src/lustre/lustreAbstractInterpretation.ml
@@ -447,18 +447,17 @@ and interpret_structured_expr f node_id ctx ty_ctx ty proj expr =
         | UserType _ | AbstractType _ | TupleType _ | GroupType _ | ArrayType _
         | EnumType _ | TArr _ | RefinementType _ | History _ | Map _ | Set _
         | SBitVector _ | UBitVector _ -> assert false)
-    | TupleProject (_, e, idx) ->
-      let parent_ty = infer e in
-      let parent_ty = interpret_expr_by_type node_id ctx ty_ctx parent_ty proj e in
-      (match parent_ty with
-      | TupleType (_, types) -> List.nth types idx
-      | _ -> assert false)
-    | IndexAccess (_, e, _, _) ->
+    | IndexAccess (_, e, idx, _) ->
       let parent_ty = infer e in
       let parent_ty = interpret_expr_by_type node_id ctx ty_ctx parent_ty proj e in
       (match parent_ty with
       | ArrayType (_, (ty, _)) -> ty
       | Map (_, _, ty) -> ty
+      | TupleType (_, types) -> 
+        let idx = match idx with 
+        | LA.Const (_, Num n) -> n |> HString.string_of_hstring |> int_of_string
+        | _ -> assert false in (* Guaranteed concrete int in type checking *)
+        List.nth types idx
       | _ -> assert false)
     | GroupExpr (_, ExprList, es) -> (
       let g = interpret_structured_expr f node_id ctx ty_ctx ty in
@@ -495,14 +494,15 @@ and interpret_int_expr node_id ctx ty_ctx proj expr =
       | UserType _ | AbstractType _ | TupleType _ | GroupType _ | ArrayType _
       | EnumType _ | TArr _ | RefinementType _ | History _ 
       | Set _ | Map _ | SBitVector _ | UBitVector _ -> assert false) 
-  | TupleProject (_, e, idx) -> (match infer e with
-    | TupleType (_, nested) -> 
-      let ty = List.nth nested idx in
-      extract_bounds_from_type ty
-    | _ -> assert false)
-  | IndexAccess (_, e, _, _) -> (match infer e with
+  | IndexAccess (_, e, idx, _) -> (match infer e with
     | ArrayType (_, (t, _)) -> extract_bounds_from_type t
     | Map (_, _, t) -> extract_bounds_from_type t
+    | TupleType (_, nested) -> 
+      let idx = match idx with 
+      | LA.Const (_, Num n) -> n |> HString.string_of_hstring |> int_of_string
+      | _ -> assert false in (* Guaranteed concrete int in type checking *)
+      let ty = List.nth nested idx in 
+      extract_bounds_from_type ty
     | _ -> assert false)
   | Const (_, const) -> (match const with
     | True | False -> assert false

--- a/src/lustre/lustreArrayDependencies.ml
+++ b/src/lustre/lustreArrayDependencies.ml
@@ -154,7 +154,6 @@ and process_expr ind_vars ctx ns proj indices expr =
   | EmptySet _ -> empty_
   | EmptyMap _ -> empty_
   | RecordProject (_, e, _) -> r e
-  | TupleProject (_, e, _) -> r e
   (* Values *)
   | Const _ -> empty_
   (* Operators *)

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -66,7 +66,6 @@ type in_kind =
   | Unknown 
   | Map
   | Set 
-  | Tuple
 
 type binary_operator =
   | And | AndThen | Or | OrElse | Xor | Impl | LazyImpl
@@ -96,6 +95,7 @@ type group_expr =
 type access_kind =
   | Array 
   | Map 
+  | Tuple
   | Unknown
 
 (** A Lustre expression *)
@@ -104,7 +104,6 @@ type expr =
   | Ident of position * ident
   | ModeRef of position * ident list
   | RecordProject of position * expr * index
-  | TupleProject of position * expr * int
   (* Values *)
   | Const of position * constant
   (* Operators *)
@@ -497,10 +496,6 @@ let rec pp_print_expr ppf =
               (pp_print_list pp_print_lustre_type ";") ty_args
         )
         (pp_print_list pp_print_field_assign ";@ ") l
-
-    | TupleProject (p, e, f) -> 
-
-      Format.fprintf ppf "%a%a.%%%a" ppos p pp_print_expr e Format.pp_print_int f
 
     | Const (p, True) -> ps p (HString.mk_hstring "true")
     | Const (p, False) -> ps p (HString.mk_hstring "false")

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -66,6 +66,7 @@ type in_kind =
   | Unknown 
   | Map
   | Set 
+  | Tuple
 
 type binary_operator =
   | And | AndThen | Or | OrElse | Xor | Impl | LazyImpl

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -82,7 +82,6 @@ type in_kind =
   | Unknown 
   | Map
   | Set 
-  | Tuple
 
 type binary_operator =
   | And | AndThen | Or | OrElse | Xor | Impl | LazyImpl
@@ -109,7 +108,7 @@ type group_expr =
   | TupleExpr (* Tuple expression *)
   | ArrayExpr (* Array expression *)
 
-type access_kind = Array | Map | Unknown
+type access_kind = Array | Map | Tuple | Unknown
 
 (** A Lustre type *)
 type lustre_type =
@@ -141,7 +140,6 @@ and expr =
   | Ident of position * ident
   | ModeRef of position * ident list
   | RecordProject of position * expr * index
-  | TupleProject of position * expr * int
   (* Values *)
   | Const of position * constant
   (* Operators *)

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -82,6 +82,7 @@ type in_kind =
   | Unknown 
   | Map
   | Set 
+  | Tuple
 
 type binary_operator =
   | And | AndThen | Or | OrElse | Xor | Impl | LazyImpl

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -321,7 +321,6 @@ and mk_graph_expr ?(only_modes = false)
     union_dependency_analysis_data (mk_graph_expr ~only_modes e1)
       (union_dependency_analysis_data (mk_graph_expr ~only_modes e2) (mk_graph_expr ~only_modes e3)) 
   | LA.RecordProject (_, e, _) -> mk_graph_expr ~only_modes e
-  | LA.TupleProject (_, e, _) -> mk_graph_expr ~only_modes e
   | LA.ArrayConstr (_, e1, e2) -> union_dependency_analysis_data (mk_graph_expr ~only_modes e1) (mk_graph_expr ~only_modes e2) 
   | LA.IndexAccess (_, e1, e2, _) -> union_dependency_analysis_data (mk_graph_expr ~only_modes e1) (mk_graph_expr ~only_modes e2)
   | LA.GroupExpr (_, _, es) ->
@@ -386,8 +385,7 @@ let rec get_node_call_from_expr: LA.expr -> (LA.ident * Lib.position) list
   | ModeRef (pos, ids) ->
     if List.length ids = 1 then []
     else [(HString.concat2 contract_prefix (List.hd ids), pos)]  
-  | RecordProject (_, e, _)
-  | TupleProject (_, e, _) -> get_node_call_from_expr e
+  | RecordProject (_, e, _) -> get_node_call_from_expr e
   (* Values *)
   | LA.Const _ -> []
   (* Operators *)
@@ -655,7 +653,6 @@ let rec vars_with_flattened_nodes: node_summary -> int -> LA.expr -> LA.SI.t
   | EmptySet (_, Some ty) -> LH.vars_of_type ty
   | EmptyMap (_, Some (kt, vt)) -> SI.union (LH.vars_of_type kt) (LH.vars_of_type vt) 
   | RecordProject (_, e, _) -> r e 
-  | TupleProject (_, e, _) -> r e
   (* Values *)
   | Const _ -> SI.empty
 
@@ -837,8 +834,7 @@ let rec mk_graph_expr2: node_summary -> LA.expr -> (dependency_analysis_data lis
      else
        R.ok (List.map (fun g -> union_dependency_analysis_data g1 g)
                (List.map2 (fun g g' -> union_dependency_analysis_data g g') g2 g3))
-  | LA.RecordProject (_, e, _)
-    | LA.TupleProject (_, e, _) -> mk_graph_expr2 m e
+  | LA.RecordProject (_, e, _) -> mk_graph_expr2 m e
   | LA.ArrayConstr (_, e1, e2) ->
      mk_graph_expr2 m e1 >>= fun g1 ->
      mk_graph_expr2 m e2 >>= fun g2 -> 

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -50,7 +50,7 @@ let id_of_expr = function
 
 let pos_of_expr = function
   | Ident (pos , _) | ModeRef (pos , _ ) | RecordProject (pos , _ , _)
-  | TupleProject (pos , _ , _) | StructUpdate (pos , _ , _ , _) | Const (pos, _)
+  | StructUpdate (pos , _ , _ , _) | Const (pos, _)
   | ConvOp (pos , _, _) | GroupExpr (pos , _, _ ) | ArrayConstr (pos , _ , _ )
   | IndexAccess (pos , _, _, _)
   | RecordExpr (pos , _ , _, _) | UnaryOp (pos , _, _) | BinaryOp (pos , _, _ , _)
@@ -128,7 +128,7 @@ let rec expr_contains_call = function
   | EmptyMap (_, Some (kt, vt)) ->
     fold_lustre_ty expr_contains_call false (||) kt || 
     fold_lustre_ty expr_contains_call false (||) vt
-  | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
+  | RecordProject (_, e, _) | UnaryOp (_, _, e)
   | ConvOp (_, _, e) | Quantifier (_, _, _, e) | When (_, e, _)
   | Pre (_, e) | Extract (_, e, _, _) | StructUpdate (_, e, _, None)
     -> expr_contains_call e
@@ -156,7 +156,7 @@ let rec expr_contains_id id = function
     fold_lustre_ty expr_is_id false (||) kt || 
     fold_lustre_ty expr_is_id false (||) vt 
   | EmptySet (_, Some ty) -> fold_lustre_ty expr_is_id false (||) ty
-  | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
+  | RecordProject (_, e, _) | UnaryOp (_, _, e)
   | ConvOp (_, _, e) | Quantifier (_, _, _, e) | When (_, e, _) | Pre (_, e) 
   | Extract (_, e, _, _) | StructUpdate (_, e, _, None)
     -> expr_contains_id id e
@@ -191,7 +191,6 @@ let rec substitute_naive (var:HString.t) t = function
   | EmptySet (p, Some ty) -> 
     EmptySet (p, Some (map_lustre_ty (substitute_naive var t) ty))
   | RecordProject (pos, e, idx) -> RecordProject (pos, substitute_naive var t e, idx)
-  | TupleProject (pos, e, idx) -> TupleProject (pos, substitute_naive var t e, idx)
   | Const (_, _) as e -> e
   | Extract (pos, e, idx1, idx2) -> Extract (pos, substitute_naive var t e, idx1, idx2)
   | UnaryOp (pos, op, e) -> UnaryOp (pos, op, substitute_naive var t e)
@@ -255,7 +254,6 @@ let rec apply_subst_in_expr sigma = function
   | EmptySet (p, Some ty) -> 
     EmptySet (p, Some (map_lustre_ty (apply_subst_in_expr sigma) ty))
   | RecordProject (pos, e, idx) -> RecordProject (pos, apply_subst_in_expr sigma e, idx)
-  | TupleProject (pos, e, idx) -> TupleProject (pos, apply_subst_in_expr sigma e, idx)
   | Const (_, _) as e -> e
   | Extract (pos, e, idx1, idx2) -> Extract (pos, apply_subst_in_expr sigma e, idx1, idx2)
   | UnaryOp (pos, op, e) -> UnaryOp (pos, op, apply_subst_in_expr sigma e)
@@ -326,7 +324,6 @@ let rec apply_type_subst_in_expr
   | Ident _ 
   | ModeRef _  -> expr
   | RecordProject (pos, e, idx) -> RecordProject (pos, apply_type_subst_in_expr sigma e, idx)
-  | TupleProject (pos, e, idx) -> TupleProject (pos, apply_type_subst_in_expr sigma e, idx)
   | Const (_, _) as e -> e
   | Extract (pos, e, idx1, idx2) -> Extract (pos, apply_type_subst_in_expr sigma e, idx1, idx2)
   | UnaryOp (pos, op, e) -> UnaryOp (pos, op, apply_type_subst_in_expr sigma e)
@@ -440,7 +437,7 @@ let rec has_unguarded_pre ung = function
     fold_lustre_ty (has_unguarded_pre ung) false (||) ty
   | RecordProject (_, e, _) | ConvOp (_, _, e)
   | UnaryOp (_, _, e) | When (_, e, _)
-  | TupleProject (_, e, _) | Quantifier (_, _, _, e) | Extract (_, e, _, _) -> has_unguarded_pre ung e
+  | Quantifier (_, _, _, e) | Extract (_, e, _, _) -> has_unguarded_pre ung e
   | AnyOp (pos, _, _) -> fail_at_position pos "'Any' operations are not supported in the old front end"
   | BinaryOp (_, _, e1, e2) | ArrayConstr (_, e1, e2) 
   | CompOp (_, _, e1, e2) ->
@@ -541,7 +538,7 @@ let rec has_unguarded_pre_no_warn ung = function
     fold_lustre_ty (has_unguarded_pre_no_warn ung) false (||) ty
   | RecordProject (_, e, _) | ConvOp (_, _, e)
   | UnaryOp (_, _, e) | When (_, e, _)
-  | TupleProject (_, e, _) | Quantifier (_, _, _, e) | Extract (_, e, _, _) -> has_unguarded_pre_no_warn ung e
+  | Quantifier (_, _, _, e) | Extract (_, e, _, _) -> has_unguarded_pre_no_warn ung e
   | AnyOp _ -> assert false (* desugared in lustreDesugarAnyOps *)
   | BinaryOp (_, _, e1, e2) | ArrayConstr (_, e1, e2) 
   | CompOp (_, _, e1, e2) ->
@@ -644,7 +641,7 @@ let rec has_pre_or_arrow = function
     fold_lustre_ty has_pre_or_arrow None (fun x1 x2 -> some_of_list [x1; x2]) ty
   | RecordProject (_, e, _) | ConvOp (_, _, e)
   | UnaryOp (_, _, e) | When (_, e, _)
-  | TupleProject (_, e, _) | Quantifier (_, _, _, e) 
+  | Quantifier (_, _, _, e) 
   | AnyOp (_, _, e) | Extract (_, e, _, _) -> 
     has_pre_or_arrow e
 
@@ -734,7 +731,7 @@ let rec lasts_of_expr acc = function
     
   | RecordProject (_, e, _) | ConvOp (_, _, e)
   | UnaryOp (_, _, e) | Current (_, e) | When (_, e, _)
-  | TupleProject (_, e, _) | Quantifier (_, _, _, e) ->
+  | Quantifier (_, _, _, e) ->
     lasts_of_expr acc e
 
   | BinaryOp (_, _, e1, e2) | CompOp (_, _, e1, e2) 
@@ -896,7 +893,6 @@ let rec vars_of_node_calls_h obs =
   | Ident (_, i) -> if obs then SI.singleton i else SI.empty
   | ModeRef (_, is) -> if obs then SI.singleton (mk_mode_ref_id is) else SI.empty
   | RecordProject (_, e, _) -> vars obs e 
-  | TupleProject (_, e, _) -> vars obs e
   | EmptyMap (_, None) | EmptySet (_, None) -> SI.empty   
   | EmptyMap (_, Some (kt, vt)) -> 
     SI.union (fold_lustre_ty (vars obs) SI.empty SI.union kt)
@@ -945,7 +941,6 @@ let rec vars_without_node_call_ids: expr -> iset =
   | Ident (_, i) -> SI.singleton i
   | ModeRef (_, is) -> SI.singleton (mk_mode_ref_id is)
   | RecordProject (_, e, _) -> vars e 
-  | TupleProject (_, e, _) -> vars e
   | EmptyMap (_, None) | EmptySet (_, None) -> SI.empty
   | EmptyMap (_, Some (kt, vt)) -> 
     SI.union (fold_lustre_ty vars SI.empty SI.union kt) 
@@ -1003,7 +998,6 @@ let rec calls_of_expr: expr -> NI.Set.t =
   | Ident _ -> NI.Set.empty
   | ModeRef _ -> NI.Set.empty
   | RecordProject (_, e, _) -> calls_of_expr e 
-  | TupleProject (_, e, _) -> calls_of_expr e
   | Const _ -> NI.Set.empty
   | Extract (_, e, _, _)
   | UnaryOp (_,_,e) -> calls_of_expr e
@@ -1037,7 +1031,6 @@ let rec vars_without_node_call_ids_current: expr -> iset =
   | Ident (_, i) -> SI.singleton i
   | ModeRef (_, is) -> SI.singleton (mk_mode_ref_id is)
   | RecordProject (_, e, _) -> vars e 
-  | TupleProject (_, e, _) -> vars e
   | EmptyMap (_, None) | EmptySet (_, None) -> SI.empty
   | EmptyMap (_, Some (kt, vt)) -> 
     SI.union (fold_lustre_ty vars SI.empty SI.union kt) 
@@ -1178,7 +1171,6 @@ let rec replace_with_constants: expr -> expr =
     | EmptySet (_, None) | EmptyMap (_, None)
     | ModeRef _ as e -> e 
   | RecordProject (p, e, i) -> RecordProject (p, replace_with_constants e, i)  
-  | TupleProject (p, e, i) -> TupleProject (p, replace_with_constants e, i)
   | EmptyMap (p, Some (kt, vt)) -> 
     EmptyMap (p, Some (map_lustre_ty replace_with_constants kt, map_lustre_ty replace_with_constants vt))
   | EmptySet (p, Some ty) -> 
@@ -1271,7 +1263,6 @@ let rec abstract_pre_subexpressions: expr -> expr = function
   | EmptySet (p, Some ty) -> 
     EmptySet (p, Some (map_lustre_ty abstract_pre_subexpressions ty))
   | RecordProject (p, e, i) -> RecordProject (p, abstract_pre_subexpressions e, i)  
-  | TupleProject (p, e, i) -> TupleProject (p, abstract_pre_subexpressions e, i)
   (* Values *)
   | Const _ as e -> e
 
@@ -1367,7 +1358,6 @@ let rec replace_idents locals1 locals2 expr =
   | UnaryOp (a, b, e) -> UnaryOp (a, b, r e)
   
   | When (a, e, b) -> When (a, r e, b)
-  | TupleProject (a, e, b) -> TupleProject (a, r e, b)
   | BinaryOp (a, b, e1, e2) -> BinaryOp (a, b, r e1, r e2)
   | CompOp (a, b, e1, e2) -> CompOp (a, b, r e1, r e2)
   | IndexAccess (a, e1, e2, k) -> IndexAccess (a, r e1, r e2, k)
@@ -1504,8 +1494,6 @@ let rec syn_expr_equal depth_limit x y : (bool, unit) result =
       Ok t
     | RecordProject (_, xe, xi), RecordProject (_, ye, yi) ->
       r (depth + 1) xe ye >>= fun e -> Ok (e && HString.equal xi yi)
-    | TupleProject (_, xe, xi), TupleProject(_, ye, yi) ->
-      r (depth + 1) xe ye >>= fun e -> Ok (e && xi = yi)
     | Const (_, True), Const(_, True) -> Ok (true)
     | Const (_, False), Const (_, False) -> Ok (true)
     | Const (_, Num x), Const (_, Num y) -> Ok (HString.equal x y)
@@ -1716,9 +1704,6 @@ let hash depth_limit expr =
       | RecordProject (_, e, i) ->
         let e_hash = r (depth + 1) e in
         Hashtbl.hash (3, e_hash, HString.hash i)
-      | TupleProject (_, e, i) ->
-        let e_hash = r (depth + 1) e in
-        Hashtbl.hash (4, e_hash, i)
       | Const (_, True) -> Hashtbl.hash (5, 0)
       | Const (_, False) -> Hashtbl.hash (5, 1)
       | Const (_, Num x) -> Hashtbl.hash (5, 2, HString.hash x)
@@ -1855,7 +1840,6 @@ let rec rename_contract_vars = function
   | EmptySet (p, Some ty) ->
     EmptySet (p, Some (map_lustre_ty rename_contract_vars ty))
   | RecordProject (pos, e, idx) -> RecordProject (pos, rename_contract_vars e, idx)
-  | TupleProject (pos, e, idx) -> TupleProject (pos, rename_contract_vars e, idx)
   | Const (_, _) as e -> e
   | Extract (pos, e, idx1, idx2) -> Extract (pos, rename_contract_vars e, idx1, idx2)
   | UnaryOp (pos, op, e) -> UnaryOp (pos, op, rename_contract_vars e)

--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -215,7 +215,7 @@ and eval_comp_op: TC.tc_context -> LA.comparison_operator
   | Gt -> R.ok (v1 > v2)
 (** try and evalutate comparison op expression to bool, return error otherwise *)
 
-and simplify_array_index ctx pos e1 idx kind =
+and simplify_index_access ctx pos e1 idx kind =
   let e1' = simplify_expr ctx e1 in
   let idx' = simplify_expr ctx idx in
   let raise_error () =
@@ -345,7 +345,7 @@ and simplify_expr ?(is_guarded = false) ?(ind_vars = []) ctx =
      (*(match (eval_int_expr ctx e2) with
       | Ok size -> LA.GroupExpr (pos, LA.ArrayExpr, List.init size (fun _ -> e1'))
       | Error _ -> e')*)
-  | LA.IndexAccess (pos, e1, e2, kind) -> simplify_array_index ctx pos e1 e2 kind
+  | LA.IndexAccess (pos, e1, e2, kind) -> simplify_index_access ctx pos e1 e2 kind
   | Call (pos, ty_args, i, es) ->
     let es' = List.map (fun e -> simplify_expr ~ind_vars ~is_guarded:false ctx e) es in
     Call (pos, ty_args, i, es')

--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -95,8 +95,7 @@ let rec is_normal_form: TC.tc_context -> LA.expr -> bool = fun ctx ->
   function
   | Const _ -> true
   | RecordExpr (_, _, _, id_exprs) -> List.for_all (fun (_, e) -> is_normal_form ctx e) id_exprs
-  | RecordProject (_, e, _)
-    | TupleProject (_, e, _) -> is_normal_form ctx e
+  | RecordProject (_, e, _) -> is_normal_form ctx e
   | _ -> false
 (** is the expression in a normal form? *)
          
@@ -235,16 +234,6 @@ and simplify_array_index ctx pos e1 idx kind =
     IndexAccess (pos, e1', idx', kind)
 (** picks out the idx'th component of an array if it can *)
 
-and simplify_tuple_proj: TC.tc_context -> Lib.position -> LA.expr -> int -> LA.expr
-  = fun ctx pos e1 idx ->
-  match (simplify_expr ctx e1) with
-  | LA.GroupExpr (_, _, es) ->
-     if List.length es > idx
-     then List.nth es idx
-     else (raise (Out_of_bounds (pos, "Tuple element access out of bounds.")))
-  | _ -> TupleProject (pos, e1, idx)
-(** picks out the idx'th component of a tuple if it is possible *)
-
 and push_pre is_guarded pos =
   let r e = push_pre is_guarded pos e in
   function
@@ -253,7 +242,6 @@ and push_pre is_guarded pos =
   | EmptySet _ as e -> LA.Pre (pos, e)
   | EmptyMap _ as e -> LA.Pre (pos, e)
   | RecordProject (p, e, i) -> RecordProject (p, r e, i)
-  | TupleProject (p, e, i) -> TupleProject (p, r e, i)
   | Const _ as e -> if is_guarded then e else Pre (pos, e)
   | UnaryOp (p, op, e) -> UnaryOp (p, op, r e)
   | BinaryOp (p, op, e1, e2) -> BinaryOp (p, op, r e1, r e2)
@@ -358,7 +346,6 @@ and simplify_expr ?(is_guarded = false) ?(ind_vars = []) ctx =
       | Ok size -> LA.GroupExpr (pos, LA.ArrayExpr, List.init size (fun _ -> e1'))
       | Error _ -> e')*)
   | LA.IndexAccess (pos, e1, e2, kind) -> simplify_array_index ctx pos e1 e2 kind
-  | LA.TupleProject (pos, e1, e2) -> simplify_tuple_proj ctx pos e1 e2  
   | Call (pos, ty_args, i, es) ->
     let es' = List.map (fun e -> simplify_expr ~ind_vars ~is_guarded:false ctx e) es in
     Call (pos, ty_args, i, es')

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -454,8 +454,8 @@ let rec mk_enum_range_expr ?(mk_enum=true) ?(mk_range=true) ctx node_id expr_typ
       let var = dpos, id_str, (A.Int dpos) in
       let body = fun e -> A.BinaryOp (dpos, A.Impl, assumption, e) in
       List.map (fun (e, is_original) -> A.Quantifier (dpos, A.Forall, [var], body e), is_original) rexpr
-    | TupleType (_, tys) ->
-      let mk_proj i = A.TupleProject (dpos, expr, i) in
+    | TupleType (p, tys) ->
+      let mk_proj i = A.IndexAccess (dpos, expr, A.Const (p, A.Num (i |> string_of_int |> HString.mk_hstring)), A.Tuple) in
       let tys = List.filter (fun ty -> Ctx.type_contains_enum_or_subrange ctx ty) tys in
       let tys = List.mapi (fun i ty -> mk ctx n ty (mk_proj i)) tys in
       List.fold_left (@) [] tys
@@ -544,7 +544,8 @@ and mk_ref_type_expr: Ctx.tc_context -> NodeId.t option -> A.expr -> A.lustre_ty
     [expr]
   | TupleType (pos, tys) 
   | GroupType (pos, tys) -> List.mapi (fun i ty ->
-      mk_ref_type_expr ctx node_id (A.TupleProject(pos, expr, i)) ty
+      let i = i |> string_of_int |> HString.mk_hstring in
+      mk_ref_type_expr ctx node_id (A.IndexAccess (pos, expr, A.Const (pos, A.Num i), A.Tuple)) ty
     ) tys |> List.flatten
   | RecordType (p, _, tis) -> 
     List.map (fun (_, id2, ty) -> 
@@ -937,9 +938,6 @@ let desugar_history_in_expr ctx ctr_id prefix expr =
   | RecordProject (pos, e, idx) ->
     let vars, e' = r map e in
     vars, RecordProject (pos, e', idx)
-  | TupleProject (pos, e, idx) ->
-    let vars, e' = r map e in
-    vars, TupleProject (pos, e', idx)
   | Const _ -> StringSet.empty, expr
   | UnaryOp (pos, op, e) ->
     let vars, e' = r map e in
@@ -2271,9 +2269,6 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
   | RecordProject (pos, expr, i) ->
     let nexpr, gids, warnings = normalize_expr ?guard info node_id map expr in
     RecordProject (pos, nexpr, i), gids, warnings
-  | TupleProject (pos, expr, i) ->
-    let nexpr, gids, warnings = normalize_expr ?guard info node_id map expr in
-    TupleProject (pos, nexpr, i), gids, warnings
   | Const _ as expr -> expr, empty (), []
   | UnaryOp (pos, op, expr) ->
     let nexpr, gids, warnings = normalize_expr ?guard info node_id map expr in
@@ -2304,7 +2299,6 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let expr = match ty with 
     | A.Map _ -> A.BinaryOp (pos, In Map, expr1, expr2) 
     | A.Set _ -> A.BinaryOp (pos, In Set, expr1, expr2) 
-    | A.TupleType _ -> A.BinaryOp (pos, In Tuple, expr1, expr2)
     | _ -> assert false
     in 
     normalize_expr ?guard info node_id map expr
@@ -2412,6 +2406,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
       match expr1_ty with
       | ArrayType _ -> A.Array
       | Map _ -> Map
+      | TupleType _ -> Tuple
       | _ -> assert false
     in
     IndexAccess (pos, nexpr1, nexpr2, kind'), union gids1 gids2, warnings1 @ warnings2
@@ -2454,7 +2449,6 @@ and expand_node_calls_in_place info node_id var count expr =
   let r = expand_node_calls_in_place info node_id var count in
   match expr with
   | A.RecordProject (p, e, i) -> A.RecordProject (p, r e, i)
-  | TupleProject (p, e, i) -> A.TupleProject (p, r e, i)
   | UnaryOp (p, op, e) -> A.UnaryOp (p, op, r e)
   | ConvOp (p, op, e) -> A.ConvOp (p, op, r e)
   | Quantifier (p, k, ids, e) -> A.Quantifier (p, k, ids, r e)

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2304,6 +2304,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let expr = match ty with 
     | A.Map _ -> A.BinaryOp (pos, In Map, expr1, expr2) 
     | A.Set _ -> A.BinaryOp (pos, In Set, expr1, expr2) 
+    | A.TupleType _ -> A.BinaryOp (pos, In Tuple, expr1, expr2)
     | _ -> assert false
     in 
     normalize_expr ?guard info node_id map expr

--- a/src/lustre/lustreDesugarAnyOps.ml
+++ b/src/lustre/lustreDesugarAnyOps.ml
@@ -94,9 +94,6 @@ fun ctx node_name fun_ids expr ->
   | RecordProject (pos, e, idx) -> 
     let e, gen_nodes = rec_call e in
     RecordProject (pos, e, idx), gen_nodes
-  | TupleProject (pos, e, idx) -> 
-    let e, gen_nodes = rec_call e in
-    TupleProject (pos, e, idx), gen_nodes
   | UnaryOp (pos, op, e) -> 
     let e, gen_nodes = rec_call e in
     UnaryOp (pos, op, e), gen_nodes

--- a/src/lustre/lustreDesugarFrameBlocks.ml
+++ b/src/lustre/lustreDesugarFrameBlocks.ml
@@ -121,7 +121,6 @@ let rec fill_ite_helper frame_pos node_id lhs fill e =
   | Extract (p, e, b, c) -> Extract (p, r e, b, c)
   | UnaryOp (p, b, e) -> UnaryOp (p, b, r e)
   | When (p, e, b) -> When (p, r e, b)
-  | TupleProject (p, e, b) -> TupleProject (p, r e, b)
   | Quantifier (p, b, c, e) -> Quantifier (p, b, c, r e)
   | BinaryOp (p, b, e1, e2) -> BinaryOp (p, b, r e1, r e2)
   | CompOp (p, b, e1, e2) -> CompOp (p, b, r e1, r e2)

--- a/src/lustre/lustreFlattenRefinementTypes.ml
+++ b/src/lustre/lustreFlattenRefinementTypes.ml
@@ -58,7 +58,8 @@ let rec flatten_ref_type ctx ty = match ty with
     | TupleType (pos, tys) | GroupType (pos, tys) -> 
       List.mapi (fun i ty ->
         let exprs = chase_refinements ty in
-        List.map (AH.substitute_naive id (A.TupleProject(pos, Ident(pos, id), i))) exprs
+        let i = i |> string_of_int |> HString.mk_hstring in
+        List.map (AH.substitute_naive id (A.IndexAccess (pos, Ident(pos, id), A.Const (pos, A.Num i), A.Tuple))) exprs
       ) tys |> List.flatten
     | Set (pos, ty) ->
       let dummy_index = AN.mk_fresh_dummy_index () in
@@ -176,7 +177,6 @@ let rec flatten_ref_types_expr: TypeCheckerContext.tc_context -> A.expr -> A.exp
   | Ident _ | EmptyMap (_, None) | EmptySet (_, None)
   | ModeRef _ as e -> e 
   | RecordProject (p, e, i) -> RecordProject (p, rec_call e, i)  
-  | TupleProject (p, e, i) -> TupleProject (p, rec_call e, i)
   | Const _ as e -> e
   | UnaryOp (p, op, e) -> UnaryOp (p, op, rec_call e)
   | BinaryOp (p, op, e1, e2) -> BinaryOp (p, op, rec_call e1, rec_call e2) 

--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -68,7 +68,7 @@ let rec expr_contains_mode_ref expr =
   | Const (_, _)
   | EmptySet _
   | EmptyMap _ -> false
-  | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
+  | RecordProject (_, e, _) | UnaryOp (_, _, e)
   | ConvOp (_, _, e) | Quantifier (_, _, _, e) | When (_, e, _)
   | Pre (_, e) | StructUpdate (_, e, _, None)
     -> r e

--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -337,9 +337,6 @@ and gen_poly_decls_expr: Ctx.tc_context -> GI.t NI.Map.t -> NI.t option -> (A.de
   | RecordProject (p, expr, id) -> 
     let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
     ctx, gids, RecordProject (p, expr, id), decls, node_decls_map
-  | TupleProject (p, expr, i) -> 
-    let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
-    ctx, gids, TupleProject (p, expr, i), decls, node_decls_map
   | ConvOp (p, op, expr) -> 
     let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
     ctx, gids, ConvOp (p, op, expr), decls, node_decls_map

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -471,7 +471,6 @@ rule token = parse
   | '^' { CARET }
   | '{' { LCURLYBRACKET }
   | '}' { RCURLYBRACKET }
-  | ".%" { DOTPERCENT }
   | "==>" { LAZY_IMPL }
   | "=>" { IMPL }
   | '#' { HASH }

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1275,7 +1275,10 @@ and compile_ast_expr
   | A.RecordProject (_, expr, field) ->
     let field = HString.string_of_hstring field in
     compile_projection bounds expr (X.RecordIndex field)
-  | A.TupleProject (_, expr, field) ->
+  | A.IndexAccess (_, expr, field, A.Tuple) ->
+    let field = match field with 
+    | A.Const (_, A.Num n) -> n |> HString.string_of_hstring |> int_of_string  
+    | _ -> assert false in (* Tuple accesses are guaranteed concrete integers in type checking *)
     compile_projection bounds expr (X.TupleIndex field)
   | A.GroupExpr (_, A.ExprList, expr_list) ->
     let rec flatten_expr_list accum = function

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -980,12 +980,6 @@ pexpr(Q):
       ) e1 updates 
     }
 
-  (*(* Tuple projection (not quantified) *)
-  | e = pexpr(Q); LSQBRACKET; i = NUMERAL; RSQBRACKET;
-  { let idx = try (int_of_string (HString.string_of_hstring i)) with
-              | _ -> fail_at_position (mk_pos $startpos(i)) "Tuple projection index exceeds int range" in
-    A.TupleProject (mk_pos $startpos, e, idx) }*)
-
   (* An array slice (not quantified) *)
   | pexpr(Q); LSQBRACKET; array_slice; RSQBRACKET
     { let pos = mk_pos $startpos in

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -44,7 +44,6 @@ let mk_span start_pos end_pos =
 %token RSQBRACKET 
 %token LPAREN 
 %token RPAREN 
-%token DOTPERCENT
 %token ASSIGN
 
 (* Tokens for enumerated types *)
@@ -238,7 +237,7 @@ let mk_span start_pos end_pos =
 %nonassoc NOT
 %nonassoc BVNOT 
 %left CARET 
-%left LSQBRACKET DOT DOTPERCENT
+%left LSQBRACKET DOT 
 
 (* Start token *)
 %start <LustreAst.t> main
@@ -981,18 +980,18 @@ pexpr(Q):
       ) e1 updates 
     }
 
-  (* Tuple projection (not quantified) *)
-  | e = pexpr(Q); DOTPERCENT; i = NUMERAL 
+  (*(* Tuple projection (not quantified) *)
+  | e = pexpr(Q); LSQBRACKET; i = NUMERAL; RSQBRACKET;
   { let idx = try (int_of_string (HString.string_of_hstring i)) with
               | _ -> fail_at_position (mk_pos $startpos(i)) "Tuple projection index exceeds int range" in
-    A.TupleProject (mk_pos $startpos, e, idx) }
+    A.TupleProject (mk_pos $startpos, e, idx) }*)
 
   (* An array slice (not quantified) *)
   | pexpr(Q); LSQBRACKET; array_slice; RSQBRACKET
     { let pos = mk_pos $startpos in
       fail_at_position pos "Unsupported operator: array slice" }
 
-  (* An array index (not quantified) *)
+  (* An index access (not quantified) *)
   | e = pexpr(Q); LSQBRACKET; i = expr; RSQBRACKET
     { A.IndexAccess (mk_pos $startpos, e, i, Unknown) }
     

--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -248,7 +248,7 @@ function
 
 | RecordProject (_, e, _) | ConvOp (_, _, e)
 | UnaryOp (_, _, e) | When (_, e, _)
-| TupleProject (_, e, _) | Quantifier (_, _, _, e) | Extract (_, e, _, _) ->
+| Quantifier (_, _, _, e) | Extract (_, e, _, _) ->
   has_stateful_op ctx e
 
 | BinaryOp (_, _, e1, e2) | CompOp (_, _, e1, e2)
@@ -634,7 +634,6 @@ let rec expr_only_supported_in_merge observer expr =
       e)
   | Ident _ | Const _ | ModeRef _ | EmptyMap _ | EmptySet _ -> Ok ()
   | RecordProject (_, e, _)
-  | TupleProject (_, e, _)
   | UnaryOp (_, _, e)
   | ConvOp (_, _, e)
   | Pre (_, e)
@@ -977,7 +976,6 @@ and check_expr: context -> (context -> LA.expr -> ([> warning] list, ([> error] 
   let res = f ctx expr in
   let check = function
     | LA.RecordProject (_, e, _)
-    | TupleProject (_, e, _)
     | UnaryOp (_, _, e)
     | ConvOp (_, _, e)
     | When (_, e, _)

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1182,6 +1182,15 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
       else
         type_error pos (ExpectedIntegerTypeForArrayIndex index_type)
     )
+    | LA.TupleType (_, tys) -> (
+      match i with 
+      | LA.Const (_, LA.Num n) -> 
+        let n = n |> HString.string_of_hstring |> int_of_string in 
+        if n >= List.length tys then error else
+          let inf_ty = List.nth tys n in
+          R.ok (inf_ty, LA.IndexAccess (pos, e, i, k), warnings1 @ warnings2)
+      | _ -> error;
+    )
     | ty -> type_error pos (IlltypedIndexAccess ty)
   )
   (* Quantified expressions *)

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -51,6 +51,7 @@ type error_kind = Unknown of string
   | IlltypedRecordProjection of tc_type
   | TupleIndexOutOfBounds of int * tc_type
   | IlltypedTupleProjection of tc_type
+  | NonConcreteTupleProjection of LA.expr 
   | UnequalIteBranchTypes of tc_type * tc_type
   | ExpectedBooleanExpression of tc_type
   | ExpectedIntegerExpression of tc_type
@@ -133,6 +134,7 @@ let error_message kind = match kind with
   | IlltypedRecordProjection ty -> "Cannot project field out of non record expression type " ^ string_of_tc_type ty
   | TupleIndexOutOfBounds (id, ty) -> "Index " ^ string_of_int id ^ " is out of bounds for tuple type " ^ string_of_tc_type ty
   | IlltypedTupleProjection ty -> "Cannot project field out of non tuple type " ^ string_of_tc_type ty
+  | NonConcreteTupleProjection e -> "Tuple projection '" ^ LA.string_of_expr e ^ "' must be a concrete natural number"
   | UnequalIteBranchTypes (ty1, ty2) -> "Expected equal types of each if-then-else branch but found: "
     ^ string_of_tc_type ty1 ^ " on the then-branch and " ^ string_of_tc_type ty2 ^ " on the the else-branch"
   | ExpectedBooleanExpression ty -> "Expected a boolean expression but found expression of type " ^ string_of_tc_type ty
@@ -327,7 +329,7 @@ let no_mismatched_clock is_bool e =
       (LH.fold_lustre_ty (check_clocks clock) (R.ok ()) (>>) vt) 
     | EmptySet (_, Some ty) -> 
       LH.fold_lustre_ty (check_clocks clock) (R.ok ()) (>>) ty
-    | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
+    | RecordProject (_, e, _) | UnaryOp (_, _, e)
     | ConvOp (_, _, e) | Pre (_, e) | Extract (_, e, _, _) | Quantifier (_, _, _, e) 
     | AnyOp (_, _, e) | StructUpdate (_, e, _, None) -> check_clocks clock e
     | BinaryOp (_, _, e1, e2) | StructUpdate (_, e1, _, Some e2)
@@ -369,7 +371,7 @@ let no_mismatched_clock is_bool e =
       (LH.fold_lustre_ty check_merge (R.ok ()) (>>) vt)
     | EmptySet (_, Some ty) -> 
       LH.fold_lustre_ty check_merge (R.ok ()) (>>) ty
-    | RecordProject (_, e, _) | TupleProject (_, e, _) | UnaryOp (_, _, e)
+    | RecordProject (_, e, _) | UnaryOp (_, _, e)
     | ConvOp (_, _, e) | Pre (_, e) | Extract (_, e, _, _) | Quantifier (_, _, _, e) 
     | AnyOp (_, _, e) | When (_, e, _) | StructUpdate (_, e, _, None) -> check_merge e
     | BinaryOp (_, _, e1, e2) | StructUpdate (_, e1, _, Some e2)
@@ -491,7 +493,6 @@ let rec infer_const_attr ctx exp =
     [res]
   | ModeRef _ -> [error exp "mode reference"]
   | RecordProject (_, e, _) -> r e
-  | TupleProject (_, e, _) -> r e
   (* Values *)
   | Const _ | EmptyMap (_, None) | EmptySet (_, None) -> [R.ok ()]
   | EmptyMap (_, Some (kt, vt)) -> 
@@ -700,9 +701,6 @@ let rec instantiate_type_variables_expr: tc_context -> NI.t -> tc_type list -> L
   | RecordProject (pos, e, idx) -> 
     let* e = call e in 
     R.ok (LA.RecordProject (pos, e, idx))
-  | TupleProject (pos, e, idx) -> 
-    let* e = call e in
-    R.ok (LA.TupleProject (pos, e, idx))
   | Const (_, _) as e -> R.ok e
   | Extract (pos, e, idx1, idx2) -> 
     let* e = call e in 
@@ -968,18 +966,6 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
         | None -> type_error pos (NotAFieldOfRecord fld))
     | _ -> type_error (LH.pos_of_expr e) (IlltypedRecordProjection rec_ty))
 
-  | LA.TupleProject (pos, e1, i) ->
-    let* tup_ty, e1, warnings = infer_type_expr ctx nname e1 in
-    let* tup_ty = expand_type_syn_reftype_history ctx tup_ty in
-    (match tup_ty with
-    | LA.TupleType (pos, tys) as ty ->
-        if List.length tys <= i
-        then type_error pos (TupleIndexOutOfBounds (i, ty))
-        else 
-          let* ty = expand_type_syn_reftype_history ctx (List.nth tys i) in 
-          R.ok (ty, LA.TupleProject (pos, e1, i), warnings)
-    | ty -> type_error pos (IlltypedTupleProjection ty))
-
   (* Values *)
   | LA.Const (pos, c) -> 
     let ty = infer_type_const pos c in 
@@ -1185,11 +1171,13 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
     | LA.TupleType (_, tys) -> (
       match i with 
       | LA.Const (_, LA.Num n) -> 
-        let n = n |> HString.string_of_hstring |> int_of_string in 
-        if n >= List.length tys then error else
-          let inf_ty = List.nth tys n in
-          R.ok (inf_ty, LA.IndexAccess (pos, e, i, k), warnings1 @ warnings2)
-      | _ -> error;
+        let n = n |> HString.string_of_hstring |> int_of_string in
+        if List.length tys <= n
+        then type_error pos (TupleIndexOutOfBounds (n, ty))
+        else 
+          let* ty = expand_type_syn_reftype_history ctx (List.nth tys n) in 
+          R.ok (ty, LA.IndexAccess (pos, e, i, k), [])
+      | _ -> type_error pos (NonConcreteTupleProjection i) 
     )
     | ty -> type_error pos (IlltypedIndexAccess ty)
   )
@@ -1373,9 +1361,6 @@ and check_type_expr: tc_context -> NI.t option -> LA.expr -> tc_type -> (LA.expr
   | RecordProject (pos, expr, fld) -> 
     let* expr, warnings = check_type_record_proj pos ctx nname expr fld exp_ty in 
     R.ok (LA.RecordProject (pos, expr, fld), warnings)
-  | TupleProject (pos, expr, idx) -> 
-    let* expr, warnings = check_type_tuple_proj pos ctx nname expr idx exp_ty in 
-    R.ok (LA.TupleProject (pos, expr, idx), warnings)
   (* Operators *)
   | Extract (pos, _, idx1, idx2) as expr -> 
     let* inf_ty, expr, warnings = infer_type_expr ctx nname expr in 

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -36,6 +36,7 @@ type error_kind = Unknown of string
   | IlltypedRecordProjection of tc_type
   | TupleIndexOutOfBounds of int * tc_type
   | IlltypedTupleProjection of tc_type
+  | NonConcreteTupleProjection of LA.expr 
   | UnequalIteBranchTypes of tc_type * tc_type
   | ExpectedBooleanExpression of tc_type
   | ExpectedIntegerExpression of tc_type

--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -541,7 +541,6 @@ let rec arity_of_expr ty_ctx = function
   | Pre (_, e) -> arity_of_expr ty_ctx e
   | Arrow (_, e, _) -> arity_of_expr ty_ctx e
   | RecordProject (_, e, _) -> arity_of_expr ty_ctx e
-  | TupleProject (_, e, _) -> arity_of_expr ty_ctx e
   | When (_, e, _) -> arity_of_expr ty_ctx e
   | Merge (_, _, cs) -> arity_of_expr ty_ctx (List.hd cs |> snd)
   | _ -> 1
@@ -858,7 +857,6 @@ let rec ty_vars_of_expr ctx node_name expr =
   | EmptyMap (_, None) | EmptySet (_, None) 
   | ModeRef _ -> SI.empty
   | RecordProject (_, e, _) -> call e 
-  | TupleProject (_, e, _) -> call e
   (* Values *)
   | Const _ -> SI.empty
   (* Operators *)

--- a/tests/lustre/typechecking/shouldPass/test_const_prop.lus
+++ b/tests/lustre/typechecking/shouldPass/test_const_prop.lus
@@ -20,7 +20,7 @@ const f3 = [true, true, true][2];
 const t3:[int, int, bool] = {t, 3, true}; -- should inline to (1, 3, true)
 const arr3 = [1, 1+1, t1+c, 5]; -- inline all t's and simplify
 
-const p = t3.%1; -- should inline to 3
+const p = t3.1; -- should inline to 3
 
 node main(x:int) returns (y:int)
 let

--- a/tests/lustre/typechecking/shouldPass/test_const_prop.lus
+++ b/tests/lustre/typechecking/shouldPass/test_const_prop.lus
@@ -20,7 +20,7 @@ const f3 = [true, true, true][2];
 const t3:[int, int, bool] = {t, 3, true}; -- should inline to (1, 3, true)
 const arr3 = [1, 1+1, t1+c, 5]; -- inline all t's and simplify
 
-const p = t3.1; -- should inline to 3
+const p = t3[1]; -- should inline to 3
 
 node main(x:int) returns (y:int)
 let

--- a/tests/regression/success/free_const_subrange.lus
+++ b/tests/regression/success/free_const_subrange.lus
@@ -10,5 +10,5 @@ const C: Nat^2;
 node N() returns (ok: bool)
 let
   check "P1" C[0] >= 0;
-  check "P2" R.f.%0 >= 0;
+  check "P2" R.f[0] >= 0;
 tel

--- a/tests/regression/success/poly_type_decl.lus
+++ b/tests/regression/success/poly_type_decl.lus
@@ -16,8 +16,8 @@ type Loc_int = Loc<int>;
 
 node F<T>() returns (z: UserType2<T>; w: int);
 let
-  z = any { x: UserType2<T> | x.%0 > 0 };
-  w = any { n: int | n>0 and z.%0 > 0 };
+  z = any { x: UserType2<T> | x[0] > 0 };
+  w = any { n: int | n>0 and z[0] > 0 };
 tel
 
 node Q<T1>(y:UserType3<T1>) returns (z:UserType3<T1>);

--- a/tests/regression/success/struct_update.lus
+++ b/tests/regression/success/struct_update.lus
@@ -6,5 +6,5 @@ let
   B = A[0 := 1];
   p2 = p1[1 := true];
   check B[0] = 1;
-  check p2.%1;
+  check p2[1];
 tel

--- a/tests/regression/success/test_const_prop.lus
+++ b/tests/regression/success/test_const_prop.lus
@@ -20,7 +20,7 @@ const f3: bool = [true, true, true][2];
 const t3:[int, int, bool] = '(t, 3, true); -- should inline to (1, 3, true)
 const arr3: int^4 = [1, 1+1, t1+c, 5]; -- inline all t's and simplify
 
-const p: int = t3.%1; -- should inline to 3
+const p: int = t3[1]; -- should inline to 3
 
 node main(x:int) returns (y:int)
 let

--- a/tests/regression/success/test_record_projection.lus
+++ b/tests/regression/success/test_record_projection.lus
@@ -13,5 +13,5 @@ type my_tuple2 = [my_tuple1, my_tuple1];
 
 node imported top2 (i : my_tuple2) returns (out : bool);
 (*@contract
-   guarantee out = i.%1.%0 and i.%0.%0; 
+   guarantee out = i[1][0] and i[0][0]; 
 *)

--- a/tests/regression/success/test_tuples.lus
+++ b/tests/regression/success/test_tuples.lus
@@ -2,7 +2,7 @@
 node x63 (e: [bool, [int, int]]) returns (c: bool; a, b: int; A: [int, int]);
 var ab: [int, int];
 let
-  c, ab = (e.%0, e.%1);
-  a = e.%1.%0; b = e.%1.%1;
-  A = e.%1;
+  c, ab = (e[0], e[1]);
+  a = e[1][0]; b = e[1][1];
+  A = e[1];
 tel;


### PR DESCRIPTION
Update tuple indexing syntax from `t.%idx` to `t[idx]`, where `idx` must be a concrete natural number in range.

The bracket syntax is now shared for tuples, maps, and arrays, so we don't know at parse time the access type. So, we have to discriminate these cases later in the pipeline. (We were already doing this for maps and arrays.)

I also noticed we didn't have a user doc pages on tuples. Since we have our own syntax that is probably not the same as Lustre V4 or V6, I added a page.