### PR TITLE
Support any/choose ops at the type level

### DIFF
--- a/src/lustre/lustreDesugarAnyChooseOps.ml
+++ b/src/lustre/lustreDesugarAnyChooseOps.ml
@@ -45,16 +45,16 @@ fun ctx node_name fun_ids ty ->
     let vt, gen_nodes2 = r vt in
     Map (p, kt, vt), gen_nodes1 @ gen_nodes2
   | Set (p, ty) ->
-    let ty', gen_nodes = r ty in
-    Set (p, ty'), gen_nodes  
+    let ty, gen_nodes = r ty in
+    Set (p, ty), gen_nodes  
   | ArrayType (p, (ty, len)) ->
-    let ty', gen_nodes1 = r ty in
-    let len', gen_nodes2 = desugar_expr ctx node_name fun_ids len in
-    ArrayType (p, (ty', len')), gen_nodes1 @ gen_nodes2
+    let ty, gen_nodes1 = r ty in
+    let len, gen_nodes2 = desugar_expr ctx node_name fun_ids len in
+    ArrayType (p, (ty, len)), gen_nodes1 @ gen_nodes2
   | TArr (p, ty1, ty2) ->
-    let ty1', gen_nodes1 = r ty1 in
-    let ty2', gen_nodes2 = r ty2 in
-    TArr (p, ty1', ty2'), gen_nodes1 @ gen_nodes2
+    let ty1, gen_nodes1 = r ty1 in
+    let ty2, gen_nodes2 = r ty2 in
+    TArr (p, ty1, ty2), gen_nodes1 @ gen_nodes2
   | GroupType (p, tys) ->
     let tys, gen_nodes = List.map r tys |> List.split in
     GroupType (p, tys), List.flatten gen_nodes 
@@ -62,12 +62,12 @@ fun ctx node_name fun_ids ty ->
     let tys, gen_nodes = List.map r tys |> List.split in
     TupleType (p, tys), List.flatten gen_nodes 
   | RecordType (p, id, tis) ->
-    let tis, gen_nodes = List.map (fun (p, id, ty) -> let ty', d = r ty in (p, id, ty'), d) tis |> List.split in
+    let tis, gen_nodes = List.map (fun (p, id, ty) -> let ty, d = r ty in (p, id, ty), d) tis |> List.split in
     RecordType (p, id, tis), List.flatten gen_nodes
   | RefinementType (p1, (p2, id, ty), e) ->
