### PR TITLE
Realizability checks for constants

### DIFF
--- a/doc/usr/source/2_input/4_refinement_types.rst
+++ b/doc/usr/source/2_input/4_refinement_types.rst
@@ -168,8 +168,9 @@ Kind 2 performs three types of realizability checks:
 3. Individual refinement types, i.e., that a global refinement type declaration is realizable
 
 You can specify a particular node or function to analyze using 
-``--lus_main <node_name>``, and a specific refinement type using 
-``--lus_main_type <type_name>``.
+``--lus_main <node_name>``, a specific refinement type using
+``--lus_main_type <type_name>``, or a specific constant using
+``--lus_main_const <const_name>``.
 
 Structured types
 ----------------

--- a/doc/usr/source/9_other/12_contract_check.rst
+++ b/doc/usr/source/9_other/12_contract_check.rst
@@ -19,8 +19,9 @@ To check the contracts of nodes and functions, run:
   kind2 --enable CONTRACTCK <lustre_file>
 
 You can specify a particular node or function to analyze using 
-``--lus_main <node_name>``, and a specific refinement type using 
-``--lus_main_type <type_name>``.
+``--lus_main <node_name>``, a specific refinement type using
+``--lus_main_type <type_name>``, or a specific constant using
+``--lus_main_const <const_name>``.
 
 If Kind 2 is able to prove some contract *unrealizable*
 and the ``--print_deadlock`` flag is true,

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -2944,6 +2944,24 @@ module Global = struct
   let lus_main () = !lus_main
  
 
+  let lus_main_const_default = None
+
+  let lus_main_const = ref lus_main_const_default
+  let _ = add_spec
+    "--lus_main_const"
+    (Arg.String (fun str -> lus_main_const := Some str))
+    (fun fmt ->
+      Format.fprintf fmt
+        "\
+          where <string> is a constant identifier from the Lustre input file@ \
+          Designate a constant declaration for which the corresponding generated function@ \
+          is the top function for the analysis@ \
+          Default: all constant declarations \
+        "
+    )
+  let lus_main_const () = !lus_main_const
+
+
   let lus_main_type_default = None
 
   let lus_main_type = ref lus_main_type_default
@@ -3720,6 +3738,7 @@ let check_reach = Global.check_reach
 let check_nonvacuity = Global.check_nonvacuity
 let check_subproperties = Global.check_subproperties
 let lus_main = Global.lus_main
+let lus_main_const = Global.lus_main_const
 let lus_main_type = Global.lus_main_type
 let debug = Global.debug
 let debug_log = Global.debug_log

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -147,6 +147,9 @@ val add_input_file : string -> bool
 (** Main node in Lustre file *)
 val lus_main : unit -> string option
 
+(** Main constant identifier in Lustre file *)
+val lus_main_const : unit -> string option
+
 (** Main type alias in Lustre file *)
 val lus_main_type : unit -> string option
 

--- a/src/kEvent.ml
+++ b/src/kEvent.ml
@@ -1651,8 +1651,8 @@ let log_contractck_analysis_start in_sys scope =
         | Type -> "type"
         | Component -> "contract of imported node"
         | Any -> "'any' operator"
-        | FreeConstant -> "global constant (free)"
-        | DefinedConstant -> "global constant (defined)"
+        | FreeConstant -> "global constant"
+        | DefinedConstant -> "global constant"
         | Choose -> "'choose' operator")
         NI.pp_print_node_id_user_name node_id
     )
@@ -1669,8 +1669,8 @@ let log_contractck_analysis_start in_sys scope =
         | Type -> "type"
         | Contract | Component -> "contract"
         | Any -> "'any' operator"
-        | DefinedConstant -> "global constant (defined)"
-        | FreeConstant -> "global constant (free)"
+        | DefinedConstant -> "global constant"
+        | FreeConstant -> "global constant"
         | Choose -> "'choose' operator");
       analysis_start_not_closed := true
     )
@@ -1688,8 +1688,8 @@ let log_contractck_analysis_start in_sys scope =
         | Type -> "type"
         | Contract | Component -> "contract"
         | Any -> "'any' operator"
-        | DefinedConstant -> "global constant (defined)"
-        | FreeConstant -> "global constant (free)"
+        | DefinedConstant -> "global constant"
+        | FreeConstant -> "global constant"
         | Choose -> "'choose' operator");
       analysis_start_not_closed := true
 

