### PR TITLE
Disallow undefined output variables

### DIFF
--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -606,7 +606,6 @@ let rec  mk_decl_map: LA.declaration option IMap.t -> LA.t -> ((LA.declaration o
   | LA.NodeParamInst _ :: _-> Lib.todo __LOC__
 (** builds an id :-> decl map  *)
                             
-(** Build dependency edges from gids.equations: for each node, add edges to nodes called in its generated equations *)
 let mk_graph_gids: GI.t NI.Map.t -> dependency_analysis_data =
   fun gids ->
   NI.Map.fold (fun node_id gid acc ->
@@ -1155,7 +1154,7 @@ let sort_declarations: LA.t -> GI.t NI.Map.t -> ((LA.t * LA.ident list), [> erro
   = fun decls gids ->
   (* 1. make an id :-> decl map  *)
   let* decl_map = mk_decl_map IMap.empty decls in
-  (* 2. build a dependency graph (from decls and from gids.equations) *)
+  (* 2. build a dependency graph *)
   let ad = mk_graph_decls decls gids in
   (* 3. try to sort it, raise an error if it is cyclic, or extract sorted decls from the decl_map *)
   let* sorted_ids = (try (R.ok (G.topological_sort ad.graph_data)) with
@@ -1469,9 +1468,7 @@ let sort_globals decls =
 
 let sort_and_check_nodes_contracts decls gids =
   (* Step 1. Sort the declarations according in their dependency order
-     This rules out the cases where we have recursive node or contract definitions.
-     gids.equations are included so that generated-node dependencies (e.g. from
-     monomorphization) are respected. *)
+     This rules out the cases where we have recursive node or contract definitions *)
   let* (sorted_decls, toplevel_nodes) = sort_declarations decls gids in
   Debug.parse "Sorting functions, nodes and contracts done.
     \n============\n%a\n============\n"

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -35,7 +35,6 @@ module LA = LustreAst
 module LH = LustreAstHelpers
 module SI = LA.SI
 module NI = NodeId
-module GI = GeneratedIdentifiers
 
 type error_kind = Unknown of string
   | IdentifierRedeclared of HString.t
@@ -606,22 +605,7 @@ let rec  mk_decl_map: LA.declaration option IMap.t -> LA.t -> ((LA.declaration o
   | LA.NodeParamInst _ :: _-> Lib.todo __LOC__
 (** builds an id :-> decl map  *)
                             
-let mk_graph_gids: GI.t NI.Map.t -> dependency_analysis_data =
-  fun gids ->
-  NI.Map.fold (fun node_id gid acc ->
-    let node_name = NI.get_internal_name node_id in
-    let node_refs = List.flatten
-      (List.map (fun (_q_vars, _sc, _lhs, expr, _source) -> get_node_call_from_expr expr) gid.GI.equations)
-    in
-    let ad = List.fold_left (fun g (nr, p) ->
-      union_dependency_analysis_data g
-        (connect_g_pos (singleton_dependency_analysis_data node_prefix nr p) node_name Lib.dummy_pos))
-      empty_dependency_analysis_data node_refs
-    in
-    union_dependency_analysis_data acc ad
-  ) gids empty_dependency_analysis_data
-
-let mk_graph_decls: LA.t -> GI.t NI.Map.t -> dependency_analysis_data
+let mk_graph_decls: LA.t -> dependency_analysis_data 
   = let mk_graph: LA.declaration -> dependency_analysis_data = function
       | TypeDecl (_, tydecl) -> mk_graph_type_decl tydecl 
       | ConstDecl (_, cdecl) -> mk_graph_const_decl cdecl
@@ -629,10 +613,8 @@ let mk_graph_decls: LA.t -> GI.t NI.Map.t -> dependency_analysis_data
       | FuncDecl ({LA.start_pos = pos}, ndecl) -> mk_graph_node_decl pos ndecl
       | ContractNodeDecl ({LA.start_pos = pos}, cdecl) -> mk_graph_contract_decl pos cdecl
       | NodeParamInst  _ -> Lib.todo __LOC__ in
-    fun decls gids ->
-    let ad_decls = List.fold_left union_dependency_analysis_data empty_dependency_analysis_data (List.map mk_graph decls) in
-    let ad_gids = mk_graph_gids gids in
-    union_dependency_analysis_data ad_decls ad_gids
+    fun decls ->
+    List.fold_left union_dependency_analysis_data empty_dependency_analysis_data (List.map mk_graph decls)
 (** Builds a dependency graph for top-level types and constant defintions (for type 1 analysis) 
    and nodes and contracts (for type 2 analysis)
    See Note {Types of dependency analysis} for more information about different kinds of
@@ -1150,12 +1132,12 @@ let sort_and_check_contract_eqns: dependency_analysis_data
       of the output streams. *)
 
 
-let sort_declarations: LA.t -> GI.t NI.Map.t -> ((LA.t * LA.ident list), [> error]) result
-  = fun decls gids ->
+let sort_declarations: LA.t -> ((LA.t * LA.ident list), [> error]) result
+  = fun decls ->
   (* 1. make an id :-> decl map  *)
   let* decl_map = mk_decl_map IMap.empty decls in
   (* 2. build a dependency graph *)
-  let ad = mk_graph_decls decls gids in
+  let ad = mk_graph_decls decls in
   (* 3. try to sort it, raise an error if it is cyclic, or extract sorted decls from the decl_map *)
   let* sorted_ids = (try (R.ok (G.topological_sort ad.graph_data)) with
    | G.CyclicGraphException ids ->
@@ -1458,7 +1440,7 @@ let rec sort_and_check_equations: dependency_analysis_data -> LA.t -> (LA.t, [> 
 (** Sort equations for contracts and check if node and function equations have circular dependencies  *)
 
 let sort_globals decls =
-  let* (sorted_decls, _) = sort_declarations decls NI.Map.empty in
+  let* (sorted_decls, _) = sort_declarations decls in
   Debug.parse "Sorting types and constants declarations done.
     \n============\n%a\n============\n"
     LA.pp_print_program sorted_decls;
@@ -1466,10 +1448,10 @@ let sort_globals decls =
 (** Returns a topological order to resolve forward references 
     of global constants and type definitions. *)  
 
-let sort_and_check_nodes_contracts decls gids =
+let sort_and_check_nodes_contracts decls =
   (* Step 1. Sort the declarations according in their dependency order
      This rules out the cases where we have recursive node or contract definitions *)
-  let* (sorted_decls, toplevel_nodes) = sort_declarations decls gids in
+  let* (sorted_decls, toplevel_nodes) = sort_declarations decls in
   Debug.parse "Sorting functions, nodes and contracts done.
     \n============\n%a\n============\n"
     LA.pp_print_program sorted_decls;

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -35,6 +35,7 @@ module LA = LustreAst
 module LH = LustreAstHelpers
 module SI = LA.SI
 module NI = NodeId
+module GI = GeneratedIdentifiers
 
 type error_kind = Unknown of string
   | IdentifierRedeclared of HString.t
@@ -605,7 +606,23 @@ let rec  mk_decl_map: LA.declaration option IMap.t -> LA.t -> ((LA.declaration o
   | LA.NodeParamInst _ :: _-> Lib.todo __LOC__
 (** builds an id :-> decl map  *)
                             
-let mk_graph_decls: LA.t -> dependency_analysis_data 
+(** Build dependency edges from gids.equations: for each node, add edges to nodes called in its generated equations *)
+let mk_graph_gids: GI.t NI.Map.t -> dependency_analysis_data =
+  fun gids ->
+  NI.Map.fold (fun node_id gid acc ->
+    let node_name = NI.get_internal_name node_id in
+    let node_refs = List.flatten
+      (List.map (fun (_q_vars, _sc, _lhs, expr, _source) -> get_node_call_from_expr expr) gid.GI.equations)
+    in
+    let ad = List.fold_left (fun g (nr, p) ->
+      union_dependency_analysis_data g
+        (connect_g_pos (singleton_dependency_analysis_data node_prefix nr p) node_name Lib.dummy_pos))
+      empty_dependency_analysis_data node_refs
+    in
+    union_dependency_analysis_data acc ad
+  ) gids empty_dependency_analysis_data
+
+let mk_graph_decls: LA.t -> GI.t NI.Map.t -> dependency_analysis_data
   = let mk_graph: LA.declaration -> dependency_analysis_data = function
       | TypeDecl (_, tydecl) -> mk_graph_type_decl tydecl 
       | ConstDecl (_, cdecl) -> mk_graph_const_decl cdecl
@@ -613,8 +630,10 @@ let mk_graph_decls: LA.t -> dependency_analysis_data
       | FuncDecl ({LA.start_pos = pos}, ndecl) -> mk_graph_node_decl pos ndecl
       | ContractNodeDecl ({LA.start_pos = pos}, cdecl) -> mk_graph_contract_decl pos cdecl
       | NodeParamInst  _ -> Lib.todo __LOC__ in
-    fun decls ->
-    List.fold_left union_dependency_analysis_data empty_dependency_analysis_data (List.map mk_graph decls)
+    fun decls gids ->
+    let ad_decls = List.fold_left union_dependency_analysis_data empty_dependency_analysis_data (List.map mk_graph decls) in
+    let ad_gids = mk_graph_gids gids in
+    union_dependency_analysis_data ad_decls ad_gids
 (** Builds a dependency graph for top-level types and constant defintions (for type 1 analysis) 
    and nodes and contracts (for type 2 analysis)
    See Note {Types of dependency analysis} for more information about different kinds of
@@ -1132,12 +1151,12 @@ let sort_and_check_contract_eqns: dependency_analysis_data
       of the output streams. *)
 
 
-let sort_declarations: LA.t -> ((LA.t * LA.ident list), [> error]) result
-  = fun decls ->
+let sort_declarations: LA.t -> GI.t NI.Map.t -> ((LA.t * LA.ident list), [> error]) result
+  = fun decls gids ->
   (* 1. make an id :-> decl map  *)
   let* decl_map = mk_decl_map IMap.empty decls in
-  (* 2. build a dependency graph *)
-  let ad = mk_graph_decls decls in
+  (* 2. build a dependency graph (from decls and from gids.equations) *)
+  let ad = mk_graph_decls decls gids in
   (* 3. try to sort it, raise an error if it is cyclic, or extract sorted decls from the decl_map *)
   let* sorted_ids = (try (R.ok (G.topological_sort ad.graph_data)) with
    | G.CyclicGraphException ids ->
@@ -1440,7 +1459,7 @@ let rec sort_and_check_equations: dependency_analysis_data -> LA.t -> (LA.t, [> 
 (** Sort equations for contracts and check if node and function equations have circular dependencies  *)
 
 let sort_globals decls =
-  let* (sorted_decls, _) = sort_declarations decls in
+  let* (sorted_decls, _) = sort_declarations decls NI.Map.empty in
   Debug.parse "Sorting types and constants declarations done.
     \n============\n%a\n============\n"
     LA.pp_print_program sorted_decls;
@@ -1448,10 +1467,12 @@ let sort_globals decls =
 (** Returns a topological order to resolve forward references 
     of global constants and type definitions. *)  
 
-let sort_and_check_nodes_contracts decls =
+let sort_and_check_nodes_contracts decls gids =
   (* Step 1. Sort the declarations according in their dependency order
-     This rules out the cases where we have recursive node or contract definitions *)
-  let* (sorted_decls, toplevel_nodes) = sort_declarations decls in
+     This rules out the cases where we have recursive node or contract definitions.
+     gids.equations are included so that generated-node dependencies (e.g. from
+     monomorphization) are respected. *)
+  let* (sorted_decls, toplevel_nodes) = sort_declarations decls gids in
   Debug.parse "Sorting functions, nodes and contracts done.
     \n============\n%a\n============\n"
     LA.pp_print_program sorted_decls;

--- a/src/lustre/lustreAstDependencies.mli
+++ b/src/lustre/lustreAstDependencies.mli
@@ -66,7 +66,7 @@ val sort_globals: LA.t -> (LA.t, [> error]) result
 (** Returns a topological order to resolve forward references of globals. 
     This step processes 1. type declarations, and 2. constant declarations *)  
                      
-val sort_and_check_nodes_contracts: LA.t -> GeneratedIdentifiers.t NodeId.Map.t -> ((LA.t * LA.ident list * node_summary), [> error]) result
+val sort_and_check_nodes_contracts: LA.t -> ((LA.t * LA.ident list * node_summary), [> error]) result
 (** Returns a topological order of declarations to resolve all forward references,
     with a list of toplevel nodes.
     It also reorders contract equations and checks for circularity of node equations.

--- a/src/lustre/lustreAstDependencies.mli
+++ b/src/lustre/lustreAstDependencies.mli
@@ -69,7 +69,5 @@ val sort_globals: LA.t -> (LA.t, [> error]) result
 val sort_and_check_nodes_contracts: LA.t -> GeneratedIdentifiers.t NodeId.Map.t -> ((LA.t * LA.ident list * node_summary), [> error]) result
 (** Returns a topological order of declarations to resolve all forward references,
     with a list of toplevel nodes.
-    [gids] is used to include dependencies from generated identifiers (e.g. gids.equations)
-    so that callees come before callers after e.g. polymorphic instantiation.
     It also reorders contract equations and checks for circularity of node equations.
     This step processes 1. nodes, 2. contracts and 3. functions *)  

--- a/src/lustre/lustreAstDependencies.mli
+++ b/src/lustre/lustreAstDependencies.mli
@@ -66,8 +66,10 @@ val sort_globals: LA.t -> (LA.t, [> error]) result
 (** Returns a topological order to resolve forward references of globals. 
     This step processes 1. type declarations, and 2. constant declarations *)  
                      
-val sort_and_check_nodes_contracts: LA.t -> ((LA.t * LA.ident list * node_summary), [> error]) result
+val sort_and_check_nodes_contracts: LA.t -> GeneratedIdentifiers.t NodeId.Map.t -> ((LA.t * LA.ident list * node_summary), [> error]) result
 (** Returns a topological order of declarations to resolve all forward references,
     with a list of toplevel nodes.
+    [gids] is used to include dependencies from generated identifiers (e.g. gids.equations)
+    so that callees come before callers after e.g. polymorphic instantiation.
     It also reorders contract equations and checks for circularity of node equations.
     This step processes 1. nodes, 2. contracts and 3. functions *)  

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -2044,3 +2044,10 @@ let rec find_type_annotation e = match e with
 | EmptyMap (p, Some (kt, vt)) -> Some (Map (p, kt, vt))
 | _ -> None
 
+(* Return the node_id of a declaration if it is a node/func/contract decl *)
+let node_id_of_decl = function
+  | NodeDecl (_, (id, _, _, _, _, _, _, _, _))
+  | FuncDecl (_, (id, _, _, _, _, _, _, _, _))
+  | ContractNodeDecl (_, (id, _, _, _, _)) -> Some id
+  | TypeDecl _ | ConstDecl _ | NodeParamInst _ -> None
+

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -214,3 +214,5 @@ val pos_of_type: lustre_type -> Lib.position
 
 val find_type_annotation: expr -> lustre_type option
 (** `find_type_annotation e` recurses down `StructUpdates` to find the leaf-level type annotation, if one exists *)
+
+val node_id_of_decl: declaration -> NodeId.t option

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -169,7 +169,7 @@ let type_check declarations =
     let node_contract_src = LDN.desugar_any_ops inlined_ctx node_contract_src in
 
     (* Step 7. Dependency analysis on nodes and contracts *)
-    let* (sorted_node_contract_decls, toplevel_nodes, node_summary) = AD.sort_and_check_nodes_contracts node_contract_src NodeId.Map.empty in
+    let* (sorted_node_contract_decls, toplevel_nodes, node_summary) = AD.sort_and_check_nodes_contracts node_contract_src in
 
     (* Step 8. Type check nodes and contracts *)
     let* global_ctx, sorted_node_contract_decls, warnings3 = TC.type_check_infer_nodes_and_contracts inlined_ctx sorted_node_contract_decls in

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -169,7 +169,7 @@ let type_check declarations =
     let node_contract_src = LDN.desugar_any_ops inlined_ctx node_contract_src in
 
     (* Step 7. Dependency analysis on nodes and contracts *)
-    let* (sorted_node_contract_decls, toplevel_nodes, node_summary) = AD.sort_and_check_nodes_contracts node_contract_src in
+    let* (sorted_node_contract_decls, toplevel_nodes, node_summary) = AD.sort_and_check_nodes_contracts node_contract_src NodeId.Map.empty in
 
     (* Step 8. Type check nodes and contracts *)
     let* global_ctx, sorted_node_contract_decls, warnings3 = TC.type_check_infer_nodes_and_contracts inlined_ctx sorted_node_contract_decls in

--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -4,6 +4,7 @@ module Ctx = TypeCheckerContext
 module Chk = LustreTypeChecker
 module LH = LustreAstHelpers
 module GI = GeneratedIdentifiers
+module AD = LustreAstDependencies
 
 let unwrap res = match res with 
 | Ok res -> res 
@@ -670,4 +671,8 @@ let instantiate_polymorphic_nodes: Ctx.tc_context -> GI.t NI.Map.t -> A.declarat
   in
 
   let ctx, gids, decls, _ = gen_poly_decls_decls ctx gids node_decls_map decls in 
-  ctx, gids, List.rev decls
+
+  let decls, _, _ =
+    AD.sort_and_check_nodes_contracts decls gids |> unwrap in
+
+  ctx, gids, decls

--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -28,12 +28,9 @@ let merge_decls decls gen_decls =
     | Some (i, _) -> i
     | None -> assert false
   in
-  let gen_after = Array.make (List.length decls) [] in
-  List.iter (fun g ->
-    let i = find_base_index g in
-    gen_after.(i) <- g :: gen_after.(i)
-  ) gen_decls;
-  List.concat (List.mapi (fun i decl -> decl :: List.rev gen_after.(i)) decls)
+  let with_base_index = List.map (fun g -> (find_base_index g, g)) gen_decls in
+  let same_index_decls i = List.filter (fun (j, _) -> j = i) with_base_index |> List.map snd in
+  List.concat (List.mapi (fun i decl -> decl :: same_index_decls i) decls)
 
 let instantiate_type_variables_ni 
 = fun ctx node_id ty_args ni  -> match ni with 

--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -1,14 +1,39 @@
 module A = LustreAst
+module AH = LustreAstHelpers
 module NI = NodeId
 module Ctx = TypeCheckerContext
 module Chk = LustreTypeChecker
 module LH = LustreAstHelpers
 module GI = GeneratedIdentifiers
-module AD = LustreAstDependencies
 
 let unwrap res = match res with 
 | Ok res -> res 
 | Error _ -> assert false
+
+(* True iff `gen_id` is a monomorphization of `base_id` *)
+let is_base_of gen_id base_id =
+  HString.equal (NI.get_name base_id) (NI.get_name gen_id)
+  && NI.get_monomorphization base_id = []
+
+(* Merge declarations: insert each monomorphization immediately after the polymorphic version *)
+let merge_decls decls gen_decls =
+  let decls_with_idx = List.mapi (fun i d -> (i, d)) decls in
+  let find_base_index gen_decl =
+    let gen_id = match AH.node_id_of_decl gen_decl with Some id -> id | None -> assert false in
+    match List.find_opt (fun (_, d) ->
+      match AH.node_id_of_decl d with
+      | None -> false
+      | Some base_id -> is_base_of gen_id base_id
+    ) decls_with_idx with
+    | Some (i, _) -> i
+    | None -> assert false
+  in
+  let gen_after = Array.make (List.length decls) [] in
+  List.iter (fun g ->
+    let i = find_base_index g in
+    gen_after.(i) <- g :: gen_after.(i)
+  ) gen_decls;
+  List.concat (List.mapi (fun i decl -> decl :: List.rev gen_after.(i)) decls)
 
 let instantiate_type_variables_ni 
 = fun ctx node_id ty_args ni  -> match ni with 
@@ -234,9 +259,8 @@ let rec gen_poly_decl: Ctx.tc_context -> GI.t NI.Map.t -> NI.t option -> (A.decl
 
     (* Recursively create new instantiations (this node could use the given polymorphic 
     instantiation to call another polymorphic node *)
-    let ctx, gids, decls, node_decls_map = gen_poly_decls_decls ctx gids node_decls_map (decls @ [called_decl]) in
-
-    ctx, gids, pnname, decls, node_decls_map                     
+    let ctx, gids, decls, gen_decls, node_decls_map = gen_poly_decls_decls ctx gids node_decls_map (decls @ [called_decl]) in
+    ctx, gids, pnname, decls @ gen_decls, node_decls_map                     
 
 and gen_poly_decls_ty: Ctx.tc_context -> GI.t NI.Map.t -> NI.t option -> (A.declaration * A.lustre_type list list) NI.Map.t ->
                            A.lustre_type -> Ctx.tc_context * GI.t NI.Map.t * A.lustre_type * A.declaration list * (A.declaration * A.lustre_type list list) NI.Map.t
@@ -556,107 +580,109 @@ and gen_poly_decls_ci
 | AssumptionVars _ -> ctx, gids, ci, [], node_decls_map
 
 and gen_poly_decls_decls
-= fun ctx gids node_decls_map decls -> 
-  let ctx, gids, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_decls, acc_node_decls_map) decl -> match decl with
+= fun ctx gids node_decls_map decls ->
+  let ctx, gids, decls, gen_decls, node_decls_map =
+  List.fold_left (fun (ctx, gids, acc_decls, acc_gen_decls, acc_node_decls_map) decl -> match decl with
   | A.FuncDecl (p, (node_id, ext, opac, ps, ips, ops, locs, nis, c)) ->
     let ctx = Chk.add_ty_params_node_ctx ctx node_id ps in
-    let ctx, gids, acc_decls, acc_node_decls_map = match NI.Map.find_opt node_id gids with  
+    let ctx, gids, gen_decls, acc_node_decls_map = match NI.Map.find_opt node_id gids with  
     | Some node_gids -> 
       let ctx, gids, decls, node_decls_map = gen_poly_decls_gids ctx node_gids gids node_id acc_node_decls_map in 
-      ctx, gids, acc_decls @ decls, node_decls_map
-    | None -> ctx, gids, acc_decls, acc_node_decls_map
+      ctx, gids, decls, node_decls_map
+    | None -> ctx, gids, [], acc_node_decls_map
     in 
-    let ctx, gids, ips, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ips, acc_decls, acc_node_decls_map) ip -> 
+    let ctx, gids, ips, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ips, acc_decls, acc_node_decls_map) ip -> 
       let ctx, gids, ip, decls, node_decls_map = gen_poly_decls_ip ctx gids (Some node_id) acc_node_decls_map ip in 
       ctx, gids, acc_ips @ [ip], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], acc_decls, acc_node_decls_map) ips in 
-    let ctx, gids, ops, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ops, acc_decls, acc_node_decls_map) op -> 
+    ) (ctx, gids, [], gen_decls, acc_node_decls_map) ips in 
+    let ctx, gids, ops, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ops, acc_decls, acc_node_decls_map) op -> 
       let ctx, gids, op, decls, node_decls_map = gen_poly_decls_op ctx gids (Some node_id) acc_node_decls_map op in 
       ctx, gids, acc_ops @ [op], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], decls, node_decls_map) ops in
-    let ctx, gids, locs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_locs, acc_decls, acc_node_decls_map) loc -> 
+    ) (ctx, gids, [], gen_decls, node_decls_map) ops in
+    let ctx, gids, locs, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_locs, acc_decls, acc_node_decls_map) loc -> 
       let ctx, gids, loc, decls, node_decls_map = gen_poly_decls_loc ctx gids (Some node_id) acc_node_decls_map loc in 
       ctx, gids, acc_locs @ [loc], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], decls, node_decls_map) locs in
-    let ctx, gids, nis, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_nis, acc_decls, acc_node_decls_map) ni -> 
+    ) (ctx, gids, [], gen_decls, node_decls_map) locs in
+    let ctx, gids, nis, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_nis, acc_decls, acc_node_decls_map) ni -> 
       let ctx, gids, ni, decls, node_decls_map = gen_poly_decls_ni ctx gids (Some node_id) acc_node_decls_map ni in 
       ctx, gids, acc_nis @ [ni], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], decls, node_decls_map) nis in (
+    ) (ctx, gids, [], gen_decls, node_decls_map) nis in (
     match c with 
     | None -> 
       let decl =  A.FuncDecl (p, (node_id, ext, opac, ps, ips, ops, locs, nis, c)) in
-      ctx, gids, decl :: decls, node_decls_map
+      ctx, gids, decl :: acc_decls, gen_decls @ acc_gen_decls, node_decls_map
     | Some (p3, c) ->
-      let ctx, gids, c, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_cis, acc_decls, acc_node_decls_map) ip -> 
+      let ctx, gids, c, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_cis, acc_decls, acc_node_decls_map) ip -> 
         let ctx, gids, ci, decls, node_decls_map = gen_poly_decls_ci ctx gids (Some node_id) acc_node_decls_map ip in 
         ctx, gids, acc_cis @ [ci], decls @ acc_decls, node_decls_map
