### PR TITLE
Fix hang in tests by avoiding `stty` call when no TTY is available

### DIFF
--- a/src/utils/pretty.ml
+++ b/src/utils/pretty.ml
@@ -20,15 +20,20 @@
 *)
 
 open Format
-open Lib
 
 (* Set width of pretty printing boxes to number of columns *)
 let vt_width =
   try
-    let stty_size = syscall "stty size < /dev/tty" in
-    let w = Scanf.sscanf stty_size "%d %d" (fun _ cols -> cols) in
-    set_margin w;
-    w
+    if Unix.isatty Unix.stdout then (
+      let cols =
+        match Sys.getenv_opt "COLUMNS" with
+        | Some s -> (try int_of_string s with _ -> 80)
+        | None -> 80
+      in
+      set_margin cols;
+      cols
+    ) else
+      80
   with _ -> 80
 
 let print_line = 


### PR DESCRIPTION
The previous implementation determined terminal width by invoking `stty size < /dev/tty`. When running under dune in some environments, this could cause the test process to be suspended (SIGTTIN) if no controlling TTY was available, leading to `dune runtest` hanging at 99%.

Replace this logic with a safer approach:
- Check `Unix.isatty` before attempting terminal-dependent behavior
- Use the `COLUMNS` environment variable when available
- Fallback to a default width (80) otherwise

This avoids interacting with `/dev/tty`, making the code safe in non-interactive environments such as dune tests and CI.