### PR TITLE
Restrict temporal types in function interface

### DIFF
--- a/src/lustre/lustreConstantsToFunctions.ml
+++ b/src/lustre/lustreConstantsToFunctions.ml
@@ -191,7 +191,7 @@ let gen_const_functions ctx decls =
         let ops = [s.start_pos, id, ty, A.ClockTrue] in
         let func_ty = A.TArr (p, GroupType (p, []), ty) in 
         let acc_ctx = Ctx.remove_const acc_ctx id in
-        let acc_ctx = Ctx.add_ty_node acc_ctx node_id func_ty in 
+        let acc_ctx = Ctx.add_ty_node acc_ctx node_id func_ty true in 
         let acc_ctx = Ctx.add_node_param_attr acc_ctx node_id [] in
         acc_decls @ [A.FuncDecl (s, (node_id, true, Default, [], [], ops, [], [], None))],
         id :: acc_new_func_ids, 
@@ -207,7 +207,7 @@ let gen_const_functions ctx decls =
         let nis = [A.Body (A.Equation (p, A.StructDef (p, [A.SingleIdent (p, id)]), e))] in 
         let func_ty = A.TArr (p, GroupType (p, []), ty) in 
         let acc_ctx = Ctx.remove_const acc_ctx id in
-        let acc_ctx = Ctx.add_ty_node acc_ctx node_id func_ty in 
+        let acc_ctx = Ctx.add_ty_node acc_ctx node_id func_ty true in 
         let acc_ctx = Ctx.add_node_param_attr acc_ctx node_id [] in
         acc_decls @ [A.FuncDecl (s, (node_id, false, Transparent, [], [], ops, [], nis, None))],
         (* Constants with definitions don't appear in `new_func_ids` because their 

--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -159,7 +159,7 @@ let contract_node_decl_to_contracts
   else R.ok ([], ctx, gids)
 
 let node_decl_to_contracts 
-= fun pos ctx (node_id, extern, _, params, inputs, outputs, locals, _, contract) ->
+= fun pos ctx (node_id, extern, _, params, inputs, outputs, locals, _, contract) is_func ->
   let base_contract = match contract with | None -> [] | Some (_, contract) -> contract in 
   let* contract', gids = mk_generated_env_contract_eqs ctx base_contract in
   let locals_as_outputs = List.map (fun local_decl -> match local_decl with 
@@ -183,7 +183,7 @@ let node_decl_to_contracts
     let environment = gen_node_id, extern, A.Opaque, params, inputs2, outputs2, [], node_items, contract' in
     if Flags.Contracts.check_environment () then 
       (* Update ctx with info about the generated node *)
-      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx environment |> unwrap in
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx environment is_func |> unwrap in
       R.ok ([environment], ctx, gids)
     else R.ok([], ctx, gids)
   else
@@ -191,12 +191,12 @@ let node_decl_to_contracts
     let contract = (gen_node_id2, extern', A.Opaque, params, inputs, locals_as_outputs @ outputs, [], node_items, contract) in
     if Flags.Contracts.check_environment () then 
       (* Update ctx with info about the generated nodes *)
-      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx environment |> unwrap in
-      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx contract |> unwrap in
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx environment is_func |> unwrap in
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx contract is_func |> unwrap in
       R.ok ([environment; contract], ctx, gids)
     else 
       (* Update ctx with info about the generated node *)
-      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx contract |> unwrap in
+      let ctx, _ = LustreTypeChecker.tc_ctx_of_node_decl pos ctx contract is_func |> unwrap in
       R.ok ([contract], ctx, gids)
 
 (* NOTE: If "ty" is a refinement type that includes a constant with
@@ -233,7 +233,7 @@ let gen_imp_nodes: Ctx.tc_context -> A.declaration list -> (A.declaration list *
         if e then p, e, opac, ps, ips, ops, locs, [A.AnnotMain (span.start_pos, true)], c
         else node_decl 
       in
-      let* decls, acc_ctx, gids = node_decl_to_contracts span.start_pos acc_ctx node_decl in
+      let* decls, acc_ctx, gids = node_decl_to_contracts span.start_pos acc_ctx node_decl false in
       let decls = List.map (fun decl -> A.NodeDecl (span, decl)) decls in
       R.ok (
         A.NodeDecl(span, node_decl) :: decls @ acc_decls, acc_ctx, 
@@ -245,7 +245,7 @@ let gen_imp_nodes: Ctx.tc_context -> A.declaration list -> (A.declaration list *
         if e then p, e, opac, ps, ips, ops, locs, [A.AnnotMain (span.start_pos, true)], c
         else func_decl 
       in
-      let* decls, acc_ctx, gids = node_decl_to_contracts span.start_pos acc_ctx func_decl in
+      let* decls, acc_ctx, gids = node_decl_to_contracts span.start_pos acc_ctx func_decl true in
       let decls = List.map (fun decl -> A.FuncDecl (span, decl)) decls in
       R.ok (
         A.FuncDecl(span, func_decl) :: decls @ acc_decls, acc_ctx, 

--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -177,7 +177,7 @@ let rec gen_poly_decl: Ctx.tc_context -> GI.t NI.Map.t -> NI.t option -> (A.decl
         let ctx = Ctx.add_ty_vars_node ctx pnname ps in
         let ctx = Ctx.add_node_param_attr ctx pnname ips in 
         let node_ty = build_node_fun_ty span.start_pos ips ops in
-        Ctx.add_ty_vars_node (Ctx.add_ty_node ctx pnname node_ty) pnname ps, 
+        Ctx.add_ty_vars_node (Ctx.add_ty_node ctx pnname node_ty true) pnname ps, 
         A.FuncDecl (span, (pnname, ext, opac, ps, ips, ops, locs, nis, c))
       else if is_contract then 
         let c = Option.get c in
@@ -192,7 +192,7 @@ let rec gen_poly_decl: Ctx.tc_context -> GI.t NI.Map.t -> NI.t option -> (A.decl
         let ctx = Ctx.add_ty_vars_node ctx pnname ps in
         let ctx = Ctx.add_node_param_attr ctx pnname ips in
         let node_ty = build_node_fun_ty span.start_pos ips ops in
-        Ctx.add_ty_vars_node (Ctx.add_ty_node ctx pnname node_ty) pnname ps, 
+        Ctx.add_ty_vars_node (Ctx.add_ty_node ctx pnname node_ty false) pnname ps, 
         NodeDecl (span, (pnname, ext, opac, ps, ips, ops, locs, nis, c))
     in
 

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -228,7 +228,7 @@ let error_message kind = match kind with
     Format.asprintf "Call requires explicit annotation; type variable %a cannot be inferred bottom-up" 
       HString.pp_print_hstring id
   | TempOperatorInFuncInterface node_id -> 
-    Format.asprintf "Interface of function %a is not allowed to use a type containing a temporal operator"
+    Format.asprintf "Interface of function %a is not allowed to use a type containing a temporal operator or node call"
       NI.pp_print_node_id_user_name node_id
 
 type warning_kind = 
@@ -1767,20 +1767,24 @@ and check_type_node_decl: Lib.position -> tc_context -> bool -> LA.node_decl -> 
       (List.map extract_ret_ctx output_vars)
     in
     (* No temporal operators in function interface *)
-    let* _ = if is_function then R.seq_ (List.map (fun (_, _, ty, _, _) -> 
+    let check_ty_for_temp_operators_or_node_calls ty = 
       let ty = expand_type_syn ctx ty in
       let combine o1 o2 = match o1, o2 with | Some x, _ | _, Some x -> Some x | None, None -> None in
       match LH.fold_lustre_ty LH.has_pre_or_arrow None combine ty with 
       | Some pos -> type_error pos (TempOperatorInFuncInterface node_name)  
-      | None -> R.ok ()
+      | None -> 
+        let contains_node_call = LH.fold_lustre_ty (expr_contains_node_call ctx_plus_ops_and_ips) false (||) ty in 
+        if contains_node_call then 
+          type_error pos (TempOperatorInFuncInterface node_name) 
+        else
+          R.ok ()
+    in
+    let* _ = if is_function then R.seq_ (List.map (fun (_, _, ty, _, _) -> 
+      check_ty_for_temp_operators_or_node_calls ty
     ) input_vars) else R.ok ()
     in
     let* _ = if is_function then R.seq_ (List.map (fun (_, _, ty, _) -> 
-      let ty = expand_type_syn ctx ty in
-      let combine o1 o2 = match o1, o2 with | Some x, _ | _, Some x -> Some x | None, None -> None in
-      match LH.fold_lustre_ty LH.has_pre_or_arrow None combine ty with 
-      | Some pos -> type_error pos (TempOperatorInFuncInterface node_name)  
-      | None -> R.ok ()
+      check_ty_for_temp_operators_or_node_calls ty
     ) output_vars) else R.ok ()
     in
     Debug.parse "Local Typing Context after extracting ips/ops/consts {%a}"
@@ -2217,8 +2221,8 @@ and tc_ctx_of_ty_decl: tc_context -> LA.type_decl -> (LA.type_decl * tc_context,
     let ctx' = add_ty_syn ctx i (LA.AbstractType (pos, i)) in
     R.ok (LA.FreeType (pos, i), add_ty_decl ctx' i)
 
-and tc_ctx_of_node_decl: Lib.position -> tc_context -> LA.node_decl -> (tc_context * [> warning] list, [> error]) result
-  = fun pos ctx (node_id, _, _, ps, ip, op, _, _, _)->
+and tc_ctx_of_node_decl: Lib.position -> tc_context -> LA.node_decl -> bool -> (tc_context * [> warning] list, [> error]) result
+  = fun pos ctx (node_id, _, _, ps, ip, op, _, _, _) is_func ->
   Debug.parse
     "Extracting type of node declaration: %a"
     NI.pp_print_node_id_user_name node_id
@@ -2229,7 +2233,7 @@ and tc_ctx_of_node_decl: Lib.position -> tc_context -> LA.node_decl -> (tc_conte
     let ctx = add_node_param_attr ctx node_id ip in
     let ctx = add_ty_vars_node ctx node_id ps in
     let* fun_ty, warnings = build_node_fun_ty pos ctx node_id ps ip op in
-    let ctx = add_ty_node ctx node_id fun_ty in 
+    let ctx = add_ty_node ctx node_id fun_ty is_func in 
     R.ok (ctx, warnings)
 (** computes the type signature of node or a function and its node summary*)
 
@@ -2320,9 +2324,11 @@ and tc_ctx_of_declaration: (LA.t * tc_context * [> warning] list) -> LA.declarat
     | LA.ConstDecl (s, const_decl) -> 
       let* const_decl, ctx, warnings = tc_ctx_const_decl ctx' Global None const_decl in 
       R.ok (decls @ [LA.ConstDecl (s, const_decl)], ctx, warnings)
-    | LA.NodeDecl ({LA.start_pos=pos}, node_decl) 
+    | LA.NodeDecl ({LA.start_pos=pos}, node_decl) as decl -> 
+      let* ctx, warnings = tc_ctx_of_node_decl pos ctx' node_decl false in 
+      R.ok (decls @ [decl], ctx, warnings)
     | LA.FuncDecl ({LA.start_pos=pos}, node_decl) as decl ->
-      let* ctx, warnings = tc_ctx_of_node_decl pos ctx' node_decl in 
+      let* ctx, warnings = tc_ctx_of_node_decl pos ctx' node_decl true in 
       R.ok (decls @ [decl], ctx, warnings)
     | LA.ContractNodeDecl ({LA.start_pos=pos} as s, contract_decl) ->
       let* ctx, warnings = tc_ctx_of_contract_node_decl pos ctx' contract_decl in 

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -2491,7 +2491,7 @@ and check_type_well_formed: tc_context -> source -> NI.t option -> bool -> tc_ty
     let ctx = add_ty ctx i ty in
     let* _ = (if is_const then 
       let ctx = add_const ctx i (LA.Ident (p, i)) ty Local in
-      check_expr_is_constant ctx "type of constant, refinement type argument, or function interface variable" e 
+      check_expr_is_constant ctx "type of constant or function interface variable" e 
     else R.ok ()) in
     let* e, warnings2 = check_type_expr ctx nname e (Bool p) in
     let* _ = check_ref_type_assumptions ctx src nname i e in 

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1716,8 +1716,8 @@ and check_type_const_decl: tc_context -> NI.t option -> LA.const_decl -> tc_type
       (R.ok (LA.TypedConst (pos, i, exp, ty), warnings))
       (type_error pos (IlltypedIdentifier (i, exp_ty, inf_ty)))
 
-and check_type_node_decl: Lib.position -> tc_context -> LA.node_decl -> (LA.node_decl * [> warning] list, [> error]) result
-  = fun pos ctx
+and check_type_node_decl: Lib.position -> tc_context -> bool -> LA.node_decl -> (LA.node_decl * [> warning] list, [> error]) result
+  = fun pos ctx is_function
         (node_name, is_extern, opacity, params, input_vars, output_vars, ldecls, items, contract)
         ->
   Debug.parse "TC declaration node: %a {" NI.pp_print_node_id_user_name node_name;
@@ -1762,6 +1762,18 @@ and check_type_node_decl: Lib.position -> tc_context -> LA.node_decl -> (LA.node
     let ctx_plus_ops_and_ips = List.fold_left union ctx_plus_ips
       (List.map extract_ret_ctx output_vars)
     in
+    let* warnings1 = (R.seq_chain (fun acc (_, _, ty, _, _) -> 
+      let is_constant = is_function in
+      let* _, warnings = check_type_well_formed ctx_plus_ops_and_ips Local (Some node_name) is_constant ty in 
+      R.ok (acc @ warnings))
+    ) [] input_vars
+    in
+    let* warnings2 = (R.seq_chain (fun acc (_, _, ty, _) -> 
+      let is_constant = is_function in
+      let* _, warnings = check_type_well_formed ctx_plus_ops_and_ips Local (Some node_name) is_constant ty in 
+      R.ok (acc @ warnings))
+    ) [] output_vars
+    in
     Debug.parse "Local Typing Context after extracting ips/ops/consts {%a}"
       pp_print_tc_context ctx_plus_ops_and_ips;
     (* Type check the contract *)
@@ -1787,12 +1799,12 @@ and check_type_node_decl: Lib.position -> tc_context -> LA.node_decl -> (LA.node
         (* Add local variable bindings to the context *)
         let local_ctx = add_local_node_ctx ctx_plus_ops_and_ips ldecls in
         (* Check locals' types and their well-formedness *)
-        let* ldecls, warnings1 = R.seq (List.map (fun local_decl -> match local_decl with 
+        let* ldecls, warnings3 = R.seq (List.map (fun local_decl -> match local_decl with 
           | LA.NodeConstDecl (p, (TypedConst (p2, i, e, ty))) -> 
             let* _ = check_expr_is_constant local_ctx "constant definition" e in
-            let* e, warnings2 = check_type_expr (add_ty local_ctx i ty) (Some node_name) e ty in 
-            let* ty, warnings3 = check_type_well_formed local_ctx Local (Some node_name) true ty in 
-            R.ok (LA.NodeConstDecl (p, (TypedConst (p2, i, e, ty))), warnings2 @ warnings3)
+            let* e, warnings1 = check_type_expr (add_ty local_ctx i ty) (Some node_name) e ty in 
+            let* ty, warnings2 = check_type_well_formed local_ctx Local (Some node_name) true ty in 
+            R.ok (LA.NodeConstDecl (p, (TypedConst (p2, i, e, ty))), warnings1 @ warnings2)
           | LA.NodeVarDecl (p, (p2, id, ty, c)) -> 
             let* ty, warnings = check_type_well_formed local_ctx Local (Some node_name) false ty in 
             R.ok (LA.NodeVarDecl (p, (p2, id, ty, c)), warnings)
@@ -1803,7 +1815,7 @@ and check_type_node_decl: Lib.position -> tc_context -> LA.node_decl -> (LA.node
         ) ldecls) |> R.map List.split in 
         Debug.parse "Local Typing Context with local state: {%a}" pp_print_tc_context local_ctx;
         (* Type check the node items now that we have all the local typing context *)
-        let* items, warnings2 = R.seq (List.map (do_item local_ctx node_name) items) |> R.map List.split in
+        let* items, warnings4 = R.seq (List.map (do_item local_ctx node_name) items) |> R.map List.split in
         (* check that the LHS of the equations are not args to node *)
         let check_lhs_eqns = List.map (fun (pos, v) ->
             if SI.mem v arg_ids then
@@ -1817,7 +1829,7 @@ and check_type_node_decl: Lib.position -> tc_context -> LA.node_decl -> (LA.node
         let decl = 
           node_name, is_extern, opacity, params, input_vars, output_vars, ldecls, items, contract 
         in
-        check_lhs_eqns >> R.ok (decl, List.flatten warnings1 @ List.flatten warnings2))
+        check_lhs_eqns >> R.ok (decl, warnings1 @ warnings2 @ List.flatten warnings3 @ List.flatten warnings4))
 
 and do_node_eqn: tc_context -> NI.t -> LA.node_equation -> (LA.node_equation * [> warning] list, [> error]) result = fun ctx nname ->
   function
@@ -2479,7 +2491,7 @@ and check_type_well_formed: tc_context -> source -> NI.t option -> bool -> tc_ty
     let ctx = add_ty ctx i ty in
     let* _ = (if is_const then 
       let ctx = add_const ctx i (LA.Ident (p, i)) ty Local in
-      check_expr_is_constant ctx "type of constant or refinement type argument" e 
+      check_expr_is_constant ctx "type of constant, refinement type argument, or function interface variable" e 
     else R.ok ()) in
     let* e, warnings2 = check_type_expr ctx nname e (Bool p) in
     let* _ = check_ref_type_assumptions ctx src nname i e in 
@@ -2719,12 +2731,12 @@ let rec type_check_group: tc_context -> LA.t ->  (LA.t * [> warning] list, [> er
   | LA.ConstDecl _ :: rest -> type_check_group global_ctx rest  
   | LA.NodeDecl (span, node_decl) :: rest ->
     let { LA.start_pos = pos } = span in
-    let* node_decl, warnings = check_type_node_decl pos global_ctx node_decl in  
+    let* node_decl, warnings = check_type_node_decl pos global_ctx false node_decl in  
     let* decls, warnings2 = type_check_group global_ctx rest in 
     R.ok (LA.NodeDecl (span, node_decl) :: decls, warnings @ warnings2)
   | LA.FuncDecl (span, node_decl):: rest ->
     let { LA.start_pos = pos } = span in
-    let* node_decl, warnings = check_type_node_decl pos global_ctx node_decl in 
+    let* node_decl, warnings = check_type_node_decl pos global_ctx true node_decl in 
     let* decls, warnings2 = type_check_group global_ctx rest in 
     R.ok (LA.FuncDecl (span, node_decl) :: decls, warnings @ warnings2)
   | LA.ContractNodeDecl (span, contract_decl) :: rest ->

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -113,6 +113,7 @@ type error_kind = Unknown of string
   | ClockMismatchInMerge
   | IllegalClockExprInActivate of LustreAst.expr
   | CallRequiresExplicitAnnotation of HString.t
+  | TempOperatorInFuncInterface of NI.t
 
 type error = [
   | `LustreTypeCheckerError of Lib.position * error_kind
@@ -226,6 +227,9 @@ let error_message kind = match kind with
   | CallRequiresExplicitAnnotation id -> 
     Format.asprintf "Call requires explicit annotation; type variable %a cannot be inferred bottom-up" 
       HString.pp_print_hstring id
+  | TempOperatorInFuncInterface node_id -> 
+    Format.asprintf "Interface of function %a is not allowed to use a type containing a temporal operator"
+      NI.pp_print_node_id_user_name node_id
 
 type warning_kind = 
   | UnusedBoundVariableWarning of HString.t
@@ -1762,17 +1766,22 @@ and check_type_node_decl: Lib.position -> tc_context -> bool -> LA.node_decl -> 
     let ctx_plus_ops_and_ips = List.fold_left union ctx_plus_ips
       (List.map extract_ret_ctx output_vars)
     in
-    let* warnings1 = (R.seq_chain (fun acc (_, _, ty, _, _) -> 
-      let is_constant = is_function in
-      let* _, warnings = check_type_well_formed ctx_plus_ops_and_ips Local (Some node_name) is_constant ty in 
-      R.ok (acc @ warnings))
-    ) [] input_vars
+    (* No temporal operators in function interface *)
+    let* _ = if is_function then R.seq_ (List.map (fun (_, _, ty, _, _) -> 
+      let ty = expand_type_syn ctx ty in
+      let combine o1 o2 = match o1, o2 with | Some x, _ | _, Some x -> Some x | None, None -> None in
+      match LH.fold_lustre_ty LH.has_pre_or_arrow None combine ty with 
+      | Some pos -> type_error pos (TempOperatorInFuncInterface node_name)  
+      | None -> R.ok ()
+    ) input_vars) else R.ok ()
     in
-    let* warnings2 = (R.seq_chain (fun acc (_, _, ty, _) -> 
-      let is_constant = is_function in
-      let* _, warnings = check_type_well_formed ctx_plus_ops_and_ips Local (Some node_name) is_constant ty in 
-      R.ok (acc @ warnings))
-    ) [] output_vars
+    let* _ = if is_function then R.seq_ (List.map (fun (_, _, ty, _) -> 
+      let ty = expand_type_syn ctx ty in
+      let combine o1 o2 = match o1, o2 with | Some x, _ | _, Some x -> Some x | None, None -> None in
+      match LH.fold_lustre_ty LH.has_pre_or_arrow None combine ty with 
+      | Some pos -> type_error pos (TempOperatorInFuncInterface node_name)  
+      | None -> R.ok ()
+    ) output_vars) else R.ok ()
     in
     Debug.parse "Local Typing Context after extracting ips/ops/consts {%a}"
       pp_print_tc_context ctx_plus_ops_and_ips;
@@ -1799,7 +1808,7 @@ and check_type_node_decl: Lib.position -> tc_context -> bool -> LA.node_decl -> 
         (* Add local variable bindings to the context *)
         let local_ctx = add_local_node_ctx ctx_plus_ops_and_ips ldecls in
         (* Check locals' types and their well-formedness *)
-        let* ldecls, warnings3 = R.seq (List.map (fun local_decl -> match local_decl with 
+        let* ldecls, warnings1 = R.seq (List.map (fun local_decl -> match local_decl with 
           | LA.NodeConstDecl (p, (TypedConst (p2, i, e, ty))) -> 
             let* _ = check_expr_is_constant local_ctx "constant definition" e in
             let* e, warnings1 = check_type_expr (add_ty local_ctx i ty) (Some node_name) e ty in 
@@ -1815,7 +1824,7 @@ and check_type_node_decl: Lib.position -> tc_context -> bool -> LA.node_decl -> 
         ) ldecls) |> R.map List.split in 
         Debug.parse "Local Typing Context with local state: {%a}" pp_print_tc_context local_ctx;
         (* Type check the node items now that we have all the local typing context *)
-        let* items, warnings4 = R.seq (List.map (do_item local_ctx node_name) items) |> R.map List.split in
+        let* items, warnings2 = R.seq (List.map (do_item local_ctx node_name) items) |> R.map List.split in
         (* check that the LHS of the equations are not args to node *)
         let check_lhs_eqns = List.map (fun (pos, v) ->
             if SI.mem v arg_ids then
@@ -1829,7 +1838,7 @@ and check_type_node_decl: Lib.position -> tc_context -> bool -> LA.node_decl -> 
         let decl = 
           node_name, is_extern, opacity, params, input_vars, output_vars, ldecls, items, contract 
         in
-        check_lhs_eqns >> R.ok (decl, warnings1 @ warnings2 @ List.flatten warnings3 @ List.flatten warnings4))
+        check_lhs_eqns >> R.ok (decl, List.flatten warnings1 @ List.flatten warnings2))
 
 and do_node_eqn: tc_context -> NI.t -> LA.node_equation -> (LA.node_equation * [> warning] list, [> error]) result = fun ctx nname ->
   function
@@ -2491,7 +2500,7 @@ and check_type_well_formed: tc_context -> source -> NI.t option -> bool -> tc_ty
     let ctx = add_ty ctx i ty in
     let* _ = (if is_const then 
       let ctx = add_const ctx i (LA.Ident (p, i)) ty Local in
-      check_expr_is_constant ctx "type of constant or function interface variable" e 
+      check_expr_is_constant ctx "type of constant" e 
     else R.ok ()) in
     let* e, warnings2 = check_type_expr ctx nname e (Bool p) in
     let* _ = check_ref_type_assumptions ctx src nname i e in 

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -98,6 +98,7 @@ type error_kind = Unknown of string
   | ClockMismatchInMerge
   | IllegalClockExprInActivate of LustreAst.expr
   | CallRequiresExplicitAnnotation of HString.t
+  | TempOperatorInFuncInterface of NodeId.t 
 
 type error = [
   | `LustreTypeCheckerError of Lib.position * error_kind

--- a/src/lustre/lustreTypeChecker.mli
+++ b/src/lustre/lustreTypeChecker.mli
@@ -220,7 +220,7 @@ val tc_ctx_of_contract_node_decl: Lib.position -> tc_context
   -> LA.contract_node_decl
   -> (tc_context * [> warning] list, [> error]) result
 
-val tc_ctx_of_node_decl: Lib.position -> tc_context -> LA.node_decl -> (tc_context * [> warning] list, [> error]) result
+val tc_ctx_of_node_decl: Lib.position -> tc_context -> LA.node_decl -> bool -> (tc_context * [> warning] list, [> error]) result
 
 
 val expr_contains_set_binop: tc_context -> NI.t option -> LA.expr -> bool 

--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -48,8 +48,11 @@ type ty_alias_store = tc_type IMap.t
 type ty_store = tc_type IMap.t
 (** A store of identifier and their types*)
 
-type node_ty_store = tc_type NI.Map.t
-(** A store of identifier and their types*)
+type node_ty_store = (tc_type * bool) NI.Map.t
+(** A store of identifier and their types. Bool is true iff the component is a function *)
+
+type contract_ty_store = tc_type NI.Map.t
+(** A store of contract identifier and their types. *)
 
 (** A store of monomorphized node names and their type arguments *)
 
@@ -82,7 +85,7 @@ type param_store = (HString.t * bool) list NI.Map.t
 
 type tc_context = { ty_syns: ty_alias_store       (* store of the type alias mappings *)
                   ; ty_ctx: ty_store              (* store of the types of identifiers and nodes *)
-                  ; contract_ctx: node_ty_store        (* store of the types of contracts *)
+                  ; contract_ctx: contract_ty_store        (* store of the types of contracts *)
                   ; node_ctx: node_ty_store       (* store of the types of nodes *)
                   ; node_param_attr: param_store  (* store of the parameter attributes of nodes *)
                   ; vl_ctx: const_store           (* store of typed constants to its value *)
@@ -228,11 +231,11 @@ let lookup_ty: tc_context -> LA.ident -> tc_type option
 (** Picks out the type of the identifier to type context map *)
 
 let lookup_contract_ty: tc_context -> NI.t -> tc_type option
-  = fun ctx i -> NI.Map.find_opt i (ctx.contract_ctx)
+  = fun ctx i -> NI.Map.find_opt i (ctx.contract_ctx) 
 (** Lookup a contract type  *)
                
 let lookup_node_ty: tc_context -> NI.t -> tc_type option
-  = fun ctx i -> NI.Map.find_opt i (ctx.node_ctx)
+  = fun ctx i -> NI.Map.find_opt i (ctx.node_ctx) |> Option.map fst
 (** Lookup a node type  *)
 
 let lookup_node_ty_vars: tc_context -> NI.t -> HString.t list option
@@ -276,8 +279,9 @@ let add_ty_contract: tc_context -> NI.t -> tc_type -> tc_context
   = fun ctx i ty -> {ctx with contract_ctx = NI.Map.add i ty (ctx.contract_ctx)}
 (**  Add the type of the contract *)
 
-let add_ty_node: tc_context -> NI.t -> tc_type -> tc_context
-  = fun ctx i ty -> {ctx with node_ctx = NI.Map.add i ty (ctx.node_ctx)}
+let add_ty_node: tc_context -> NI.t -> tc_type -> bool -> tc_context
+  = fun ctx i ty is_func -> {ctx with node_ctx = 
+  NI.Map.add i (ty, is_func) (ctx.node_ctx)}
 (**  Add the type of the node *)
 
 let add_ty_vars_node: tc_context -> NI.t -> LA.ident list -> tc_context
@@ -426,7 +430,15 @@ let pp_print_type_binding: Format.formatter -> (LA.ident * tc_type) -> unit
   = fun ppf (i, ty) -> Format.fprintf ppf "(%a:%a)" LA.pp_print_ident i LA.pp_print_lustre_type ty
 (** Pretty print type bindings*)  
 
-let pp_print_type_binding_node: Format.formatter -> (NI.t * tc_type) -> unit
+let pp_print_type_binding_node: Format.formatter -> (NI.t * (tc_type * bool)) -> unit
+  = fun ppf (i, (ty, is_func)) -> 
+    if is_func then 
+      Format.fprintf ppf "(function %a:%a)" NI.pp_print_node_id_user_name i LA.pp_print_lustre_type ty
+    else 
+      Format.fprintf ppf "(node %a:%a)" NI.pp_print_node_id_user_name i LA.pp_print_lustre_type ty
+(** Pretty print type bindings*)  
+
+let pp_print_type_binding_contract: Format.formatter -> (NI.t * tc_type) -> unit
   = fun ppf (i, ty) -> Format.fprintf ppf "(%a:%a)" NI.pp_print_node_id_user_name i LA.pp_print_lustre_type ty
 (** Pretty print type bindings*)  
 
@@ -463,6 +475,10 @@ let pp_print_tymap: Format.formatter -> ty_store -> unit
 
 let pp_print_tymap_node: Format.formatter -> node_ty_store -> unit
   = fun ppf m -> Lib.pp_print_list (pp_print_type_binding_node) ", " ppf (NI.Map.bindings m)
+(** Pretty print type binding context *)
+
+let pp_print_tymap_contract: Format.formatter -> contract_ty_store -> unit
+  = fun ppf m -> Lib.pp_print_list (pp_print_type_binding_contract) ", " ppf (NI.Map.bindings m)
 (** Pretty print type binding context *)
                
 let pp_print_vstore: Format.formatter -> const_store -> unit
@@ -518,7 +534,7 @@ let pp_print_tc_context: Format.formatter -> tc_context -> unit
       pp_print_ty_syns (ctx.ty_syns)
       pp_print_tymap (ctx.ty_ctx)
       pp_print_tymap_node (ctx.node_ctx)
-      pp_print_tymap_node (ctx.contract_ctx)
+      pp_print_tymap_contract (ctx.contract_ctx)
       pp_print_vstore (ctx.vl_ctx)
       pp_print_u_types (ctx.u_types)
       pp_print_contract_exports (ctx.contract_export_ctx)
@@ -922,3 +938,43 @@ and ty_vars_of_type ctx node_name ty =
   )
   | History _ | Int _ | Bool _ | IntRange _ | Real _  | EnumType _ 
   | SBitVector _ | UBitVector _ -> SI.empty
+
+
+let node_id_is_node = fun ctx node_id -> 
+  match NI.Map.find_opt node_id ctx.node_ctx with 
+  | Some (_, is_func) -> not is_func 
+  | None -> false
+
+let rec expr_contains_node_call ctx expr = 
+  let r = expr_contains_node_call ctx in
+  match expr with
+  | LA.Ident (_, _) | ModeRef (_, _) | Const (_, _) -> false 
+  | EmptySet (_, Some ty) -> 
+    LH.fold_lustre_ty r false (||) ty
+  | EmptySet (_, None)
+  | EmptyMap (_, None) -> false
+  | EmptyMap (_, Some (kt, vt)) ->
+    LH.fold_lustre_ty r false (||) kt || 
+    LH.fold_lustre_ty r false (||) vt
+  | RecordProject (_, e, _) | UnaryOp (_, _, e)
+  | ConvOp (_, _, e) | Quantifier (_, _, _, e) | When (_, e, _)
+  | Pre (_, e) | Extract (_, e, _, _) | StructUpdate (_, e, _, None)
+    -> r e
+  | BinaryOp (_, _, e1, e2) | CompOp (_, _, e1, e2) | StructUpdate (_, e1, _, Some e2)
+  | ArrayConstr (_, e1, e2) | IndexAccess (_, e1, e2, _)
+  | Arrow (_, e1, e2)
+    -> r e1 || r e2
+  | TernaryOp (_, _, e1, e2, e3)
+    -> r e1 || r e2 || r e3
+  | GroupExpr (_, _, expr_list)
+    -> List.fold_left (fun acc x -> acc || r x) false expr_list
+  | RecordExpr (_, _, _, expr_list) | Merge (_, _, expr_list)
+    -> List.fold_left (fun acc (_, e) -> acc || r e) false expr_list
+  | Activate (_, _, e1, e2, expr_list) -> 
+    r e1 || r e2
+    || List.fold_left (fun acc x -> acc || r x) false expr_list
+  | AnyOp (_, _, _) -> true 
+  | ChooseOp (_, _, _) -> false
+  | Call (_, _, ni, _) | Condact (_, _, _, ni, _, _) | RestartEvery (_, ni, _, _) -> 
+    node_id_is_node ctx ni  
+

--- a/src/lustre/typeCheckerContext.mli
+++ b/src/lustre/typeCheckerContext.mli
@@ -134,8 +134,8 @@ val add_ty_syn: tc_context -> LA.ident -> tc_type -> tc_context
 val add_ty: tc_context -> LA.ident -> tc_type -> tc_context
 (** Add type binding into the typing context *)
 
-val add_ty_node: tc_context -> NI.t -> tc_type -> tc_context
-(** Add node/function type binding into the typing context *)
+val add_ty_node: tc_context -> NI.t -> tc_type -> bool -> tc_context
+(** Add node/function type binding into the typing context. Bool arg is true iff the component is a function *)
 
 val add_ty_vars_node: tc_context -> NI.t -> HString.t list -> tc_context 
 (** Add node/function type variables into the typing context *)
@@ -300,3 +300,6 @@ val ty_vars_of_expr: tc_context -> NI.t -> LA.expr -> SI.t
 
 val ty_vars_of_type: tc_context -> NI.t -> LA.lustre_type -> SI.t
 (** [ty_vars_of_type ctx node_id ty] returns all type variable identifiers that appear in the type [ty] *)
+
+val expr_contains_node_call: tc_context -> LA.expr -> bool
+(** [expr_contains_node_call ctx expr] returns true iff `expr` contains a node (NOT a function) call *)

--- a/tests/ounit/lustre/lustreTypeChecker/temporal_fun_contract.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/temporal_fun_contract.lus
@@ -1,0 +1,7 @@
+function f (inp: subtype { x: int | true -> x > pre x }) returns (out: subtype { x: int | true -> x > pre x })
+(* @contract
+  assume true -> inp > pre inp;
+*)
+let
+  out = inp;
+tel

--- a/tests/ounit/lustre/lustreTypeChecker/temporal_fun_contract_2.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/temporal_fun_contract_2.lus
@@ -1,0 +1,8 @@
+node N() returns (out: int)
+let
+tel
+
+function f (inp: int) returns (out: subtype { x: int | x > N() })
+let
+  out = inp;
+tel

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -216,6 +216,10 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
 (*                   Lustre Ast Array Dependencies Checks                      *)
 (* *************************************************************************** *)
 let _ = run_test_tt_main ("frontend lustreArrayDependencies error tests" >::: [
+  mk_test "test function contract with temporal interface" (fun () ->
+    match load_file "./lustreTypeChecker/temporal_fun_contract.lus" with
+    | Error (`LustreTypeCheckerError (_, ExpectedConstant _)) -> true
+    | _ -> false); 
   mk_test "test record type inference 1" (fun () ->
     match load_file "./lustreTypeChecker/record_type_inference_1.lus" with
     | Error (`LustreTypeCheckerError (_, IlltypedRecord _)) -> true

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -218,7 +218,7 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
 let _ = run_test_tt_main ("frontend lustreArrayDependencies error tests" >::: [
   mk_test "test function contract with temporal interface" (fun () ->
     match load_file "./lustreTypeChecker/temporal_fun_contract.lus" with
-    | Error (`LustreTypeCheckerError (_, ExpectedConstant _)) -> true
+    | Error (`LustreTypeCheckerError (_, TempOperatorInFuncInterface _)) -> true
     | _ -> false); 
   mk_test "test record type inference 1" (fun () ->
     match load_file "./lustreTypeChecker/record_type_inference_1.lus" with

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -216,6 +216,10 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
 (*                   Lustre Ast Array Dependencies Checks                      *)
 (* *************************************************************************** *)
 let _ = run_test_tt_main ("frontend lustreArrayDependencies error tests" >::: [
+  mk_test "test function contract with temporal interface 2" (fun () ->
+    match load_file "./lustreTypeChecker/temporal_fun_contract_2.lus" with
+    | Error (`LustreTypeCheckerError (_, TempOperatorInFuncInterface _)) -> true
+    | _ -> false); 
   mk_test "test function contract with temporal interface" (fun () ->
     match load_file "./lustreTypeChecker/temporal_fun_contract.lus" with
     | Error (`LustreTypeCheckerError (_, TempOperatorInFuncInterface _)) -> true


### PR DESCRIPTION
Conservatively reject temporal operators in the types of function interfaces.

Note/question: Re-reading the old error message "`type of constant or refinement type argument`", what does `refinement type argument` mean here? Is it what we intend?

EDIT: updated the error message