-      ) (ctx, gids, [], decls, node_decls_map) c in 
+      ) (ctx, gids, [], gen_decls, node_decls_map) c in 
       let decl = A.FuncDecl (p, (node_id, ext, opac, ps, ips, ops, locs, nis, Some (p3, c))) in
-      ctx, gids, decl :: decls, node_decls_map
+      ctx, gids, decl :: acc_decls, gen_decls @ acc_gen_decls, node_decls_map
     )
   | NodeDecl (p, (node_id, ext, opac, ps, ips, ops, locs, nis, c)) ->
     let ctx = Chk.add_ty_params_node_ctx ctx node_id ps in
-    let ctx, gids, acc_decls, acc_node_decls_map = match NI.Map.find_opt node_id gids with  
+    let ctx, gids, gen_decls, acc_node_decls_map = match NI.Map.find_opt node_id gids with  
     | Some node_gids -> 
       let ctx, gids, decls, node_decls_map = gen_poly_decls_gids ctx node_gids gids node_id acc_node_decls_map in 
-      ctx, gids, acc_decls @ decls, node_decls_map
-    | None -> ctx, gids, acc_decls, acc_node_decls_map
+      ctx, gids, decls, node_decls_map
+    | None -> ctx, gids, [], acc_node_decls_map
     in 
