### PR TITLE
Map and set type user documentation

### DIFF
--- a/doc/usr/source/2_input/10_sets.rst
+++ b/doc/usr/source/2_input/10_sets.rst
@@ -1,0 +1,27 @@
+Sets
+==================
+
+Set types have the syntax ``set<T>``, where ``T`` is any type that does not contain 
+sets, maps, or arrays. For example ``set<int>`` denotes (streams of) sets of integers, and 
+``set<[bool, int]>`` denotes (streams of) sets of Boolean and integer pairs.
+
+**Set literals** can be constructed with curly braces with comma-separated elements, 
+e.g. ``{ 1 }``, ``{ 1, 2, 3 }``, and ``{ x, 4 }`` (assuming ``x`` has type ``int``).
+Type annotations are *required* for empty sets (e.g. ``{}@<int>``)
+and optional for non-empty set literals (e.g. ``{ 1 }@<int>``).
+
+The built-in set operators are **set union** (denoted by ``+``), 
+**set intersection** (denoted by ``*``), and 
+**set membership** (denoted by ``in``). 
+All are infix and take the expected semantics; 
+see below for an example.
+
+.. code-block:: none
+
+   node N (s1, s2: set<int>) returns (out: set<int>) 
+   let
+     out = s1 * { 1, 2, 3 } + {}@<int>;
+
+     check forall (i: int) not (i in s1 + s2) = (not (i in s1) and not (i in s2));
+     check forall (i: int) i in out => (i = 1 or i = 2 or i = 3);
+   tel

--- a/doc/usr/source/2_input/11_maps.rst
+++ b/doc/usr/source/2_input/11_maps.rst
@@ -20,6 +20,10 @@ The built-in map operators are **map insertion/update**
 Indexing a map with ``m[k]`` returns the associated value for ``k`` in map ``m``. 
 If ``m`` does not have a binding for ``k``, 
 then the output of the operation is unconstrained.
+However, the output is still *functional* in the sense that 
+indexing a map will always yield the same value for a fixed key and timestep
+(i.e., for all maps ``m`` and keys ``k`` of the proper type, 
+``m[k] = m[k]`` is valid, even if key ``k`` is not in the map ``m``).
 Otherwise, the operators all take the expected semantics.
 See below for an example.
 

