### PR TITLE
Fix order of monomorphizations

### DIFF
--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -324,7 +324,7 @@ and gen_poly_decls_expr: Ctx.tc_context -> GI.t NI.Map.t -> NI.t option -> (A.de
         |> Ctx.SI.elements
         |> List.map (fun ty_var -> A.UserType (pos, [], ty_var))
     in
-    ctx, gids, Call (pos, ty_args, pnname, exprs), decls1 @ decls2, node_decls_map
+    ctx, gids, Call (pos, ty_args, pnname, exprs), decls2 @ decls1, node_decls_map
   | Call (pos, [], node_id, exprs) ->
     let ctx, gids, exprs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_exprs, acc_decls, acc_node_decls_map) expr -> 
       let ctx, gids, expr, decls, node_decls_map = gen_poly_decls_expr ctx gids caller_nname acc_node_decls_map expr in 

--- a/tests/regression/falsifiable/stack.lus
+++ b/tests/regression/falsifiable/stack.lus
@@ -1,0 +1,73 @@
+const MAX_SIZE: subrange[1,*] of int;
+
+type Index = subtype { i: int | -1 <= i and i < MAX_SIZE };
+
+type Stack<T> = struct {
+  items: T^MAX_SIZE;
+  top_pos: Index;
+};
+
+function push<T>(s_in: Stack<T>; e: T) returns (s_out: Stack<T>);
+con
+  assume "Stack is not full" not is_full(s_in);
+  guarantee "Size has increased by one" size(s_out)=size(s_in)+1;
+  guarantee "The top element is 'e'" top(s_out)=e;
+noc
+var new_items: T^MAX_SIZE;
+let
+  new_items[i] = if i=s_in.top_pos+1 then e else s_in.items[i];
+  s_out = Stack@<T> {
+    items = new_items;
+    top_pos = s_in.top_pos + 1;
+  };
+tel
+
+function pop<T>(s_in: Stack<T>) returns (s_out: Stack<T>);
+con
+  assume "Stack is not empty" not is_empty(s_in);
+  guarantee "Size has decreased by one" size(s_out)=size(s_in)-1;
+noc
+let
+  s_out = Stack@<T> {
+    items = s_in.items;
+    top_pos = s_in.top_pos - 1;
+  };
+tel
+
+function empty_stack<T>() returns (s: Stack<T>);
+let
+  s = Stack@<T> {
+    items = any@<T^MAX_SIZE>;
+    top_pos = -1;
+  };
+tel
+
+function is_empty<T>(s: Stack<T>) returns (r: bool);
+let
+   r = s.top_pos = -1;
+tel
+
+function is_full<T>(s: Stack<T>) returns (r: bool);
+let
+   r = s.top_pos = MAX_SIZE - 1;
+tel
+
+function size<T>(s: Stack<T>) returns (sz: int);
+let
+  sz = s.top_pos + 1;
+tel
+
+function top<T>(s: Stack<T>) returns (t: T);
+con
+  assume "Stack is not empty" not is_empty(s);
+noc
+let
+  t = s.items[s.top_pos];
+tel
+
+node N(s1:Stack<int>) returns (s2:Stack<int>; z1,z2:int);
+let
+
+  s2 = push(pop(s1), 3);
+  --%MAIN;
+tel


### PR DESCRIPTION
A preprocessing step is to order the nodes such that if node `A` calls node `B`, then node `B` comes before node `A` in the list of nodes 

The attached test case used to throw an exception because Kind 2 generated a monomorphization that was called by a node before it in the list of nodes