--- a/src/lustre/NodeId.ml
+++ b/src/lustre/NodeId.ml
@@ -62,6 +62,9 @@ let pp_print_node_id_input_name ppf { name; } =
 let pp_print_node_id_user_name ppf { user_name; } = 
   Format.fprintf ppf "%a" HString.pp_print_hstring user_name
 
+let pp_print_node_id_internal_name ppf { internal_name; } =
+  Format.fprintf ppf "%a" HString.pp_print_hstring internal_name
+
 let mk_node_id ?(node_type=Component) ?(monomorphization = []) ?user_name name = 
   let user_name = Option.value user_name ~default:name in
   let internal_name = 

--- a/src/lustre/NodeId.mli
+++ b/src/lustre/NodeId.mli
@@ -25,6 +25,7 @@ type t
 val mk_node_id: ?node_type:node_type -> ?monomorphization:int list -> ?user_name:HString.t -> HString.t -> t
 val pp_print_node_id_input_name: Format.formatter -> t -> unit
 val pp_print_node_id_user_name: Format.formatter -> t -> unit
+val pp_print_node_id_internal_name: Format.formatter -> t -> unit
 val hash: t -> int 
 val equal: t -> t -> bool 
 val compare: t -> t -> int

--- a/src/lustre/contractChecker.ml
+++ b/src/lustre/contractChecker.ml
@@ -329,8 +329,8 @@ let pp_print_realizability_result_pt
       | Type -> "Type"
       | Component -> "Contract of imported node"
       | Any -> "'Any' operator"
-      | DefinedConstant -> "Global constant (defined)"
-      | FreeConstant -> "Global constant (free)"
+      | DefinedConstant -> "Global constant"
+      | FreeConstant -> "Global constant"
       | Choose -> "'Choose' operator")
       NI.pp_print_node_id_user_name node_id
       (Realizability.result_to_string result)
@@ -571,8 +571,8 @@ let pp_print_satisfiability_result_pt in_sys param fmt result =
       | Type -> "Type"
       | Component -> "Contract of imported node"
       | Any -> "'Any' operator"
-      | DefinedConstant -> "Global constant (defined)"
-      | FreeConstant -> "Global constant (free)"
+      | DefinedConstant -> "Global constant"
+      | FreeConstant -> "Global constant"
       | Choose -> "'Choose' operator")
       NI.pp_print_node_id_user_name node_id
       (Stat.get_float Stat.analysis_time)
@@ -594,8 +594,8 @@ let pp_print_satisfiability_result_pt in_sys param fmt result =
       | Type -> "Type"
       | Component -> "Contract of imported node"
       | Any -> "'Any' operator"
-      | DefinedConstant -> "Global constant (defined)"
-      | FreeConstant -> "Global constant (free)"
+      | DefinedConstant -> "Global constant"
+      | FreeConstant -> "Global constant"
       | Choose -> "'Choose' operator")
       NI.pp_print_node_id_user_name node_id
       (satisfiability_result_to_string result)

