### PR TITLE
Array index types

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -306,16 +306,46 @@ let new_contract_reference () =
   contract_ref := ! contract_ref + 1;
   HString.mk_hstring (string_of_int !contract_ref)
 
+(** Extract array size from an index type (IntRange or RefinementType).
+    Returns Some for IntRange with concrete bounds, None otherwise. *)
 let extract_array_size_opt = function
-  | A.ArrayType (_, (_, size)) -> (match size with
-    | A.Const (_, Num x) -> Some (x |> HString.string_of_hstring |> int_of_string)
-    | _ -> None)
+  | A.IntRange (_, lb, ub) -> (
+      match lb, ub with
+      | Some (A.Const (_, A.Num l)), Some (A.Const (_, A.Num u)) ->
+        let lv = int_of_string (HString.string_of_hstring l) in
+        let uv = int_of_string (HString.string_of_hstring u) in
+        Some (uv - lv + 1)
+      | _, _ -> None)
   | _ -> None
 
 let extract_array_size t =
   match extract_array_size_opt t with
   | Some s -> s
   | None -> assert false
+
+(** Build index type [0, size-1] for one dimension. Uses IntRange if size is
+    concrete, RefinementType otherwise. *)
+let mk_index_type pos idx_var size_expr =
+  match size_expr with
+  | A.Const (_, A.Num n) ->
+    let nv = int_of_string (HString.string_of_hstring n) in
+    let zero = A.Const (pos, A.Num (HString.mk_hstring "0")) in
+    let upper = A.Const (pos, A.Num (HString.mk_hstring (string_of_int (nv - 1)))) in
+    A.IntRange (pos, Some zero, Some upper)
+  | _ ->
+    let id = HString.mk_hstring "_" in
+    let zero = A.Const (pos, A.Num (HString.mk_hstring "0")) in
+    let bound_var = A.Ident (pos, id) in
+    let lb = A.CompOp (pos, A.Lte, zero, bound_var) in
+    let ub = A.CompOp (pos, A.Lt, bound_var, size_expr) in
+    A.RefinementType (pos, (pos, id, A.Int pos),
+      A.BinaryOp (pos, A.And, lb, ub))
+
+let rec index_types_of_array_type pos idx_vars ty : A.lustre_type list =
+  match ty, idx_vars with
+  | A.ArrayType (_, (inner_ty, size_expr)), i :: rest ->
+    index_types_of_array_type pos rest inner_ty @ [mk_index_type pos i size_expr]
+  | _, _ -> []
 
 let generalize_to_array_expr name ind_vars expr nexpr =
   let (eq_lhs, nexpr) =
@@ -823,12 +853,15 @@ let add_history_var_and_equation info id h_id =
   in
   { (empty ()) with locals; equations }
 
