### PR TITLE
Contract syntax 2

### DIFF
--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -401,6 +401,7 @@ For instance:
    ) returns (
      engaged: real
    ) ;
+   con
      var bool_eng: bool = engage <> 0.0 ;
      var bool_dis: bool = disengage <> 0.0 ;
      var bool_enged: bool = engaged <> 0.0 ;
@@ -420,6 +421,7 @@ For instance:
      ) ;
 
      import spec (bool_eng, bool_dis) returns (bool_enged) ;
+   noc
    let ... tel
 
 Mode references
@@ -722,16 +724,18 @@ node
 .. code-block:: none
 
    node count (trigger: bool) returns (count: int ; error: bool) ;
-   var once: bool = trigger or (false -> pre once) ;
-   guarantee count >= 0 ;
-   mode still_zero (
-     require not once ;
-     ensure count = 0 ;
-   ) ;
-   mode gt (
-     require not ::still_zero ;
-     ensure count > 0 ;
-   ) ;
+   con
+     var once: bool = trigger or (false -> pre once) ;
+     guarantee count >= 0 ;
+     mode still_zero (
+       require not once ;
+       ensure count = 0 ;
+     ) ;
+     mode gt (
+       require not ::still_zero ;
+       ensure count > 0 ;
+     ) ;
+   noc
    let
      count = (if trigger then 1 else 0) + (0 -> pre count) ;
    tel
@@ -1204,9 +1208,11 @@ node declaration of a polymorphic node as a local contract.
 .. code-block:: none
 
    node M<T>(x: int) returns (y: int);
+   con
       guarantee 
          (y = x) or
          (true -> (y = pre x));
+   noc
    let
       y = pre x;
    tel
@@ -1229,8 +1235,10 @@ operator to define a local stream ``l`` of arbitrary odd values.
 .. code-block:: none
 
    node N(y: int) returns (z:int);
+   con
      assume "y is odd" y mod 2 = 1;
      guarantee "z is even" z mod 2 = 0;
+   noc
      var l: int;
    let
      l = any { x: int | x mod 2 = 1 };

--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -764,8 +764,10 @@ given, then the implicit (rather weak) contract
 
 .. code-block:: none
 
-   assume true ;
-   guarantee true ;
+   con
+     assume true ;
+     guarantee true ;
+   noc
 
 is used.
 
@@ -1186,14 +1188,18 @@ node call).
    tel
 
    node N (x: int) returns (y: int);
+   con 
       import Stutter@<int>(x) returns (y);
+   noc
    let
       y = pre x;
    tel
 
 
    node P<U>(x: U) returns (y: U);
+   con 
       import Stutter@<U>(x) returns (y);
+   noc
    let
       y = pre x;
    tel

--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -211,7 +211,7 @@ syntaxes.
 Inline syntax
 ^^^^^^^^^^^^^
 
-A local contract is a special comment between the signature of the node
+A local contract is a block between the signature of the node
 
 .. code-block:: none
 
@@ -220,11 +220,13 @@ A local contract is a special comment between the signature of the node
 and its body. That is, between the ``;`` of the node signature and the ``let``
 opening its body.
 
-A local contract is simply a list of contract items:
+A local contract block is denoted by the keywords `con` and `noc`:
 
 .. code-block:: none
 
-   [item]+
+   con
+     [item]+
+   noc
 
 The original contract syntax (which is deprecated but still available) 
 is a special block comment of the form
@@ -273,26 +275,22 @@ Ghost variables and constants
 
 A ghost variable (constant) is a stream that is local to the contract. That is,
 it is not accessible from the body of the node specified. Ghost variables
-(constants) are defined with the ``gvar`` (\ ``gconst``\ ) keyword. Kind 2 performs type
+(constants) are defined with the ``var`` (\ ``const``\ ) keyword. Kind 2 performs type
 -inference for constants so in most cases type annotations are not necessary.
 
 The general syntax is
 
 .. code-block:: none
 
-   gconst <id> [: <type>] = <expr> ;
-   gvar   <id>  : <type>  = <expr> ;
+   const <id> [: <type>] = <expr> ;
+   var   <id>  : <type>  = <expr> ;
 
 For instance:
 
 .. code-block:: none
 
-   gconst max = 42 ;
-   gvar ghost_stream: real = if input > max then max else input ;
-
-If using the deprecated block comment for syntax (i.e., ``(*@contract ... *)``), 
-then one can alternatively substitute ``const`` or ``var`` for ``gconst`` or ``gvar``, 
-respectively.
+   const max = 42 ;
+   var ghost_stream: real = if input > max then max else input ;
 
 Assumptions
 ~~~~~~~~~~~