--- a/src/lustre/lustreConstantsToFunctions.ml
+++ b/src/lustre/lustreConstantsToFunctions.ml
@@ -183,8 +183,9 @@ let gen_const_functions ctx decls =
     List.fold_left (fun (acc_decls, acc_new_func_ids, acc_ctx) decl -> match decl with 
     | A.ConstDecl (s, A.FreeConst (_, id, ty)) -> 
       let ctx = Ctx.add_ty ctx id ty in
-      if ty_contains_gids ctx None ty then 
-        (* Only generate a function if necessary (we need it to handle generated identifiers *)
+      if ty_contains_gids ctx None ty || List.mem `CONTRACTCK (Flags.enabled ()) then
+        (* Generate a function for free constants when necessary to preserve generated identifiers,
+           and for realizability checking of free constants. *)
         let p = s.start_pos in
         let node_type = NI.FreeConstant in
         let node_id = NI.mk_node_id ~node_type id in
@@ -209,7 +210,17 @@ let gen_const_functions ctx decls =
         let acc_ctx = Ctx.remove_const acc_ctx id in
         let acc_ctx = Ctx.add_ty_node acc_ctx node_id func_ty true in 
         let acc_ctx = Ctx.add_node_param_attr acc_ctx node_id [] in
-        acc_decls @ [A.FuncDecl (s, (node_id, false, Transparent, [], [], ops, [], nis, None))],
+        let func_decl1 =
+          A.FuncDecl (s, (node_id, false, Transparent, [], [], ops, [], nis, None))
+        in
+        (if List.mem `CONTRACTCK (Flags.enabled ()) then
+          let func_decl2 =
+            let node_id = NI.mk_node_id ~node_type:NI.FreeConstant id in
+            A.FuncDecl (s, (node_id, true, Default, [], [], ops, [], [], None))
+          in
+          acc_decls @ [func_decl1; func_decl2]
+        else
+          acc_decls @ [func_decl1]),
         (* Constants with definitions don't appear in `new_func_ids` because their 
            references don't need to be converted to calls (these constants are inlined) *)
         acc_new_func_ids,

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -314,24 +314,26 @@ let of_channel only_parse in_ch =
     let result =
       let* (ctx, gids, decls, toplevel_nodes, _) = type_check declarations in
       let nodes, globals = LNG.compile ctx gids decls in
+      let contractck_enabled = List.mem `CONTRACTCK (Flags.enabled ()) in
       let main_nodes = match Flags.lus_main () with
         | Some s -> 
           let s_ident = LustreIdent.mk_string_ident s in (
-          try 
-            let main_lustre_node =  LN.node_of_input_name s_ident nodes in 
+          try
+            let node_id = NI.mk_node_id ~node_type:Component (HString.mk_hstring s) in
+            let main_lustre_node =  LN.node_of_node_id node_id nodes in 
             (* If checking realizability, then 
               we are actually checking realizability of Kind 2-generated imported nodes representing 
               the (1) the main node's contract instrumented with type info and 
                   (2) the main node's enviornment, if environment checking is enabled *)
             let main_nodes = 
-              if (not main_lustre_node.is_extern) && List.mem `CONTRACTCK (Flags.enabled ()) then 
+              if (not main_lustre_node.is_extern) && contractck_enabled then 
                 let node_id = NI.mk_node_id ~node_type:Contract (HString.mk_hstring s) in 
                 let _ = LN.node_of_node_id node_id nodes in
                 [node_id]
-              else [NI.mk_node_id (HString.mk_hstring s)] 
+              else [node_id] 
             in
             let main_nodes = 
-              if (Flags.Contracts.check_environment ()) && List.mem `CONTRACTCK (Flags.enabled ()) then
+              if (Flags.Contracts.check_environment ()) && contractck_enabled then
                 let node_id = NI.mk_node_id ~node_type:Environment (HString.mk_hstring s) in 
                 let _ = LN.node_of_node_id node_id nodes in
                 node_id :: main_nodes 
@@ -348,18 +350,65 @@ let of_channel only_parse in_ch =
             raise (NoMainNode msg)
         )
         | None -> (
-          match LustreNode.get_main_annotated_nodes nodes with
-          | (_ :: _ as node_names) -> node_names
-          | [] ->
-            match toplevel_nodes with
-            | [] -> raise (NoMainNode "No node defined in input model")
-            | _ -> toplevel_nodes |> List.map (fun s -> NI.mk_node_id s)
+          match contractck_enabled, Flags.lus_main_const (), Flags.lus_main_type () with
+          | true, None, None
+          | false, None, _ -> (
+            match LustreNode.get_main_annotated_nodes nodes with
+            | (_ :: _ as node_names) -> node_names
+            | [] ->
+              match toplevel_nodes with
+              | [] -> raise (NoMainNode "No node defined in input model")
+              | _ -> toplevel_nodes |> List.map (fun s -> NI.mk_node_id s)
+          )
+          | _ -> []
+        )
+      in
+      let main_nodes = match Flags.lus_main_const () with
+        | Some s ->
+          let s_ident = LustreIdent.mk_string_ident s in (
+          try 
+            let node_id =
+              if contractck_enabled then
+                (* Constants with definitions are treated as free constants
+                   when checking realizability. *)
+                NI.mk_node_id ~node_type:FreeConstant (HString.mk_hstring s)
+              else
+                NI.mk_node_id ~node_type:DefinedConstant (HString.mk_hstring s)
+            in
+            let _ = LN.node_of_node_id node_id nodes in
+            node_id :: main_nodes
+          (* User-specified main constant in command-line input might not exist *)
+          with Not_found -> 
+            let msg =
+              Format.asprintf "No %s '%a' found in input"
+                (if contractck_enabled then "free constant" else "defined constant")
+                (LustreIdent.pp_print_ident false) s_ident
+            in
+            raise (NoMainNode msg)
+          )
+        | None -> (
+          match contractck_enabled, Flags.lus_main (), Flags.lus_main_type () with
+          | true, None, None -> (
+            List.fold_left (fun acc n ->
+              if NI.get_node_type n.LustreNode.node_id = FreeConstant then
+                n.LustreNode.node_id :: acc
+              else acc
+            ) main_nodes nodes
+          )
+          | false, None, _ -> (
+            List.fold_left (fun acc n ->
+              if NI.get_node_type n.LustreNode.node_id = DefinedConstant then
+                n.LustreNode.node_id :: acc
+              else acc
+            ) main_nodes nodes
+          )
+          | _ -> main_nodes
         )
       in
       let main_nodes = match Flags.lus_main_type () with
         | Some s -> 
           let s_ident = LustreIdent.mk_string_ident s in 
-          if not (List.mem `CONTRACTCK (Flags.enabled ())) then
+          if not contractck_enabled then
             let msg =
               Format.asprintf "Option --lus_main_type can only be used when realizability checking is enabled (--enable CONTRACTCK)"
             in
@@ -367,10 +416,8 @@ let of_channel only_parse in_ch =
           else (
             try 
               let node_id = NI.mk_node_id ~node_type:Type (HString.mk_hstring s) in
-              let _ = LN.node_of_node_id node_id nodes in  
-              match Flags.lus_main () with 
-              | Some _ -> node_id :: main_nodes
-              | None -> [node_id]
+              let _ = LN.node_of_node_id node_id nodes in
+              node_id :: main_nodes
             (* User-specified type alias in command-line input might not exist *)
             with Not_found -> 
               let msg =
@@ -379,14 +426,8 @@ let of_channel only_parse in_ch =
               in
               raise (NoMainNode msg)
           )
-        | None -> main_nodes in
-      let defined_const_funcs = List.filter_map (fun n -> 
-      if NI.get_node_type n.LustreNode.node_id = DefinedConstant then 
-         Some n.LustreNode.node_id 
-      else 
-        None
-      ) nodes in 
-      let main_nodes = main_nodes @ defined_const_funcs in 
+        | None -> main_nodes
+      in
       Ok (nodes, globals, main_nodes)
     in
 

--- a/src/lustre/lustrePath.ml
+++ b/src/lustre/lustrePath.ml
@@ -1129,8 +1129,8 @@ let rec pp_print_lustre_path_pt' ?(full_contract=false) is_top const_map const_f
     | Type -> "Type"
     | Component -> "Node"
     | Any -> "'Any' operator"
-    | DefinedConstant -> "Global constant (defined)"
-    | FreeConstant -> "Global constant (free)"
+    | DefinedConstant -> "Global constant"
+    | FreeConstant -> "Global constant"
     | Choose -> "'Choose' operator"
   in
   

--- a/src/modelElement.ml
+++ b/src/modelElement.ml
@@ -252,8 +252,8 @@ let pp_print_core_data in_sys param sys fmt cpd =
       | Type -> "Type"
       | Component -> "Node"
       | Any -> "'Any' operator"
-      | DefinedConstant -> "Global constant (defined)"
-      | FreeConstant -> "Global constant (free)"
+      | DefinedConstant -> "Global constant"
+      | FreeConstant -> "Global constant"
       | Choose -> "'Choose' operator")
     NI.pp_print_node_id_user_name node_id ;
     Format.fprintf fmt "  @[<v>" ;


### PR DESCRIPTION
This PR introduces a new option `--lus_main_const` to designate a constant declaration as the main model element of the analysis. This is required to disambiguate which model element the user is referring to, since nodes/functions, constants, and types belong to different namespaces and may share the same name. Realizability checks of constants with definitions are achieved by treating them as free constants (which is why printed messages no longer distinguish between the two kinds of constants).