-    let ctx, gids, ips, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ips, acc_decls, acc_node_decls_map) ip -> 
+    let ctx, gids, ips, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ips, acc_decls, acc_node_decls_map) ip -> 
       let ctx, gids, ip, decls, node_decls_map = gen_poly_decls_ip ctx gids (Some node_id) acc_node_decls_map ip in 
       ctx, gids, acc_ips @ [ip], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], acc_decls, acc_node_decls_map) ips in 
-    let ctx, gids, ops, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ops, acc_decls, acc_node_decls_map) op -> 
+    ) (ctx, gids, [], gen_decls, acc_node_decls_map) ips in 
+    let ctx, gids, ops, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ops, acc_decls, acc_node_decls_map) op -> 
       let ctx, gids, op, decls, node_decls_map = gen_poly_decls_op ctx gids (Some node_id) acc_node_decls_map op in 
       ctx, gids, acc_ops @ [op], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], decls, node_decls_map) ops in
-    let ctx, gids, locs, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_locs, acc_decls, acc_node_decls_map) loc -> 
+    ) (ctx, gids, [], gen_decls, node_decls_map) ops in
+    let ctx, gids, locs, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_locs, acc_decls, acc_node_decls_map) loc -> 
       let ctx, gids, loc, decls, node_decls_map = gen_poly_decls_loc ctx gids (Some node_id) acc_node_decls_map loc in 
       ctx, gids, acc_locs @ [loc], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], decls, node_decls_map) locs in