--- a/doc/usr/source/2_input/11_maps.rst
+++ b/doc/usr/source/2_input/11_maps.rst
@@ -1,0 +1,38 @@
+Maps
+==================
+
+Map types have the syntax ``map<K, V>`` (or ``map<K; V>``), where ``V`` is any type, and 
+``K`` is any type that does not contain sets, maps, or arrays. 
+For example ``map<int, int>`` denotes (streams of) maps of integers to integers, and 
+``map<set<[bool, int]>, real>`` denotes (streams of) maps of Boolean and integer pairs to reals.
+
+**Map literals** can be built with the constructor ``map[k1 := v1; ...; kn := v2]`` 
+which creates a map with keys ``k1`` through ``kn``, each mapping to its corresponding value.
+For example, ``map[0 := 0; 1 := 1]``, ``map[{ '(false, 0) } := 0.0]``, and ``map[x := y]`` 
+are all valid map literals.
+Type annotations are *required* for empty maps (e.g. ``map[]@<int, int>``)
+and optional for non-empty map literals (e.g. ``map[1 := 1]@<int, int>``).
+
+The built-in map operators are **map insertion/update** 
+(denoted by ``m[k1 := v1; ...; kn := vn]`` for map expression ``m``), 
+**map index access** (denoted by ``m[k]``), and
+**map (key) membership** (denoted by ``in``). 
+Indexing a map with ``m[k]`` returns the associated value for ``k`` in map ``m``. 
+If ``m`` does not have a binding for ``k``, 
+then the output of the operation is unconstrained.
+Otherwise, the operators all take the expected semantics.
+See below for an example.
+
+.. code-block:: none
+
+   node N (inp: map<int, int>) returns (out, out2: map<int, int>) 
+   let
+     out = inp[0 := 0; 1 := 1; 2 := 2]; 
+     out2 = map[0 := 0; 1 := 1];
+
+     check 0 in out;
+     check out[0] = 0; 
+     check forall (i: int) not (i in { 0, 1, 2 }) => out[i] = inp[i];
+     check forall (i: int) not (i = 0 or i = 1) => not (i in out2);
+   tel
+

--- a/doc/usr/source/2_input/11_maps.rst
+++ b/doc/usr/source/2_input/11_maps.rst
@@ -20,7 +20,7 @@ The built-in map operators are **map insertion/update**
 Indexing a map with ``m[k]`` returns the associated value for ``k`` in map ``m``. 
 If ``m`` does not have a binding for ``k``, 
 then the output of the operation is unconstrained.
-However, the output is still *functional* in the sense that 
+However, the operation is still *functional* in the sense that 
 indexing a map will always yield the same value for a fixed key and timestep
 (i.e., for all maps ``m`` and keys ``k`` of the proper type, 
 ``m[k] = m[k]`` is valid, even if key ``k`` is not in the map ``m``).

--- a/doc/usr/source/2_input/4_refinement_types.rst
+++ b/doc/usr/source/2_input/4_refinement_types.rst
@@ -158,7 +158,7 @@ One way to make the above interface realizable is to add a refinement type for `
 
    node M(x: int | x >= 0) returns (y: int | 0 <= y and y <= x);
 
-To check the realizability refinement types, one can call ``kind2 <filename> --enable CONTRACTCK``.
+To check the realizability of refinement types, one can call ``kind2 <filename> --enable CONTRACTCK``.
 Kind 2 performs three types of realizability checks:
 
 1. Node and imported node contracts, including type information

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2320,7 +2320,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let nexpr2, gids2, warnings2 = normalize_expr ?guard info node_id map expr2 in 
     i := !i + 1; 
     let prefix = HString.mk_hstring (string_of_int !i) in 
-    let name1 = HString.concat2 prefix (HString.mk_hstring "_set_union") in 
+    let name1 = HString.concat2 prefix (HString.mk_hstring "_set_binop") in 
     let name2 = HString.concat2 prefix (HString.mk_hstring "_idx") in 
     let ty = match Chk.infer_type_expr info.context node_id expr1 with 
     | Ok (ty, _, _) -> (

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -2425,7 +2425,7 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
     List.fold_left over_set_insertions [] gids.GI.set_insertions
   in
   let gequations = gequations @ set_insertions_eqs in
-  let set_union_eqs = 
+  let set_binop_eqs = 
     let over_set_binops acc (id, nexpr1, nexpr2, fresh_idx_name, op, _) =
       (* Desugar to lhs[i] = i in nexpr1 <op> i in nexpr2 *)
       let fresh_idx = A.Ident (dummy_pos, fresh_idx_name) in 
@@ -2445,12 +2445,12 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
       (* Format.fprintf Format.std_formatter "lhs: %a@.rhs: %a@.@.\n"
         (X.pp_print_index_trie true StateVar.pp_print_state_var) eq_lhs
         (X.pp_print_index_trie true (E.pp_print_lustre_expr true)) eq_rhs; *)
-      let set_union_eqs = expand_tuple Lib.dummy_pos eq_lhs eq_rhs in
-      set_union_eqs @ acc
+      let set_binop_eqs = expand_tuple Lib.dummy_pos eq_lhs eq_rhs in
+      set_binop_eqs @ acc
     in 
     List.fold_left over_set_binops [] gids.GI.set_binops
   in
-  let gequations = gequations @ set_union_eqs in
+  let gequations = gequations @ set_binop_eqs in
   (* ****************************************************************** *)
   (* Node Equations                                                     *)
   (* ****************************************************************** *)


### PR DESCRIPTION
I also added some very minor unrelated tweaks that seemed inconsequential enough to include in this PR:
1. grammar fix in refinement type docs
2. generated variable renaming "set_union" -> "set_binop" for sanity (since it also covers intersections)
3. variable renaming in lustreNodeGen analogous with point 2