-    let ty', gen_nodes1 = r ty in
-    let e', gen_nodes2 = desugar_expr ctx node_name fun_ids e in
-    RefinementType (p1, (p2, id, ty'), e'), gen_nodes1 @ gen_nodes2
+    let ty, gen_nodes1 = r ty in
+    let e, gen_nodes2 = desugar_expr ctx node_name fun_ids e in
+    RefinementType (p1, (p2, id, ty), e), gen_nodes1 @ gen_nodes2
 
 and desugar_expr: Ctx.tc_context -> NI.t -> NI.t list -> A.expr -> A.expr * A.declaration list =
 fun ctx node_name fun_ids expr -> 
@@ -132,8 +132,8 @@ fun ctx node_name fun_ids expr ->
   | ModeRef (_, _) as e -> e, []
   | A.EmptySet (pos, None) -> A.EmptySet (pos, None), []
   | A.EmptySet (pos, Some ty) ->
-    let ty', gen_nodes = desugar_type ctx node_name fun_ids ty in
-    A.EmptySet (pos, Some ty'), gen_nodes
+    let ty, gen_nodes = desugar_type ctx node_name fun_ids ty in
+    A.EmptySet (pos, Some ty), gen_nodes
   | A.EmptyMap (pos, None) -> A.EmptyMap (pos, None), []
   | A.EmptyMap (pos, Some (kt, vt)) ->
     let kt', gen_nodes1 = desugar_type ctx node_name fun_ids kt in
@@ -191,9 +191,9 @@ fun ctx node_name fun_ids expr ->
     let e2, gen_nodes2 = rec_call e2 in
     IndexAccess (pos, e1, e2, kind), gen_nodes1 @ gen_nodes2
   | Quantifier (pos, kind, tis , e) ->
-    let tis, gen_nodes_ty = List.map (fun (p, id', ty) ->
-      let ty', gen_nodes = desugar_type ctx node_name fun_ids ty in
-      (p, id', ty'), gen_nodes
+    let tis, gen_nodes_ty = List.map (fun (p, id, ty) ->
+      let ty, gen_nodes = desugar_type ctx node_name fun_ids ty in
+      (p, id, ty), gen_nodes
     ) tis |> List.split in
     let e, gen_nodes = rec_call e in
     Quantifier (pos, kind, tis, e), List.flatten gen_nodes_ty @ gen_nodes
@@ -241,8 +241,8 @@ fun ctx node_name fun_ids ci ->
     let lhs, gen_nodes_ty = match lhs with
       | A.GhostVarDec (p, tis) ->
           let tis, gen_nodes_ty = List.map (fun (p, id, ty) ->
-            let ty', gen_nodes = desugar_type ctx node_name fun_ids ty in
-            (p, id, ty'), gen_nodes
+            let ty, gen_nodes = desugar_type ctx node_name fun_ids ty in
+            (p, id, ty), gen_nodes
           ) tis |> List.split in
           A.GhostVarDec (p, tis), List.flatten gen_nodes_ty
     in
@@ -330,14 +330,14 @@ fun ctx decls ->
       ) outputs |> List.split in
       let locals, gen_nodes_loc = List.map (function
         | A.NodeVarDecl (pos, (p, id', ty, c)) ->
-            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
-            A.NodeVarDecl (pos, (p, id', ty', c)), gen_nodes
+            let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeVarDecl (pos, (p, id', ty, c)), gen_nodes
         | A.NodeConstDecl (pos, A.FreeConst (_, id', ty)) ->
-            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
-            A.NodeConstDecl (pos, A.FreeConst (pos, id', ty')), gen_nodes
+            let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeConstDecl (pos, A.FreeConst (pos, id', ty)), gen_nodes
         | A.NodeConstDecl (pos, A.TypedConst (_, id', e, ty)) ->
-            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
-            A.NodeConstDecl (pos, A.TypedConst (pos, id', e, ty')), gen_nodes
+            let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeConstDecl (pos, A.TypedConst (pos, id', e, ty)), gen_nodes
         | A.NodeConstDecl (pos, (A.UntypedConst _ as cd)) ->
             A.NodeConstDecl (pos, cd), []
       ) locals |> List.split in
@@ -357,14 +357,14 @@ fun ctx decls ->
       ) outputs |> List.split in
       let locals, gen_nodes_loc = List.map (function
         | A.NodeVarDecl (pos, (p, id', ty, c)) ->
-            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
-            A.NodeVarDecl (pos, (p, id', ty', c)), gen_nodes
+            let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeVarDecl (pos, (p, id', ty, c)), gen_nodes
         | A.NodeConstDecl (pos, A.FreeConst (_, id', ty)) ->
-            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
-            A.NodeConstDecl (pos, A.FreeConst (pos, id', ty')), gen_nodes
+            let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeConstDecl (pos, A.FreeConst (pos, id', ty)), gen_nodes
         | A.NodeConstDecl (pos, A.TypedConst (_, id', e, ty)) ->
-            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
-            A.NodeConstDecl (pos, A.TypedConst (pos, id', e, ty')), gen_nodes
+            let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeConstDecl (pos, A.TypedConst (pos, id', e, ty)), gen_nodes
         | A.NodeConstDecl (pos, (A.UntypedConst _ as cd)) ->
             A.NodeConstDecl (pos, cd), []
       ) locals |> List.split in

--- a/src/lustre/lustreDesugarAnyChooseOps.ml
+++ b/src/lustre/lustreDesugarAnyChooseOps.ml
@@ -75,6 +75,7 @@ fun ctx node_name fun_ids expr ->
   match expr with
   | A.ChooseOp (pos, (_, id, ty), expr1)
   | A.AnyOp (pos, (_, id, ty), expr1) -> 
+    let ty, ty_gen_nodes = desugar_type ctx node_name fun_ids ty in
     let span = { A.start_pos = pos; A.end_pos = pos } in
     let contract = 
       [A.Guarantee (AH.pos_of_expr expr1, None, false, expr1)] 
@@ -125,12 +126,19 @@ fun ctx node_name fun_ids expr ->
         name
     | _ -> assert false
     in
-    A.Call(pos, ty_vars, name, inputs_call), [generated_node]
+    A.Call(pos, ty_vars, name, inputs_call), ty_gen_nodes @ [generated_node]
 
   | Ident _ as e -> e, []
   | ModeRef (_, _) as e -> e, []
-  | EmptySet _ as e -> e, []
-  | EmptyMap _ as e -> e, []
+  | A.EmptySet (pos, None) -> A.EmptySet (pos, None), []
+  | A.EmptySet (pos, Some ty) ->
+    let ty', gen_nodes = desugar_type ctx node_name fun_ids ty in
+    A.EmptySet (pos, Some ty'), gen_nodes
+  | A.EmptyMap (pos, None) -> A.EmptyMap (pos, None), []
+  | A.EmptyMap (pos, Some (kt, vt)) ->
+    let kt', gen_nodes1 = desugar_type ctx node_name fun_ids kt in
+    let vt', gen_nodes2 = desugar_type ctx node_name fun_ids vt in
+    A.EmptyMap (pos, Some (kt', vt')), gen_nodes1 @ gen_nodes2
   | Const (_, _) as e -> e, []
   | RecordProject (pos, e, idx) -> 
     let e, gen_nodes = rec_call e in
@@ -158,11 +166,12 @@ fun ctx node_name fun_ids expr ->
     let e, gen_nodes = rec_call e in 
     Extract (pos, e, ub, lb), gen_nodes
   | RecordExpr (pos, ident, ps, expr_list) ->
+    let ps, gen_nodes_ty = List.map (desugar_type ctx node_name fun_ids) ps |> List.split in
     let id_list, exprs_gen_nodes = 
       List.map (fun (i, e) -> (i, (rec_call) e)) expr_list |> List.split 
     in
     let expr_list, gen_nodes = List.split exprs_gen_nodes in
-    RecordExpr (pos, ident, ps, List.combine id_list expr_list), List.flatten gen_nodes
+    RecordExpr (pos, ident, ps, List.combine id_list expr_list), List.flatten gen_nodes_ty @ List.flatten gen_nodes
   | GroupExpr (pos, kind, expr_list) ->
     let expr_list, gen_nodes = List.map (rec_call) expr_list |> List.split in
     GroupExpr (pos, kind, expr_list), List.flatten gen_nodes
@@ -181,9 +190,13 @@ fun ctx node_name fun_ids expr ->
     let e1, gen_nodes1 = rec_call e1 in
     let e2, gen_nodes2 = rec_call e2 in
     IndexAccess (pos, e1, e2, kind), gen_nodes1 @ gen_nodes2
-  | Quantifier (pos, kind, idents, e) ->
+  | Quantifier (pos, kind, tis , e) ->
+    let tis, gen_nodes_ty = List.map (fun (p, id', ty) ->
+      let ty', gen_nodes = desugar_type ctx node_name fun_ids ty in
+      (p, id', ty'), gen_nodes
+    ) tis |> List.split in
     let e, gen_nodes = rec_call e in
-    Quantifier (pos, kind, idents, e), gen_nodes
+    Quantifier (pos, kind, tis, e), List.flatten gen_nodes_ty @ gen_nodes
   | When (pos, e, clock) -> 
     let e, gen_nodes = rec_call e in
     When (pos, e, clock), gen_nodes
@@ -216,16 +229,25 @@ fun ctx node_name fun_ids expr ->
     let e2, gen_nodes2 = rec_call e2 in
     Arrow (pos, e1, e2), gen_nodes1 @ gen_nodes2
   | Call (pos, ty_args, id, expr_list) ->
+    let ty_args, gen_nodes_ty = List.map (desugar_type ctx node_name fun_ids) ty_args |> List.split in
     let expr_list, gen_nodes = List.map rec_call expr_list |> List.split in
-    Call (pos, ty_args, id, expr_list), List.flatten gen_nodes
+    Call (pos, ty_args, id, expr_list), List.flatten gen_nodes_ty @ List.flatten gen_nodes
 
 let desugar_contract_item: Ctx.tc_context -> NI.t -> NI.t list -> A.contract_node_equation -> A.contract_node_equation * A.declaration list =
 fun ctx node_name fun_ids ci ->
   let rec_call = desugar_expr ctx node_name fun_ids in
   match ci with
-  | A.GhostVars (pos, lhs, e) -> 
-    let e, gen_nodes = rec_call e in 
-    A.GhostVars (pos, lhs, e), gen_nodes
+  | A.GhostVars (pos, lhs, e) ->
+    let lhs, gen_nodes_ty = match lhs with
+      | A.GhostVarDec (p, tis) ->
+          let tis, gen_nodes_ty = List.map (fun (p, id, ty) ->
+            let ty', gen_nodes = desugar_type ctx node_name fun_ids ty in
+            (p, id, ty'), gen_nodes
+          ) tis |> List.split in
+          A.GhostVarDec (p, tis), List.flatten gen_nodes_ty
+    in
+    let e, gen_nodes = rec_call e in
+    A.GhostVars (pos, lhs, e), gen_nodes_ty @ gen_nodes
   | Assume (pos, name, b, e) ->
     let e, gen_nodes = rec_call e in 
     Assume (pos, name, b, e), gen_nodes
@@ -242,9 +264,10 @@ fun ctx node_name fun_ids ci ->
       List.map (fun (pos, id, (expr, decls)) -> ((pos, id, expr), decls)) |> 
       List.split in 
     Mode (pos, i, reqs, enss), (List.flatten gen_nodes1) @ (List.flatten gen_nodes2)
-  | ContractCall (pos, i, ty_args, exprs, ids) -> 
-    let (exprs, gen_nodes) = List.map rec_call exprs |> List.split in 
-    ContractCall (pos, i, ty_args, exprs, ids), List.flatten gen_nodes
+  | ContractCall (pos, i, ty_args, exprs, ids) ->
+    let ty_args, gen_nodes_ty = List.map (desugar_type ctx node_name fun_ids) ty_args |> List.split in
+    let (exprs, gen_nodes) = List.map rec_call exprs |> List.split in
+    ContractCall (pos, i, ty_args, exprs, ids), List.flatten gen_nodes_ty @ List.flatten gen_nodes
   | GhostConst _ 
   | AssumptionVars _ as ci -> ci, []
 
@@ -297,26 +320,73 @@ fun ctx decls ->
     match decl with
     | A.NodeDecl (span, (id, ext, opac, params, inputs, outputs, locals, items, contract)) ->
       let ctx = Chk.add_full_node_ctx ctx id params inputs outputs locals in
-      let outputs, gen_nodes1 = List.map (fun (p, id', ty, c) -> (*!! Like this *)
-        let ty, gen_nodes = desugar_type ctx id fun_ids ty in  
+      let inputs, gen_nodes_in = List.map (fun (p, id', ty, c, b) ->
+        let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+        (p, id', ty, c, b), gen_nodes
+      ) inputs |> List.split in
+      let outputs, gen_nodes1 = List.map (fun (p, id', ty, c) ->
+        let ty, gen_nodes = desugar_type ctx id fun_ids ty in
         (p, id', ty, c), gen_nodes
       ) outputs |> List.split in
-      let items, gen_nodes2 = List.map (desugar_node_item ctx id fun_ids) items |> List.split in 
+      let locals, gen_nodes_loc = List.map (function
+        | A.NodeVarDecl (pos, (p, id', ty, c)) ->
+            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeVarDecl (pos, (p, id', ty', c)), gen_nodes
+        | A.NodeConstDecl (pos, A.FreeConst (_, id', ty)) ->
+            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeConstDecl (pos, A.FreeConst (pos, id', ty')), gen_nodes
+        | A.NodeConstDecl (pos, A.TypedConst (_, id', e, ty)) ->
+            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeConstDecl (pos, A.TypedConst (pos, id', e, ty')), gen_nodes
+        | A.NodeConstDecl (pos, (A.UntypedConst _ as cd)) ->
+            A.NodeConstDecl (pos, cd), []
+      ) locals |> List.split in
+      let items, gen_nodes2 = List.map (desugar_node_item ctx id fun_ids) items |> List.split in
       let contract, gen_nodes3 = desugar_contract ctx id fun_ids contract in
-      let gen_nodes = List.flatten gen_nodes1 @ List.flatten gen_nodes2 @ gen_nodes3 in
+      let gen_nodes = List.flatten gen_nodes_in @ List.flatten gen_nodes1 @ List.flatten gen_nodes_loc @ List.flatten gen_nodes2 @ gen_nodes3 in
       decls @ gen_nodes @ [A.NodeDecl (span, (id, ext, opac, params, inputs, outputs, locals, items, contract))]
     | A.FuncDecl (span, (id, ext, opac, params, inputs, outputs, locals, items, contract)) ->
       let ctx = Chk.add_full_node_ctx ctx id params inputs outputs locals in
-      let items, gen_nodes = List.map (desugar_node_item ctx id fun_ids) items |> List.split in 
+      let inputs, gen_nodes_in = List.map (fun (p, id', ty, c, b) ->
+        let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+        (p, id', ty, c, b), gen_nodes
+      ) inputs |> List.split in
+      let outputs, gen_nodes_out = List.map (fun (p, id', ty, c) ->
+        let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+        (p, id', ty, c), gen_nodes
+      ) outputs |> List.split in
+      let locals, gen_nodes_loc = List.map (function
+        | A.NodeVarDecl (pos, (p, id', ty, c)) ->
+            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeVarDecl (pos, (p, id', ty', c)), gen_nodes
+        | A.NodeConstDecl (pos, A.FreeConst (_, id', ty)) ->
+            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeConstDecl (pos, A.FreeConst (pos, id', ty')), gen_nodes
+        | A.NodeConstDecl (pos, A.TypedConst (_, id', e, ty)) ->
+            let ty', gen_nodes = desugar_type ctx id fun_ids ty in
+            A.NodeConstDecl (pos, A.TypedConst (pos, id', e, ty')), gen_nodes
+        | A.NodeConstDecl (pos, (A.UntypedConst _ as cd)) ->
+            A.NodeConstDecl (pos, cd), []
+      ) locals |> List.split in
+      let items, gen_nodes = List.map (desugar_node_item ctx id fun_ids) items |> List.split in
       let contract, gen_nodes2 = desugar_contract ctx id fun_ids contract in
-      let gen_nodes = List.flatten gen_nodes in
+      let gen_nodes = List.flatten gen_nodes_in @ List.flatten gen_nodes_out @ List.flatten gen_nodes_loc @ List.flatten gen_nodes in
       decls @ gen_nodes @ gen_nodes2 @ [A.FuncDecl (span, (id, ext, opac, params, inputs, outputs, locals, items, contract))]
     | A.ContractNodeDecl (span, (id, params, inputs, outputs, contract)) ->
       let ctx = Chk.add_io_node_ctx ctx id params inputs outputs in
+      let inputs, gen_nodes_in = List.map (fun (p, id', ty, c, b) ->
+        let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+        (p, id', ty, c, b), gen_nodes
+      ) inputs |> List.split in
+      let outputs, gen_nodes_out = List.map (fun (p, id', ty, c) ->
+        let ty, gen_nodes = desugar_type ctx id fun_ids ty in
+        (p, id', ty, c), gen_nodes
+      ) outputs |> List.split in
       let contract, gen_nodes = desugar_contract ctx id fun_ids (Some contract) in
       let contract = match contract with
       | Some contract -> contract
       | None -> assert false in (* Must have a contract *)
+      let gen_nodes = List.flatten gen_nodes_in @ List.flatten gen_nodes_out @ gen_nodes in
       decls @ gen_nodes @ [A.ContractNodeDecl (span, (id, params, inputs, outputs, contract))]
     | _ -> decl :: decls
   ) [] decls in 

--- a/src/lustre/lustreDesugarAnyChooseOps.ml
+++ b/src/lustre/lustreDesugarAnyChooseOps.ml
@@ -33,7 +33,43 @@ fun pos node_id node_type ->
   let name = HString.concat2 name pos in
   NI.mk_node_id ~node_type ~user_name:name name
 
-let rec desugar_expr: Ctx.tc_context -> NI.t -> NI.t list -> A.expr -> A.expr * A.declaration list =
+let rec desugar_type: Ctx.tc_context -> NI.t -> NI.t list -> A.lustre_type -> A.lustre_type * A.declaration list =
+fun ctx node_name fun_ids ty -> 
+  let r = desugar_type ctx node_name fun_ids in 
+  match ty with 
+  | Int _ | Bool _ | Real _ | SBitVector _ | UBitVector _ 
+  | IntRange _ | EnumType _ | AbstractType _ 
+  | UserType _ | History _ -> ty, [] 
+  | Map (p, kt, vt) -> 
+    let kt, gen_nodes1 = r kt in 
+    let vt, gen_nodes2 = r vt in
+    Map (p, kt, vt), gen_nodes1 @ gen_nodes2
+  | Set (p, ty) ->
+    let ty', gen_nodes = r ty in
+    Set (p, ty'), gen_nodes  
+  | ArrayType (p, (ty, len)) ->
+    let ty', gen_nodes1 = r ty in
+    let len', gen_nodes2 = desugar_expr ctx node_name fun_ids len in
+    ArrayType (p, (ty', len')), gen_nodes1 @ gen_nodes2
+  | TArr (p, ty1, ty2) ->
+    let ty1', gen_nodes1 = r ty1 in
+    let ty2', gen_nodes2 = r ty2 in
+    TArr (p, ty1', ty2'), gen_nodes1 @ gen_nodes2
+  | GroupType (p, tys) ->
+    let tys, gen_nodes = List.map r tys |> List.split in
+    GroupType (p, tys), List.flatten gen_nodes 
+  | TupleType (p, tys) ->
+    let tys, gen_nodes = List.map r tys |> List.split in
+    TupleType (p, tys), List.flatten gen_nodes 
+  | RecordType (p, id, tis) ->
+    let tis, gen_nodes = List.map (fun (p, id, ty) -> let ty', d = r ty in (p, id, ty'), d) tis |> List.split in
+    RecordType (p, id, tis), List.flatten gen_nodes
+  | RefinementType (p1, (p2, id, ty), e) ->
+    let ty', gen_nodes1 = r ty in
+    let e', gen_nodes2 = desugar_expr ctx node_name fun_ids e in
+    RefinementType (p1, (p2, id, ty'), e'), gen_nodes1 @ gen_nodes2
+
+and desugar_expr: Ctx.tc_context -> NI.t -> NI.t list -> A.expr -> A.expr * A.declaration list =
 fun ctx node_name fun_ids expr -> 
   let rec_call = desugar_expr ctx node_name fun_ids in
   match expr with
@@ -261,10 +297,14 @@ fun ctx decls ->
     match decl with
     | A.NodeDecl (span, (id, ext, opac, params, inputs, outputs, locals, items, contract)) ->
       let ctx = Chk.add_full_node_ctx ctx id params inputs outputs locals in
-      let items, gen_nodes = List.map (desugar_node_item ctx id fun_ids) items |> List.split in 
-      let contract, gen_nodes2 = desugar_contract ctx id fun_ids contract in
-      let gen_nodes = List.flatten gen_nodes in
-      decls @ gen_nodes @ gen_nodes2 @ [A.NodeDecl (span, (id, ext, opac, params, inputs, outputs, locals, items, contract))]
+      let outputs, gen_nodes1 = List.map (fun (p, id', ty, c) -> (*!! Like this *)
+        let ty, gen_nodes = desugar_type ctx id fun_ids ty in  
+        (p, id', ty, c), gen_nodes
+      ) outputs |> List.split in
+      let items, gen_nodes2 = List.map (desugar_node_item ctx id fun_ids) items |> List.split in 
+      let contract, gen_nodes3 = desugar_contract ctx id fun_ids contract in
+      let gen_nodes = List.flatten gen_nodes1 @ List.flatten gen_nodes2 @ gen_nodes3 in
+      decls @ gen_nodes @ [A.NodeDecl (span, (id, ext, opac, params, inputs, outputs, locals, items, contract))]
     | A.FuncDecl (span, (id, ext, opac, params, inputs, outputs, locals, items, contract)) ->
       let ctx = Chk.add_full_node_ctx ctx id params inputs outputs locals in
       let items, gen_nodes = List.map (desugar_node_item ctx id fun_ids) items |> List.split in 

--- a/src/lustre/lustreDesugarAnyChooseOps.ml
+++ b/src/lustre/lustreDesugarAnyChooseOps.ml
@@ -268,7 +268,16 @@ fun ctx node_name fun_ids ci ->
     let ty_args, gen_nodes_ty = List.map (desugar_type ctx node_name fun_ids) ty_args |> List.split in
     let (exprs, gen_nodes) = List.map rec_call exprs |> List.split in
     ContractCall (pos, i, ty_args, exprs, ids), List.flatten gen_nodes_ty @ List.flatten gen_nodes
-  | GhostConst _ 
+  | A.GhostConst (A.FreeConst (pos, id, ty)) ->
+    let ty, gen_nodes = desugar_type ctx node_name fun_ids ty in
+    A.GhostConst (A.FreeConst (pos, id, ty)), gen_nodes
+  | A.GhostConst (A.TypedConst (pos, id, e, ty)) ->
+    let ty, gen_nodes_ty = desugar_type ctx node_name fun_ids ty in
+    let e, gen_nodes = rec_call e in
+    A.GhostConst (A.TypedConst (pos, id, e, ty)), gen_nodes_ty @ gen_nodes
+  | A.GhostConst (A.UntypedConst (pos, id, e)) ->
+    let e, gen_nodes = rec_call e in
+    A.GhostConst (A.UntypedConst (pos, id, e)), gen_nodes
   | AssumptionVars _ as ci -> ci, []
 
 let desugar_contract: Ctx.tc_context -> NI.t -> NI.t list -> A.contract option -> A.contract option * A.declaration list =

--- a/tests/regression/falsifiable/any_op_type.lus
+++ b/tests/regression/falsifiable/any_op_type.lus
@@ -1,0 +1,4 @@
+node N() returns (out: int | out > any@<int>)
+let
+  out = 3;
+tel


### PR DESCRIPTION
Previously, the `lustreDesugarAnyChooseOps` module did not properly support any/choose operators at the type level. This PR is essentially boilerplate that extends the module to also recurse through the types and collect the generated nodes/functions.

The new test case used to throw an exception because the `any` operator in the refinement type was not desugared.