### PR TITLE
Generate refinement type constraints for map and set type annotations

### DIFF
--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -2038,3 +2038,9 @@ let pos_of_type ty = match ty with
   | TupleType (p, _)  | RecordType (p, _, _)  
   | RefinementType (p, _, _) -> p
 
+let rec find_type_annotation e = match e with 
+| StructUpdate (_, e, _, _) -> find_type_annotation e
+| EmptySet (_, ta) -> ta
+| EmptyMap (p, Some (kt, vt)) -> Some (Map (p, kt, vt))
+| _ -> None
+

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -211,3 +211,6 @@ val contains_subtype_satisfying: (lustre_type -> bool) -> lustre_type -> bool
 
 val pos_of_type: lustre_type -> Lib.position 
 (** `pos_of_type ty` returns the position of `ty` *)
+
+val find_type_annotation: expr -> lustre_type option
+(** `find_type_annotation e` recurses down `StructUpdates` to find the leaf-level type annotation, if one exists *)

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1090,11 +1090,12 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
   |> List.filter (fun (_, id) -> 
     let ty = get_type_of_id info node_id id in
     Ctx.type_contains_subrange info.context ty)
-  |> List.fold_left (fun acc (p, id) ->
+  |> List.fold_left (fun (acc_g, acc_w) (p, id) ->
     let ty = get_type_of_id info node_id id in
     let ty = AIC.inline_constants_of_lustre_type info.context ty in
-    union acc (mk_fresh_subrange_constraint kind info map p node_id (A.Ident (p, id)) ty))
-    (empty ())
+    let gids, warnings = mk_fresh_subrange_constraint kind info map p node_id (A.Ident (p, id)) ty in
+    union acc_g gids, acc_w @ warnings)
+    (empty (), [])
 
   and mk_fresh_refinement_type_constraint source info map pos node_id expr expr_type =
     let ref_type_exprs = mk_ref_type_expr info.context node_id expr expr_type in
@@ -1119,7 +1120,7 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
   (* `force_prop` forces Kind 2 to treat the generated property as a real (non-candidate) property *)
   and mk_fresh_subrange_constraint ?(force_prop = false) source info map pos node_id expr expr_type =
     let range_exprs = mk_range_expr ~force_prop info.context node_id expr_type expr in
-    let gids = List.map (fun (range_expr, is_original) ->
+    let gids, warnings = List.map (fun (range_expr, is_original) ->
       i := !i + 1;
       let output_expr = AH.rename_contract_vars range_expr in
       let prefix = HString.mk_hstring (string_of_int !i) in
@@ -1132,10 +1133,10 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
         subrange_constraints = [(source, info.contract_scope, is_original, pos, name, output_nexpr)];
         equations = [(info.quantified_variables, info.contract_scope, eq_lhs, range_nexpr, None)]; }
       in
-      union (union gids1 gids2) gids3)
-      range_exprs
+      union (union gids1 gids2) gids3, warnings1 @ warnings2)
+      range_exprs |> List.split
     in
