### PR TITLE
Hide generated constants from output

### DIFF
--- a/src/lustre/lustreGlobals.ml
+++ b/src/lustre/lustreGlobals.ml
@@ -26,8 +26,8 @@ type t =
 
   { 
 
-    (* Free constants *)
-    free_constants : (LustreIdent.t * Var.t LustreIndex.t) list;
+    (* Free constants: ident, variable index, is_generated *)
+    free_constants : (LustreIdent.t * Var.t LustreIndex.t * bool) list;
     
     (* register bounds of state variables for later use *)
     state_var_bounds : state_var_bounds;

--- a/src/lustre/lustreGlobals.mli
+++ b/src/lustre/lustreGlobals.mli
@@ -27,8 +27,8 @@ type state_var_bounds = (LustreExpr.expr LustreExpr.bound_or_fixed list)
 
 type t = 
   { 
-    free_constants : (LustreIdent.t * Var.t LustreIndex.t) list;
-    (** Free constants *)
+    free_constants : (LustreIdent.t * Var.t LustreIndex.t * bool) list;
+    (** Free constants: ident, variable index, is_generated *)
 
     state_var_bounds : state_var_bounds;
     (** Register bounds of state variables for later use *)

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -275,10 +275,13 @@ let print_nodes_and_globals nodes globals =
   ^^ "All State Variables: [@[<hv>%a@]];@ \n\n"
   ^^ "===============================================\n")
   (pp_print_list
-    (pp_print_pair
-      (LustreIdent.pp_print_ident true)
-      (LustreIndex.pp_print_index_trie true Var.pp_print_var)
-      " = ")
+    (fun ppf (id, vt, _) ->
+      pp_print_pair
+        (LustreIdent.pp_print_ident true)
+        (LustreIndex.pp_print_index_trie true Var.pp_print_var)
+        " = "
+        ppf
+        (id, vt))
     ";@ ") globals.LG.free_constants
   (pp_print_list
     (pp_print_pair

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -50,7 +50,7 @@ module StringMap = HString.HStringMap
 type compiler_state = {
   nodes : LustreNode.t list;
   type_alias : Type.t LustreIndex.t StringMap.t;
-  free_constants : (HString.t option * HString.t * Var.t LustreIndex.t) list;
+  free_constants : (HString.t option * HString.t * Var.t LustreIndex.t * bool) list;
   local_constants : LustreAst.expr StringMap.t;
   other_constants : LustreAst.expr StringMap.t;
   state_var_bounds : (LustreExpr.expr LustreExpr.bound_or_fixed list)
@@ -653,9 +653,8 @@ let rec compile ctx gids decls =
   let over_decls cstate decl = compile_declaration cstate gids ctx decl in
   let output = List.fold_left over_decls (empty_compiler_state ()) decls in 
   let free_constants = output.free_constants
-    |> List.map (fun (_, id, v) -> mk_ident id, v)
-    
-  in 
+    |> List.map (fun (_, id, v, is_generated) -> mk_ident id, v, is_generated)
+  in
   output.nodes,
     { G.free_constants = free_constants;
       G.state_var_bounds = output.state_var_bounds;
@@ -849,7 +848,7 @@ and compile_ast_expr
       H.find !map.array_index ident
     with Not_found ->
     try
-      let (_, _, var) = List.find (fun (n, i, _) -> match (n, !map.node_name) with
+      let (_, _, var, _) = List.find (fun (n, i, _, _) -> match (n, !map.node_name) with
         | Some n, Some n' -> n = n' && i = id_str
         | None, _ -> i = id_str
         | _ -> false)
@@ -1858,7 +1857,7 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
     List.fold_left
       (fun cstate (id, ty) ->
         let g = A.FreeConst (dummy_pos, id, ty) in
-        compile_const_decl cstate ctx map true (node_scope @ ["res"]) g
+        compile_const_decl ~is_generated:true cstate ctx map true (node_scope @ ["res"]) g
       )
       cstate
       gids.GI.free_constants
@@ -2835,7 +2834,7 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
   }
 
 
-and compile_const_decl cstate ctx map is_local scope = function
+and compile_const_decl ?(is_generated=false) cstate ctx map is_local scope = function
   | A.FreeConst (p, i, ty) -> (
     let ident = mk_ident i in
     let cty = compile_ast_type cstate ctx map ty in
@@ -2883,7 +2882,7 @@ and compile_const_decl cstate ctx map is_local scope = function
       else cstate.global_constraints
     in
     { cstate with
-      free_constants = (!map.node_name, i, vt) :: cstate.free_constants;
+      free_constants = (!map.node_name, i, vt, is_generated) :: cstate.free_constants;
       global_constraints
     }
   )

--- a/src/lustre/lustrePath.ml
+++ b/src/lustre/lustrePath.ml
@@ -694,12 +694,14 @@ let node_path_of_subsystems
   (* Map from scopes to constants (empty scope = global scope) *)
   let const_map =
     let constants =
-      List.fold_left (fun acc (_, vt) ->
-        let l =
-          (D.bindings vt)
-          |> List.map (fun (i,v) -> (i, Var.state_var_of_state_var_instance v))
-        in
-        List.rev_append l acc
+      List.fold_left (fun acc (_, vt, is_generated) ->
+        if is_generated then acc
+        else
+          let l =
+            (D.bindings vt)
+            |> List.map (fun (i,v) -> (i, Var.state_var_of_state_var_instance v))
+          in
+          List.rev_append l acc
       ) [] globals.LustreGlobals.free_constants
       |> List.rev
     in

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2558,7 +2558,7 @@ let rec trans_sys_of_node' options globals top_name analysis_param
           let global_consts =
             (* Format.eprintf "Global constants: %d@." *)
             (*   (List.length globals.G.free_constants); *)
-            List.fold_left (fun acc (_, vt) ->
+            List.fold_left (fun acc (_, vt, _) ->
                 D.fold (fun _ v acc ->
                     (* Format.eprintf "Gobal constant: %a@." Var.pp_print_var v; *)
                     v :: acc) vt acc


### PR DESCRIPTION
Consider the example pasted below. It has a quantified variable passed to a function. We handle this by inlining the function definition at the call site. But, the function also has a contract, and this contract has an assumption which must generate a proof obligation for the caller, even if we are inlining. So, we generate a fresh constant with the same type as the quantified variable and generate a new call to check the assumption (outside the scope of the quantifier, but the check ends up being equivalent). Before this PR, this generated constant was not being hidden from Kind 2 output; it was leaked (named `quant_arg_2`). 

This PR introduces a flag for free constants that distinguishes generated from non-generated constants, and hides generated constants from output. They are hidden from output by being ommited from the `const_map` in `lustrePath.ml`, which is used by the (output) printing functions.

The code changes in this PR were almost entirely authored by generative AI.

```
transparent function F(inp: int) returns (out: int)
con
  assume inp > 0;
noc
let
  out = inp + 1;
tel

node N() returns ()
let
  check forall (i: int) F(i) > i;
tel
```