-    let ctx, gids, nis, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_nis, acc_decls, acc_node_decls_map) ni -> 
+    ) (ctx, gids, [], gen_decls, node_decls_map) locs in
+    let ctx, gids, nis, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_nis, acc_decls, acc_node_decls_map) ni -> 
       let ctx, gids, ni, decls, node_decls_map = gen_poly_decls_ni ctx gids (Some node_id) acc_node_decls_map ni in 
       ctx, gids, acc_nis @ [ni], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], decls, node_decls_map) nis in (
+    ) (ctx, gids, [], gen_decls, node_decls_map) nis in (
     match c with 
       | None -> 
         let decl =  A.NodeDecl (p, (node_id, ext, opac, ps, ips, ops, locs, nis, c)) in
-        ctx, gids, decl :: decls, node_decls_map
+        ctx, gids, decl :: acc_decls, gen_decls @ acc_gen_decls, node_decls_map
       | Some (p3, c) ->
-        let ctx, gids, c, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_cis, acc_decls, acc_node_decls_map) ip -> 
+        let ctx, gids, c, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_cis, acc_decls, acc_node_decls_map) ip -> 
           let ctx, gids, ci, decls, node_decls_map = gen_poly_decls_ci ctx gids (Some node_id) acc_node_decls_map ip in 
           ctx, gids, acc_cis @ [ci], decls @ acc_decls, node_decls_map
-        ) (ctx, gids, [], decls, node_decls_map) c in 
+        ) (ctx, gids, [], gen_decls, node_decls_map) c in 
         let decl = A.NodeDecl (p, (node_id, ext, opac, ps, ips, ops, locs, nis, Some (p3, c))) in
-        ctx, gids, decl :: decls, node_decls_map
+        ctx, gids, decl :: acc_decls, gen_decls @ acc_gen_decls, node_decls_map
     )
   | ContractNodeDecl (p, (cname, ps, ips, ops, (p3, c))) ->
     let ctx = Chk.add_ty_params_node_ctx ctx cname ps in
-    let ctx, gids, acc_decls, acc_node_decls_map = match NI.Map.find_opt cname gids with  
+    let ctx, gids, gen_decls, acc_node_decls_map = match NI.Map.find_opt cname gids with  
     | Some node_gids -> 
       let ctx, gids, decls, node_decls_map = gen_poly_decls_gids ctx node_gids gids cname acc_node_decls_map in 
-      ctx, gids, acc_decls @ decls, node_decls_map
-    | None -> ctx, gids, acc_decls, acc_node_decls_map
+      ctx, gids, decls, node_decls_map
+    | None -> ctx, gids, [], acc_node_decls_map
     in 
-    let ctx, gids, ips, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ips, acc_decls, acc_node_decls_map) ip -> 
+    let ctx, gids, ips, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ips, acc_decls, acc_node_decls_map) ip -> 
       let ctx, gids, ip, decls, node_decls_map = gen_poly_decls_ip ctx gids (Some cname) acc_node_decls_map ip in 
       ctx, gids, acc_ips @ [ip], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], acc_decls, acc_node_decls_map) ips in 
-    let ctx, gids, ops, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ops, acc_decls, acc_node_decls_map) op -> 
+    ) (ctx, gids, [], gen_decls, acc_node_decls_map) ips in 
+    let ctx, gids, ops, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_ops, acc_decls, acc_node_decls_map) op -> 
       let ctx, gids, op, decls, node_decls_map = gen_poly_decls_op ctx gids (Some cname) acc_node_decls_map op in 
       ctx, gids, acc_ops @ [op], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], decls, node_decls_map) ops in
-    let ctx, gids, c, decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_cis, acc_decls, acc_node_decls_map) ip -> 
+    ) (ctx, gids, [], gen_decls, node_decls_map) ops in
+    let ctx, gids, c, gen_decls, node_decls_map = List.fold_left (fun (ctx, gids, acc_cis, acc_decls, acc_node_decls_map) ip -> 
       let ctx, gids, ci, decls, node_decls_map = gen_poly_decls_ci ctx gids (Some cname) acc_node_decls_map ip in 
       ctx, gids, acc_cis @ [ci], decls @ acc_decls, node_decls_map
-    ) (ctx, gids, [], decls, node_decls_map) c in 
+    ) (ctx, gids, [], gen_decls, node_decls_map) c in 
     let decl = A.ContractNodeDecl (p, (cname, ps, ips, ops, (p3, c))) in
-    ctx, gids, decl :: decls, node_decls_map
+    ctx, gids, decl :: acc_decls, gen_decls @ acc_gen_decls, node_decls_map
   | TypeDecl _ 
   | ConstDecl _ 
-  | NodeParamInst _ -> ctx, gids, decl :: acc_decls, node_decls_map
-  ) (ctx, gids, [], node_decls_map) decls in
-  ctx, gids, decls, node_decls_map
+  | NodeParamInst _ -> ctx, gids, decl :: acc_decls, acc_gen_decls, acc_node_decls_map
+  ) (ctx, gids, [], [], node_decls_map) decls in
+  let decls = List.rev decls in
+  ctx, gids, decls, gen_decls, node_decls_map 
 
 let instantiate_polymorphic_nodes: Ctx.tc_context -> GI.t NI.Map.t -> A.declaration list -> Ctx.tc_context * GI.t NI.Map.t  * A.declaration list 
 = fun ctx gids decls -> 
@@ -670,9 +696,6 @@ let instantiate_polymorphic_nodes: Ctx.tc_context -> GI.t NI.Map.t -> A.declarat
   ) NI.Map.empty decls 
   in
 