@@ -403,11 +401,11 @@ For instance:
    ) returns (
      engaged: real
    ) ;
-     gvar bool_eng: bool = engage <> 0.0 ;
-     gvar bool_dis: bool = disengage <> 0.0 ;
-     gvar bool_enged: bool = engaged <> 0.0 ;
+     var bool_eng: bool = engage <> 0.0 ;
+     var bool_dis: bool = disengage <> 0.0 ;
+     var bool_enged: bool = engaged <> 0.0 ;
 
-     gvar never_triggered: bool = (
+     var never_triggered: bool = (
        not bool_eng -> not bool_eng and pre never_triggered
      ) ;
 
@@ -724,7 +722,7 @@ node
 .. code-block:: none
 
    node count (trigger: bool) returns (count: int ; error: bool) ;
-   gvar once: bool = trigger or (false -> pre once) ;
+   var once: bool = trigger or (false -> pre once) ;
    guarantee count >= 0 ;
    mode still_zero (
      require not once ;

--- a/doc/usr/source/2_input/4_refinement_types.rst
+++ b/doc/usr/source/2_input/4_refinement_types.rst
@@ -96,9 +96,11 @@ Conceptually, the refinement types can be viewed as an augmentation of
 .. code-block::
 
    node M(x1: int; x2: int) returns (y: int);
+   con
       assume x1 mod 2 = 0; 
       assume x2 mod 2 = 1;
       guarantee y mod 2 = 1;
+   noc
    let
       y = x1 + x2;
       --%MAIN;

--- a/doc/usr/source/2_input/7_abstract_types.rst
+++ b/doc/usr/source/2_input/7_abstract_types.rst
@@ -24,7 +24,9 @@ to a finite domain are inconsistent (such an example is shown in the following c
 
     type T;
     function id_T (x: T) returns (y: T);
-    assume forall (x: T) (forall (y: T) x = y);
+    con
+        assume forall (x: T) (forall (y: T) x = y);
+    noc
     let
         y = x;
     tel

--- a/doc/usr/source/9_other/10_inductive_validity_core.rst
+++ b/doc/usr/source/9_other/10_inductive_validity_core.rst
@@ -45,7 +45,9 @@ Let's consider the following Lustre code:
   tel;
 
   node f(u, v : real) returns (r : real);
-  import fSpec(u,v) returns (r) ; 
+  con
+      import fSpec(u,v) returns (r) ; 
+  noc
   var m1,m2: real;
   let
       m1 = if v > u then v else u;

--- a/doc/usr/source/9_other/11_minimal_cut_set.rst
+++ b/doc/usr/source/9_other/11_minimal_cut_set.rst
@@ -41,7 +41,9 @@ Let's consider the following Lustre code:
   tel;
 
   node main(x, y : real) returns (z : real);
-    import spec(x,y) returns (z) ; 
+  con
+      import spec(x,y) returns (z) ; 
+  noc 
     var P : bool;
   let
       z = x + y;

--- a/doc/usr/source/9_other/13_assumption_generation.rst
+++ b/doc/usr/source/9_other/13_assumption_generation.rst
@@ -19,8 +19,10 @@ For instance, consider the following Lustre program:
 .. code-block:: none
 
    node Arbiter (s1,s2: bool; e1,e2:int) returns(o: int);
+   con
      guarantee "G1" s1 => o=e1;
      guarantee "G2" s2 => o=e2;
+   noc
    let
      if s1 and s2 then
        o = any { o:int | o = e1 or o = e2 };

--- a/doc/usr/source/9_other/2_contract_semantics.rst
+++ b/doc/usr/source/9_other/2_contract_semantics.rst
@@ -85,6 +85,7 @@ For instance, a (linear) contract for non-linear multiplication could be
    let res = if in < 0.0 then - in else in ; tel
 
    node times (lhs, rhs: real) returns (res: real) ;
+   con
      mode absorbing (
        require lhs = 0.0 or rhs = 0.0 ;
        ensure res = 0.0 ;
@@ -115,6 +116,7 @@ For instance, a (linear) contract for non-linear multiplication could be
        ) ;
        ensure res < 0.0 ;
      ) ;
+   noc
    let
      res = lhs * rhs ;
    tel

--- a/doc/usr/source/9_other/3_test_generation.rst
+++ b/doc/usr/source/9_other/3_test_generation.rst
@@ -68,7 +68,9 @@ system:
    tel
 
    node stopwatch ( toggle, reset : bool ) returns ( count : int ) ;
+   con
      import stopwatchSpec ( toggle, reset ) returns ( count ) ;
+   noc
    var running : bool ;
    let
      running = (false -> pre running) <> toggle ;

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -1055,21 +1055,21 @@ let pp_print_contract_ghost_const ppf = function
   | FreeConst (_, s, t) -> 
 
     Format.fprintf ppf 
-      "@[<hv 3>gconst %a:@ %a;@]" 
+      "@[<hv 3>const %a:@ %a;@]" 
       pp_print_ident s 
       pp_print_lustre_type t
 
   | UntypedConst (_, s, e) -> 
 
     Format.fprintf ppf 
-      "@[<hv 3>gconst %a =@ %a;@]" 
+      "@[<hv 3>const %a =@ %a;@]" 
       pp_print_ident s 
       pp_print_expr e
 
   | TypedConst (_, s, e, t) -> 
 
     Format.fprintf ppf 
-      "@[<hv 3>gconst %a:@ %a =@ %a;@]" 
+      "@[<hv 3>const %a:@ %a =@ %a;@]" 
       pp_print_ident s 
       pp_print_lustre_type t
       pp_print_expr e
@@ -1077,7 +1077,7 @@ let pp_print_contract_ghost_const ppf = function
 
 let pp_print_contract_ghost_vars ppf = fun (_, lhs, e) ->
   Format.fprintf ppf 
-  "@[<hv 3>gvar %a =@ %a;@]" 
+  "@[<hv 3>var %a =@ %a;@]" 
   pp_print_typed_contract_eq_lhs lhs
   pp_print_expr e
 

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -1174,7 +1174,11 @@ let pp_print_contract fmt contract =
 
 let pp_print_contract_spec ppf = function
 | None -> ()
-| Some (_, contract) -> pp_print_contract ppf contract
+| Some (_, contract) ->
+  Format.fprintf 
+    ppf
+    "@[<v 2>con %a@]@ noc@ "
+    pp_print_contract contract
 
 (* Pretty-prints a contract node. *)
 let pp_print_contract_node_decl ppf (n,p,i,o,(_,e))

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -248,7 +248,6 @@ let keyword_table = mk_hashtbl [
 
   (* Constant/parameter declaration *)
   "const", CONST ;
-  "gconst", GCONST ;
   "param", PARAM ;
   
   (* Node / function declaration *)
@@ -259,9 +258,10 @@ let keyword_table = mk_hashtbl [
   "function", FUNCTION ;
   "returns", RETURNS ;
   "var", VAR ;
-  "gvar", GVAR ;
   "let", LET ;
   "tel", TEL ;
+  "con", CON ; 
+  "noc", NOC ;
   
   (* Assertion *)
   "assert", ASSERT ;

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -596,7 +596,6 @@ contract_decl:
        List.flatten o,
        (mk_pos $startpos, e)) }
 
-(* Deprecated contract syntax *)
 contract_spec:
   (* Block contract, `con` and `noc`. *)
   | CON ;

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -1,4 +1,4 @@
-(* This file is part of the Kind 2 model checker.lustreparser.
+(* This file is part of the Kind 2 model checker.
 
    Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -1,4 +1,4 @@
-(* This file is part of the Kind 2 model checker.
+(* This file is part of the Kind 2 model checker.lustreparser.
 
    Copyright (c) 2015 by the Board of Trustees of the University of Iowa
 
@@ -94,7 +94,6 @@ let mk_span start_pos end_pos =
 
 (* Token for constant/parameter declarations *)
 %token CONST
-%token GCONST
 %token PARAM
     
 (* Tokens for node declarations *)
@@ -105,9 +104,10 @@ let mk_span start_pos end_pos =
 %token FUNCTION
 %token RETURNS
 %token VAR
-%token GVAR
 %token LET
 %token TEL
+%token CON 
+%token NOC
     
 (* Tokens for annotations *)
 
@@ -488,14 +488,10 @@ node_decl:
   RETURNS;
   o = tlist(LPAREN, SEMICOLON, RPAREN, clocked_typed_idents);
   option(SEMICOLON);
-  r = contract_option; 
+  r = option(contract_spec); 
   {
     (NI.mk_node_id n, p, List.flatten i, List.flatten o, r)
   }
-
-contract_option:
-  | r = list(contract_item) { if r = [] then None else Some (mk_pos $startpos, r) }
-  | r = contract_spec { Some r }
 
 (* A node definition (locals + body). *)
 node_def:
@@ -508,24 +504,10 @@ node_def:
   { (List.flatten l, e) }
 
 contract_ghost_vars:
-  | GVAR; l = typed_idents_list; EQUALS; e = expr; SEMICOLON
-    { A.GhostVars (mk_pos $startpos, GhostVarDec (mk_pos $startpos, l), e) }
-
-(* DEPRECATED contract syntax (var instead of gvar), but still here to support tools like VERDICT *)
-old_contract_ghost_vars:
   | VAR; l = typed_idents_list; EQUALS; e = expr; SEMICOLON
     { A.GhostVars (mk_pos $startpos, GhostVarDec (mk_pos $startpos, l), e) }
 
 contract_ghost_const:
-  | GCONST; i = ident; COLON; t = lustre_type; SEMICOLON
-    { A.GhostConst (A.FreeConst (mk_pos $startpos, i, t)) }
-  | GCONST; i = ident; COLON; t = lustre_type; EQUALS; e = qexpr; SEMICOLON 
-    { A.GhostConst (A.TypedConst (mk_pos $startpos, i, e, t)) }
-  | GCONST; i = ident; EQUALS; e = qexpr; SEMICOLON 
-    { A.GhostConst (A.UntypedConst (mk_pos $startpos, i, e)) }
-
-(* DEPRECATED contract syntax (const instead of gconst), but still here to support tools like VERDICT *)
-old_contract_ghost_const:
   | CONST; i = ident; COLON; t = lustre_type; SEMICOLON
     { A.GhostConst (A.FreeConst (mk_pos $startpos, i, t)) }
   | CONST; i = ident; COLON; t = lustre_type; EQUALS; e = qexpr; SEMICOLON 
@@ -591,22 +573,8 @@ contract_item:
   | i = contract_import { i }
   | a = assumption_vars { a }
 
-(* Support DEPRECATED contract syntax (var instead of gvar) in contract blocks 
-   to support tools like VERDICT *)
-old_contract_item:
-  | e = old_contract_ghost_vars { e }
-  | e = contract_ghost_vars { e }
-  | c = old_contract_ghost_const { c }
-  | c = contract_ghost_const { c }
-  | a = contract_assume { a }
-  | g = contract_guarantee { g }
-  | m = mode_equation { m }
-  | i = contract_import { i }
-  | a = assumption_vars { a }
-
 contract_in_block:
-  | c = nonempty_list(old_contract_item) { c }
-
+  | c = nonempty_list(contract_item) { c }
 
 (* A contract node declaration. *)
 contract_decl:
@@ -630,6 +598,12 @@ contract_decl:
 
 (* Deprecated contract syntax *)
 contract_spec:
+  (* Block contract, `con` and `noc`. *)
+  | CON ;
+    eqs = contract_in_block
+    NOC ; 
+    { (mk_pos $startpos, eqs) }
+  (* DEPRECATED contract syntax, but still here to support tools like VERDICT *)
   (* Block contract, parenthesis star (PS). *)
   | CONTRACT_PSATBLOCK ;
     eqs = contract_in_block

--- a/tests/lustre/typechecking/shouldFail/test_output_in_assume.lus
+++ b/tests/lustre/typechecking/shouldFail/test_output_in_assume.lus
@@ -1,7 +1,7 @@
 
 node top(x: int) returns (y: int);
 (*@contract
-  gvar g: int = y + 1;
+  var g: int = y + 1;
   assume g>0;
 *)
 let

--- a/tests/lustre/typechecking/shouldFail/test_output_in_assume2.lus
+++ b/tests/lustre/typechecking/shouldFail/test_output_in_assume2.lus
@@ -5,7 +5,7 @@ tel
 
 node top(x: int) returns (y: int);
 (*@contract
-  gvar g: int = b(y) + 1;
+  var g: int = b(y) + 1;
   assume g>0;
 *)
 let

--- a/tests/ounit/lustre/lustreAstDependencies/ghost_variable_redeclaration.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/ghost_variable_redeclaration.lus
@@ -8,10 +8,10 @@ tel
 contract counter_spec (init: int) returns(out: int);
 let
   (* Test different ways to assign ghost variables in parallel *)
-   gvar out1, out2: int = counter2(init);
-   gvar out2, out4: int = counter2(init);
-   gvar out5: int, out6: int, out7: int = counter3(init);
-   gvar out8, out9: int, out10, out11: bool = (1, 2, false, true);
+   var out1, out2: int = counter2(init);
+   var out2, out4: int = counter2(init);
+   var out5: int, out6: int, out7: int = counter3(init);
+   var out8, out9: int, out10, out11: bool = (1, 2, false, true);
 
    guarantee out2 + out2 >= out;
    guarantee out1 - out2 = 0;

--- a/tests/ounit/lustre/lustreAstDependencies/ghost_variable_redeclaration2.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/ghost_variable_redeclaration2.lus
@@ -8,10 +8,10 @@ tel
 contract counter_spec (init: int) returns(out: int);
 let
   (* Test different ways to assign ghost variables in parallel *)
-   gvar out1, out2: int = counter2(init);
-   gvar out2: int = counter_clone(init);
-   gvar out5: int, out6: int, out7: int = counter3(init);
-   gvar out8, out9: int, out10, out11: bool = (1, 2, false, true);
+   var out1, out2: int = counter2(init);
+   var out2: int = counter_clone(init);
+   var out5: int, out6: int, out7: int = counter3(init);
+   var out8, out9: int, out10, out11: bool = (1, 2, false, true);
 
    guarantee out2 + out2 >= out;
    guarantee out1 - out2 = 0;

--- a/tests/ounit/lustre/lustreAstDependencies/ghost_variable_redeclaration3.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/ghost_variable_redeclaration3.lus
@@ -8,10 +8,10 @@ tel
 contract counter_spec (init: int) returns(out: int);
 let
   (* Test different ways to assign ghost variables in parallel *)
-   gvar out1: int = counter_clone(init);
-   gvar out1, out2: int = counter2(init);
-   gvar out5: int, out6: int, out7: int = counter3(init);
-   gvar out8, out9: int, out10, out11: bool = (1, 2, false, true);
+   var out1: int = counter_clone(init);
+   var out1, out2: int = counter2(init);
+   var out5: int, out6: int, out7: int = counter3(init);
+   var out8, out9: int, out10, out11: bool = (1, 2, false, true);
 
    guarantee out2 + out2 >= out;
    guarantee out1 - out2 = 0;

--- a/tests/ounit/lustre/lustreAstDependencies/test_circular_contract_eqns.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_circular_contract_eqns.lus
@@ -5,6 +5,6 @@ tel;
 
 contract c(x: int) returns (y: int);
 let
-   gvar v:int = c;
-   gvar c:int = n(v) + 1;
+   var v:int = c;
+   var c:int = n(v) + 1;
 tel

--- a/tests/ounit/lustre/lustreAstDependencies/test_out_param_in_contract_assume2.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_out_param_in_contract_assume2.lus
@@ -5,7 +5,7 @@ node imported f(x,z: int) returns (y: int);
 
 node imported top(x: int) returns (y: int);
 (*@contract
-    gvar g: int = f(x, y);
+    var g: int = f(x, y);
     assume g>0;
     guarantee y>g;
 *)

--- a/tests/ounit/lustre/lustreAstDependencies/test_out_param_in_contract_assume3.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_out_param_in_contract_assume3.lus
@@ -6,7 +6,7 @@ node imported f(x,z: int) returns (y: int);
 
 node imported top(x: int) returns (y: int);
 (*@contract
-    gvar g: int = f(x, y);
+    var g: int = f(x, y);
     assume f(x, y)>0;
     guarantee y>g;
 *) 

--- a/tests/ounit/lustre/lustreAstDependencies/test_out_param_in_contract_import.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_out_param_in_contract_import.lus
@@ -11,7 +11,7 @@ tel
 
 node imported top(x: int) returns (y: int);
 (*@contract
-    gvar g: int = f(x, y);
+    var g: int = f(x, y);
     import C1(g) returns (y);
     guarantee y>g;
 *)

--- a/tests/ounit/lustre/lustreAstDependencies/test_out_param_in_contract_import2.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_out_param_in_contract_import2.lus
@@ -10,7 +10,7 @@ tel
 
 node imported top(x: int) returns (y: int);
 (*@contract
-    gvar g: int = f(x, y);
+    var g: int = f(x, y);
     import C1(y) returns (y);
     guarantee y>g;
 *)

--- a/tests/ounit/lustre/lustreAstDependencies/test_output_in_assume.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_output_in_assume.lus
@@ -1,7 +1,7 @@
 
 node top(x: int) returns (y: int);
 (*@contract
-  gvar g: int = y + 1;
+  var g: int = y + 1;
   assume g>0;
 *)
 let

--- a/tests/ounit/lustre/lustreAstDependencies/test_output_in_assume2.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_output_in_assume2.lus
@@ -5,7 +5,7 @@ tel
 
 node top(x: int) returns (y: int);
 (*@contract
-  gvar g: int = b(y) + 1;
+  var g: int = b(y) + 1;
   assume g>0;
 *)
 let

--- a/tests/ounit/lustre/lustreTypeChecker/mode_reqs_by_idents_shadowing.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/mode_reqs_by_idents_shadowing.lus
@@ -34,8 +34,8 @@ node my_node (i: int ; i_pos: int) returns (out: int) ;
 
 (*@contract
 
-  gconst bound = 10 ;
-  gvar i_bounded: bool = abs(i) < bound ;
+  const bound = 10 ;
+  var i_bounded: bool = abs(i) < bound ;
 
   assume i_bounded ;
   guarantee out >= - bound ;

--- a/tests/ounit/lustre/lustreTypeChecker/test-func-sliced.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/test-func-sliced.lus
@@ -1,9 +1,9 @@
 function imported sincos(i: real) returns (sin: real; cos: real);
 (*@contract
-  gconst max = 1.0;
-  gconst pi = 3.14;
-  gconst tau = 2.0 * pi;
-  gvar min:real = - max;
+  const max = 1.0;
+  const pi = 3.14;
+  const tau = 2.0 * pi;
+  var min:real = - max;
   assume i <= 0.0 or i >= 0.0;
   guarantee min <= sin and sin <= max;
 
@@ -29,10 +29,10 @@ tel;
 
 node id (i: real) returns (out: int);
 (*@contract
-  gconst max = 1.0;
-  gconst pi = 3.14;
-  gconst tau = 2.0 * pi;
-  gvar min:real = - max;
+  const max = 1.0;
+  const pi = 3.14;
+  const tau = 2.0 * pi;
+  var min:real = - max;
   assume - tau <= i ;
 *)
 var inn: real ; ok: bool ;

--- a/tests/ounit/lustre/lustreTypeChecker/unequal_equation_widths_contract.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/unequal_equation_widths_contract.lus
@@ -8,7 +8,7 @@ tel
 contract counter_spec (init: int) returns(out: int);
 let
   (* Test different ways to assign ghost variables in parallel *)
-   gvar out1, out2, out3: int = counter2(init);
+   var out1, out2, out3: int = counter2(init);
 tel
 
 node counter (init : int) returns (out : int);

--- a/tests/ounit/lustre/lustreTypeChecker/unequal_equation_widths_contract2.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/unequal_equation_widths_contract2.lus
@@ -8,7 +8,7 @@ tel
 contract counter_spec (init: int) returns(out: int);
 let
   (* Test different ways to assign ghost variables in parallel *)
-   gvar out1: int = counter2(init);
+   var out1: int = counter2(init);
 tel
 
 node counter (init : int) returns (out : int);

--- a/tests/regression/error/contract_syntax.lus
+++ b/tests/regression/error/contract_syntax.lus
@@ -1,8 +1,10 @@
 node N (inp: int) returns (x: int)
 var l: int;
-assume inp > 0;
-guarantee l > 2; 
-guarantee x > 2;
+con
+  assume inp > 0;
+  guarantee l > 2; 
+  guarantee x > 2;
+noc
 let
   l = 3;
   x = inp + l;

--- a/tests/regression/falsifiable/contract_import_indirection.lus
+++ b/tests/regression/falsifiable/contract_import_indirection.lus
@@ -17,7 +17,7 @@ tel
 
 contract B (x:bool) returns (y:bool) ;
 let
-  gvar v: bool = not (not x);
+  var v: bool = not (not x);
 
   assume H(x);
   import A (x) returns (y);
@@ -37,7 +37,7 @@ tel
 
 node N (u:bool) returns (v:bool);
 (*@contract
-  gvar h1: bool = not u;
+  var h1: bool = not u;
   import C (h1) returns (v);
   guarantee ::C::B::A::Am;
 *)

--- a/tests/regression/falsifiable/inductive_array.lus
+++ b/tests/regression/falsifiable/inductive_array.lus
@@ -34,8 +34,8 @@ returns ( Accepted : bool^n; SharedValue : int ) ;
   assume n > 0 ;
   assume n <= 4 ;
 
-  gvar NoOtherRequests : bool^n = Since_array(n, Accepted, count(n,Request) = 0);
-  gvar LastWrite : int^n = Last_array(n, Accepted, Value, Init) ;
+  var NoOtherRequests : bool^n = Since_array(n, Accepted, count(n,Request) = 0);
+  var LastWrite : int^n = Last_array(n, Accepted, Value, Init) ;
 
   guarantee "maintain" true ->
    forall (i:int) 0 <= i and i < n =>

--- a/tests/regression/falsifiable/ref_type_ghost_var.lus
+++ b/tests/regression/falsifiable/ref_type_ghost_var.lus
@@ -1,6 +1,6 @@
 node N(x: int) returns (y: int);
 (*@contract
-  gvar ghost: subtype { x: int | x >= 0 } = -1;
+  var ghost: subtype { x: int | x >= 0 } = -1;
 *)
 let
   check true;

--- a/tests/regression/falsifiable/test-issue-715.lus
+++ b/tests/regression/falsifiable/test-issue-715.lus
@@ -1,8 +1,8 @@
 node model(a, b: int) returns (r : bool);
 (*@contract
 
-    gvar pre_a: int = 0 -> pre(a);
-    gvar pre_b: int = 0 -> pre(b);
+    var pre_a: int = 0 -> pre(a);
+    var pre_b: int = 0 -> pre(b);
 
     assume "a increments with reset at 2"
         if pre_a = 0 then

--- a/tests/regression/falsifiable/test_contract_calls.lus
+++ b/tests/regression/falsifiable/test_contract_calls.lus
@@ -6,17 +6,17 @@ tel
 
 contract A(x: int; b: bool) returns (y: int);
 let
-   gvar z: int = n2(x);
+   var z: int = n2(x);
    mode m1
    (require z = x;);
 tel
 
 contract C(x: int) returns (y: int);
 let
-  gvar s1: int = x;
-  gvar z: int = x + 1;
+  var s1: int = x;
+  var z: int = x + 1;
 
-  -- gvar s2: bool = ::m2; 
+  -- var s2: bool = ::m2; 
 
   mode m4
   (require ::m2;);
@@ -33,8 +33,8 @@ tel
 
 --   -- import A(s1) returns (y);
 
---   gvar s1: int = x;
---   gvar z: int = x + 1;
+--   var s1: int = x;
+--   var z: int = x + 1;
 
  
 --    mode m2

--- a/tests/regression/success/block_annot_syntax.lus
+++ b/tests/regression/success/block_annot_syntax.lus
@@ -33,8 +33,8 @@ node my_node (i: int) returns (out: int) ;
 
 (*@contract
 
-  gconst bound = 10 ;
-  gvar i_bounded: bool = abs(i) < bound ;
+  const bound = 10 ;
+  var i_bounded: bool = abs(i) < bound ;
 
   assume i_bounded ;
   guarantee out >= - bound ;

--- a/tests/regression/success/contract_syntax.lus
+++ b/tests/regression/success/contract_syntax.lus
@@ -1,8 +1,10 @@
 node N (inp: int) returns (x: int)
-gvar l: int = 3;
-assume inp > 0;
-guarantee l > 2; 
-guarantee x > 2;
+con
+  var l: int = 3;
+  assume inp > 0;
+  guarantee l > 2; 
+  guarantee x > 2;
+noc
 var l: int;
 let
   l = 3;

--- a/tests/regression/success/ghost_in_core.lus
+++ b/tests/regression/success/ghost_in_core.lus
@@ -6,8 +6,8 @@ tel
 
 node imported f(x:int) returns (y,z:int);
 (*@contract
-  gvar g1: bool = y >= 0;
-  gvar g2: bool = y >= x;
+  var g1: bool = y >= 0;
+  var g2: bool = y >= x;
   guarantee "G1" g1;
   guarantee "G2" g2;
   guarantee "G3" g1 and g2 and z>=0;

--- a/tests/regression/success/ghost_var_mult_assign.lus
+++ b/tests/regression/success/ghost_var_mult_assign.lus
@@ -8,10 +8,10 @@ tel
 contract counter_spec (init: int) returns(out: int);
 let
   (* Test different ways to assign ghost variables in parallel *)
-   gvar out1, out2: int = counter2(init);
-   gvar out3, out4: int = counter2(init);
-   gvar out5: int, out6: int, out7: int = counter3(init);
-   gvar out8, out9: int, out10, out11: bool = (1, 2, false, true);
+   var out1, out2: int = counter2(init);
+   var out3, out4: int = counter2(init);
+   var out5: int, out6: int, out7: int = counter3(init);
+   var out8, out9: int, out10, out11: bool = (1, 2, false, true);
 
    guarantee out3 + out2 >= out;
    guarantee out1 - out2 = 0;

--- a/tests/regression/success/ghost_var_mult_assign2.lus
+++ b/tests/regression/success/ghost_var_mult_assign2.lus
@@ -7,7 +7,7 @@ tel
 
 node counter (init : int) returns (out : int);
 (*@contract
-   gvar out1, out2: int = counter2(init);
+   var out1, out2: int = counter2(init);
 
    guarantee out1 - out2 = 0;
    guarantee out >= out1 - out2; 

--- a/tests/regression/success/imported_node_calling_regular_node.lus
+++ b/tests/regression/success/imported_node_calling_regular_node.lus
@@ -8,7 +8,7 @@ tel
 node imported top(x: int)
 returns (y: int);
 (*@contract
-    gvar g: int = f(x, y);
+    var g: int = f(x, y);
     assume g>0;
     guarantee y>g;
 *)

--- a/tests/regression/success/infer_tight_subrange.lus
+++ b/tests/regression/success/infer_tight_subrange.lus
@@ -30,8 +30,8 @@ tel;
 
 node N4 (i: t1) returns (o: int);
 (*@contract
-    gvar v1 : int = i + 1;
-    gvar v2 : int = v1 * 2;
+    var v1 : int = i + 1;
+    var v2 : int = v1 * 2;
     guarantee 1 <= v1 and v1 <= 2;
     guarantee 2 <= v2 and v2 <= 4;
 *)

--- a/tests/regression/success/inlined_contract_03.lus
+++ b/tests/regression/success/inlined_contract_03.lus
@@ -1,7 +1,7 @@
 
 node top(x: int) returns (y: int);
 (*@contract
-  gvar r: int = 5;
+  var r: int = 5;
   guarantee y >= (x + r);
 *)
 let

--- a/tests/regression/success/mode_reqs_by_idents.lus
+++ b/tests/regression/success/mode_reqs_by_idents.lus
@@ -34,8 +34,8 @@ node my_node (i: int) returns (out: int) ;
 
 (*@contract
 
-  gconst bound = 10 ;
-  gvar i_bounded: bool = abs(i) < bound ;
+  const bound = 10 ;
+  var i_bounded: bool = abs(i) < bound ;
 
   assume i_bounded ;
   guarantee out >= - bound ;

--- a/tests/regression/success/shared_local_and_ghost_name.lus
+++ b/tests/regression/success/shared_local_and_ghost_name.lus
@@ -2,7 +2,7 @@
 
 node N(i:bool) returns (out:bool);
 (*@contract
-  gvar A : bool = true;
+  var A : bool = true;
 *)
 var A: bool;
 let

--- a/tests/regression/success/test_enum_value_in_contract.lus
+++ b/tests/regression/success/test_enum_value_in_contract.lus
@@ -3,7 +3,7 @@ type my_enum = enum { A, B };
 
 node top(x:my_enum) returns (y: int);
 (*@contract
-  gvar g: bool = x = A;
+  var g: bool = x = A;
   guarantee g => y=0;
 *)
 let

--- a/tests/regression/success/test_ghost_vars.lus
+++ b/tests/regression/success/test_ghost_vars.lus
@@ -1,7 +1,7 @@
 node top (i:bool) returns (out:bool);
 (*@contract
-  gvar v2 : bool = false -> pre v1;
-  gvar v1 : bool = false;
+  var v2 : bool = false -> pre v1;
+  var v1 : bool = false;
   guarantee true;
 *)
 let
@@ -12,8 +12,8 @@ node top2 (i:bool) returns (out:bool);
 (*@contract
  mode m1 (
  require true -> pre(v2) = pre(v2););
- gvar v2 : bool = false -> pre v1;
- gvar v1 : bool = true -> v2;
+ var v2 : bool = false -> pre v1;
+ var v1 : bool = true -> v2;
  guarantee true;
 *)
 let


### PR DESCRIPTION
Use a dedicated block for contracts with the `con` and `noc` keywords. With this syntax, we can revert back to using `var` and `const` (rather than `gvar` and `gconst`), since the disambiguation is no longer necessary.

In the future (for Lucent), we discussed the possibility of using syntax:
```
contract begin 
   ...
end
```
But, the above would stylistically clash with the rest of the current language, so we may roll out a bunch of syntactic changes all at once.