+(*!! Array length extraction was only working for single-dimensional arrays. 
+     And the whole thing of storing the whole array type with inductive variable didn't make sense *)
+
 let get_expr_ty info map node_id expr =
   let ty =
-  let ivars = info.inductive_variables in
+  (*let ivars = info.inductive_variables in
   if expr_has_inductive_var ivars expr then
     (StringMap.choose_opt info.inductive_variables) |> get |> snd
-  else
+  else*)
     let ctx =
       match node_id with 
       | Some node_id -> (
@@ -1767,17 +1800,22 @@ and normalize_equation info node_id map = function
     let items = match lhs with | A.StructDef (_, items) -> items in
     let info = List.fold_left (fun info item -> match item with
       | A.ArrayDef (pos, v, is) ->
-        let info = List.fold_left (fun info i -> { info with
-          context = Ctx.add_ty info.context i (A.Int pos); })
-          info
-          is
-        in
-        let ty = match Ctx.lookup_ty info.context v with 
+        let ty = match Ctx.lookup_ty info.context v with
           | Some t -> t | None -> assert false
         in
-        let ivars = List.fold_left (fun m i -> StringMap.add i ty m)
+        let index_types = index_types_of_array_type pos is ty in
+        let info = List.fold_left2
+          (fun info i index_ty ->
+            { info with context = Ctx.add_ty info.context i index_ty })
+          info
+          is
+          index_types
+        in
+        let ivars = List.fold_left2
+          (fun m i index_ty -> StringMap.add i index_ty m)
           StringMap.empty
           is
+          index_types
         in { info with inductive_variables = ivars}
       | _ -> info)
       info
@@ -1973,7 +2011,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
             args
         in
         let ind_vars = List.map 
-          (fun (v, _) -> (Lib.dummy_pos, v, A.Int Lib.dummy_pos))
+          (fun (v, ty) -> (Lib.dummy_pos, v, ty))
           (StringMap.bindings info.inductive_variables)
         in
         List.fold_left
@@ -2427,7 +2465,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
       | ArrayType _ -> A.Array
       | Map _ -> Map
       | TupleType _ -> Tuple
-      | _ -> assert false
+      | _ -> Format.printf "expr1_ty: %a\n" A.pp_print_lustre_type expr1_ty; assert false
     in
     IndexAccess (pos, nexpr1, nexpr2, kind'), union gids1 gids2, warnings1 @ warnings2
   | Quantifier (pos, kind, vars, expr) ->

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -326,7 +326,7 @@ let extract_array_size t =
 
 (** Build index type [0, size-1] for one dimension. Uses IntRange if size is
     concrete, RefinementType otherwise. *)
-let mk_index_type pos idx_var size_expr =
+let mk_index_type pos size_expr =
   match size_expr with
   | A.Const (_, A.Num n) ->
     let nv = int_of_string (HString.string_of_hstring n) in
@@ -342,11 +342,11 @@ let mk_index_type pos idx_var size_expr =
     A.RefinementType (pos, (pos, id, A.Int pos),
       A.BinaryOp (pos, A.And, lb, ub))
 
-let rec index_types_of_array_type pos idx_vars ty : A.lustre_type list =
-  match ty, idx_vars with
-  | A.ArrayType (_, (inner_ty, size_expr)), i :: rest ->
-    index_types_of_array_type pos rest inner_ty @ [mk_index_type pos i size_expr]
-  | _, _ -> []
+let rec index_types_of_array_type pos ty =
+  match ty with
+  | A.ArrayType (_, (inner_ty, size_expr)) ->
+    index_types_of_array_type pos inner_ty @ [mk_index_type pos size_expr]
+  | _ -> []
 
 let generalize_to_array_expr name ind_vars expr nexpr =
   let (eq_lhs, nexpr) =
@@ -856,10 +856,10 @@ let add_history_var_and_equation info id h_id =
 
 let get_expr_ty info map node_id expr =
   let ty =
-  (*let ivars = info.inductive_variables in
+  let ivars = info.inductive_variables in
   if expr_has_inductive_var ivars expr then
-    (StringMap.choose_opt info.inductive_variables) |> get |> snd
-  else*)
+    (StringMap.choose_opt info.inductive_variables) |> get |> snd |> snd
+  else
     let ctx =
       match node_id with 
       | Some node_id -> (
@@ -1801,7 +1801,7 @@ and normalize_equation info node_id map = function
         let ty = match Ctx.lookup_ty info.context v with
           | Some t -> t | None -> assert false
         in
-        let index_types = index_types_of_array_type pos is ty in
+        let index_types = index_types_of_array_type pos ty in
         let info = List.fold_left2
           (fun info i index_ty ->
             { info with context = Ctx.add_ty info.context i index_ty })

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -854,9 +854,6 @@ let add_history_var_and_equation info id h_id =
   in
   { (empty ()) with locals; equations }
 
-(*!! Array length extraction was only working for single-dimensional arrays. 
-     And the whole thing of storing the whole array type with inductive variable didn't make sense *)
-
 let get_expr_ty info map node_id expr =
   let ty =
   (*let ivars = info.inductive_variables in
@@ -2466,7 +2463,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
       | ArrayType _ -> A.Array
       | Map _ -> Map
       | TupleType _ -> Tuple
-      | _ -> Format.printf "expr1_ty: %a\n" A.pp_print_lustre_type expr1_ty; assert false
+      | _ -> assert false
     in
     IndexAccess (pos, nexpr1, nexpr2, kind'), union gids1 gids2, warnings1 @ warnings2
   | Quantifier (pos, kind, vars, expr) ->

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -154,7 +154,8 @@ let clear_cache () =
 type info = {
   context : Ctx.tc_context;
   abstract_interp_context : LustreAbstractInterpretation.context;
-  inductive_variables : LustreAst.lustre_type StringMap.t;
+  (* (Index variable type * array type) StringMap.t *)
+  inductive_variables : (LustreAst.lustre_type * LustreAst.lustre_type) StringMap.t;
   quantified_variables : LustreAst.typed_ident list;
   node_is_input_const : (bool list) NI.Map.t;
   contract_calls_info : LustreAst.contract_node_decl NI.Map.t;
@@ -1691,9 +1692,9 @@ and normalize_contract info node_id map ivars ovars (p, items) =
           in the future.*)
           let array_sizes =
             StringMap.fold
-              (fun v ty acc ->
+              (fun v (ind_ty, _) acc ->
                 if A.SI.mem v vars_of_calls then
-                  (v, extract_array_size_opt ty) :: acc
+                  (v, extract_array_size_opt ind_ty) :: acc
                 else acc
               )
               info.inductive_variables
@@ -1710,8 +1711,8 @@ and normalize_contract info node_id map ivars ovars (p, items) =
         let (nexpr, gids1, warnings), expanded = (
           if expand && lhs_arity <> rhs_arity then
             (match StringMap.choose_opt info.inductive_variables with
-            | Some (ivar, ty) ->
-              let size = extract_array_size ty in
+            | Some (ivar, (ind_ty, _)) ->
+              let size = extract_array_size ind_ty in
               let expanded_expr = expand_node_calls_in_place info node_id ivar size expr in
               let exprs, gids, warnings = Lib.split3 (List.init lhs_arity
                 (
@@ -1728,8 +1729,8 @@ and normalize_contract info node_id map ivars ovars (p, items) =
             
           else if expand && lhs_arity = rhs_arity then
             let expanded_expr = List.fold_left
-              (fun acc (v, ty) -> 
-                let size = extract_array_size ty in
+              (fun acc (v, (ind_ty, _)) -> 
+                let size = extract_array_size ind_ty in
                 expand_node_calls_in_place info node_id v size acc)
               expr
               (StringMap.bindings info.inductive_variables)
@@ -1812,7 +1813,7 @@ and normalize_equation info node_id map = function
           index_types
         in
         let ivars = List.fold_left2
-          (fun m i index_ty -> StringMap.add i index_ty m)
+          (fun m i index_ty -> StringMap.add i (index_ty, ty) m)
           StringMap.empty
           is
           index_types
@@ -1829,9 +1830,9 @@ and normalize_equation info node_id map = function
     let vars_of_calls = AH.vars_of_node_calls expr in
     let array_sizes =
       StringMap.fold
-        (fun v ty acc ->
+        (fun v (ind_ty, _) acc ->
           if A.SI.mem v vars_of_calls then
-            (v, extract_array_size_opt ty) :: acc
+            (v, extract_array_size_opt ind_ty) :: acc
           else acc
         )
         info.inductive_variables
@@ -1848,8 +1849,8 @@ and normalize_equation info node_id map = function
     let (nexpr, gids1, warnings), expanded = (
       if expand && lhs_arity <> rhs_arity then
         (match StringMap.choose_opt info.inductive_variables with
-        | Some (ivar, ty) ->
-          let size = extract_array_size ty in
+        | Some (ivar, (ind_ty, _)) ->
+          let size = extract_array_size ind_ty in
           let expanded_expr = expand_node_calls_in_place info node_id ivar size expr in
           let exprs, gids, warnings = Lib.split3 (List.init lhs_arity
             (fun i -> 
@@ -1862,8 +1863,8 @@ and normalize_equation info node_id map = function
         | None -> normalize_expr info (Some node_id) map expr, false)
       else if expand && lhs_arity = rhs_arity then
         let expanded_expr = List.fold_left
-          (fun acc (v, ty) -> 
-            let size = extract_array_size ty in
+          (fun acc (v, (ind_ty, _)) -> 
+            let size = extract_array_size ind_ty in
             expand_node_calls_in_place info node_id v size acc)
           expr
           (StringMap.bindings info.inductive_variables)
@@ -1891,7 +1892,7 @@ and abstract_expr ?guard force info (node_id : NI.t option) map expr =
     let ivars = info.inductive_variables in
     let pos = AH.pos_of_expr expr in
     let ty = if expr_has_inductive_var ivars expr then
-      (StringMap.choose_opt info.inductive_variables) |> get |> snd
+      (StringMap.choose_opt info.inductive_variables) |> get |> snd |> snd
     else 
       Chk.infer_type_expr info.context node_id expr |> unwrap |> fun (ty, _, _) -> ty in 
     let iexpr, gids2 = mk_fresh_local force info pos ivars ty nexpr in
@@ -1966,7 +1967,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let ivars = info.inductive_variables in
     let pos = AH.pos_of_expr expr in
     let ty = if expr_has_inductive_var ivars expr then
-      (StringMap.choose_opt info.inductive_variables) |> get |> snd
+      (StringMap.choose_opt info.inductive_variables) |> get |> snd |> snd
     else 
       Chk.infer_type_expr info.context node_id expr |> unwrap |> fun (ty, _, _) -> ty in 
     let nexpr, gids = mk_fresh_local false info pos ivars ty nexpr in
@@ -1990,7 +1991,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
       let ivars = info.inductive_variables in
       let pos = AH.pos_of_expr expr in
       let ty = if expr_has_inductive_var ivars expr then
-        (StringMap.choose_opt info.inductive_variables) |> get |> snd
+        (StringMap.choose_opt info.inductive_variables) |> get |> snd |> snd
       else 
         Chk.infer_type_expr info.context node_id expr |> unwrap |> fun (ty, _, _) -> ty in
       let iexpr, gids2 = mk_fresh_node_arg_local info pos is_const ty nexpr in
@@ -2011,7 +2012,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
             args
         in
         let ind_vars = List.map 
-          (fun (v, ty) -> (Lib.dummy_pos, v, ty))
+          (fun (v, (ind_ty, _)) -> (Lib.dummy_pos, v, ind_ty))
           (StringMap.bindings info.inductive_variables)
         in
         List.fold_left
@@ -2145,7 +2146,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
   | Pre (pos, expr) ->
     let ivars = info.inductive_variables in
     let ty, force = if expr_has_inductive_var ivars expr then
-        (StringMap.choose_opt info.inductive_variables) |> get |> snd, true
+        (StringMap.choose_opt info.inductive_variables) |> get |> snd |> snd, true
       else 
         let ty, _, _ = Chk.infer_type_expr info.context node_id expr |> unwrap in 
         ty, false

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -345,7 +345,7 @@ let mk_index_type pos size_expr =
 let rec index_types_of_array_type pos ty =
   match ty with
   | A.ArrayType (_, (inner_ty, size_expr)) ->
-    index_types_of_array_type pos inner_ty @ [mk_index_type pos size_expr]
+    mk_index_type pos size_expr :: index_types_of_array_type pos inner_ty 
   | _ -> []
 
 let generalize_to_array_expr name ind_vars expr nexpr =

--- a/tests/regression/success/array_index_types.lus
+++ b/tests/regression/success/array_index_types.lus
@@ -1,0 +1,15 @@
+type nat = subrange [0,*] of int;
+type pos = subrange [1,*] of int;
+const N: pos;
+const M: pos;
+
+transparent function F(x,y: nat) returns (o: pos | o <= M;);
+let
+  o = 1+y;
+tel
+
+
+node Obs() returns (A:int^N^M)
+let
+  A[i][j] = F(i, j);
+tel

--- a/tests/regression/success/array_index_types.lus
+++ b/tests/regression/success/array_index_types.lus
@@ -3,7 +3,7 @@ type pos = subrange [1,*] of int;
 const N: pos;
 const M: pos;
 
-transparent function F(x,y: nat) returns (o: pos | o <= M;);
+transparent function F(x,y: nat) returns (o: pos | o <= N;);
 let
   o = 1+y;
 tel


### PR DESCRIPTION
Addresses kind2-mc/kind2-dev#157

Before this PR, `info.inductive_variables` had type `lustre_type StringMap.t`, where the type was the index variable's corresponding array type. To retrieve array bounds, `extract_array_size` took the *outermost* array size. I think this is not correct in general, since index variables of a multidimensional array may have different bounds. So, I updated `info.inductive_variables` to type `(lustre_type * lustre_type) StringMap.t`, where the first type denotes the type of the index variable (subrange if concrete bound, refinement type otherwise), and the second type is the corresponding array type. Sometimes we want the former type, and sometimes the latter.