### PR TITLE
Tuple Square Bracket Support in Interpreter Input

### DIFF
--- a/doc/usr/source/9_other/8_interpreter.rst
+++ b/doc/usr/source/9_other/8_interpreter.rst
@@ -100,3 +100,14 @@ can be assigned as follows:
       "t": { "0":"36", "1": false, "2":"5.0" }
     }
   ]
+
+Alternatively, a tuple can be expressed as a JSON array.
+
+.. code-block:: json
+
+  [
+    {
+      "t": [ "36", false, "5.0" ]
+    }
+  ]
+

--- a/doc/usr/source/9_other/8_interpreter.rst
+++ b/doc/usr/source/9_other/8_interpreter.rst
@@ -101,7 +101,7 @@ can be assigned as follows:
     }
   ]
 
-Alternatively, a tuple can be expressed as a JSON array.
+Alternatively, a tuple can be expressed using a JSON array.
 
 .. code-block:: json
 

--- a/src/inputParser.ml
+++ b/src/inputParser.ml
@@ -213,7 +213,7 @@ let rec read_val ?(only_inputs = true) scope name indexes arr_indexes json  =
     )
     |> List.flatten
     )
-    with Not_an_input str -> (* If it is not an array, it must be a tuple *)
+    with Not_an_input _ -> (* If it is not an array, it must be a tuple *)
       lst |> List.mapi (
             fun i json ->
             read_val scope name ((LustreIndex.TupleIndex i)::indexes) arr_indexes  json

--- a/src/inputParser.ml
+++ b/src/inputParser.ml
@@ -202,13 +202,25 @@ let rec read_val ?(only_inputs = true) scope name indexes arr_indexes json  =
           |> List.flatten 
       end
     end
-  | `List lst -> lst |>
-    List.mapi (
+  | `List lst ->
+    (* Can represent an array or a tuple *)
+    begin try (
+      lst |>
+      List.mapi (
       fun i json ->
       let new_index = LustreIndex.ArrayVarIndex (LustreExpr.mk_int_expr Numeral.one) in
       read_val scope name (new_index::indexes) (i::arr_indexes) json
     )
     |> List.flatten
+    )
+    with Not_an_input str -> (* If it is not an array, it must be a tuple *)
+      lst |> List.mapi (
+            fun i json ->
+            read_val scope name ((LustreIndex.TupleIndex i)::indexes) arr_indexes  json
+          )
+          |> List.flatten 
+      end
+    
   | json ->
     let indexes = List.rev indexes in
     let arr_indexes = List.rev arr_indexes in


### PR DESCRIPTION
Added:
- New interpreter syntax for tuples which is identical to the array syntax
- The actual type of the input value is determined by the Lustre definitions (relying on the fact that we flatten tuples)
   - This is done the same way as records are done (they also rely on the fact that we flatten tuples)