### PR TITLE
 Convert ghost constants into variables in generated environment

### DIFF
--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -90,10 +90,38 @@ let rec expr_contains_mode_ref expr =
   | AnyOp (_, _, _) | ChooseOp (_, _, _)
     -> false
 
-let mk_generated_env_contract_eqs ctx base_contract = 
+let mk_generated_env_contract_eqs ctx node_id base_contract =
   let* res = R.seq (List.map (fun ci -> 
     match ci with
-    | A.GhostConst _ | GhostVars _ -> R.ok (Some (ci, GI.empty ()))
+    (* Ghost constant definitions are converted into ghost variable definitions
+       because the definition may include constant inputs from the original contract
+       that become outputs in the generated contract. This avoids failures when
+       the constant definition includes outputs that are not constant in the new
+       generated contract.
+    *)
+    | A.GhostConst (TypedConst (pos, id, exp, ty)) -> (
+      let ci =
+        A.GhostVars (pos, GhostVarDec (pos, [(pos, id, ty)]), exp)
+      in
+      R.ok (Some (ci, GI.empty ()))
+    )
+    | A.GhostConst (UntypedConst (pos, id, exp)) -> (
+      let contract_ctx =
+        Chk.tc_ctx_of_contract ~ignore_modes:true ctx Ghost node_id (pos, base_contract)
+        |> unwrap |> (fun (_, ctx, _) -> ctx)
+      in
+      let ty =
+        match Ctx.lookup_const contract_ctx id with
+        | Some (_, Some ty, _) -> ty
+        | _ -> assert false
+      in
+      let ci =
+        A.GhostVars (pos, GhostVarDec (pos, [(pos, id, ty)]), exp)
+      in
+      R.ok (Some (ci, GI.empty ()))
+    )
+    | A.GhostConst (FreeConst _)
+    | A.GhostVars _ -> R.ok (Some (ci, GI.empty ()))
     | A.Assume (pos, name, b, expr) ->
       if expr_contains_mode_ref expr then mk_error pos EnvRealizabilityCheckModeRefAssumption else
       R.ok (Some (A.Guarantee (pos, name, b, expr), GI.empty ()))
@@ -145,7 +173,7 @@ let mk_swapped_inputs_and_outputs ctx inputs outputs =
 
 let contract_node_decl_to_contracts
 = fun ctx (node_id, params, inputs, outputs, (pos, base_contract)) -> 
-  let* contract', gids = mk_generated_env_contract_eqs ctx base_contract in
+  let* contract', gids = mk_generated_env_contract_eqs ctx node_id base_contract in
   let gen_node_id = NI.mk_node_id ~node_type:Environment (NI.get_name node_id) in
   let inputs2, outputs2 = mk_swapped_inputs_and_outputs ctx inputs outputs in
   (* We generate a contract representing this contract's inputs/environment *)
@@ -161,7 +189,7 @@ let contract_node_decl_to_contracts
 let node_decl_to_contracts 
 = fun pos ctx (node_id, extern, _, params, inputs, outputs, locals, _, contract) is_func ->
   let base_contract = match contract with | None -> [] | Some (_, contract) -> contract in 
-  let* contract', gids = mk_generated_env_contract_eqs ctx base_contract in
+  let* contract', gids = mk_generated_env_contract_eqs ctx node_id base_contract in
   let locals_as_outputs = List.map (fun local_decl -> match local_decl with 
     | A.NodeConstDecl (pos, FreeConst (_, id, ty)) 
     | A.NodeConstDecl (pos, TypedConst (_, id, _, ty)) ->  Some (pos, id, ty, A.ClockTrue)

--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -173,7 +173,10 @@ let mk_swapped_inputs_and_outputs ctx inputs outputs =
 
 let contract_node_decl_to_contracts
 = fun ctx (node_id, params, inputs, outputs, (pos, base_contract)) -> 
-  let* contract', gids = mk_generated_env_contract_eqs ctx node_id base_contract in
+  let contract_ctx = Chk.add_full_node_ctx ctx node_id params inputs outputs [] in
+  let* contract', gids =
+    mk_generated_env_contract_eqs contract_ctx node_id base_contract
+  in
   let gen_node_id = NI.mk_node_id ~node_type:Environment (NI.get_name node_id) in
   let inputs2, outputs2 = mk_swapped_inputs_and_outputs ctx inputs outputs in
   (* We generate a contract representing this contract's inputs/environment *)
@@ -189,7 +192,10 @@ let contract_node_decl_to_contracts
 let node_decl_to_contracts 
 = fun pos ctx (node_id, extern, _, params, inputs, outputs, locals, _, contract) is_func ->
   let base_contract = match contract with | None -> [] | Some (_, contract) -> contract in 
-  let* contract', gids = mk_generated_env_contract_eqs ctx node_id base_contract in
+  let contract_ctx = Chk.add_full_node_ctx ctx node_id params inputs outputs locals in
+  let* contract', gids =
+    mk_generated_env_contract_eqs contract_ctx node_id base_contract
+  in
   let locals_as_outputs = List.map (fun local_decl -> match local_decl with 
     | A.NodeConstDecl (pos, FreeConst (_, id, ty)) 
     | A.NodeConstDecl (pos, TypedConst (_, id, _, ty)) ->  Some (pos, id, ty, A.ClockTrue)


### PR DESCRIPTION
After this PR, Kind 2 converts ghost constant definitions into ghost variable definitions in the generated contract for an environment component. The change is necessary because the definition may include constant inputs from the original contract that become outputs in the generated contract. Converting them prevents failures when the constant definition references outputs that are not constant in the generated contract.

For instance, when checking realizability for the following input:
```
node imported Controller (const TH, UB, ERR: real; alt: real) returns (pitch: real);
(*@contract
  const LIMIT = TH - (UB + 2.0*ERR);
  guarantee "L1" alt > LIMIT => pitch < 0.0;
*)
```