### PR TITLE
LSP Output: Classify free constants as params

### DIFF
--- a/src/lustre/lspInfo.ml
+++ b/src/lustre/lspInfo.ml
@@ -50,27 +50,29 @@ let lsp_type_decl_json ppf ctx { Ast.start_pos = spos; Ast.end_pos = epos } tyd 
   | LustreAst.FreeType (p, id) -> print p id []
 
 
-let lsp_const_decl_json ppf { Ast.start_pos = spos; Ast.end_pos = epos } =
-  function
-  | LustreAst.FreeConst (_, id, _)
-  | LustreAst.UntypedConst (_, id, _)
-  | LustreAst.TypedConst (_, id, _, _) ->
-      let file, slnum, scnum = Lib.file_row_col_of_pos spos in
-      let _, elnum, ecnum = Lib.file_row_col_of_pos epos in
-      Format.fprintf ppf
-        ",@.{@[<v 1>@,\
-         \"objectType\" : \"lsp\",@,\
-         \"source\" : \"lsp\",@,\
-         \"kind\" : \"constDecl\",@,\
-         \"name\" : \"%a\",@,\
-         %a\"startLine\" : %d,@,\
-         \"startColumn\" : %d,@,\
-         \"endLine\" : %d,@,\
-         \"endColumn\" : %d@]@.}@."
-        HString.pp_print_hstring id
-        pp_print_fname_json file
-        slnum scnum
-        elnum ecnum
+let lsp_const_decl_json ppf { Ast.start_pos = spos; Ast.end_pos = epos } decl =
+  let id, type_str = match decl with
+    | LustreAst.FreeConst (_, id, _) -> id, "paramDecl"
+    | LustreAst.UntypedConst (_, id, _) 
+    | LustreAst.TypedConst (_, id, _, _) -> id, "constDecl"
+  in
+    let file, slnum, scnum = Lib.file_row_col_of_pos spos in
+    let _, elnum, ecnum = Lib.file_row_col_of_pos epos in
+    Format.fprintf ppf
+      ",@.{@[<v 1>@,\
+        \"objectType\" : \"lsp\",@,\
+        \"source\" : \"lsp\",@,\
+        \"kind\" : \"%s\",@,\
+        \"name\" : \"%a\",@,\
+        %a\"startLine\" : %d,@,\
+        \"startColumn\" : %d,@,\
+        \"endLine\" : %d,@,\
+        \"endColumn\" : %d@]@.}@."
+      type_str
+      HString.pp_print_hstring id
+      pp_print_fname_json file
+      slnum scnum
+      elnum ecnum
 
 let lsp_node_json ppf { Ast.start_pos = spos; Ast.end_pos = epos }
     (node_id, imported, _, _, _, _, _, _, contract) =


### PR DESCRIPTION
Changed:

The LSP mode now differentiates a constant declaration that has a definition (`constDecl`) from a constant declaration without a definition (`paramDecl`).

This information is emitted in the LSP JSON under the `kind` attribute, previously only having `constDecl` as its value.
The `kind` of a constant without a declaration is now `paramDecl`.