### PR TITLE
Type ascription user doc and syntax-test.lus

### DIFF
--- a/doc/usr/source/2_input/4_refinement_types.rst
+++ b/doc/usr/source/2_input/4_refinement_types.rst
@@ -138,6 +138,29 @@ For example, in the node call ``M(z)``
 (where ``z`` has type ``int`` and ``M`` takes a single parameter of type ``Nat``),
 ``M``'s typing assumption on its input will be violated if ``z`` can be negative. 
 
+Type Ascription
+---------------
+
+To check if an expression satisfies a refinement (or subrange) type, one can use a 
+type ascription operator of the form ``(e: T)``.
+The type ascription operator generates a proof obligation that ``e`` satisfies type ``T``;
+it does *not* introduce an assumption that ``e`` satisfies type ``T``.
+For example, the ascription ``(1: Nat)`` would introduce a proof obligation that ``1`` is a natural number 
+(assuming ``Nat`` is a type capturing the natural numbers); this proof obligation would be discharged by Kind 2.
+Assuming ``x`` is an input variable of type ``int``, 
+the ``check`` statement ``check (x: Nat) >= 0`` 
+would generate two proof obligations: 
+First, it would generate the proof obligation associated with the ``check`` statement that ``x >= 0``, 
+and second, it would generated the proof obligation that ``x`` satisfies type ``Nat``.
+Both these proof obligations would fail because Kind 2 cannot prove that ``x`` is a natural number, 
+as it is an input of type ``int``.
+Again, the ascription introduces a proof obligation, not an assumption.
+
+Ascriptions can also be used with non-refinement types. 
+For example, the ascription ``(1 + 2: bool)`` would trigger a type checking error by Kind 2 before reaching 
+the model checking phase. On the other hand, ``(false or true: bool)`` would pass type checking but not generate 
+any proof obligations.
+
 Realizability
 -------------
 

--- a/examples/syntax-test.lus
+++ b/examples/syntax-test.lus
@@ -135,12 +135,17 @@ returns
 
 -- Local variable declarations are optional
 let 
--- Node equations are optional
+-- Node equations are not optional
+  x = any@<k>;
+  y = any@<[int, [bool, real]]>;
+  z = any@<[int, [bool, real]]>;
+  u = any@<i2>;
+  v = any@<int>;
 tel;
 
 type y_t = { a: int; b: real };
 
-node y (const a: bool) returns (b: int);
+node y (const a: bool) returns ();
 
 -- Local constant declarations
 const c : int = 1; d : int = 2;
@@ -198,7 +203,7 @@ var t : int;
 let t = n; tel;
 
 -- External contract definition
-contract countSpec(trigger: bool; val: int) returns (count: int ; error: bool) ;
+contract countSpec(trigger: bool; val: int) returns (count: int ; ) ;
 let
   assume val >= 0;
   var initVal: int = val -> pre(initVal);
@@ -215,9 +220,9 @@ let
 tel
 
 -- Partially defined node with imported contract
-node my_count (trigger: bool; val: int) returns (count: int ; error: bool) ;
+node my_count (trigger: bool; val: int) returns (count: int ;) ;
 con
-  import countSpec(trigger, val) returns (count, error);
+  import countSpec(trigger, val) returns (count);
 noc
 let
   count = (if trigger then 1 else 0) + (val -> pre count) ;
@@ -543,12 +548,12 @@ const
   unknown: int;
 type T;
 const c_T: T;
-node N (const n: int) returns (x: int);
-
+node N (const n: int) returns (x: int) 
 -- Array of fixed size determined by node input 
 var V: T^(2*n);
 let
   V = c_T^(2*n); -- Local variables must have definitions
+  x = any@<int>; 
 tel;
 
 
@@ -596,8 +601,6 @@ let tel;
 
 -- Section 6
 
-node N4 (U, V, W: int) returns (X: int; Y: real); let tel;
-
 node x61 (C: bool; E, E1: int; F, F1: real) returns (X: int; Y: real);
 let 
   -- (X, Y) = if C then (E, F) else (E1, F1);
@@ -637,7 +640,7 @@ let
   e4 = if g then a else e -> f;
 tel
 
-node x74 (e1, e2, e3: int; f2: bool) returns (e: int^3; f: [int, bool, int]);
+node x74 (e1, e2, e3: int; f2: bool) returns (e: int^3;);
 let
    e = [e1, e2, e3];
 tel
@@ -848,6 +851,15 @@ let
   l2 = any@<int>;
 
   z = y + l1 + l2;
+tel
+
+-- ------------------------------------------------------------
+-- type ascription 
+-- ------------------------------------------------------------
+type Nat = subrange [0, *] of int;
+node M3() returns (z:int);
+let
+  z = (3: Nat);
 tel
 
 -- ------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,11 @@ test_cases = {
 # Where to find the regression tests
 regression_dir = Path("regression").absolute()
 
+# Extra files to test with a fixed expected result, as (path, expected) pairs
+extra_files = [
+    (Path("../examples/syntax-test.lus").resolve(), "falsifiable"),
+]
+
 # Where to write log files
 log_dir = Path("logs")
 
@@ -47,7 +52,6 @@ return_codes = (
 
 expected_to_code = {expected: code for expected, code in return_codes}
 code_to_expected = {code: expected for expected, code in return_codes}
-
 
 def pytest_collect_file(parent, file_path: Path):
     try:
@@ -77,6 +81,17 @@ class LustreFile(pytest.File):
                 case=case,
                 case_name=case_name,
             )
+
+
+# Make `extra_files` visible (they may be outside the `tests` directory)
+def pytest_collection_modifyitems(session, items):
+    extra_items = []
+    for extra_path, expected in extra_files:
+        collector = LustreFile.from_parent(session, path=extra_path, expected=expected)
+        for item in collector.collect():
+            item._nodeid = f"examples/{extra_path.name}::{item.name}"
+            extra_items.append(item)
+    items[:] = extra_items + items
 
 
 class LustreException(Exception): ...


### PR DESCRIPTION
Unrelated changes in this PR: Requiring outputs to be defined broke `syntax-test.lus`, so I also fixed that here. Analogously, I updated `tests/conftest.py` to include `./examples/syntax-test.lus` in the regression suite so a similar problem does not happen in the future.