-  let ctx, gids, decls, _ = gen_poly_decls_decls ctx gids node_decls_map decls in 
-
-  let decls, _, _ =
-    AD.sort_and_check_nodes_contracts decls gids |> unwrap in
-
-  ctx, gids, decls
+  let ctx, gids, decls, gen_decls, _ = gen_poly_decls_decls ctx gids node_decls_map decls in
+  let merged_decls = merge_decls decls gen_decls in
+  ctx, gids, merged_decls

--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -44,6 +44,7 @@ type error_kind = Unknown of string
   | UndefinedLocal of HString.t
   | DuplicateLocal of HString.t * Lib.position
   | DuplicateOutput of HString.t * Lib.position
+  | UndefinedOutput of HString.t 
   | DuplicateProperty of HString.t
   | UndefinedNode of HString.t
   | UndefinedContract of HString.t
@@ -80,13 +81,15 @@ type error = [
 let error_message kind = match kind with
   | Unknown s -> s
   | UndefinedLocal id -> "Local variable '"
-    ^ HString.string_of_hstring id ^ "' has no definition"
+    ^ HString.string_of_hstring id ^ "' is not defined via an equation or frame block"
   | DuplicateLocal (id, pos) -> "Local variable '"
     ^ HString.string_of_hstring id ^ "' has already been defined at position " ^ 
      (Lib.string_of_t Lib.pp_print_position pos) 
   | DuplicateOutput (id, pos) -> "Output variable '"
     ^ HString.string_of_hstring id ^ "' has already been defined at position " ^
     (Lib.string_of_t Lib.pp_print_position pos) 
+  | UndefinedOutput id -> "Output variable '"
+    ^ HString.string_of_hstring id ^ "' is not defined via an equation or frame block"
   | DuplicateProperty id -> "Property '"
   ^ HString.string_of_hstring id ^ "' has more than one definition"
   | UndefinedNode id -> "Node or function '"
@@ -487,12 +490,12 @@ let locals_exactly_one_definition locals items =
   in
   Res.seq (List.map over_locals locals)
 
-let outputs_at_most_one_definition outputs items =
+let outputs_exactly_one_definition outputs items =
   let over_outputs = function
-  | (_, id, _, _) ->
+  | (p, id, _, _) ->
     let poss = List.map (find_var_def_count id) items |> List.flatten in
     match List.length poss with
-      | 0 
+      | 0 -> syntax_error p (UndefinedOutput id) 
       | 1 -> Ok ()
       | _ -> 
         let poss = List.sort Lib.compare_pos poss in
@@ -759,7 +762,7 @@ and check_node_decl ctx span (node_id, ext, opac, params, inputs, outputs, local
   in
   check_opacity span.start_pos (NI.get_internal_name node_id) contract ext opac
   >> (locals_exactly_one_definition locals items)
-  >> (outputs_at_most_one_definition outputs items)
+  >> (if ext then (Res.ok []) else (outputs_exactly_one_definition outputs items))
   >> (Res.seq_ (List.map check_input_items inputs))
   >> (Res.seq_ (List.map check_output_items outputs)) >> 
   let* warnings1 = (match contract with

--- a/src/lustre/lustreSyntaxChecks.mli
+++ b/src/lustre/lustreSyntaxChecks.mli
@@ -25,6 +25,7 @@ type error_kind = Unknown of string
   | UndefinedLocal of HString.t
   | DuplicateLocal of HString.t * Lib.position
   | DuplicateOutput of HString.t * Lib.position
+  | UndefinedOutput of HString.t 
   | DuplicateProperty of HString.t
   | UndefinedNode of HString.t
   | UndefinedContract of HString.t

--- a/tests/ounit/lustre/lustreAstDependencies/contract_output_redeclaration.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/contract_output_redeclaration.lus
@@ -9,4 +9,5 @@ node N(x:int) returns (y,z: int);
 *)
 let
   y = x + 1;
+  z = any@<int>;
 tel

--- a/tests/ounit/lustre/lustreAstDependencies/test_circular_contracts.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_circular_contracts.lus
@@ -10,4 +10,5 @@ node n (x: int) returns (y: int);
 *)     
 let
     x = y;
+    y = any@<int>;
 tel;

--- a/tests/ounit/lustre/lustreAstDependencies/test_circular_eqns_flatten_nodes.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_circular_eqns_flatten_nodes.lus
@@ -10,5 +10,6 @@ tel
 node a (x: int) returns (y: int)
 let
 y = x;
+x = any@<int>;
 tel
 

--- a/tests/ounit/lustre/lustreAstDependencies/test_fail_to_assign_node_inputs.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_fail_to_assign_node_inputs.lus
@@ -2,4 +2,5 @@ node n(x,z:int) returns (y:int)
 var t: int;
 let
 (x, t, z) = (0 -> x, 0 -> t, x);
+y = any@<int>;
 tel;

--- a/tests/ounit/lustre/lustreAstDependencies/test_node_decls2.lus
+++ b/tests/ounit/lustre/lustreAstDependencies/test_node_decls2.lus
@@ -4,4 +4,5 @@ var h: int;
 let
    e = [e1, e2, e3];
    g, h = ((e1, e2), e3);
+   f = any@<[int, bool, int]>;
 tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/array_quantified_var.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/array_quantified_var.lus
@@ -1,4 +1,5 @@
 node N() returns (o: bool);
 let
+  o = any@<bool>;
   check exists (A: int^3) A[0]=0;
 tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/choose_op_func.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/choose_op_func.lus
@@ -1,5 +1,6 @@
 node n(x: int) returns (y: int);
 let
+  y = any@<int>;
 tel
 
 function f() returns (y: int);

--- a/tests/ounit/lustre/lustreSyntaxChecks/constants_to_calls.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/constants_to_calls.lus
@@ -5,5 +5,6 @@ const S4: subtype { x: int | x in S1 * S2 };
 
 node N () returns (out: int^S4) 
 let
+  out = any@<int^S4>;
   check S1 * S2 = S3;
 tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_1.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_1.lus
@@ -1,4 +1,4 @@
-node N(x: int) returns (y: int); 
+node N(x: int) returns (); 
 let 
     check forall (n: int) forall (z: history(n)) true; 
 tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_2.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_2.lus
@@ -1,4 +1,4 @@
-node N(x: int) returns (y: int); 
+node N(x: int) returns (); 
 let 
     check forall (n: int; z: history(n)) true;  
 tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_3.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/history_quantified_var_3.lus
@@ -1,4 +1,4 @@
-node N(x: int) returns (y: int); 
+node N(x: int) returns (); 
 let 
     check forall (z: history(z)) true;  
 tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/undeclared_lhs.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/undeclared_lhs.lus
@@ -1,4 +1,5 @@
 node N(i:bool) returns (out:bool);
 let
   x = i;
+  out = any@<bool>;
 tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/undefined_output.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/undefined_output.lus
@@ -1,0 +1,3 @@
+node N () returns (o: int)
+let
+tel

--- a/tests/ounit/lustre/lustreTypeChecker/bad_array_size_2.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/bad_array_size_2.lus
@@ -1,4 +1,5 @@
 
 node M() returns (A: int^(0 -> 1));
 let
+  A = any@<int^(0 -> 1)>;
 tel

--- a/tests/ounit/lustre/lustreTypeChecker/bad_array_size_3.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/bad_array_size_3.lus
@@ -2,4 +2,5 @@
 
 node M() returns (A: int^(pre 0));
 let
+  A = any@<int^(pre 0)>;
 tel

--- a/tests/ounit/lustre/lustreTypeChecker/bad_bound_var_type.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/bad_bound_var_type.lus
@@ -1,5 +1,6 @@
 
 node N() returns (ok: bool);
 let
+  ok = any@<bool>;
   check forall (x: subrange [0.0,5.0] of int) x>=0;
 tel

--- a/tests/ounit/lustre/lustreTypeChecker/bad_subrange_bound_1.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/bad_subrange_bound_1.lus
@@ -3,5 +3,6 @@
 node N() returns (ok:bool);
 var s: subrange [0,X()] of int;
 let
+  ok = any@<bool>;
   s = 0;
 tel

--- a/tests/ounit/lustre/lustreTypeChecker/bad_ty_annot_2.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/bad_ty_annot_2.lus
@@ -1,5 +1,6 @@
 node Bad<T>(inp: T) returns (out: T)
 let
+  out = any@<T>;
 tel
 
 node N(inp: int) returns (out: int)

--- a/tests/ounit/lustre/lustreTypeChecker/bad_type_inference.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/bad_type_inference.lus
@@ -1,5 +1,6 @@
 node Bad<T>() returns (out: T)
 let
+  out = any@<T>;
 tel
 
 node N() returns (out: int)

--- a/tests/ounit/lustre/lustreTypeChecker/const_01.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/const_01.lus
@@ -2,5 +2,6 @@ const N: int;
 
 node top(x: int) returns (y: int);
 let
+  y = any@<int>;
   N = x;
 tel

--- a/tests/ounit/lustre/lustreTypeChecker/enum_01.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/enum_01.lus
@@ -3,5 +3,6 @@ type my_enum = enum {A, B, C};
 
 node top(x: my_enum) returns (y: my_enum);
 let
+  y = any@<my_enum>;
   A = x;
 tel

--- a/tests/ounit/lustre/lustreTypeChecker/map_dangling_type_id.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/map_dangling_type_id.lus
@@ -2,5 +2,6 @@ type T = int;
 
 node N() returns (m: map<T,R>);
 let
+  m = any@<map<T,R>>;
 tel
 

--- a/tests/ounit/lustre/lustreTypeChecker/poly_fail.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/poly_fail.lus
@@ -6,4 +6,5 @@ tel
 node M(x1: int; x2: bool) returns (y1: int; y2: bool)
 let
     y1 = N@<bool>(x2);
+    y2 = any@<bool>;
 tel

--- a/tests/ounit/lustre/lustreTypeChecker/poly_type_checking.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/poly_type_checking.lus
@@ -1,5 +1,6 @@
 node N<T; U>(x: T) returns (y: U)
 let 
+  y = any@<U>;
   check true;
 tel
 

--- a/tests/ounit/lustre/lustreTypeChecker/provided.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/provided.lus
@@ -1,6 +1,7 @@
 
 node main(c: bool) returns (y: int);
 let
+  y = any@<int>;
   check y < 50 provided y+8;
 tel
 

--- a/tests/ounit/lustre/lustreTypeChecker/record_type_inference_1.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/record_type_inference_1.lus
@@ -7,7 +7,7 @@ type Stack<T> = struct {
   top_pos: Index;
 };
 
-node N(s1:Stack<bool>) returns (s2:Stack<int>; z1,z2:int);
+node N(s1:Stack<bool>) returns (s2:Stack<int>;);
 let
   s2 = Stack@<bool> {  
     items = 2^MAX_SIZE;

--- a/tests/ounit/lustre/lustreTypeChecker/record_type_inference_2.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/record_type_inference_2.lus
@@ -7,7 +7,7 @@ type Stack<T> = struct {
   top_pos: Index;
 };
 
-node N(s1:Stack<bool>) returns (s2:Stack<int>; z1,z2:int);
+node N(s1:Stack<bool>) returns (s2:Stack<int>;);
 let
   s2 = Stack@<int, int> {  
     items = 2^MAX_SIZE;

--- a/tests/ounit/lustre/lustreTypeChecker/record_type_inference_3.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/record_type_inference_3.lus
@@ -11,7 +11,7 @@ type Bad<T> = struct {
   val: int;
 };
 
-node N(s1:Stack<bool>) returns (s2:Stack<int>; b: Bad<bool>; z1,z2:int);
+node N(s1:Stack<bool>) returns (s2:Stack<int>; b: Bad<bool>;);
 let
   s2 = Stack {  
     items = 2^MAX_SIZE;

--- a/tests/ounit/lustre/lustreTypeChecker/record_type_inference_4.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/record_type_inference_4.lus
@@ -8,7 +8,7 @@ type Stack<T> = struct {
   top_pos: Index;
 };
 
-node N(s1:Stack<bool>) returns (s2:Stack<int>; z1,z2:int);
+node N(s1:Stack<bool>) returns (s2:Stack<int>;);
 let
   s2 = Stack {  
     items = 3^MAX_SIZE;

--- a/tests/ounit/lustre/lustreTypeChecker/symbolic_subrange_bound_2.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/symbolic_subrange_bound_2.lus
@@ -5,4 +5,5 @@ node N() returns (ok:bool);
 var s: subrange [X,*] of int;
 let
   s = 0;
+  ok = any@<bool>;
 tel

--- a/tests/ounit/lustre/lustreTypeChecker/temporal_fun_contract_2.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/temporal_fun_contract_2.lus
@@ -1,5 +1,6 @@
 node N() returns (out: int)
 let
+  out = any@<int>;
 tel
 
 function f (inp: int) returns (out: subtype { x: int | x > N() })

--- a/tests/ounit/lustre/lustreTypeChecker/test-type.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/test-type.lus
@@ -91,7 +91,7 @@ let
 
   -- Must fail: forward reference to a node
   xu = Y(xt);
-
+  xv = any@<v>;
   -- Must fail: reference to a nonexistent node
   -- xv = Z(xt);
 tel

--- a/tests/ounit/lustre/lustreTypeChecker/type-grammer.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/type-grammer.lus
@@ -9,6 +9,7 @@ tel;
 node f(const x : int) returns (xb : int^true);
 var b: bool^5;
 let
+  xb = any@<int^true>;
   --%PROPERTY b[1] = false;
   b = false ^ x;
 tel;

--- a/tests/ounit/lustre/lustreTypeChecker/type_redeclaration.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/type_redeclaration.lus
@@ -2,6 +2,7 @@ type T;
 
 node N() returns (y: T);
 let
+  y = any@<T>;
 tel
 
 node M<T>() returns (y3: T)

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -70,6 +70,10 @@ let _ = run_test_tt_main ("frontend LustreSyntaxChecks error tests" >::: [
     match load_file "./lustreSyntaxChecks/any_op_func.lus" with
     | Error (`LustreSyntaxChecksError (_, IllegalAnyOp _)) -> true
     | _ -> false);
+  mk_test "test undefined output" (fun () ->
+    match load_file "./lustreSyntaxChecks/undefined_output.lus" with
+    | Error (`LustreSyntaxChecksError (_, UndefinedOutput _)) -> true
+    | _ -> false);
   mk_test "test any operator in contract import" (fun () ->
     match load_file "./lustreSyntaxChecks/any_op_contract_import.lus" with
     | Error (`LustreSyntaxChecksError (_, IllegalImportOfStatefulContract _)) -> true

--- a/tests/regression/falsifiable/double_mono.lus
+++ b/tests/regression/falsifiable/double_mono.lus
@@ -1,11 +1,16 @@
 node M<T1, T2> () returns (y1: T1; y2: T2)
 let
+  y1 = any@<T1>;
+  y2 = any@<T2>;
 tel
 
 node N<T> (c: bool;) returns (y1: T; y2: int)
 let
   if c then 
     y1, y2 = M@<T, int>();
+  else 
+    y1 = any@<T>; 
+    y2 = any@<int>;
   fi
 
   check y2 + 3 < 4;

--- a/tests/regression/falsifiable/frame-mono.lus
+++ b/tests/regression/falsifiable/frame-mono.lus
@@ -1,6 +1,8 @@
 node Swap<T>(x1, x2:T) returns (y1,y2:T);
 let
  check false;
+ y1 = any@<T>;
+ y2 = any@<T>;
 tel
 
 node N(x1,x2:int) returns (y1,y2:int);

--- a/tests/regression/falsifiable/free_const_array.lus
+++ b/tests/regression/falsifiable/free_const_array.lus
@@ -1,6 +1,6 @@
 const Ids: int^2;
 
-node N() returns (ok: bool)
+node N() returns ()
 let
   check Ids[0]=0;
 tel

--- a/tests/regression/falsifiable/irrelevant_array_variable.lus
+++ b/tests/regression/falsifiable/irrelevant_array_variable.lus
@@ -1,4 +1,6 @@
 node irrelevant_array_variable() returns (y: int^3; x:int);
 let
+  y = any@<int^3>;
+  x = any@<int>;
   check x>0;
 tel;

--- a/tests/regression/falsifiable/map_indices_3.lus
+++ b/tests/regression/falsifiable/map_indices_3.lus
@@ -10,6 +10,7 @@ const M: subtype {x : int | x > 3};
 
 node N(m: M) returns (A: int^N^M; s: Set);
 let
+  A = any@<int^N^M>;
   s = map[]@<M,bool>;
   check m in s;
 tel

--- a/tests/regression/falsifiable/map_ref_types_invalid.lus
+++ b/tests/regression/falsifiable/map_ref_types_invalid.lus
@@ -19,5 +19,6 @@ let
     out2 = inp2;
     out3 = inp3;
     out4 = inp4;
+    out5 = any@<map<R, R>>;
     out6 = inp6;
 tel

--- a/tests/regression/falsifiable/poly_ref_ty2.lus
+++ b/tests/regression/falsifiable/poly_ref_ty2.lus
@@ -5,5 +5,6 @@ tel
 
 node M<T2>() returns (y3: int | Poly@<int>(y3) < 5;)
 let
+    y3 = any@<int>;
     check true -> (Poly@<int>(y3) = (y3 -> pre y3));
 tel

--- a/tests/regression/falsifiable/polymorphic_gids.lus
+++ b/tests/regression/falsifiable/polymorphic_gids.lus
@@ -1,11 +1,16 @@
 node M<T> () returns (y1, y2: T)
 let
+  y1 = any@<T>;
+  y2 = any@<T>;
 tel
 
 node N<T> (c: bool;) returns (y1, y2: T)
 let
   if c then 
     y1, y2 = M@<T>();
+  else 
+    y1 = any@<T>;
+    y2 = any@<T>;
   fi
 tel
 

--- a/tests/regression/falsifiable/record_type_inference.lus
+++ b/tests/regression/falsifiable/record_type_inference.lus
@@ -13,4 +13,6 @@ let
     items = 2^MAX_SIZE;
     top_pos = 3;
   };
+  z1 = any@<int>;
+  z2 = any@<int>;
 tel

--- a/tests/regression/falsifiable/ref_type_ghost_var.lus
+++ b/tests/regression/falsifiable/ref_type_ghost_var.lus
@@ -3,5 +3,6 @@ node N(x: int) returns (y: int);
   var ghost: subtype { x: int | x >= 0 } = -1;
 *)
 let
+  y = any@<int>;
   check true;
 tel

--- a/tests/regression/falsifiable/stack.lus
+++ b/tests/regression/falsifiable/stack.lus
@@ -65,7 +65,7 @@ let
   t = s.items[s.top_pos];
 tel
 
-node N(s1:Stack<int>) returns (s2:Stack<int>; z1,z2:int);
+node N(s1:Stack<int>) returns (s2:Stack<int>);
 let
 
   s2 = push(pop(s1), 3);

--- a/tests/regression/falsifiable/structural_equality.lus
+++ b/tests/regression/falsifiable/structural_equality.lus
@@ -5,6 +5,13 @@ node N  (sc_x: int; x1: bool^N; x2: [int, int]; x3: [int, int]^N; x4: [map<[int,
 returns (sc_y: int; y1: bool^N; y2: [int, int]; y3: [int, int]^N; y4: [map<[int, int], bool>, map<[int, int], bool>];
          y5: map<int, bool>; y6: set<int>)
 let
+  sc_y = any@<int>;
+  y1 = any@<bool^N>;
+  y2 = any@<[int, int]>;
+  y3 = any@<[int, int]^N>;
+  y4 = any@<[map<[int, int], bool>, map<[int, int], bool>]>;
+  y5 = any@<map<int, bool>>;
+  y6 = any@<set<int>>;
   check sc_x = sc_y;
   check x2 = y2;
   check x1 = y1;

--- a/tests/regression/falsifiable/subrange_bug.lus
+++ b/tests/regression/falsifiable/subrange_bug.lus
@@ -1,5 +1,5 @@
 node main () returns (y: subrange [0, 7] of int); 
 let 
-
+  y = any@<int>;
   check y <= 7;
 tel;

--- a/tests/regression/falsifiable/test_contract_calls.lus
+++ b/tests/regression/falsifiable/test_contract_calls.lus
@@ -58,6 +58,7 @@ node n (x, y, z, w: t; blah:int) returns (ok: bool; ok2:int);
 *)
 let
   ok = x = A or x = B or x = C;
+  ok2 = any@<int>;
   --%PROPERTY ok;
   --%PROPERTY x = y or x = z or x = w or y = z or y = w;
 tel

--- a/tests/regression/falsifiable/test_forward_ref_contracts.lus
+++ b/tests/regression/falsifiable/test_forward_ref_contracts.lus
@@ -4,6 +4,7 @@ node mod_real(x, y: real;)returns( z: real );
         assume pre (abs_real(z)) < abs_real(y);
         guarantee abs_real(z) < abs_real(y); *)
 let
+  z = any@<real>;
 tel
 
 node abs_real (x: real) returns(y:real);

--- a/tests/regression/success/forall_enum.lus
+++ b/tests/regression/success/forall_enum.lus
@@ -6,5 +6,6 @@ type R = struct {
 
 node N() returns (y:int);
 let
+  y = any@<int>;
   check forall (x: R) (x.f=E1 or x.f=E2);
 tel

--- a/tests/regression/success/frame_block.lus
+++ b/tests/regression/success/frame_block.lus
@@ -17,6 +17,8 @@ let
       y2 = counter(0);
     fi
   tel
+  y4 = any@<int>;
+  p3 = any@<bool>;
 tel
 
 node counter(x: int) returns (y: int);

--- a/tests/regression/success/frame_block_no_init.lus
+++ b/tests/regression/success/frame_block_no_init.lus
@@ -16,6 +16,7 @@ let
     fi
   tel
 
+  out = any@<int>;
   check (x1 = 24 or x1 = 37 or x1 = 34);
   check (true -> (x2 = pre x2));
 tel

--- a/tests/regression/success/frame_block_unguarded_pres.lus
+++ b/tests/regression/success/frame_block_unguarded_pres.lus
@@ -17,7 +17,7 @@ let
     y2 = pre oscillate(true);
   tel
 
-  
+  p3 = any@<bool>;
 tel;
 
 node counter2(x: int) returns (y: int; z: int);

--- a/tests/regression/success/free_const_subrange.lus
+++ b/tests/regression/success/free_const_subrange.lus
@@ -9,6 +9,7 @@ const C: Nat^2;
 
 node N() returns (ok: bool)
 let
+  ok = any@<bool>;
   check "P1" C[0] >= 0;
   check "P2" R.f[0] >= 0;
 tel

--- a/tests/regression/success/generated_equation_ctx.lus
+++ b/tests/regression/success/generated_equation_ctx.lus
@@ -7,6 +7,6 @@ let
     a, b = W(t = 34);
   else
     a = any@<int>;
-    b = any@<int>;
+    b = any@<bool>;
   fi
 tel

--- a/tests/regression/success/generated_equation_ctx.lus
+++ b/tests/regression/success/generated_equation_ctx.lus
@@ -2,7 +2,11 @@ node imported W(b: bool) returns (a: int; r: bool);
 
 node main(c : bool) returns (t: int; a: int; b: bool);
 let
+  t = any@<int>;
   if c then
     a, b = W(t = 34);
+  else
+    a = any@<int>;
+    b = any@<int>;
   fi
 tel

--- a/tests/regression/success/imperative_if.lus
+++ b/tests/regression/success/imperative_if.lus
@@ -1,9 +1,9 @@
-node test(x: int) returns (y1, y2, y3: int; p1, p2, p3: bool);
+node test(x: int) returns (y1, y2, y3: int; p: bool);
 let 
-  --p1 = (y1 = 1);
-  --p2 = (y2 = 3);
-  p3 = (y3 = 888);
-  --%PROPERTY p3;
+  y1 = any@<int>;
+  y2 = any@<int>;
+  p = (y3 = 888);
+  --%PROPERTY p;
   
   if (true)
   then 

--- a/tests/regression/success/imperative_if_mult_assign.lus
+++ b/tests/regression/success/imperative_if_mult_assign.lus
@@ -1,4 +1,4 @@
-node test(x: int) returns (y1, y2, y3: int; p1, p2, p3: bool);
+node test(x: int) returns (y1, y2, y3: int; p1, p2: bool);
 let 
   p1 = (y1 = 10);
   p2 = (y2 = 24);
@@ -12,6 +12,7 @@ let
     y1 = 10;
     y2 = 4;
   fi
+  y3 = any@<int>;
 tel
 
 node node2(a, b: int) returns (c, d: int);

--- a/tests/regression/success/imperative_if_oracle.lus
+++ b/tests/regression/success/imperative_if_oracle.lus
@@ -15,5 +15,6 @@ let
   else 
     y1 = 6;
   fi
-  
+  p1 = any@<bool>;
+  p3 = any@<bool>;
 tel

--- a/tests/regression/success/imperative_if_oracle2.lus
+++ b/tests/regression/success/imperative_if_oracle2.lus
@@ -1,4 +1,4 @@
-node test(x: int) returns (y1, y2, y3: int; p1, p2, p3: bool);
+node test(x: int) returns (y1, y2, y3: int; p1, p2: bool);
 let 
   p1 = (y1 = 5) or (y1 = 6);
   p2 = (counter(0) < 5 => (y2 = 10));
@@ -13,7 +13,7 @@ let
   else 
     y1 = 6;
   fi
-  
+  y3 = any@<int>;
 tel
 
 node counter(init: int) returns (y: int);

--- a/tests/regression/success/imperative_if_simplify.lus
+++ b/tests/regression/success/imperative_if_simplify.lus
@@ -1,9 +1,9 @@
-node test(x: int) returns (y1, y2, y3: int; p1, p2, p3: bool);
+node test(x: int) returns (y1, y2, y3: int; p: bool);
 let 
-  --p1 = (y1 = 1);
-  --p2 = (y2 = 3);
-  p3 = (y3 = 6);
-  --%PROPERTY p3;
+  y1 = any@<int>;
+  y2 = any@<int>;
+  p = (y3 = 6);
+  --%PROPERTY p;
   
   if (true)
   then 

--- a/tests/regression/success/index_access_bug.lus
+++ b/tests/regression/success/index_access_bug.lus
@@ -1,5 +1,6 @@
 node N(m1: map<int,int>; m2: map<int,bool>) returns (r: bool); 
 (*@contract assume "A" m2[m1[0]]; *) 
 let 
+  r = any@<bool>;
   check true;
 tel

--- a/tests/regression/success/list_flattening.lus
+++ b/tests/regression/success/list_flattening.lus
@@ -19,6 +19,7 @@ node N(x,y:int; c: bool) returns (ok: bool);
 var a0,a1,a2,a3,a4,a5,a6,a7,a8,a9:int;
     b0,b1,b2,b3,b4,b5,b6:int;
 let
+  ok = any@<bool>;
   a0, a1 = F2(F1(x,y),F1(x,y));
   a2, a3 = F2(F1(x,y),y,F0(x));
   a4, a5 = F2((x,y),F0(x),y);

--- a/tests/regression/success/map_subrange_enum_types.lus
+++ b/tests/regression/success/map_subrange_enum_types.lus
@@ -26,6 +26,11 @@ let
   out1 = inp1;
   out2 = inp2;
   out3 = inp3;
+  out4 = any@<T>;
+  n1 = any@<int>;
+  n2 = any@<int>;
+  n3 = any@<T>;
+  n4 = any@<T>;
  
   check n1 = n2 and (n1 in out1) and (n2 in out1) => out1[n1] = out1[n2];
   check n3 = n4 and (n3 in out2) and (n4 in out2) => out2[n3] = out2[n4];

--- a/tests/regression/success/mult_two_polys.lus
+++ b/tests/regression/success/mult_two_polys.lus
@@ -20,5 +20,6 @@ var x2: int;
 let 
   x1 = s2(n);
   x2 = s3(n);
+  x = any@<bool>;
   check x1 = x2;
 tel

--- a/tests/regression/success/num_const_evaluation.lus
+++ b/tests/regression/success/num_const_evaluation.lus
@@ -3,6 +3,7 @@ const M: int = 1;
 
 node main() returns (ok: bool);
 let 
+  ok = any@<bool>;
   check "EQ" M = 1;
   check "LTE" M <= 1;
   check "GTE" M >= 1;

--- a/tests/regression/success/poly_type_decl.lus
+++ b/tests/regression/success/poly_type_decl.lus
@@ -35,6 +35,7 @@ tel
 node N(x: UserType2<real>) returns (y: UserType2<real>; w:int; l: Loc_int; z: R<real>);
 let
   y = x;
+  w = any@<int>;
   z = R@<real> { f1 = x; f2 = true };
   l = Loc_int { x=1; y=2 };
   check y = x;

--- a/tests/regression/success/provided.lus
+++ b/tests/regression/success/provided.lus
@@ -1,6 +1,7 @@
 
 node main(c: bool) returns (y: int);
 let
+  y = any@<int>;
   check y < 50 provided y < 25;
 tel
 

--- a/tests/regression/success/quantified_subrange_var.lus
+++ b/tests/regression/success/quantified_subrange_var.lus
@@ -5,6 +5,7 @@ type E = enum {E1, E2};
 
 node N() returns (ok: bool);
 let
+  ok = any@<bool>;
   check forall (x: T) x<5;
   check exists (x:T) 0<x;
   check forall (x: E) x=E1 or x=E2;

--- a/tests/regression/success/ref_type_alias_quantified.lus
+++ b/tests/regression/success/ref_type_alias_quantified.lus
@@ -1,6 +1,6 @@
 type T1 = subtype {x : int | x > 5};
 
-node N(x:subtype {x : subtype {x : int | x > 5} | x > 0}) returns (r:bool);
+node N(x:subtype {x : subtype {x : int | x > 5} | x > 0}) returns ();
 let
   check forall (x:subtype {x : T1 | x > 0}) x>5;
   check forall (x:subtype {x : subtype {x : int | x > 5} | x > 0}) x>5;

--- a/tests/regression/success/ref_type_quantifier.lus
+++ b/tests/regression/success/ref_type_quantifier.lus
@@ -1,5 +1,6 @@
 
 node N() returns (y:int);
 let
+  y = any@<int>;
   check forall (i: subtype {x : int | x >= 0 }) 2*i>=0;
 tel

--- a/tests/regression/success/ref_type_sorting.lus
+++ b/tests/regression/success/ref_type_sorting.lus
@@ -1,5 +1,6 @@
 node M(x: int) returns (out: bool)
 let
+  out = any@<bool>;
 tel
 
 contract C(x: int | M(x)) returns (y: int);

--- a/tests/regression/success/test_array_concat_slice.lus
+++ b/tests/regression/success/test_array_concat_slice.lus
@@ -8,7 +8,6 @@ let
 tel
 
 node y (const a: bool) returns (b: int);
-
 -- Local constant declarations
 const c : int = 1; d: int = 2;
 
@@ -22,6 +21,7 @@ var t : y_t;
     q: bool;
     g, h, i: real;
 let
+  b = any@<int>;
 
   -- (Constant) stream definitions 
   e = 1;

--- a/tests/regression/success/test_node_decls2.lus
+++ b/tests/regression/success/test_node_decls2.lus
@@ -10,5 +10,6 @@ var g: int^2;
 var h: int;
 let
    e = [e1, e2, e3];
+   f = any@<[int, bool, int]>;
    h, g = n(e1, [e1, e2]);
 tel

--- a/tests/regression/success/test_node_eqn_with_pre_not_circular.lus
+++ b/tests/regression/success/test_node_eqn_with_pre_not_circular.lus
@@ -14,6 +14,7 @@ var q: int;
 let
    q = pre p;
    p = pre q;
+   y = any@<int>;
 tel
 
 

--- a/tests/regression/success/test_node_eqns.lus
+++ b/tests/regression/success/test_node_eqns.lus
@@ -1,7 +1,6 @@
 type y_t = { a: int; b: real };
 
 node y (const a: bool) returns (b: int);
-
 -- Local constant declarations
 const c : int = 1; d : int = 2;
 const r : y_t =  y_t { b = 3.0; a = 1 };
@@ -14,7 +13,7 @@ var t : y_t;
     y_l: int;
     m: real;
 let
-
+  b = any@<int>;
   -- (Constant) stream definitions 
   e = 1;
   (f) = 2;

--- a/tests/regression/success/type_inference_calls.lus
+++ b/tests/regression/success/type_inference_calls.lus
@@ -5,6 +5,7 @@ tel
 
 node M2<T>(inp: T) returns (out: T)
 let
+  out = any@<T>;
 tel
 
 node N(inp: int^3; inp2: int) returns (out: int^3; out2: int;)


### PR DESCRIPTION
Add check to disallow undefined node and function outputs. 

After adding this check (and the corresponding `output_var = any@<ty>;` equations to test cases), test file `tests/regression/falsifiable/double_mono.lus` was throwing an exception. The root cause was that monomorphizations were being generated in such an order that some node was called before it was defined in the declaration list. 

We have faced the same problem before, and I spent a good deal of time trying to find the error in the order of the generated declarations. After enough time, I decided that the most robust solution is to simply re-sort the declarations after monomorphization (after these bugs, I don't know if there is any straightforward way to generate all the monomorphizations with the correct order by construction). 

Re-sorting simply involves a call to `sort_and_check_nodes_contracts` from the dependency analysis module. However, I also extended the module to check the generated equations for dependencies, as they may be hidden there.