### PR TITLE
Fix realizability of functions with free constants

### DIFF
--- a/src/lustre/contractChecker.ml
+++ b/src/lustre/contractChecker.ml
@@ -192,21 +192,24 @@ let check_contract_realizability in_sys sys =
   in
 
   let vars_of_term term =
-    match Term.destruct term with
-    | Term.T.App (s, args) when
-      (match (Symbol.node_of_symbol s) with `UF _ -> true | _ -> false)
-      -> ( (* Case of a node call *)
-      let ufs = Symbol.uf_of_symbol s in
-      match UFM.find_opt ufs call_output_args with
-      | None -> Term.vars_of_term term
-      | Some (s, k) -> (
-        Lib.list_slice args s (s+k-1)
-        |> List.fold_left
-          (fun acc t -> VS.union acc (Term.vars_of_term t))
-          VS.empty
+    if Term.is_forall term || Term.is_exists term then
+      Term.vars_of_term term
+    else
+      match Term.destruct term with
+      | Term.T.App (s, args) when
+        (match (Symbol.node_of_symbol s) with `UF _ -> true | _ -> false)
+        -> ( (* Case of a node call *)
+        let ufs = Symbol.uf_of_symbol s in
+        match UFM.find_opt ufs call_output_args with
+        | None -> Term.vars_of_term term
+        | Some (s, k) -> (
+          Lib.list_slice args s (s+k-1)
+          |> List.fold_left
+            (fun acc t -> VS.union acc (Term.vars_of_term t))
+            VS.empty
+        )
       )
-    )
-    | _ -> Term.vars_of_term term
+      | _ -> Term.vars_of_term term
   in
 
   realizability_check

--- a/src/lustre/lustreConstantsToFunctions.ml
+++ b/src/lustre/lustreConstantsToFunctions.ml
@@ -214,8 +214,9 @@ let gen_const_functions ctx decls =
     List.fold_left (fun (acc_decls, acc_new_func_ids, acc_ctx) decl -> match decl with 
     | A.ConstDecl (s, A.FreeConst (_, id, ty)) -> 
       let ctx = Ctx.add_ty ctx id ty in
-      if ty_contains_gids ctx None ty || List.mem `CONTRACTCK (Flags.enabled ()) then
-        (* Generate a function for free constants when necessary to preserve generated identifiers,
+      let contains_gids = ty_contains_gids ctx None ty in
+      if contains_gids || List.mem `CONTRACTCK (Flags.enabled ()) then
+        (* Generate a function for free constants when the type includes generated identifiers,
            and for realizability checking of free constants. *)
         let p = s.start_pos in
         let node_type = NI.FreeConstant in
@@ -225,9 +226,20 @@ let gen_const_functions ctx decls =
         let acc_ctx = Ctx.remove_const acc_ctx id in
         let acc_ctx = Ctx.add_ty_node acc_ctx node_id func_ty true in 
         let acc_ctx = Ctx.add_node_param_attr acc_ctx node_id [] in
-        acc_decls @ [A.FuncDecl (s, (node_id, true, Default, [], [], ops, [], [], None))],
-        id :: acc_new_func_ids, 
-        acc_ctx
+        let acc_decls =
+          acc_decls @ [A.FuncDecl (s, (node_id, true, Default, [], [], ops, [], [], None))]
+        in
+        let acc_decls, acc_new_func_ids =
+          (* If type does not contain generated identifiers, and we are only generating
+             an imported function for realizability checking, then we don't need to
+             convert references to this constant to calls, so we keep original declaration,
+             and we don't include the id in new_func_ids *)
+          if not contains_gids then
+            acc_decls @ [decl], acc_new_func_ids
+          else
+            acc_decls, id :: acc_new_func_ids
+        in
+        acc_decls, acc_new_func_ids, acc_ctx
       else 
         acc_decls @ [decl], acc_new_func_ids, acc_ctx
     | A.ConstDecl (s, A.TypedConst (_, id, e, ty)) -> 

--- a/src/realizability.ml
+++ b/src/realizability.ml
@@ -50,10 +50,13 @@ let term_partition vars_of_term var_lst term_lst =
 
 
 let rec get_conjucts term =
-  match Term.destruct term with
-  | Term.T.App (s, args) when s == Symbol.s_and ->
-     List.map get_conjucts args |> List.flatten
-  | _ -> [term]
+  if Term.is_forall term || Term.is_exists term then
+    [term]
+  else
+    match Term.destruct term with
+    | Term.T.App (s, args) when s == Symbol.s_and ->
+      List.map get_conjucts args |> List.flatten
+    | _ -> [term]
 
 
 (*

--- a/tests/lustre/realizability_constants_1.lus
+++ b/tests/lustre/realizability_constants_1.lus
@@ -1,0 +1,19 @@
+
+type Nat = subrange [0,*] of int;
+
+type T = int;
+
+const R: int;
+
+const N: subtype {x: int | x >= R} ;
+
+function imported f(x: int) returns (y: int);
+(*@contract
+  guarantee y > R;
+*)
+
+node M() returns (x: int);
+let
+  x = N + 1;
+  check x>1;
+tel

--- a/tests/lustre/realizability_constants_2.lus
+++ b/tests/lustre/realizability_constants_2.lus
@@ -1,0 +1,9 @@
+
+type Nat = subrange [0,*] of int;
+
+const R: subtype {s: set<int> | s = {1,2,3}};
+
+function imported f(x: int) returns (y: int);
+(*@contract
+  guarantee y in R;
+*)


### PR DESCRIPTION
In order to check the realizability of free constants, PR #1312 generates an associated imported function for each free constant. This reuses existing functionality that generates imported functions for free constants whose types lead to generated identifiers (such as subtypes involving set operations).

This has the consequence of replacing all constants with calls to their associated functions. However, calls to imported functions are not supported in realizability checks.

To address this, the change avoids replacing constants whose types do not lead to generated identifiers, allowing realizability checks for functions that refer to those constants.