-    List.fold_left union (empty ()) gids
+    List.fold_left union (empty ()) gids, List.flatten warnings
 
 
 (* In this function, we normalize generated identifiers that were created earlier in the pipeline. 
@@ -1270,27 +1271,29 @@ and normalize_node_contract info (node_id : NI.t) map cref inputs outputs (id, _
      Future improvement: filter out variables based on subtyping relation
      on their types instead of equality.
   *)
-  let gids3 =
+  let gids3, warnings4 =
     let vars = List.map (fun (p,id,ty,_,_) -> (p,id,ty)) ivars in
     let vars = compute_vars inputs vars in
     add_subrange_constraints info map (Some id) Input vars
   in
-  let gids4 = 
+  let gids4, warnings5 = 
     let vars = List.map (fun (p,id,ty,_) -> (p,id,ty)) ovars in
     let vars = compute_vars outputs vars in
     add_subrange_constraints info map (Some id) Output vars
   in
-  let gids5, warnings4 =
+  let gids5, warnings6 =
     let vars = List.map (fun (p,id,ty,_,_) -> (p,id,ty)) ivars in
     add_ref_type_constraints info map Input (Some node_id) vars
   in
-  let gids6, warnings5 = 
+  let gids6, warnings7 = 
     let vars = List.map (fun (p,id,ty,_) -> (p,id,ty)) ovars in
     add_ref_type_constraints info map Output (Some node_id) vars
   in
   let nbody, gids7, _, warnings3 = normalize_contract info node_id map ivars ovars body in
   let gids = List.fold_left union (empty ()) [union_list gids1; union_list gids2; gids3; gids4; gids5; gids6; gids7] in
-  nbody, gids, List.flatten (warnings1 @ warnings2) @ warnings3 @ warnings4 @ warnings5, StringMap.empty
+  nbody, gids, 
+  List.flatten (warnings1 @ warnings2) @ warnings3 @ warnings4 @ warnings5 @ warnings6 @ warnings7, 
+  StringMap.empty
 
 and normalize_ghost_declaration info node_id map = function
   | A.UntypedConst (pos, id, expr) ->
@@ -1340,15 +1343,15 @@ and normalize_node info map
     let vars = List.map (fun (p,id,ty,_,_) -> (p,id,ty)) inputs in
     let vars' = List.map (fun (p,id,_,_,_) -> (p,id)) inputs in
     let gids, warnings = add_ref_type_constraints info map Input (Some node_id) vars in
-    union (add_subrange_constraints info map (Some node_id) Input vars') 
-          gids, warnings 
+    let gids', warnings' = add_subrange_constraints info map (Some node_id) Input vars' in
+    union gids gids', warnings @ warnings'
   in
   let gids5, warnings5 = 
     let vars = List.map (fun (p,id,ty,_) -> (p,id,ty)) outputs in
     let vars' = List.map (fun (p,id,_,_) -> (p,id)) outputs in
     let gids, warnings = (add_ref_type_constraints info map Output (Some node_id) vars) in
-    union (add_subrange_constraints info map (Some node_id) Output vars') 
-          gids, warnings 
+    let gids', warnings' = add_subrange_constraints info map (Some node_id) Output vars' in 
+    union gids gids', warnings @ warnings' 
   in
   (* We have to handle contracts before locals
     Otherwise the typing contexts collide *)
@@ -1380,9 +1383,9 @@ and normalize_node info map
       | A.NodeConstDecl (p, TypedConst (_, id, _, _)) ->  
         let ty = get_type_of_id info (Some node_id) id in
         let ty = AIC.inline_constants_of_lustre_type info.context ty in
-        let gids = union acc_g (mk_fresh_subrange_constraint Local info map p (Some node_id) (A.Ident (p, id)) ty) in 
-        let gids2, warnings = mk_fresh_refinement_type_constraint Local info map p (Some node_id) (A.Ident (p, id)) ty in
-        union gids gids2, acc_w @ warnings 
+        let gids1, warnings1 = (mk_fresh_subrange_constraint Local info map p (Some node_id) (A.Ident (p, id)) ty) in 
+        let gids2, warnings2 = mk_fresh_refinement_type_constraint Local info map p (Some node_id) (A.Ident (p, id)) ty in
+        union acc_g (union gids1 gids2), acc_w @ warnings1 @ warnings2
       | A.NodeConstDecl (_, FreeConst _)
       | A.NodeConstDecl (_, UntypedConst _)-> assert false)
       (empty (), [])
@@ -1731,18 +1734,19 @@ and normalize_contract info node_id map ivars ovars (p, items) =
           let tis, gids_list, warnings = (
             List.map (
               fun (pos, i, ty) -> 
-                let ty, gids, warnings1 = normalize_ty ~id:(Some i) info (Some node_id) map ty in
+                let ty, gids1, warnings1 = normalize_ty ~id:(Some i) info (Some node_id) map ty in
                 let new_id = StringMap.find i info.interpretation in
                 if Ctx.type_contains_subrange info.context ty || Ctx.type_contains_ref info.context ty then
                   let gids2, warnings2 = 
                     mk_fresh_refinement_type_constraint Ghost info map pos (Some node_id) (A.Ident (pos, new_id)) ty 
                   in
+                  let gids3, warnings3 = 
+                    mk_fresh_subrange_constraint Ghost info map pos (Some node_id) (A.Ident (p, new_id)) ty
+                  in
                   (pos, i, ty),
-                  union gids (
-                  union (mk_fresh_subrange_constraint Ghost info map pos (Some node_id) (A.Ident (p, new_id)) ty)
-                        gids2), 
-                  warnings1 @ warnings2 
-                else (pos, i, ty), gids, []
+                  union gids1 (union gids2 gids3), 
+                  warnings1 @ warnings2 @ warnings3
+                else (pos, i, ty), gids1, []
             )
             tis |> Lib.split3
           ) in
@@ -2257,18 +2261,18 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let gids1, warnings1 = match AH.find_type_annotation expr1 with 
                  (*!! What to put for `kind`? *)
     | Some (Map (_, kt, vt)) -> 
-        (*!! Should also incorporate expr3 *)
+        (*!! SHould vt constraint be consequent of implication where antecedent is KT constraint? *)
       Format.printf "vt: %a\n"
         A.pp_print_lustre_type vt;
       let gids, warnings = mk_fresh_refinement_type_constraint Local info map pos node_id expr2 kt in 
       let gids', warnings' = mk_fresh_refinement_type_constraint Local info map pos node_id expr3 vt in  
-      let gids'' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr2 kt in 
-      let gids''' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr3 vt in  
+      let gids'', warnings'' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr2 kt in 
+      let gids''', warnings''' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr3 vt in  
       Format.printf "gids'': %a\ngids''': %a\n" 
         pp_print_generated_identifiers gids'' 
         pp_print_generated_identifiers gids''';
       let gids = List.fold_left union (empty ()) [gids; gids'; gids''; gids'''] in
-      gids,  warnings @ warnings'
+      gids,  warnings @ warnings' @ warnings'' @ warnings'''
     | None -> empty (), []
     | _ -> assert false (* Type annotation must be `Map` type, enforced by the parser *) 
     in
@@ -2306,8 +2310,8 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
                  (*!! What to put for `kind`? *)
     | Some ty -> 
       let gids, warnings =  mk_fresh_refinement_type_constraint Local info map pos node_id expr2 ty in
-      let gids' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr2 ty in  
-      union gids gids', warnings 
+      let gids', warnings' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr2 ty in  
+      union gids gids', warnings @ warnings'
     | None -> empty (), [] 
     in
     (* Don't supply the guard when normalizing subexpressions, 

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1107,11 +1107,11 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
   vars
   |> List.filter (fun (_, _, ty) -> 
     Ctx.type_contains_ref info.context ty)
-  |> List.fold_left (fun acc (p, id, ty) ->
+  |> List.fold_left (fun (acc_gids, acc_w) (p, id, ty) ->
     let ty = AIC.inline_constants_of_lustre_type info.context ty in
     let gids, warnings = mk_fresh_refinement_type_constraint kind info map p node_id (A.Ident (p, id)) ty in
-    union acc gids)
-    (empty ())
+    union acc_gids gids, acc_w @ warnings)
+    (empty (), [])
 
   and mk_fresh_refinement_type_constraint source info map pos node_id id expr_type =
     let ref_type_exprs = mk_ref_type_expr info.context node_id id expr_type in
@@ -1276,17 +1276,17 @@ and normalize_node_contract info (node_id : NI.t) map cref inputs outputs (id, _
     let vars = compute_vars outputs vars in
     add_subrange_constraints info (Some id) Output vars
   in
-  let gids5 =
+  let gids5, warnings4 =
     let vars = List.map (fun (p,id,ty,_,_) -> (p,id,ty)) ivars in
     add_ref_type_constraints info map Input (Some node_id) vars
   in
-  let gids6 = 
+  let gids6, warnings5 = 
     let vars = List.map (fun (p,id,ty,_) -> (p,id,ty)) ovars in
     add_ref_type_constraints info map Output (Some node_id) vars
   in
   let nbody, gids7, _, warnings3 = normalize_contract info node_id map ivars ovars body in
   let gids = List.fold_left union (empty ()) [union_list gids1; union_list gids2; gids3; gids4; gids5; gids6; gids7] in
-  nbody, gids, List.flatten (warnings1 @ warnings2) @ warnings3, StringMap.empty
+  nbody, gids, List.flatten (warnings1 @ warnings2) @ warnings3 @ warnings4 @ warnings5, StringMap.empty
 
 and normalize_ghost_declaration info node_id map = function
   | A.UntypedConst (pos, id, expr) ->
@@ -1332,21 +1332,23 @@ and normalize_node info map
       A.NodeVarDecl (p1, (p2, id, ty, cl)), gids, warnings
   ) locals |> Lib.split3 in
   (* Record subrange and refinement type constraints on inputs, outputs *)
-  let gids4 =
+  let gids4, warnings4 =
     let vars = List.map (fun (p,id,ty,_,_) -> (p,id,ty)) inputs in
     let vars' = List.map (fun (p,id,_,_,_) -> (p,id)) inputs in
+    let gids, warnings = add_ref_type_constraints info map Input (Some node_id) vars in
     union (add_subrange_constraints info (Some node_id) Input vars') 
-          (add_ref_type_constraints info map Input (Some node_id) vars) 
+          gids, warnings 
   in
-  let gids5 = 
+  let gids5, warnings5 = 
     let vars = List.map (fun (p,id,ty,_) -> (p,id,ty)) outputs in
     let vars' = List.map (fun (p,id,_,_) -> (p,id)) outputs in
+    let gids, warnings = (add_ref_type_constraints info map Output (Some node_id) vars) in
     union (add_subrange_constraints info (Some node_id) Output vars') 
-          (add_ref_type_constraints info map Output (Some node_id) vars)
+          gids, warnings 
   in
   (* We have to handle contracts before locals
     Otherwise the typing contexts collide *)
-  let ncontracts, gids6, interpretation, warnings4 = match contract with
+  let ncontracts, gids6, interpretation, warnings6 = match contract with
     | Some contract ->
       let ctx = Chk.tc_ctx_of_contract info.context Ghost node_id contract |> unwrap |> fun (_, ctx, _) -> ctx
       in
@@ -1361,7 +1363,7 @@ and normalize_node info map
   let ctx = Chk.add_local_node_ctx ctx locals in
   let info = { info with context = ctx } in
   (* Record subrange constraints on locals *)
-  let gids7 = locals
+  let gids7, warnings7 = locals
     |> List.filter (function
       | A.NodeVarDecl (_, (_, id, _, _)) 
       | A.NodeConstDecl (_, TypedConst (_, id, _, _)) -> 
@@ -1369,17 +1371,17 @@ and normalize_node info map
         Ctx.type_contains_subrange ctx ty || Ctx.type_contains_ref ctx ty
       | A.NodeConstDecl (_, FreeConst _)
       | A.NodeConstDecl (_, UntypedConst _) -> false)
-    |> List.fold_left (fun acc l -> match l with
+    |> List.fold_left (fun (acc_g, acc_w) l -> match l with
       | A.NodeVarDecl (p, (_, id, _, _)) 
       | A.NodeConstDecl (p, TypedConst (_, id, _, _)) ->  
         let ty = get_type_of_id info (Some node_id) id in
         let ty = AIC.inline_constants_of_lustre_type info.context ty in
-        let gids = union acc (mk_fresh_subrange_constraint Local info p (Some node_id) id ty) in 
+        let gids = union acc_g (mk_fresh_subrange_constraint Local info p (Some node_id) id ty) in 
         let gids2, warnings = mk_fresh_refinement_type_constraint Local info map p (Some node_id) (A.Ident (p, id)) ty in
-        union gids gids2 
+        union gids gids2, acc_w @ warnings 
       | A.NodeConstDecl (_, FreeConst _)
       | A.NodeConstDecl (_, UntypedConst _)-> assert false)
-      (empty ())
+      (empty (), [])
   in
   let items =
     if Flags.check_reach () then
@@ -1399,7 +1401,7 @@ and normalize_node info map
     Flags.check_reach () && List.exists reachability_prop_with_bounds items
   in
   (* Normalize equations and the contract *)
-  let nitems, gids8, warnings5 = normalize_list (normalize_item info node_id map) items in
+  let nitems, gids8, warnings8 = normalize_list (normalize_item info node_id map) items in
   let gids6_8 = union gids6 gids8 in
   let gids9 =
     if exists_reachability_prop_with_bounds ||
@@ -1411,11 +1413,12 @@ and normalize_node info map
   in
   let new_gids = union_list [union_list gids1; union_list gids2; union_list gids3; 
                              gids4; gids5; gids7; gids6_8; gids9] in
-  let old_gids, warnings6 = normalize_gid_equations { info with interpretation = interpretation; } map (Some node_id) in
+  let old_gids, warnings9 = normalize_gid_equations { info with interpretation = interpretation; } map (Some node_id) in
   let map = NI.Map.add node_id (union old_gids new_gids) map in
   (node_id, is_extern, opac, params, inputs, outputs, locals, List.flatten nitems, ncontracts),
   map, 
-  List.flatten warnings1 @ List.flatten warnings2 @ List.flatten warnings3 @ warnings4 @ warnings5 @ warnings6
+  List.flatten warnings1 @ List.flatten warnings2 @ List.flatten warnings3 
+  @ warnings4 @ warnings5 @ warnings6 @ warnings7 @ warnings8 @ warnings9
 
 
 and desugar_history info expr =
@@ -1724,17 +1727,17 @@ and normalize_contract info node_id map ivars ovars (p, items) =
           let tis, gids_list, warnings = (
             List.map (
               fun (pos, i, ty) -> 
-                let ty, gids, warnings = normalize_ty ~id:(Some i) info (Some node_id) map ty in
+                let ty, gids, warnings1 = normalize_ty ~id:(Some i) info (Some node_id) map ty in
                 let new_id = StringMap.find i info.interpretation in
                 if Ctx.type_contains_subrange info.context ty || Ctx.type_contains_ref info.context ty then
-                  let gids2, warnings = 
+                  let gids2, warnings2 = 
                     mk_fresh_refinement_type_constraint Ghost info map pos (Some node_id) (A.Ident (pos, new_id)) ty 
                   in
                   (pos, i, ty),
                   union gids (
                   union (mk_fresh_subrange_constraint Ghost info pos (Some node_id) new_id ty)
                         gids2), 
-                  warnings
+                  warnings1 @ warnings2 
                 else (pos, i, ty), gids, []
             )
             tis |> Lib.split3
@@ -2247,7 +2250,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let nexpr = A.Ident (pos, name) in
     nexpr, union (union gids1 gids2) gids3, warnings1 @ warnings2
   | StructUpdate (pos, expr1, [A.MapIndex (_, expr2)], Some expr3) as expr ->
-    let gids1, warnings = match AH.find_type_annotation expr1 with 
+    let gids1, warnings1 = match AH.find_type_annotation expr1 with 
                  (*!! What to put for `kind`? *)
     | Some ty -> 
         (*!! Should also incorporate expr3 *)
@@ -2262,9 +2265,9 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let nexpr3, gids4, _ = normalize_expr info node_id map expr3 in 
     (* Hacky: to generate correct user-facing warnings, we call normalize_expr 
        while supplying the guard, but ignore all other outputs *)
-    let _, _, warnings1 = normalize_expr ?guard info node_id map expr1 in 
-    let _, _, warnings2 = normalize_expr ?guard info node_id map expr2 in 
-    let _, _, warnings3 = normalize_expr ?guard info node_id map expr3 in 
+    let _, _, warnings2 = normalize_expr ?guard info node_id map expr1 in 
+    let _, _, warnings3 = normalize_expr ?guard info node_id map expr2 in 
+    let _, _, warnings4 = normalize_expr ?guard info node_id map expr3 in 
     i := !i + 1; 
     let prefix = HString.mk_hstring (string_of_int !i) in 
     let name1 = HString.concat2 prefix (HString.mk_hstring "_map_update") in 
@@ -2282,9 +2285,9 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     } in 
     let nexpr = A.Ident (pos, name1) in 
     let gids = List.fold_left union (empty ()) [gids1; gids2; gids3; gids4; gids5] in 
-    nexpr, gids, warnings1 @ warnings2 @ warnings3 
+    nexpr, gids, warnings1 @ warnings2 @ warnings3 @ warnings4
     | StructUpdate (pos, expr1, [A.SetIndex (_, expr2)], None) as expr ->
-    let gids1, warnings = match AH.find_type_annotation expr1 with 
+    let gids1, warnings1 = match AH.find_type_annotation expr1 with 
                  (*!! What to put for `kind`? *)
     | Some ty -> mk_fresh_refinement_type_constraint Local info map pos node_id expr2 ty 
     | None -> empty (), [] 
@@ -2296,8 +2299,8 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let nexpr2, gids3, _ = normalize_expr info node_id map expr2 in 
     (* Hacky: to generate correct user-facing warnings, we call normalize_expr 
        while supplying the guard, but ignore all other outputs *)
-    let _, _, warnings1 = normalize_expr ?guard info node_id map expr1 in 
-    let _, _, warnings2 = normalize_expr ?guard info node_id map expr2 in 
+    let _, _, warnings2 = normalize_expr ?guard info node_id map expr1 in 
+    let _, _, warnings3 = normalize_expr ?guard info node_id map expr2 in 
     i := !i + 1; 
     let prefix = HString.mk_hstring (string_of_int !i) in 
     let name1 = HString.concat2 prefix (HString.mk_hstring "_set_update") in 
@@ -2314,7 +2317,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     } in 
     let nexpr = A.Ident (pos, name1) in 
     let gids = List.fold_left union (empty ()) [gids1; gids2; gids3; gids4] in 
-    nexpr, gids, warnings1 @ warnings2 
+    nexpr, gids, warnings1 @ warnings2 @ warnings3
 
   | RecordProject (pos, expr, i) ->
     let nexpr, gids, warnings = normalize_expr ?guard info node_id map expr in
@@ -2555,14 +2558,14 @@ and normalize_ty ?(guard = None) ?(id = None) info node_id map ty =
     in
     let expr = AH.substitute_naive id2 (A.Ident (p1, id')) expr in
     let info = match id with 
-    | Some id -> info
+    | Some _ -> info
     | None -> { info with context = Ctx.add_ty info.context id' ty2 }
     in 
     let info, h_gids, expr = desugar_history info expr in
     let nexpr, gids, warnings = normalize_expr info node_id map expr in
     let gids1 = union h_gids gids in
     let gids2 = match id with 
-    | Some id -> empty () 
+    | Some _ -> empty () 
     | None -> { gids with locals = StringMap.singleton id' ty2 } 
     in
     A.RefinementType (p1, (p2, id', ty2), nexpr), union gids1 gids2, warnings

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2229,10 +2229,14 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let nexpr = A.Ident (pos, name) in
     nexpr, union (union gids1 gids2) gids3, warnings1 @ warnings2
   | StructUpdate (pos, expr1, [A.MapIndex (_, expr2)], Some expr3) as expr ->
-    let gids1 = match AH.find_type_annotation expr1 with 
+    let gids1, warnings1 = match AH.find_type_annotation expr1 with 
                  (*!! What to put for `kind`? *)
-    | Some ty -> mk_fresh_refinement_type_constraint Local info pos node_id expr2 ty
-    | None -> empty () 
+    | Some ty -> 
+        (*!! Should also incorporate expr3 *)
+      let ty, gids, warnings = normalize_ty info None map ty in 
+      let gids' = mk_fresh_refinement_type_constraint Local info pos node_id expr2 ty in 
+      union gids gids', warnings
+    | None -> empty (), [] 
     in
     (* Don't supply the guard when normalizing subexpressions, 
        because we need to generate oracle variables in initial step 
@@ -2242,9 +2246,9 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let nexpr3, gids4, _ = normalize_expr info node_id map expr3 in 
     (* Hacky: to generate correct user-facing warnings, we call normalize_expr 
        while supplying the guard, but ignore all other outputs *)
-    let _, _, warnings1 = normalize_expr ?guard info node_id map expr1 in 
-    let _, _, warnings2 = normalize_expr ?guard info node_id map expr2 in 
-    let _, _, warnings3 = normalize_expr ?guard info node_id map expr3 in 
+    let _, _, warnings2 = normalize_expr ?guard info node_id map expr1 in 
+    let _, _, warnings3 = normalize_expr ?guard info node_id map expr2 in 
+    let _, _, warnings4 = normalize_expr ?guard info node_id map expr3 in 
     i := !i + 1; 
     let prefix = HString.mk_hstring (string_of_int !i) in 
     let name1 = HString.concat2 prefix (HString.mk_hstring "_map_update") in 
@@ -2259,12 +2263,15 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     } in 
     let nexpr = A.Ident (pos, name1) in 
     let gids = List.fold_left union (empty ()) [gids1; gids2; gids3; gids4; gids5] in 
-    nexpr, gids, warnings1 @ warnings2 @ warnings3 
+    nexpr, gids, warnings1 @ warnings2 @ warnings3 @ warnings4
     | StructUpdate (pos, expr1, [A.SetIndex (_, expr2)], None) as expr ->
-    let gids1 = match AH.find_type_annotation expr1 with 
+    let gids1, warnings1 = match AH.find_type_annotation expr1 with 
                  (*!! What to put for `kind`? *)
-    | Some ty -> mk_fresh_refinement_type_constraint Local info pos node_id expr2 ty
-    | None -> empty () 
+    | Some ty -> 
+      let ty, gids, warnings = normalize_ty info None map ty in 
+      let gids' = mk_fresh_refinement_type_constraint Local info pos node_id expr2 ty in 
+      union gids gids', warnings
+    | None -> empty (), [] 
     in
     (* Don't supply the guard when normalizing subexpressions, 
        because we need to generate oracle variables in initial step 
@@ -2273,8 +2280,8 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let nexpr2, gids3, _ = normalize_expr info node_id map expr2 in 
     (* Hacky: to generate correct user-facing warnings, we call normalize_expr 
        while supplying the guard, but ignore all other outputs *)
-    let _, _, warnings1 = normalize_expr ?guard info node_id map expr1 in 
-    let _, _, warnings2 = normalize_expr ?guard info node_id map expr2 in 
+    let _, _, warnings2 = normalize_expr ?guard info node_id map expr1 in 
+    let _, _, warnings3 = normalize_expr ?guard info node_id map expr2 in 
     i := !i + 1; 
     let prefix = HString.mk_hstring (string_of_int !i) in 
     let name1 = HString.concat2 prefix (HString.mk_hstring "_set_update") in 
@@ -2289,7 +2296,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     } in 
     let nexpr = A.Ident (pos, name1) in 
     let gids = List.fold_left union (empty ()) [gids1; gids2; gids3; gids4] in 
-    nexpr, gids, warnings1 @ warnings2 
+    nexpr, gids, warnings1 @ warnings2 @ warnings3
 
   | RecordProject (pos, expr, i) ->
     let nexpr, gids, warnings = normalize_expr ?guard info node_id map expr in

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2335,7 +2335,6 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
   | StructUpdate (pos, expr1, [A.MapIndex (_, expr2)], Some expr3) as expr ->
     let gids1, warnings1 = match AH.find_type_annotation expr1 with 
     | Some (Map (_, kt, vt)) -> 
-      (*!! Here (and in the set case) I use `Local`, as the expression may reference local variables *)
       let gids, warnings = mk_fresh_refinement_type_constraint Local info map pos node_id expr2 kt in 
       let gids', warnings' = mk_fresh_refinement_type_constraint Local info map pos node_id expr3 vt in  
       let gids1 = gen_map_ty_annot_constraints_refty info gids gids' in 

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1115,7 +1115,6 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
     in
     List.fold_left union (empty ()) gids, List.flatten warnings
 
-  (* `force_prop` forces Kind 2 to treat the generated property as a real (non-candidate) property *)
   and mk_fresh_subrange_constraint source info map pos node_id expr expr_type =
     let range_exprs = mk_range_expr info.context node_id expr_type expr in
     let gids, warnings = List.map (fun (range_expr, is_original) ->

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1198,10 +1198,10 @@ and normalize_declaration info map = function
     let map = NI.Map.add id ngids map in
     None, map, warnings
   | ConstDecl (p, FreeConst (p2, id, ty)) ->
-    let ty, _, warnings = normalize_ty info None map id ty in 
+    let ty, _, warnings = normalize_ty ~id:(Some id) info None map ty in 
     Some (A.ConstDecl (p, FreeConst (p2, id, ty))), map, warnings 
   | ConstDecl (p, TypedConst (p2, id, expr, ty)) ->
-    let ty, _, warnings1 = normalize_ty info None map id ty in 
+    let ty, _, warnings1 = normalize_ty ~id:(Some id) info None map ty in 
     let expr, _, warnings2 = normalize_expr info None map expr in 
     Some (A.ConstDecl (p, TypedConst (p2, id, expr, ty))), map, warnings1 @ warnings2
   | ConstDecl (p, UntypedConst (p2, id, expr)) ->
@@ -1212,11 +1212,11 @@ and normalize_declaration info map = function
 and normalize_node_contract info (node_id : NI.t) map cref inputs outputs (id, _, ivars, ovars, body) =
   (* Normalize types *)
   let ivars, gids1, warnings1 = List.map (fun (p, id, ty, cl, c) -> 
-    let ty, gids, warnings = normalize_ty info (Some node_id) map id ty in 
+    let ty, gids, warnings = normalize_ty ~id:(Some id) info (Some node_id) map ty in 
     (p, id, ty, cl, c), gids, warnings
   ) ivars |> Lib.split3 in
   let ovars, gids2, warnings2 = List.map (fun (p, id, ty, cl) -> 
-    let ty, gids, warnings = normalize_ty info (Some node_id) map id ty in 
+    let ty, gids, warnings = normalize_ty ~id:(Some id) info (Some node_id) map ty in 
     (p, id, ty, cl), gids, warnings
   ) ovars |> Lib.split3 in
   let contract_ref = cref in
@@ -1290,12 +1290,12 @@ and normalize_ghost_declaration info node_id map = function
     let nexpr, map, warnings = normalize_expr ?guard:None info (Some node_id) map expr in
     A.UntypedConst (pos, new_id, nexpr), map, warnings
   | TypedConst (pos, id, expr, ty) ->
-    let ty, map1, warnings1 = normalize_ty info (Some node_id) map id ty in
+    let ty, map1, warnings1 = normalize_ty ~id:(Some id) info (Some node_id) map ty in
     let new_id = StringMap.find id info.interpretation in
     let nexpr, map2, warnings2 = normalize_expr ?guard:None info (Some node_id) map expr in
     A.TypedConst (pos, new_id, nexpr, ty), union map1 map2, warnings1 @ warnings2
   | FreeConst (pos, id, ty) -> 
-    let ty, map, warnings = normalize_ty info (Some node_id) map id ty in
+    let ty, map, warnings = normalize_ty ~id:(Some id) info (Some node_id) map ty in
     FreeConst (pos, id, ty), map, warnings
 
 and normalize_node info map
@@ -1306,25 +1306,25 @@ and normalize_node info map
   let info = { info with context = ctx } in
   (* Normalize types *)
   let inputs, gids1, warnings1 = List.map (fun (p, id, ty, cl, c) -> 
-    let ty, gids, warnings = normalize_ty info (Some node_id) map id ty in 
+    let ty, gids, warnings = normalize_ty ~id:(Some id) info (Some node_id) map ty in 
     (p, id, ty, cl, c), gids, warnings
   ) inputs |> Lib.split3 in
   let outputs, gids2, warnings2 = List.map (fun (p, id, ty, cl) -> 
-    let ty, gids, warnings = normalize_ty info (Some node_id) map id ty in 
+    let ty, gids, warnings = normalize_ty ~id:(Some id) info (Some node_id) map ty in 
     (p, id, ty, cl), gids, warnings
   ) outputs |> Lib.split3 in
   let locals, gids3, warnings3 = List.map (fun decl -> 
     match decl with 
     | A.NodeConstDecl (p1, FreeConst (p2, id, ty)) ->
-      let ty, gids, warnings = normalize_ty info (Some node_id) map id ty in 
+      let ty, gids, warnings = normalize_ty ~id:(Some id) info (Some node_id) map ty in 
       A.NodeConstDecl (p1, FreeConst (p2, id, ty)), gids, warnings
     | A.NodeConstDecl (p1, UntypedConst (p2, id, e)) ->
       A.NodeConstDecl (p1, UntypedConst (p2, id, e)), empty (), []
     | A.NodeConstDecl (p, TypedConst (p2, id, e, ty)) -> 
-      let ty, gids, warnings = normalize_ty info (Some node_id) map id ty in
+      let ty, gids, warnings = normalize_ty ~id:(Some id) info (Some node_id) map ty in
       A.NodeConstDecl (p, TypedConst (p2, id, e, ty)), gids, warnings
     | A.NodeVarDecl (p1, (p2, id, ty, cl)) -> 
-      let ty, gids, warnings = normalize_ty info (Some node_id) map id ty in 
+      let ty, gids, warnings = normalize_ty ~id:(Some id) info (Some node_id) map ty in 
       A.NodeVarDecl (p1, (p2, id, ty, cl)), gids, warnings
   ) locals |> Lib.split3 in
   (* Record subrange and refinement type constraints on inputs, outputs *)
@@ -1719,7 +1719,7 @@ and normalize_contract info node_id map ivars ovars (p, items) =
           let tis, gids_list, warnings = (
             List.map (
               fun (pos, i, ty) -> 
-                let ty, gids, warnings = normalize_ty info (Some node_id) map i ty in
+                let ty, gids, warnings = normalize_ty ~id:(Some i) info (Some node_id) map ty in
                 let new_id = StringMap.find i info.interpretation in
                 if Ctx.type_contains_subrange info.context ty || Ctx.type_contains_ref info.context ty then
                   (pos, i, ty),
@@ -2201,37 +2201,45 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let expr = A.StructUpdate (p1, EmptyMap (p2, Some (kt, vt)), [A.MapIndex (p3, e1)], Some e2) in 
     normalize_expr info node_id map expr
   | StructUpdate (p1, EmptySet (p2, None), [A.SetIndex (p3, e)], None) ->
-    let ty, _, _ = Chk.infer_type_expr info.context node_id e |> Result.get_ok in 
+    let ty, _, _ = Chk.infer_type_expr info.context node_id e |> Result.get_ok in
     let expr = A.StructUpdate (p1, EmptySet (p2, Some ty), [A.SetIndex (p3, e)], None) in 
     normalize_expr info node_id map expr
   | EmptyMap (_, None) | EmptySet (_, None) -> assert false 
   | EmptySet (pos, Some ty) -> 
     i := !i + 1;
+    let ty, gids1, warnings = normalize_ty info None map ty in 
     let prefix = HString.mk_hstring (string_of_int !i) in
     let name = HString.concat2 prefix (HString.mk_hstring "_empty_set") in
-    let gids = { (empty ()) with 
+    let gids2 = { (empty ()) with 
       empty_sets = [ name, ty ]; 
       locals = StringMap.singleton name (A.Set (pos, ty));
     } in
     let nexpr = A.Ident (pos, name) in 
-    nexpr, gids, []
+    nexpr, union gids1 gids2, warnings 
   | EmptyMap (pos, Some (kt, vt)) -> 
     i := !i + 1;
+    let kt, gids1, warnings1 = normalize_ty info None map kt in 
+    let vt, gids2, warnings2 = normalize_ty info None map vt in 
     let prefix = HString.mk_hstring (string_of_int !i) in
     let name = HString.concat2 prefix (HString.mk_hstring "_empty_map") in
-    let gids = { (empty ()) with 
+    let gids3 = { (empty ()) with 
       empty_maps = [ name, kt, vt ]; 
       locals = StringMap.singleton name (A.Map (pos, kt, vt));
     } in
     let nexpr = A.Ident (pos, name) in
-    nexpr, gids, []
+    nexpr, union (union gids1 gids2) gids3, warnings1 @ warnings2
   | StructUpdate (pos, expr1, [A.MapIndex (_, expr2)], Some expr3) as expr ->
+    let gids1 = match AH.find_type_annotation expr1 with 
+                 (*!! What to put for `kind`? *)
+    | Some ty -> mk_fresh_refinement_type_constraint Local info pos node_id expr2 ty
+    | None -> empty () 
+    in
     (* Don't supply the guard when normalizing subexpressions, 
        because we need to generate oracle variables in initial step 
        if there are unguarded pres *)
-    let nexpr1, gids1, _ = normalize_expr info node_id map expr1 in 
-    let nexpr2, gids2, _ = normalize_expr info node_id map expr2 in 
-    let nexpr3, gids3, _ = normalize_expr info node_id map expr3 in 
+    let nexpr1, gids2, _ = normalize_expr info node_id map expr1 in 
+    let nexpr2, gids3, _ = normalize_expr info node_id map expr2 in 
+    let nexpr3, gids4, _ = normalize_expr info node_id map expr3 in 
     (* Hacky: to generate correct user-facing warnings, we call normalize_expr 
        while supplying the guard, but ignore all other outputs *)
     let _, _, warnings1 = normalize_expr ?guard info node_id map expr1 in 
@@ -2245,19 +2253,24 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     | Ok (A.Map (_, kt, vt), _, _) -> kt, vt 
     | _ -> assert false 
     in 
-    let gids4 = { (empty ()) with   
+    let gids5 = { (empty ()) with   
       map_element_updates = [ name1, nexpr1, nexpr2, nexpr3, name2, kt, vt ]; 
       locals = StringMap.add name2 kt (StringMap.singleton name1 (A.Map (pos, kt, vt)));
     } in 
     let nexpr = A.Ident (pos, name1) in 
-    let gids = List.fold_left union (empty ()) [gids1; gids2; gids3; gids4] in 
+    let gids = List.fold_left union (empty ()) [gids1; gids2; gids3; gids4; gids5] in 
     nexpr, gids, warnings1 @ warnings2 @ warnings3 
     | StructUpdate (pos, expr1, [A.SetIndex (_, expr2)], None) as expr ->
+    let gids1 = match AH.find_type_annotation expr1 with 
+                 (*!! What to put for `kind`? *)
+    | Some ty -> mk_fresh_refinement_type_constraint Local info pos node_id expr2 ty
+    | None -> empty () 
+    in
     (* Don't supply the guard when normalizing subexpressions, 
        because we need to generate oracle variables in initial step 
        if there are unguarded pres *)
-    let nexpr1, gids1, _ = normalize_expr info node_id map expr1 in 
-    let nexpr2, gids2, _ = normalize_expr info node_id map expr2 in 
+    let nexpr1, gids2, _ = normalize_expr info node_id map expr1 in 
+    let nexpr2, gids3, _ = normalize_expr info node_id map expr2 in 
     (* Hacky: to generate correct user-facing warnings, we call normalize_expr 
        while supplying the guard, but ignore all other outputs *)
     let _, _, warnings1 = normalize_expr ?guard info node_id map expr1 in 
@@ -2270,12 +2283,12 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     | Ok (A.Set (_, ty), _, _) -> ty
     | _ -> assert false 
     in 
-    let gids3 = { (empty ()) with   
+    let gids4 = { (empty ()) with   
       set_insertions = [ name1, nexpr1, nexpr2, name2, ty ]; 
       locals = StringMap.add name2 ty (StringMap.singleton name1 (A.Set (pos, ty)));
     } in 
     let nexpr = A.Ident (pos, name1) in 
-    let gids = List.fold_left union (empty ()) [gids1; gids2; gids3] in 
+    let gids = List.fold_left union (empty ()) [gids1; gids2; gids3; gids4] in 
     nexpr, gids, warnings1 @ warnings2 
 
   | RecordProject (pos, expr, i) ->
@@ -2508,46 +2521,54 @@ and expand_node_calls_in_place info node_id var count expr =
     expand_node_call info (Some node_id) e var count
   | e -> e
 
-and normalize_ty ?(guard = None) info node_id map id ty = 
+and normalize_ty ?(guard = None) ?(id = None) info node_id map ty = 
   match ty with 
   | A.RefinementType (p1, (p2, id2, ty2), expr) -> 
-    let expr = AH.substitute_naive id2 (A.Ident (p1, id)) expr in
+    let expr, info = match id with 
+    | Some id -> 
+      AH.substitute_naive id2 (A.Ident (p1, id)) expr, info
+    | None -> expr, { info with context = Ctx.add_ty info.context id2 ty2 }
+    in 
     let info, h_gids, expr = desugar_history info expr in
     let nexpr, gids, warnings = normalize_expr info node_id map expr in
     let gids = union h_gids gids in
+    let id = match id with 
+    | Some id -> id 
+    | None -> id2 
+    in
     A.RefinementType (p1, (p2, id, ty2), nexpr), gids, warnings
   | TupleType (p, tys) -> 
-    let tys, gids, warnings = List.map (normalize_ty ~guard info node_id map id) tys |> Lib.split3 in
+    let tys, gids, warnings = List.map (normalize_ty ~guard ~id info node_id map) tys |> Lib.split3 in
     let gids = List.fold_left union (empty ()) gids in 
     let warnings = List.concat warnings in
     TupleType (p, tys), gids, warnings 
   | GroupType (p, tys) ->
-    let tys, gids, warnings = List.map (normalize_ty ~guard info node_id map id) tys |> Lib.split3 in
+    let tys, gids, warnings = List.map (normalize_ty ~guard ~id info node_id map) tys |> Lib.split3 in
     let gids = List.fold_left union (empty ()) gids in 
     let warnings = List.concat warnings in
     GroupType (p, tys), gids, warnings 
   | RecordType (p, id, tis) -> 
     let tis, gids, warnings = List.map (fun (p, id, ty) -> 
-      let ty, gids, warnings = normalize_ty ~guard info node_id map id ty in 
+      let ty, gids, warnings = normalize_ty ~guard ~id:(Some id) info node_id map ty in 
       (p, id, ty), gids, warnings 
     ) tis |> Lib.split3 in 
     let gids = List.fold_left union (empty ()) gids in 
     let warnings = List.concat warnings in
     RecordType (p, id, tis), gids, warnings 
   | ArrayType (p, (ty, len)) -> 
-    let ty, gids1, warnings1 = normalize_ty ~guard info node_id map id ty in 
+    let ty, gids1, warnings1 = normalize_ty ~guard ~id info node_id map ty in 
     let len, gids2, warnings2  = normalize_expr ?guard info node_id  map len in 
     ArrayType (p, (ty, len)), union gids1 gids2, warnings1 @ warnings2
   | TArr (p, ty1, ty2) ->
-    let ty1, gids1, warnings1 = normalize_ty ~guard info node_id map id ty1 in 
-    let ty2, gids2, warnings2 = normalize_ty ~guard info node_id map id ty2 in 
+    let ty1, gids1, warnings1 = normalize_ty ~guard ~id info node_id map ty1 in 
+    let ty2, gids2, warnings2 = normalize_ty ~guard ~id info node_id map ty2 in 
     TArr (p, ty1, ty2 ), union gids1 gids2, warnings1 @ warnings2 
   | Map (p, kt, vt) -> 
-    let kt, gids1, warnings1 = normalize_ty ~guard info node_id map id kt in 
-    let vt, gids2, warnings2 = normalize_ty ~guard info node_id map id vt in 
+    let kt, gids1, warnings1 = normalize_ty ~guard ~id info node_id map kt in 
+    let vt, gids2, warnings2 = normalize_ty ~guard ~id info node_id map vt in 
     Map (p, kt, vt), union gids1 gids2, warnings1 @ warnings2 
   | Set (p, ty) -> 
-    let ty, gids, warnings = normalize_ty ~guard info node_id map id ty in 
+    let ty, gids, warnings = normalize_ty ~guard ~id info node_id map ty in 
     Set (p, ty), gids, warnings 
   | Int _ | History _ | Bool _ | Real _ | IntRange _ 
   | UserType _ | AbstractType _ 

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -387,7 +387,7 @@ let mk_fresh_dummy_index _ =
   let name = HString.concat2 prefix (HString.mk_hstring "_index") in
   name
 
-let rec mk_enum_range_expr ?(force_prop = false) ?(mk_enum=true) ?(mk_range=true) ctx node_id expr_type expr =
+let rec mk_enum_range_expr ?(mk_enum=true) ?(mk_range=true) ctx node_id expr_type expr =
   let rec mk ctx n expr_type expr = 
     let expr_type = Chk.expand_type_syn_reftype_history ctx expr_type |> unwrap in
     match expr_type with
@@ -428,8 +428,8 @@ let rec mk_enum_range_expr ?(force_prop = false) ?(mk_enum=true) ?(mk_range=true
                 | None, Some u' -> [A.CompOp (dpos, A.Lte, expr, u'), true]
                 | None, None -> [(A.Const (dpos, A.True)), true]
           in
-          user_prop, is_original || force_prop
-        | A.Int _ -> [], false || force_prop
+          user_prop, is_original 
+        | A.Int _ -> [], false 
         | _ -> assert false
       in (match l, u with 
         | Some l, Some u -> 
@@ -626,7 +626,7 @@ and mk_ref_type_expr: Ctx.tc_context -> NodeId.t option -> A.expr -> A.lustre_ty
 
   | _ -> []
 
-let mk_range_expr ?(force_prop = false) = mk_enum_range_expr ~force_prop ~mk_enum:false ~mk_range:true
+let mk_range_expr = mk_enum_range_expr ~mk_enum:false ~mk_range:true
 
 let mk_enum_subrange_reftype_constraints node_id info vars =
   let enum_subrange_reftype_vars =
@@ -1116,8 +1116,8 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
     List.fold_left union (empty ()) gids, List.flatten warnings
 
   (* `force_prop` forces Kind 2 to treat the generated property as a real (non-candidate) property *)
-  and mk_fresh_subrange_constraint ?(force_prop = false) source info map pos node_id expr expr_type =
-    let range_exprs = mk_range_expr ~force_prop info.context node_id expr_type expr in
+  and mk_fresh_subrange_constraint source info map pos node_id expr expr_type =
+    let range_exprs = mk_range_expr info.context node_id expr_type expr in
     let gids, warnings = List.map (fun (range_expr, is_original) ->
       i := !i + 1;
       let output_expr = AH.rename_contract_vars range_expr in
@@ -1940,6 +1940,84 @@ and combine_args_with_const info args flags =
   List.fold_left over_args_arity (0, []) (List.combine args output_arity)
   |> snd |> List.rev
 
+(* The generation of type annotation constraints for maps is more complicated 
+   than for sets. Consider map[ -1 := -1 ]@<Nat, Nat>. This should generate two constraints, 
+   `-1 >= 0` (for the key) and `-1 >= 0 => -1 >= 0` (for the value). 
+   The antecedent for the value constraint states that the key satisfies its type. 
+   (We view maps as functions of sorts, and you only get the value/output guarantee if the 
+    input/key guarantee is satisfied.) Most of the extra work in this function 
+   (compared to the case of set type annotations) is in generating this implication 
+   from the generated key and value constraints. *)
+and gen_map_ty_annot_constraints_refty info gids gids' = 
+  let reftype_constraints_kt, eqs_kt = match gids.refinement_type_constraints with 
+  | [] -> [], []
+  | (_, pos, _, c) :: cs -> 
+    let e = List.fold_left (fun acc (_, _, _, c) -> 
+      A.BinaryOp (pos, And, acc, c)
+    ) c cs in 
+    i := !i + 1;
+    let id = HString.concat2 (!i |> string_of_int |> HString.mk_hstring) (HString.mk_hstring "_reftype") in
+    let nexpr = A.Ident (pos, id) in
+    let (eq_lhs, _) = generalize_to_array_expr id StringMap.empty e nexpr in
+    [Local, pos, id, e], [(info.quantified_variables, info.contract_scope, eq_lhs, e, None)]
+  in
+  let reftype_constraints_vt, eqs_vt = match gids'.refinement_type_constraints with 
+  | [] -> [], [] 
+  | (_, pos, _, c) :: cs -> 
+    let e = List.fold_left (fun acc (_, _, _, c) -> 
+      A.BinaryOp (pos, And, acc, c)
+    ) c cs in 
+    let e = match reftype_constraints_kt with 
+    | [] -> e 
+    | (_, _, _, c) :: _ -> A.BinaryOp (pos, Impl, c, e) 
+    in
+    i := !i + 1;
+    let id = HString.concat2 (!i |> string_of_int |> HString.mk_hstring) (HString.mk_hstring "_reftype") in
+    let nexpr = A.Ident (pos, id) in
+    let (eq_lhs, _) = generalize_to_array_expr id StringMap.empty e nexpr in
+    [Local, pos, id, e], [(info.quantified_variables, info.contract_scope, eq_lhs, e, None)]
+  in
+  { (union gids gids') with 
+    refinement_type_constraints = reftype_constraints_kt @ reftype_constraints_vt ; 
+    equations = eqs_kt @ eqs_vt
+  } 
+
+(* Analogous to `gen_map_ty_annot_constraints_refty`, but for subranges. 
+   See the other function for explanation. *)
+and gen_map_ty_annot_constraints_subrange info gids gids' = 
+  let subrange_constraints_kt, eqs_kt = match gids.subrange_constraints with 
+  | [] -> [], []
+  | (_, _, _, pos, _, c) :: cs -> 
+    let e = List.fold_left (fun acc (_, _, _, _, _, c) -> 
+      A.BinaryOp (pos, And, acc, c)
+    ) c cs in 
+    i := !i + 1;
+    let id = HString.concat2 (!i |> string_of_int |> HString.mk_hstring) (HString.mk_hstring "_subrange") in
+    let nexpr = A.Ident (pos, id) in
+    let (eq_lhs, _) = generalize_to_array_expr id StringMap.empty e nexpr in
+    [Local, info.contract_scope, true, pos, id, e], [(info.quantified_variables, info.contract_scope, eq_lhs, e, None)]
+  in
+  let subrange_constraints_vt, eqs_vt = match gids'.subrange_constraints with 
+  | [] -> [], [] 
+  | (_, _, _, pos, _, c) :: cs -> 
+    let e = List.fold_left (fun acc (_, _, _, _, _, c) -> 
+      A.BinaryOp (pos, And, acc, c)
+    ) c cs in 
+    let e = match subrange_constraints_kt with 
+    | [] -> e 
+    | (_, _, _, _, _, c) :: _ -> A.BinaryOp (pos, Impl, c, e) 
+    in
+    i := !i + 1;
+    let id = HString.concat2 (!i |> string_of_int |> HString.mk_hstring) (HString.mk_hstring "_reftype") in
+    let nexpr = A.Ident (pos, id) in
+    let (eq_lhs, _) = generalize_to_array_expr id StringMap.empty e nexpr in
+    [Local, info.contract_scope, true, pos, id, e], [(info.quantified_variables, info.contract_scope, eq_lhs, e, None)]
+  in
+  { (union gids gids') with 
+    subrange_constraints = subrange_constraints_kt @ subrange_constraints_vt ; 
+    equations = eqs_kt @ eqs_vt
+  } 
+
 and normalize_expr ?guard info (node_id : NI.t option) map =
   let abstract_array_literal info expr nexpr =
     let ivars = info.inductive_variables in
@@ -2257,15 +2335,15 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     nexpr, union (union gids1 gids2) gids3, warnings1 @ warnings2
   | StructUpdate (pos, expr1, [A.MapIndex (_, expr2)], Some expr3) as expr ->
     let gids1, warnings1 = match AH.find_type_annotation expr1 with 
-                 (*!! What to put for `kind`? *)
     | Some (Map (_, kt, vt)) -> 
-        (*!! SHould vt constraint be consequent of implication where antecedent is KT constraint? *)
+      (*!! Here (and in the set case) I use `Local`, as the expression may reference local variables *)
       let gids, warnings = mk_fresh_refinement_type_constraint Local info map pos node_id expr2 kt in 
       let gids', warnings' = mk_fresh_refinement_type_constraint Local info map pos node_id expr3 vt in  
-      let gids'', warnings'' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr2 kt in 
-      let gids''', warnings''' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr3 vt in  
-      let gids = List.fold_left union (empty ()) [gids; gids'; gids''; gids'''] in
-      gids,  warnings @ warnings' @ warnings'' @ warnings'''
+      let gids1 = gen_map_ty_annot_constraints_refty info gids gids' in 
+      let gids, warnings'' = mk_fresh_subrange_constraint Local info map pos node_id expr2 kt in 
+      let gids', warnings''' = mk_fresh_subrange_constraint Local info map pos node_id expr3 vt in  
+      let gids2 = gen_map_ty_annot_constraints_subrange info gids gids' in 
+      union gids1 gids2,  warnings @ warnings' @ warnings'' @ warnings'''
     | None -> empty (), []
     | _ -> assert false (* Type annotation must be `Map` type, enforced by the parser *) 
     in
@@ -2300,10 +2378,9 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     nexpr, gids, warnings1 @ warnings2 @ warnings3 @ warnings4
     | StructUpdate (pos, expr1, [A.SetIndex (_, expr2)], None) as expr ->
     let gids1, warnings1 = match AH.find_type_annotation expr1 with 
-                 (*!! What to put for `kind`? *)
     | Some ty -> 
       let gids, warnings =  mk_fresh_refinement_type_constraint Local info map pos node_id expr2 ty in
-      let gids', warnings' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr2 ty in  
+      let gids', warnings' = mk_fresh_subrange_constraint Local info map pos node_id expr2 ty in  
       union gids gids', warnings @ warnings'
     | None -> empty (), [] 
     in

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -712,24 +712,6 @@ let mk_fresh_constant pos name expr_type =
   in
   nexpr, name, gids
 
-let mk_fresh_refinement_type_constraint source info pos node_id id expr_type =
-  let ref_type_exprs = mk_ref_type_expr info.context node_id id expr_type in
-  let gids = List.map (fun ref_type_expr ->
-    i := !i + 1;
-    let output_expr = AH.rename_contract_vars ref_type_expr in
-    let prefix = HString.mk_hstring (string_of_int !i) in
-    let name = HString.concat2 prefix (HString.mk_hstring "_reftype") in
-    let nexpr = A.Ident (pos, name) in
-    let (eq_lhs, _) = generalize_to_array_expr name StringMap.empty ref_type_expr nexpr in
-    let gids = { (empty ()) with
-      refinement_type_constraints = [(source, pos, name, output_expr)];
-      equations = [(info.quantified_variables, info.contract_scope, eq_lhs, ref_type_expr, None)]; }
-    in
-    gids)
-    ref_type_exprs
-  in
-  List.fold_left union (empty ()) gids
-
 let add_step_counter info =
   let dpos = Lib.dummy_pos in
   let eq_lhs = A.StructDef (dpos, [SingleIdent (dpos, ctr_id)]) in
@@ -771,15 +753,6 @@ let add_subrange_constraints info (node_id : NI.t option) kind vars =
     let ty = get_type_of_id info node_id id in
     let ty = AIC.inline_constants_of_lustre_type info.context ty in
     union acc (mk_fresh_subrange_constraint kind info p node_id id ty))
-    (empty ())
-
-let add_ref_type_constraints info kind node_id vars =
-  vars
-  |> List.filter (fun (_, _, ty) -> 
-    Ctx.type_contains_ref info.context ty)
-  |> List.fold_left (fun acc (p, id, ty) ->
-    let ty = AIC.inline_constants_of_lustre_type info.context ty in
-    union acc (mk_fresh_refinement_type_constraint kind info p node_id (A.Ident (p, id)) ty))
     (empty ())
 
 let get_history_type ctx id =
@@ -1130,6 +1103,37 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
 
   Res.ok (ast, map, warnings)
 
+  and add_ref_type_constraints info map kind node_id vars =
+  vars
+  |> List.filter (fun (_, _, ty) -> 
+    Ctx.type_contains_ref info.context ty)
+  |> List.fold_left (fun acc (p, id, ty) ->
+    let ty = AIC.inline_constants_of_lustre_type info.context ty in
+    let gids, warnings = mk_fresh_refinement_type_constraint kind info map p node_id (A.Ident (p, id)) ty in
+    union acc gids)
+    (empty ())
+
+  and mk_fresh_refinement_type_constraint source info map pos node_id id expr_type =
+    let ref_type_exprs = mk_ref_type_expr info.context node_id id expr_type in
+    let gids, warnings = List.map (fun ref_type_expr ->
+      i := !i + 1;
+      let output_expr = AH.rename_contract_vars ref_type_expr in
+      let prefix = HString.mk_hstring (string_of_int !i) in
+      let name = HString.concat2 prefix (HString.mk_hstring "_reftype") in
+      let nexpr = A.Ident (pos, name) in
+      let (eq_lhs, _) = generalize_to_array_expr name StringMap.empty ref_type_expr nexpr in
+      (*!! Don't throw away warnings? guard? *)
+      let output_nexpr, gids1, warnings1 = normalize_expr info node_id map output_expr in
+      let ref_type_nexpr, gids2, warnings2 = normalize_expr info node_id map ref_type_expr in 
+      let gids3 = { (empty ()) with
+        refinement_type_constraints = [(source, pos, name, output_nexpr)];
+        equations = [(info.quantified_variables, info.contract_scope, eq_lhs, ref_type_nexpr, None)]; }
+      in
+      union (union gids1 gids2) gids3, warnings1 @ warnings2
+    ) ref_type_exprs |> List.split
+    in
+    List.fold_left union (empty ()) gids, List.flatten warnings
+
 (* In this function, we normalize generated identifiers that were created earlier in the pipeline. 
    It is a bit hacky with respect to how scoping is handled. More concretely, 
    because these equations were not generated within the normalizer,
@@ -1274,11 +1278,11 @@ and normalize_node_contract info (node_id : NI.t) map cref inputs outputs (id, _
   in
   let gids5 =
     let vars = List.map (fun (p,id,ty,_,_) -> (p,id,ty)) ivars in
-    add_ref_type_constraints info Input (Some node_id) vars
+    add_ref_type_constraints info map Input (Some node_id) vars
   in
   let gids6 = 
     let vars = List.map (fun (p,id,ty,_) -> (p,id,ty)) ovars in
-    add_ref_type_constraints info Output (Some node_id) vars
+    add_ref_type_constraints info map Output (Some node_id) vars
   in
   let nbody, gids7, _, warnings3 = normalize_contract info node_id map ivars ovars body in
   let gids = List.fold_left union (empty ()) [union_list gids1; union_list gids2; gids3; gids4; gids5; gids6; gids7] in
@@ -1332,13 +1336,13 @@ and normalize_node info map
     let vars = List.map (fun (p,id,ty,_,_) -> (p,id,ty)) inputs in
     let vars' = List.map (fun (p,id,_,_,_) -> (p,id)) inputs in
     union (add_subrange_constraints info (Some node_id) Input vars') 
-          (add_ref_type_constraints info Input (Some node_id) vars) 
+          (add_ref_type_constraints info map Input (Some node_id) vars) 
   in
   let gids5 = 
     let vars = List.map (fun (p,id,ty,_) -> (p,id,ty)) outputs in
     let vars' = List.map (fun (p,id,_,_) -> (p,id)) outputs in
     union (add_subrange_constraints info (Some node_id) Output vars') 
-          (add_ref_type_constraints info Output (Some node_id) vars)
+          (add_ref_type_constraints info map Output (Some node_id) vars)
   in
   (* We have to handle contracts before locals
     Otherwise the typing contexts collide *)
@@ -1370,8 +1374,9 @@ and normalize_node info map
       | A.NodeConstDecl (p, TypedConst (_, id, _, _)) ->  
         let ty = get_type_of_id info (Some node_id) id in
         let ty = AIC.inline_constants_of_lustre_type info.context ty in
-        let gids = union acc (mk_fresh_subrange_constraint Local info p (Some node_id) id ty)
-        in union gids (mk_fresh_refinement_type_constraint Local info p (Some node_id) (A.Ident (p, id)) ty)
+        let gids = union acc (mk_fresh_subrange_constraint Local info p (Some node_id) id ty) in 
+        let gids2, warnings = mk_fresh_refinement_type_constraint Local info map p (Some node_id) (A.Ident (p, id)) ty in
+        union gids gids2 
       | A.NodeConstDecl (_, FreeConst _)
       | A.NodeConstDecl (_, UntypedConst _)-> assert false)
       (empty ())
@@ -1722,10 +1727,13 @@ and normalize_contract info node_id map ivars ovars (p, items) =
                 let ty, gids, warnings = normalize_ty ~id:(Some i) info (Some node_id) map ty in
                 let new_id = StringMap.find i info.interpretation in
                 if Ctx.type_contains_subrange info.context ty || Ctx.type_contains_ref info.context ty then
+                  let gids2, warnings = 
+                    mk_fresh_refinement_type_constraint Ghost info map pos (Some node_id) (A.Ident (pos, new_id)) ty 
+                  in
                   (pos, i, ty),
                   union gids (
                   union (mk_fresh_subrange_constraint Ghost info pos (Some node_id) new_id ty)
-                        (mk_fresh_refinement_type_constraint Ghost info pos (Some node_id) (A.Ident (pos, new_id)) ty)), 
+                        gids2), 
                   warnings
                 else (pos, i, ty), gids, []
             )
@@ -2198,15 +2206,22 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
   | StructUpdate (p1, EmptyMap (p2, None), [A.MapIndex (p3, e1)], Some e2) -> 
     let kt, _, _ = Chk.infer_type_expr info.context node_id e1 |> Result.get_ok in 
     let vt, _, _ = Chk.infer_type_expr info.context node_id e2 |> Result.get_ok in 
+    (* Use base types *)
+    let kt = Chk.expand_type_syn_reftype_history_subrange info.context kt |> Result.get_ok in
+    let vt = Chk.expand_type_syn_reftype_history_subrange info.context vt |> Result.get_ok in
     let expr = A.StructUpdate (p1, EmptyMap (p2, Some (kt, vt)), [A.MapIndex (p3, e1)], Some e2) in 
     normalize_expr info node_id map expr
   | StructUpdate (p1, EmptySet (p2, None), [A.SetIndex (p3, e)], None) ->
     let ty, _, _ = Chk.infer_type_expr info.context node_id e |> Result.get_ok in
+    (* Use base types *)
+    let ty = Chk.expand_type_syn_reftype_history_subrange info.context ty |> Result.get_ok in
     let expr = A.StructUpdate (p1, EmptySet (p2, Some ty), [A.SetIndex (p3, e)], None) in 
     normalize_expr info node_id map expr
   | EmptyMap (_, None) | EmptySet (_, None) -> assert false 
   | EmptySet (pos, Some ty) -> 
     i := !i + 1;
+    (* Use base types *)
+    let ty = Chk.expand_type_syn_reftype_history_subrange info.context ty |> Result.get_ok in
     let ty, gids1, warnings = normalize_ty info None map ty in 
     let prefix = HString.mk_hstring (string_of_int !i) in
     let name = HString.concat2 prefix (HString.mk_hstring "_empty_set") in
@@ -2218,6 +2233,9 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     nexpr, union gids1 gids2, warnings 
   | EmptyMap (pos, Some (kt, vt)) -> 
     i := !i + 1;
+    (* Use base types *)
+    let kt = Chk.expand_type_syn_reftype_history_subrange info.context kt |> Result.get_ok in
+    let vt = Chk.expand_type_syn_reftype_history_subrange info.context vt |> Result.get_ok in
     let kt, gids1, warnings1 = normalize_ty info None map kt in 
     let vt, gids2, warnings2 = normalize_ty info None map vt in 
     let prefix = HString.mk_hstring (string_of_int !i) in
@@ -2229,14 +2247,12 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let nexpr = A.Ident (pos, name) in
     nexpr, union (union gids1 gids2) gids3, warnings1 @ warnings2
   | StructUpdate (pos, expr1, [A.MapIndex (_, expr2)], Some expr3) as expr ->
-    let gids1, warnings1 = match AH.find_type_annotation expr1 with 
+    let gids1, warnings = match AH.find_type_annotation expr1 with 
                  (*!! What to put for `kind`? *)
     | Some ty -> 
         (*!! Should also incorporate expr3 *)
-      let ty, gids, warnings = normalize_ty info None map ty in 
-      let gids' = mk_fresh_refinement_type_constraint Local info pos node_id expr2 ty in 
-      union gids gids', warnings
-    | None -> empty (), [] 
+      mk_fresh_refinement_type_constraint Local info map pos node_id expr2 ty
+    | None -> empty (), []
     in
     (* Don't supply the guard when normalizing subexpressions, 
        because we need to generate oracle variables in initial step 
@@ -2246,9 +2262,9 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let nexpr3, gids4, _ = normalize_expr info node_id map expr3 in 
     (* Hacky: to generate correct user-facing warnings, we call normalize_expr 
        while supplying the guard, but ignore all other outputs *)
-    let _, _, warnings2 = normalize_expr ?guard info node_id map expr1 in 
-    let _, _, warnings3 = normalize_expr ?guard info node_id map expr2 in 
-    let _, _, warnings4 = normalize_expr ?guard info node_id map expr3 in 
+    let _, _, warnings1 = normalize_expr ?guard info node_id map expr1 in 
+    let _, _, warnings2 = normalize_expr ?guard info node_id map expr2 in 
+    let _, _, warnings3 = normalize_expr ?guard info node_id map expr3 in 
     i := !i + 1; 
     let prefix = HString.mk_hstring (string_of_int !i) in 
     let name1 = HString.concat2 prefix (HString.mk_hstring "_map_update") in 
@@ -2257,20 +2273,20 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     | Ok (A.Map (_, kt, vt), _, _) -> kt, vt 
     | _ -> assert false 
     in 
+    (* Use base types *)
+    let kt = Chk.expand_type_syn_reftype_history_subrange info.context kt |> Result.get_ok in
+    let vt = Chk.expand_type_syn_reftype_history_subrange info.context vt |> Result.get_ok in
     let gids5 = { (empty ()) with   
       map_element_updates = [ name1, nexpr1, nexpr2, nexpr3, name2, kt, vt ]; 
       locals = StringMap.add name2 kt (StringMap.singleton name1 (A.Map (pos, kt, vt)));
     } in 
     let nexpr = A.Ident (pos, name1) in 
     let gids = List.fold_left union (empty ()) [gids1; gids2; gids3; gids4; gids5] in 
-    nexpr, gids, warnings1 @ warnings2 @ warnings3 @ warnings4
+    nexpr, gids, warnings1 @ warnings2 @ warnings3 
     | StructUpdate (pos, expr1, [A.SetIndex (_, expr2)], None) as expr ->
-    let gids1, warnings1 = match AH.find_type_annotation expr1 with 
+    let gids1, warnings = match AH.find_type_annotation expr1 with 
                  (*!! What to put for `kind`? *)
-    | Some ty -> 
-      let ty, gids, warnings = normalize_ty info None map ty in 
-      let gids' = mk_fresh_refinement_type_constraint Local info pos node_id expr2 ty in 
-      union gids gids', warnings
+    | Some ty -> mk_fresh_refinement_type_constraint Local info map pos node_id expr2 ty 
     | None -> empty (), [] 
     in
     (* Don't supply the guard when normalizing subexpressions, 
@@ -2280,8 +2296,8 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let nexpr2, gids3, _ = normalize_expr info node_id map expr2 in 
     (* Hacky: to generate correct user-facing warnings, we call normalize_expr 
        while supplying the guard, but ignore all other outputs *)
-    let _, _, warnings2 = normalize_expr ?guard info node_id map expr1 in 
-    let _, _, warnings3 = normalize_expr ?guard info node_id map expr2 in 
+    let _, _, warnings1 = normalize_expr ?guard info node_id map expr1 in 
+    let _, _, warnings2 = normalize_expr ?guard info node_id map expr2 in 
     i := !i + 1; 
     let prefix = HString.mk_hstring (string_of_int !i) in 
     let name1 = HString.concat2 prefix (HString.mk_hstring "_set_update") in 
@@ -2290,13 +2306,15 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     | Ok (A.Set (_, ty), _, _) -> ty
     | _ -> assert false 
     in 
+    (* Use base types *)
+    let ty = Chk.expand_type_syn_reftype_history_subrange info.context ty |> Result.get_ok in
     let gids4 = { (empty ()) with   
       set_insertions = [ name1, nexpr1, nexpr2, name2, ty ]; 
       locals = StringMap.add name2 ty (StringMap.singleton name1 (A.Set (pos, ty)));
     } in 
     let nexpr = A.Ident (pos, name1) in 
     let gids = List.fold_left union (empty ()) [gids1; gids2; gids3; gids4] in 
-    nexpr, gids, warnings1 @ warnings2 @ warnings3
+    nexpr, gids, warnings1 @ warnings2 
 
   | RecordProject (pos, expr, i) ->
     let nexpr, gids, warnings = normalize_expr ?guard info node_id map expr in
@@ -2531,19 +2549,23 @@ and expand_node_calls_in_place info node_id var count expr =
 and normalize_ty ?(guard = None) ?(id = None) info node_id map ty = 
   match ty with 
   | A.RefinementType (p1, (p2, id2, ty2), expr) -> 
-    let expr, info = match id with 
-    | Some id -> 
-      AH.substitute_naive id2 (A.Ident (p1, id)) expr, info
-    | None -> expr, { info with context = Ctx.add_ty info.context id2 ty2 }
+    let id' = match id with 
+    | Some id -> id 
+    | None -> mk_fresh_dummy_index () 
+    in
+    let expr = AH.substitute_naive id2 (A.Ident (p1, id')) expr in
+    let info = match id with 
+    | Some id -> info
+    | None -> { info with context = Ctx.add_ty info.context id' ty2 }
     in 
     let info, h_gids, expr = desugar_history info expr in
     let nexpr, gids, warnings = normalize_expr info node_id map expr in
-    let gids = union h_gids gids in
-    let id = match id with 
-    | Some id -> id 
-    | None -> id2 
+    let gids1 = union h_gids gids in
+    let gids2 = match id with 
+    | Some id -> empty () 
+    | None -> { gids with locals = StringMap.singleton id' ty2 } 
     in
-    A.RefinementType (p1, (p2, id, ty2), nexpr), gids, warnings
+    A.RefinementType (p1, (p2, id', ty2), nexpr), union gids1 gids2, warnings
   | TupleType (p, tys) -> 
     let tys, gids, warnings = List.map (normalize_ty ~guard ~id info node_id map) tys |> Lib.split3 in
     let gids = List.fold_left union (empty ()) gids in 

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -584,11 +584,9 @@ and mk_ref_type_expr: Ctx.tc_context -> NodeId.t option -> A.expr -> A.lustre_ty
     in
     let var = dpos, dummy_index, base_kt in
     let body = fun e a -> A.BinaryOp (dpos, A.Impl, a, e) in
-    let r = List.map (fun e -> 
+    List.map (fun e -> 
       A.Quantifier (dpos, A.Forall, [var], body e assumption1)
-    ) exprs1 in
-    Format.printf "r: %a\n" (Lib.pp_print_list A.pp_print_expr ", ") r;
-    r
+    ) exprs1
   | Map (_, kt, vt) -> 
     let pos = AH.pos_of_expr expr in
     let dummy_index = mk_fresh_dummy_index () in
@@ -2262,15 +2260,10 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
                  (*!! What to put for `kind`? *)
     | Some (Map (_, kt, vt)) -> 
         (*!! SHould vt constraint be consequent of implication where antecedent is KT constraint? *)
-      Format.printf "vt: %a\n"
-        A.pp_print_lustre_type vt;
       let gids, warnings = mk_fresh_refinement_type_constraint Local info map pos node_id expr2 kt in 
       let gids', warnings' = mk_fresh_refinement_type_constraint Local info map pos node_id expr3 vt in  
       let gids'', warnings'' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr2 kt in 
       let gids''', warnings''' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr3 vt in  
-      Format.printf "gids'': %a\ngids''': %a\n" 
-        pp_print_generated_identifiers gids'' 
-        pp_print_generated_identifiers gids''';
       let gids = List.fold_left union (empty ()) [gids; gids'; gids''; gids'''] in
       gids,  warnings @ warnings' @ warnings'' @ warnings'''
     | None -> empty (), []

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -387,7 +387,7 @@ let mk_fresh_dummy_index _ =
   let name = HString.concat2 prefix (HString.mk_hstring "_index") in
   name
 
-let rec mk_enum_range_expr ?(mk_enum=true) ?(mk_range=true) ctx node_id expr_type expr =
+let rec mk_enum_range_expr ?(force_prop = false) ?(mk_enum=true) ?(mk_range=true) ctx node_id expr_type expr =
   let rec mk ctx n expr_type expr = 
     let expr_type = Chk.expand_type_syn_reftype_history ctx expr_type |> unwrap in
     match expr_type with
@@ -428,8 +428,8 @@ let rec mk_enum_range_expr ?(mk_enum=true) ?(mk_range=true) ctx node_id expr_typ
                 | None, Some u' -> [A.CompOp (dpos, A.Lte, expr, u'), true]
                 | None, None -> [(A.Const (dpos, A.True)), true]
           in
-          user_prop, is_original
-        | A.Int _ -> [], false
+          user_prop, is_original || force_prop
+        | A.Int _ -> [], false || force_prop
         | _ -> assert false
       in (match l, u with 
         | Some l, Some u -> 
@@ -584,9 +584,11 @@ and mk_ref_type_expr: Ctx.tc_context -> NodeId.t option -> A.expr -> A.lustre_ty
     in
     let var = dpos, dummy_index, base_kt in
     let body = fun e a -> A.BinaryOp (dpos, A.Impl, a, e) in
-    List.map (fun e -> 
+    let r = List.map (fun e -> 
       A.Quantifier (dpos, A.Forall, [var], body e assumption1)
-    ) exprs1
+    ) exprs1 in
+    Format.printf "r: %a\n" (Lib.pp_print_list A.pp_print_expr ", ") r;
+    r
   | Map (_, kt, vt) -> 
     let pos = AH.pos_of_expr expr in
     let dummy_index = mk_fresh_dummy_index () in
@@ -626,26 +628,7 @@ and mk_ref_type_expr: Ctx.tc_context -> NodeId.t option -> A.expr -> A.lustre_ty
 
   | _ -> []
 
-let mk_range_expr = mk_enum_range_expr ~mk_enum:false ~mk_range:true
-
-let mk_fresh_subrange_constraint source info pos node_id constrained_name expr_type =
-  let expr = A.Ident(pos, constrained_name) in
-  let range_exprs = mk_range_expr info.context node_id expr_type expr in
-  let gids = List.map (fun (range_expr, is_original) ->
-    i := !i + 1;
-    let output_expr = AH.rename_contract_vars range_expr in
-    let prefix = HString.mk_hstring (string_of_int !i) in
-    let name = HString.concat2 prefix (HString.mk_hstring "_subrange") in
-    let nexpr = A.Ident (pos, name) in
-    let (eq_lhs, _) = generalize_to_array_expr name StringMap.empty range_expr nexpr in
-    let gids = { (empty ()) with
-      subrange_constraints = [(source, info.contract_scope, is_original, pos, name, output_expr)];
-      equations = [(info.quantified_variables, info.contract_scope, eq_lhs, range_expr, None)]; }
-    in
-    gids)
-    range_exprs
-  in
-  List.fold_left union (empty ()) gids
+let mk_range_expr ?(force_prop = false) = mk_enum_range_expr ~force_prop ~mk_enum:false ~mk_range:true
 
 let mk_enum_subrange_reftype_constraints node_id info vars =
   let enum_subrange_reftype_vars =
@@ -743,17 +726,6 @@ let should_not_abstract info force = function
   | A.Ident (_, id) ->
     not (Ctx.is_enum_variant info.context id) && not force
   | _ -> false
-
-let add_subrange_constraints info (node_id : NI.t option) kind vars =
-  vars
-  |> List.filter (fun (_, id) -> 
-    let ty = get_type_of_id info node_id id in
-    Ctx.type_contains_subrange info.context ty)
-  |> List.fold_left (fun acc (p, id) ->
-    let ty = get_type_of_id info node_id id in
-    let ty = AIC.inline_constants_of_lustre_type info.context ty in
-    union acc (mk_fresh_subrange_constraint kind info p node_id id ty))
-    (empty ())
 
 let get_history_type ctx id =
   let base_ty = Ctx.lookup_ty ctx id |> get in
@@ -1113,8 +1085,19 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
     union acc_gids gids, acc_w @ warnings)
     (empty (), [])
 
-  and mk_fresh_refinement_type_constraint source info map pos node_id id expr_type =
-    let ref_type_exprs = mk_ref_type_expr info.context node_id id expr_type in
+  and add_subrange_constraints info map (node_id : NI.t option) kind vars =
+  vars
+  |> List.filter (fun (_, id) -> 
+    let ty = get_type_of_id info node_id id in
+    Ctx.type_contains_subrange info.context ty)
+  |> List.fold_left (fun acc (p, id) ->
+    let ty = get_type_of_id info node_id id in
+    let ty = AIC.inline_constants_of_lustre_type info.context ty in
+    union acc (mk_fresh_subrange_constraint kind info map p node_id (A.Ident (p, id)) ty))
+    (empty ())
+
+  and mk_fresh_refinement_type_constraint source info map pos node_id expr expr_type =
+    let ref_type_exprs = mk_ref_type_expr info.context node_id expr expr_type in
     let gids, warnings = List.map (fun ref_type_expr ->
       i := !i + 1;
       let output_expr = AH.rename_contract_vars ref_type_expr in
@@ -1122,7 +1105,6 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
       let name = HString.concat2 prefix (HString.mk_hstring "_reftype") in
       let nexpr = A.Ident (pos, name) in
       let (eq_lhs, _) = generalize_to_array_expr name StringMap.empty ref_type_expr nexpr in
-      (*!! Don't throw away warnings? guard? *)
       let output_nexpr, gids1, warnings1 = normalize_expr info node_id map output_expr in
       let ref_type_nexpr, gids2, warnings2 = normalize_expr info node_id map ref_type_expr in 
       let gids3 = { (empty ()) with
@@ -1133,6 +1115,28 @@ let rec normalize ctx ai_ctx inlinable_funcs (decls:LustreAst.t) gids =
     ) ref_type_exprs |> List.split
     in
     List.fold_left union (empty ()) gids, List.flatten warnings
+
+  (* `force_prop` forces Kind 2 to treat the generated property as a real (non-candidate) property *)
+  and mk_fresh_subrange_constraint ?(force_prop = false) source info map pos node_id expr expr_type =
+    let range_exprs = mk_range_expr ~force_prop info.context node_id expr_type expr in
+    let gids = List.map (fun (range_expr, is_original) ->
+      i := !i + 1;
+      let output_expr = AH.rename_contract_vars range_expr in
+      let prefix = HString.mk_hstring (string_of_int !i) in
+      let name = HString.concat2 prefix (HString.mk_hstring "_subrange") in
+      let nexpr = A.Ident (pos, name) in
+      let (eq_lhs, _) = generalize_to_array_expr name StringMap.empty range_expr nexpr in
+      let output_nexpr, gids1, warnings1 = normalize_expr info node_id map output_expr in
+      let range_nexpr, gids2, warnings2 = normalize_expr info node_id map range_expr in 
+      let gids3 = { (empty ()) with
+        subrange_constraints = [(source, info.contract_scope, is_original, pos, name, output_nexpr)];
+        equations = [(info.quantified_variables, info.contract_scope, eq_lhs, range_nexpr, None)]; }
+      in
+      union (union gids1 gids2) gids3)
+      range_exprs
+    in
+    List.fold_left union (empty ()) gids
+
 
 (* In this function, we normalize generated identifiers that were created earlier in the pipeline. 
    It is a bit hacky with respect to how scoping is handled. More concretely, 
@@ -1269,12 +1273,12 @@ and normalize_node_contract info (node_id : NI.t) map cref inputs outputs (id, _
   let gids3 =
     let vars = List.map (fun (p,id,ty,_,_) -> (p,id,ty)) ivars in
     let vars = compute_vars inputs vars in
-    add_subrange_constraints info (Some id) Input vars
+    add_subrange_constraints info map (Some id) Input vars
   in
   let gids4 = 
     let vars = List.map (fun (p,id,ty,_) -> (p,id,ty)) ovars in
     let vars = compute_vars outputs vars in
-    add_subrange_constraints info (Some id) Output vars
+    add_subrange_constraints info map (Some id) Output vars
   in
   let gids5, warnings4 =
     let vars = List.map (fun (p,id,ty,_,_) -> (p,id,ty)) ivars in
@@ -1336,14 +1340,14 @@ and normalize_node info map
     let vars = List.map (fun (p,id,ty,_,_) -> (p,id,ty)) inputs in
     let vars' = List.map (fun (p,id,_,_,_) -> (p,id)) inputs in
     let gids, warnings = add_ref_type_constraints info map Input (Some node_id) vars in
-    union (add_subrange_constraints info (Some node_id) Input vars') 
+    union (add_subrange_constraints info map (Some node_id) Input vars') 
           gids, warnings 
   in
   let gids5, warnings5 = 
     let vars = List.map (fun (p,id,ty,_) -> (p,id,ty)) outputs in
     let vars' = List.map (fun (p,id,_,_) -> (p,id)) outputs in
     let gids, warnings = (add_ref_type_constraints info map Output (Some node_id) vars) in
-    union (add_subrange_constraints info (Some node_id) Output vars') 
+    union (add_subrange_constraints info map (Some node_id) Output vars') 
           gids, warnings 
   in
   (* We have to handle contracts before locals
@@ -1376,7 +1380,7 @@ and normalize_node info map
       | A.NodeConstDecl (p, TypedConst (_, id, _, _)) ->  
         let ty = get_type_of_id info (Some node_id) id in
         let ty = AIC.inline_constants_of_lustre_type info.context ty in
-        let gids = union acc_g (mk_fresh_subrange_constraint Local info p (Some node_id) id ty) in 
+        let gids = union acc_g (mk_fresh_subrange_constraint Local info map p (Some node_id) (A.Ident (p, id)) ty) in 
         let gids2, warnings = mk_fresh_refinement_type_constraint Local info map p (Some node_id) (A.Ident (p, id)) ty in
         union gids gids2, acc_w @ warnings 
       | A.NodeConstDecl (_, FreeConst _)
@@ -1735,7 +1739,7 @@ and normalize_contract info node_id map ivars ovars (p, items) =
                   in
                   (pos, i, ty),
                   union gids (
-                  union (mk_fresh_subrange_constraint Ghost info pos (Some node_id) new_id ty)
+                  union (mk_fresh_subrange_constraint Ghost info map pos (Some node_id) (A.Ident (p, new_id)) ty)
                         gids2), 
                   warnings1 @ warnings2 
                 else (pos, i, ty), gids, []
@@ -2252,10 +2256,21 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
   | StructUpdate (pos, expr1, [A.MapIndex (_, expr2)], Some expr3) as expr ->
     let gids1, warnings1 = match AH.find_type_annotation expr1 with 
                  (*!! What to put for `kind`? *)
-    | Some ty -> 
+    | Some (Map (_, kt, vt)) -> 
         (*!! Should also incorporate expr3 *)
-      mk_fresh_refinement_type_constraint Local info map pos node_id expr2 ty
+      Format.printf "vt: %a\n"
+        A.pp_print_lustre_type vt;
+      let gids, warnings = mk_fresh_refinement_type_constraint Local info map pos node_id expr2 kt in 
+      let gids', warnings' = mk_fresh_refinement_type_constraint Local info map pos node_id expr3 vt in  
+      let gids'' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr2 kt in 
+      let gids''' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr3 vt in  
+      Format.printf "gids'': %a\ngids''': %a\n" 
+        pp_print_generated_identifiers gids'' 
+        pp_print_generated_identifiers gids''';
+      let gids = List.fold_left union (empty ()) [gids; gids'; gids''; gids'''] in
+      gids,  warnings @ warnings'
     | None -> empty (), []
+    | _ -> assert false (* Type annotation must be `Map` type, enforced by the parser *) 
     in
     (* Don't supply the guard when normalizing subexpressions, 
        because we need to generate oracle variables in initial step 
@@ -2289,7 +2304,10 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     | StructUpdate (pos, expr1, [A.SetIndex (_, expr2)], None) as expr ->
     let gids1, warnings1 = match AH.find_type_annotation expr1 with 
                  (*!! What to put for `kind`? *)
-    | Some ty -> mk_fresh_refinement_type_constraint Local info map pos node_id expr2 ty 
+    | Some ty -> 
+      let gids, warnings =  mk_fresh_refinement_type_constraint Local info map pos node_id expr2 ty in
+      let gids' = mk_fresh_subrange_constraint ~force_prop:true Local info map pos node_id expr2 ty in  
+      union gids gids', warnings 
     | None -> empty (), [] 
     in
     (* Don't supply the guard when normalizing subexpressions, 

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1939,84 +1939,6 @@ and combine_args_with_const info args flags =
   List.fold_left over_args_arity (0, []) (List.combine args output_arity)
   |> snd |> List.rev
 
-(* The generation of type annotation constraints for maps is more complicated 
-   than for sets. Consider map[ -1 := -1 ]@<Nat, Nat>. This should generate two constraints, 
-   `-1 >= 0` (for the key) and `-1 >= 0 => -1 >= 0` (for the value). 
-   The antecedent for the value constraint states that the key satisfies its type. 
-   (We view maps as functions of sorts, and you only get the value/output guarantee if the 
-    input/key guarantee is satisfied.) Most of the extra work in this function 
-   (compared to the case of set type annotations) is in generating this implication 
-   from the generated key and value constraints. *)
-and gen_map_ty_annot_constraints_refty info gids gids' = 
-  let reftype_constraints_kt, eqs_kt = match gids.refinement_type_constraints with 
-  | [] -> [], []
-  | (_, pos, _, c) :: cs -> 
-    let e = List.fold_left (fun acc (_, _, _, c) -> 
-      A.BinaryOp (pos, And, acc, c)
-    ) c cs in 
-    i := !i + 1;
-    let id = HString.concat2 (!i |> string_of_int |> HString.mk_hstring) (HString.mk_hstring "_reftype") in
-    let nexpr = A.Ident (pos, id) in
-    let (eq_lhs, _) = generalize_to_array_expr id StringMap.empty e nexpr in
-    [Local, pos, id, e], [(info.quantified_variables, info.contract_scope, eq_lhs, e, None)]
-  in
-  let reftype_constraints_vt, eqs_vt = match gids'.refinement_type_constraints with 
-  | [] -> [], [] 
-  | (_, pos, _, c) :: cs -> 
-    let e = List.fold_left (fun acc (_, _, _, c) -> 
-      A.BinaryOp (pos, And, acc, c)
-    ) c cs in 
-    let e = match reftype_constraints_kt with 
-    | [] -> e 
-    | (_, _, _, c) :: _ -> A.BinaryOp (pos, Impl, c, e) 
-    in
-    i := !i + 1;
-    let id = HString.concat2 (!i |> string_of_int |> HString.mk_hstring) (HString.mk_hstring "_reftype") in
-    let nexpr = A.Ident (pos, id) in
-    let (eq_lhs, _) = generalize_to_array_expr id StringMap.empty e nexpr in
-    [Local, pos, id, e], [(info.quantified_variables, info.contract_scope, eq_lhs, e, None)]
-  in
-  { (union gids gids') with 
-    refinement_type_constraints = reftype_constraints_kt @ reftype_constraints_vt ; 
-    equations = eqs_kt @ eqs_vt
-  } 
-
-(* Analogous to `gen_map_ty_annot_constraints_refty`, but for subranges. 
-   See the other function for explanation. *)
-and gen_map_ty_annot_constraints_subrange info gids gids' = 
-  let subrange_constraints_kt, eqs_kt = match gids.subrange_constraints with 
-  | [] -> [], []
-  | (_, _, _, pos, _, c) :: cs -> 
-    let e = List.fold_left (fun acc (_, _, _, _, _, c) -> 
-      A.BinaryOp (pos, And, acc, c)
-    ) c cs in 
-    i := !i + 1;
-    let id = HString.concat2 (!i |> string_of_int |> HString.mk_hstring) (HString.mk_hstring "_subrange") in
-    let nexpr = A.Ident (pos, id) in
-    let (eq_lhs, _) = generalize_to_array_expr id StringMap.empty e nexpr in
-    [Local, info.contract_scope, true, pos, id, e], [(info.quantified_variables, info.contract_scope, eq_lhs, e, None)]
-  in
-  let subrange_constraints_vt, eqs_vt = match gids'.subrange_constraints with 
-  | [] -> [], [] 
-  | (_, _, _, pos, _, c) :: cs -> 
-    let e = List.fold_left (fun acc (_, _, _, _, _, c) -> 
-      A.BinaryOp (pos, And, acc, c)
-    ) c cs in 
-    let e = match subrange_constraints_kt with 
-    | [] -> e 
-    | (_, _, _, _, _, c) :: _ -> A.BinaryOp (pos, Impl, c, e) 
-    in
-    i := !i + 1;
-    let id = HString.concat2 (!i |> string_of_int |> HString.mk_hstring) (HString.mk_hstring "_reftype") in
-    let nexpr = A.Ident (pos, id) in
-    let (eq_lhs, _) = generalize_to_array_expr id StringMap.empty e nexpr in
-    [Local, info.contract_scope, true, pos, id, e], [(info.quantified_variables, info.contract_scope, eq_lhs, e, None)]
-  in
-  { (union gids gids') with 
-    subrange_constraints = subrange_constraints_kt @ subrange_constraints_vt ; 
-    equations = eqs_kt @ eqs_vt
-  } 
-
 and normalize_expr ?guard info (node_id : NI.t option) map =
   let abstract_array_literal info expr nexpr =
     let ivars = info.inductive_variables in
@@ -2337,11 +2259,11 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     | Some (Map (_, kt, vt)) -> 
       let gids, warnings = mk_fresh_refinement_type_constraint Local info map pos node_id expr2 kt in 
       let gids', warnings' = mk_fresh_refinement_type_constraint Local info map pos node_id expr3 vt in  
-      let gids1 = gen_map_ty_annot_constraints_refty info gids gids' in 
-      let gids, warnings'' = mk_fresh_subrange_constraint Local info map pos node_id expr2 kt in 
-      let gids', warnings''' = mk_fresh_subrange_constraint Local info map pos node_id expr3 vt in  
-      let gids2 = gen_map_ty_annot_constraints_subrange info gids gids' in 
-      union gids1 gids2,  warnings @ warnings' @ warnings'' @ warnings'''
+      let gids'', warnings'' = mk_fresh_subrange_constraint Local info map pos node_id expr2 kt in 
+      let gids''', warnings''' = mk_fresh_subrange_constraint Local info map pos node_id expr3 vt in  
+      let gids = List.fold_left union (empty ()) [gids; gids'; gids''; gids'''] in 
+      let warnings = warnings @ warnings' @ warnings'' @ warnings''' in
+      gids,  warnings 
     | None -> empty (), []
     | _ -> assert false (* Type annotation must be `Map` type, enforced by the parser *) 
     in

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -85,7 +85,6 @@ val error_if_lus_strict : warning_kind -> bool
 val mk_fresh_dummy_index : 'a -> HString.t
 
 val mk_enum_range_expr :
-  ?force_prop:bool ->
   ?mk_enum:bool ->
   ?mk_range:bool ->
   TypeCheckerContext.tc_context ->
@@ -100,7 +99,7 @@ val mk_ref_type_expr : TypeCheckerContext.tc_context ->
   LustreAst.lustre_type ->
   LustreAst.expr list
 
-val mk_range_expr : ?force_prop:bool -> TypeCheckerContext.tc_context ->
+val mk_range_expr : TypeCheckerContext.tc_context ->
   NodeId.t option ->
   LustreAst.lustre_type ->
   LustreAst.expr ->

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -85,6 +85,7 @@ val error_if_lus_strict : warning_kind -> bool
 val mk_fresh_dummy_index : 'a -> HString.t
 
 val mk_enum_range_expr :
+  ?force_prop:bool ->
   ?mk_enum:bool ->
   ?mk_range:bool ->
   TypeCheckerContext.tc_context ->
@@ -99,7 +100,7 @@ val mk_ref_type_expr : TypeCheckerContext.tc_context ->
   LustreAst.lustre_type ->
   LustreAst.expr list
 
-val mk_range_expr : TypeCheckerContext.tc_context ->
+val mk_range_expr : ?force_prop:bool -> TypeCheckerContext.tc_context ->
   NodeId.t option ->
   LustreAst.lustre_type ->
   LustreAst.expr ->

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -2268,8 +2268,6 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
   in let compile_struct_item struct_item = match struct_item with
     | A.SingleIdent (_, i) ->
       let ident = mk_ident i in
-      Format.printf "ident: %a\n"
-        (I.pp_print_ident true) ident;
       let expr = H.find !map.expr ident in
       let result = X.map state_var_of_expr expr in
       result, 0

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1410,10 +1410,7 @@ and compile_ast_expr
   | A.IndexAccess (_, expr, k, Map) ->
     let expr = compile_map_index bounds expr k in
     X.find_prefix [(X.TupleIndex 1)] expr
-  | A.IndexAccess _ -> 
-    Format.printf "index access expr: %a\n"
-      A.pp_print_expr expr;
-      assert false
+  | A.IndexAccess (_, _, _, Unknown) -> assert false
   (* ****************************************************************** *)
   (* Not Implemented                                                    *)
   (* ****************************************************************** *)

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -2268,6 +2268,8 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
   in let compile_struct_item struct_item = match struct_item with
     | A.SingleIdent (_, i) ->
       let ident = mk_ident i in
+      Format.printf "ident: %a\n"
+        (I.pp_print_ident true) ident;
       let expr = H.find !map.expr ident in
       let result = X.map state_var_of_expr expr in
       result, 0

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1410,7 +1410,10 @@ and compile_ast_expr
   | A.IndexAccess (_, expr, k, Map) ->
     let expr = compile_map_index bounds expr k in
     X.find_prefix [(X.TupleIndex 1)] expr
-  | A.IndexAccess _ -> assert false
+  | A.IndexAccess _ -> 
+    Format.printf "index access expr: %a\n"
+      A.pp_print_expr expr;
+      assert false
   (* ****************************************************************** *)
   (* Not Implemented                                                    *)
   (* ****************************************************************** *)

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -953,9 +953,12 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
   (* only reachable through previous 2 cases *)
   | LA.EmptyMap (_, None) | LA.EmptySet (_, None) -> assert false 
   | LA.EmptyMap (pos, Some (kt, vt)) ->
-    R.ok (LA.Map (pos, kt, vt), e, [])
+    let* kt, warnings1 = check_type_well_formed ctx Local nname true kt in 
+    let* vt, warnings2 = check_type_well_formed ctx Local nname true vt in 
+    R.ok (LA.Map (pos, kt, vt), e, warnings1 @ warnings2)
   | LA.EmptySet (pos, Some ty) -> 
-    R.ok (LA.Set (pos, ty), e, [])
+    let* ty, warnings = check_type_well_formed ctx Local nname true ty in 
+    R.ok (LA.Set (pos, ty), e, warnings)
   | LA.RecordProject (pos, e, fld) ->
     let* rec_ty, e, warnings = infer_type_expr ctx nname e in
     let* rec_ty = expand_type_syn_reftype_history ctx rec_ty in

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -953,11 +953,11 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
   (* only reachable through previous 2 cases *)
   | LA.EmptyMap (_, None) | LA.EmptySet (_, None) -> assert false 
   | LA.EmptyMap (pos, Some (kt, vt)) ->
-    let* kt, warnings1 = check_type_well_formed ctx Local nname true kt in 
-    let* vt, warnings2 = check_type_well_formed ctx Local nname true vt in 
+    let* kt, warnings1 = check_type_well_formed ctx Local nname false kt in 
+    let* vt, warnings2 = check_type_well_formed ctx Local nname false vt in 
     R.ok (LA.Map (pos, kt, vt), e, warnings1 @ warnings2)
   | LA.EmptySet (pos, Some ty) -> 
-    let* ty, warnings = check_type_well_formed ctx Local nname true ty in 
+    let* ty, warnings = check_type_well_formed ctx Local nname false ty in 
     R.ok (LA.Set (pos, ty), e, warnings)
   | LA.RecordProject (pos, e, fld) ->
     let* rec_ty, e, warnings = infer_type_expr ctx nname e in

--- a/tests/regression/falsifiable/enforce_ty_annots.lus
+++ b/tests/regression/falsifiable/enforce_ty_annots.lus
@@ -1,0 +1,13 @@
+node n () returns (set1, set2: set<[int, int]>; set3: set<int>; 
+                   map1, map2: map<[int, real], [int, real]>; map3: map<real, real>)
+let
+  set1 = { '(-1, -1) }@<subtype { x: [int, int] | pre x[0] >= 0 }>;
+  set2 = { '(-1, -1), '(-2, -2) }@<subtype { x: [int, int] | x[0] >= 0 }>;
+  set3 = { -1 }@<subtype { x: int | x >= 0 }>;
+
+  map1 = map[ '(-1, -1.0) := '(-1, 0.0) ]
+           @<subtype { x: [int, real] | pre x[0] >= 0 }, subtype { x: [int, real] | pre x[0] >= 0 }>;
+  map2 = map[ '(-1, -1.0) := '(-1, -1.0); '(-2, -2.0) := '(-1, -1.0) ]
+           @<subtype { x: [int, real] | x[1] >= 0.0 }, subtype { x: [int, real] | pre x[0] >= 0 }>;
+  map3 = map[ -1.0 := -1.0 ]@<subtype { x: real | x >= 0.0 }, subtype { x: real | x >= 0.0 }>;
+tel


### PR DESCRIPTION
See test case. There is one internal comment intentionally left in for now (starting with `(*!! ...*)`). I think it is alright, but please read and confirm if my understanding is correct. 

There was an ordering issue between normalization of types and erasure of refinement type bound variables. Consider a type annotation `{ 1 }@<subtype { x: int | x = pre x }>`. If we normalize the refinement type and then substitute, we get the constraint `1 = pre 1`. However, this violates the (post-normalization) assumption that an argument to `pre` is an identifier. So, we have to generate the refinement type constraints, and then normalize after. To do this, we have to call `normalize_expr` within `mk_fresh_refinement_type_constraint`; however, doing this required moving `mk_fresh_refinement_type_constraint` within the file so that `normalize_expr` would be in scope. I performed analogous handling for subranges.

EDIT -- internal comment addressed