### PR TITLE
Fix global constant bugs

### DIFF
--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -297,8 +297,9 @@ let rec mk_graph_type: LA.lustre_type -> dependency_analysis_data = function
   | Set (_, ty) -> mk_graph_type ty
   | Map (_, ty1, ty2) -> union_dependency_analysis_data (mk_graph_type ty1) (mk_graph_type ty2)
   | TArr (_, aty, rty) -> union_dependency_analysis_data (mk_graph_type aty) (mk_graph_type rty)
-  (* Circular dependencies in refinement type predicates are allowed *)
-  | RefinementType (_, (_, _, ty), e) -> union_dependency_analysis_data (mk_graph_type ty) (mk_graph_expr e)
+  | RefinementType (_, (_, i, ty), e) -> 
+    let g_expr = remove (mk_graph_expr e) i in (* `i` shadows global constants *)
+    union_dependency_analysis_data (mk_graph_type ty) g_expr 
 (** This graph is useful for analyzing top level constant and type declarations *)
 
 and mk_graph_expr ?(only_modes = false)

--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -697,7 +697,7 @@ and check_declaration: context -> LA.declaration -> ([> warning] list * LA.decla
     check_ty_node_calls id ty >> Ok ([], LA.TypeDecl (span, AliasType (pos, id, ps, ty)))
   | ConstDecl (span, decl) ->
     let* warnings = match decl with
-      | LA.FreeConst _ -> Ok []
+      | LA.FreeConst (_, i, ty) -> check_ty_node_calls i ty >> Res.ok [] 
       | UntypedConst (_, i, e) -> check_const_expr_decl i ctx e
       | TypedConst (_, i, e, ty) -> check_ty_node_calls i ty >> check_const_expr_decl i ctx e 
     in

--- a/tests/ounit/lustre/lustreSyntaxChecks/global_ref_ty_any.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/global_ref_ty_any.lus
@@ -1,1 +1,1 @@
-const C: subtype { c: int | C > any@<int> };
+const C: subtype { x: int | x > any@<int> };

--- a/tests/ounit/lustre/lustreSyntaxChecks/global_ref_ty_any.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/global_ref_ty_any.lus
@@ -1,0 +1,1 @@
+const C: subtype { c: int | C > any@<int> };

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -66,6 +66,10 @@ let _ = run_test_tt_main ("frontend LustreAstInlineConstants error tests" >::: [
 (*                           Lustre Syntax Checks                              *)
 (* *************************************************************************** *)
 let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
+  mk_test "test any operator in global refinement type" (fun () ->
+    match load_file "./lustreSyntaxChecks/global_ref_ty_any.lus" with
+    | Error (`LustreSyntaxChecksError (_, NodeCallInGlobalTypeDecl _)) -> true
+    | _ -> false);
   mk_test "test unsupported arraydef" (fun () ->
     match load_file "./lustreSyntaxChecks/arraydef_bug_2.lus" with
     | Error (`LustreSyntaxChecksError (_, InductiveVarsWithArrayConstr _)) -> true
@@ -634,7 +638,7 @@ let _ = run_test_tt_main ("frontend LustreTypeChecker error tests" >::: [
     | _ -> false);
   mk_test "test invalid expression for array size 1" (fun () ->
     match load_file "./lustreTypeChecker/node_call_in_array_size_expr.lus" with
-    | Error (`LustreTypeCheckerError (_, ExpectedConstant _)) -> true
+    | Error (`LustreSyntaxChecksError (_, NodeCallInGlobalTypeDecl _)) -> true
     | _ -> false);
   mk_test "test undeclared 1" (fun () ->
     match load_file "./lustreTypeChecker/undeclared_type_01.lus" with
@@ -710,7 +714,7 @@ let _ = run_test_tt_main ("frontend LustreTypeChecker error tests" >::: [
     | _ -> false);
   mk_test "test illegal node call in array size expression" (fun () ->
     match load_file "./lustreTypeChecker/bad_array_size_1.lus" with
-    | Error (`LustreTypeCheckerError (_, ExpectedConstant _)) -> true
+    | Error (`LustreSyntaxChecksError (_, NodeCallInGlobalTypeDecl _)) -> true
     | _ -> false);
   mk_test "test illegal arrow operator in array size expression" (fun () ->
     match load_file "./lustreTypeChecker/bad_array_size_2.lus" with

--- a/tests/regression/success/ref_type_dep_shadow.lus
+++ b/tests/regression/success/ref_type_dep_shadow.lus
@@ -1,1 +1,6 @@
 const C: subtype { C: int | C > 0 };
+
+node N () returns () 
+let
+  check C > 0;
+tel

--- a/tests/regression/success/ref_type_dep_shadow.lus
+++ b/tests/regression/success/ref_type_dep_shadow.lus
@@ -1,0 +1,1 @@
+const C: subtype { C: int | C > 0 };


### PR DESCRIPTION
Fix bug that caused Kind 2 to spuriously report a cyclic dependency for global constants in cases like `const C: subtype { C: ...` (the bound variable name `C` should shadow the global constant `C`). 

Along the way, I discovered we were missing a syntax check for node calls in the types of free global constants (see lustreSyntaxChecks.ml change)

The first bug test case is `ref_type_dep_shadow.lus`, and the second is `global_ref_ty_any.lus`