### PR TITLE
Stack crash normalizer bug

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1905,10 +1905,11 @@ and abstract_expr ?guard force info (node_id : NI.t option) map expr =
     let ty = if expr_has_inductive_var ivars expr then
       (StringMap.choose_opt info.inductive_variables) |> get |> snd |> snd
     else (
-      (*!! 3. Inferring type of normalized (from (1)) call_context. 
-              But from variable naming, expr is seemingly assumed to be
-              unnormalized. Note we also have nexpr, but use expr here. 
-              By updating (1) to use an unnormalized expr, we avoid this. *)
+      (*!! 3. Inferring type of call_context, which used to be normalized but now is not. 
+              From the (pre-existing) variable naming, `expr` was seemingly assumed to be
+              unnormalized to begin with. Note we also have `nexpr`, but used `expr` here. 
+              By updating (1) to use an unnormalized expr, we avoid inferring the type of a 
+              normalized expression. *)
       Format.printf "Inferring type of %a\n"
         A.pp_print_expr expr;
       Chk.infer_type_expr info.context node_id expr |> unwrap |> fun (ty, _, _) -> ty ) in 
@@ -1929,8 +1930,9 @@ and mk_fresh_call ?(vmap=[]) info (id : NI.t) map pos cond restart args defaults
             A.BinaryOp (dpos, A.And, c', acc))
           c cs
       in
-      (*!! 2. We call abstract_expr on call_context, which (before my change in (1)) was already normalized. *)
-      let info = { info with call_context = [] } in (* I added this line, otherwise there is an infinite loop if the current expression (which we got from call_context) contains a call. I don't know if this works in general. *)
+      (*!! 2. We call abstract_expr on call_context, which (before my change in (1)) was already normalized, 
+              but now is not normalized. *)
+      let info = { info with call_context = [] } in (* !! 2. I added this line, otherwise there is an infinite loop if the current expression (which we got from call_context) contains a call. I don't know if this works in general. *)
       let nexpr, gids, warnings = abstract_expr false info (Some id) map conj in
       assert (warnings = []);
       match AH.id_of_expr nexpr with
@@ -2455,12 +2457,12 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
   | TernaryOp (pos, LazyIte, expr1, expr2, expr3) ->
     let nexpr1, gids1, warnings1= normalize_expr ?guard info node_id map expr1 in
     (*!! 1. call_context is normalized. I commented out the original line of code and am recording 
-            the unnormalized expr. *)
+            the unnormalized expr. I think this is OK, as we will normalize later (see other comments). *)
     (*let info2 = { info with call_context = nexpr1 :: info.call_context } in*)
     let info2 = { info with call_context = expr1 :: info.call_context } in
     let nexpr2, gids2, warnings2 = normalize_expr ?guard info2 node_id map expr2 in
-    (*!! 1. Notice here we are not using normalized expressions. I think this was intentional, as we will normalize later. *)
     let info3 = { info with call_context =
+      (*A.UnaryOp (AH.pos_of_expr expr1, Not, nexpr1) :: info.call_context }*)
       A.UnaryOp (AH.pos_of_expr expr1, Not, expr1) :: info.call_context }
     in
     let nexpr3, gids3, warnings3 = normalize_expr ?guard info3 node_id map expr3 in

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1892,16 +1892,26 @@ and normalize_equation info node_id map = function
     Equation (pos, lhs, nexpr), union gids1 gids2, warnings
 
 and abstract_expr ?guard force info (node_id : NI.t option) map expr = 
+  Format.printf "Abstracting %a\n"
+    A.pp_print_expr expr;
   let nexpr, gids1, warnings = normalize_expr ?guard info node_id map expr in
   if should_not_abstract info force nexpr then
     nexpr, gids1, warnings
   else
     let ivars = info.inductive_variables in
     let pos = AH.pos_of_expr expr in
+    (*Format.printf "%a\n"
+      Ctx.pp_print_tc_context info.context;*)
     let ty = if expr_has_inductive_var ivars expr then
       (StringMap.choose_opt info.inductive_variables) |> get |> snd |> snd
-    else 
-      Chk.infer_type_expr info.context node_id expr |> unwrap |> fun (ty, _, _) -> ty in 
+    else (
+      (*!! 3. Inferring type of normalized (from (1)) call_context. 
+              But from variable naming, expr is seemingly assumed to be
+              unnormalized. Note we also have nexpr, but use expr here. 
+              By updating (1) to use an unnormalized expr, we avoid this. *)
+      Format.printf "Inferring type of %a\n"
+        A.pp_print_expr expr;
+      Chk.infer_type_expr info.context node_id expr |> unwrap |> fun (ty, _, _) -> ty ) in 
     let iexpr, gids2 = mk_fresh_local force info pos ivars ty nexpr in
     iexpr, union gids1 gids2, warnings
 
@@ -1919,6 +1929,8 @@ and mk_fresh_call ?(vmap=[]) info (id : NI.t) map pos cond restart args defaults
             A.BinaryOp (dpos, A.And, c', acc))
           c cs
       in
+      (*!! 2. We call abstract_expr on call_context, which (before my change in (1)) was already normalized. *)
+      let info = { info with call_context = [] } in (* I added this line, otherwise there is an infinite loop if the current expression (which we got from call_context) contains a call. I don't know if this works in general. *)
       let nexpr, gids, warnings = abstract_expr false info (Some id) map conj in
       assert (warnings = []);
       match AH.id_of_expr nexpr with
@@ -2013,7 +2025,9 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
   (* ************************************************************************ *)
   (* Node calls                                                               *)
   (* ************************************************************************ *)
-  | Call (pos, _, id, args) ->
+  | Call (pos, _, id, args) as e ->
+    Format.printf "Processing call %a\n"
+      A.pp_print_expr e;
     let is_inlinable = NI.Map.mem id info.inlinable_funcs in
     let info, vmap, gids0 =
       if is_inlinable then (* Only generate variables if inlinable *)
@@ -2054,6 +2068,8 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
         (fun (arg, is_const) -> abstract_node_arg ?guard:None false is_const info map arg)
         (combine_args_with_const info args flags)
       in
+      Format.printf "nargs to call: %a\n"
+        (Lib.pp_print_list A.pp_print_expr ", ") nargs;
       let nexpr, gids2 =
         mk_fresh_call ~vmap info id map pos cond restart nargs None
       in
@@ -2438,10 +2454,14 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     TernaryOp (pos, Ite, nexpr1, nexpr2, nexpr3), gids, warnings
   | TernaryOp (pos, LazyIte, expr1, expr2, expr3) ->
     let nexpr1, gids1, warnings1= normalize_expr ?guard info node_id map expr1 in
-    let info2 = { info with call_context = nexpr1 :: info.call_context } in
+    (*!! 1. call_context is normalized. I commented out the original line of code and am recording 
+            the unnormalized expr. *)
+    (*let info2 = { info with call_context = nexpr1 :: info.call_context } in*)
+    let info2 = { info with call_context = expr1 :: info.call_context } in
     let nexpr2, gids2, warnings2 = normalize_expr ?guard info2 node_id map expr2 in
+    (*!! 1. Notice here we are not using normalized expressions. I think this was intentional, as we will normalize later. *)
     let info3 = { info with call_context =
-      A.UnaryOp (AH.pos_of_expr expr1, Not, nexpr1) :: info.call_context }
+      A.UnaryOp (AH.pos_of_expr expr1, Not, expr1) :: info.call_context }
     in
     let nexpr3, gids3, warnings3 = normalize_expr ?guard info3 node_id map expr3 in
     let gids = union (union gids1 gids2) gids3 in

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1909,7 +1909,8 @@ and abstract_expr ?guard force info (node_id : NI.t option) map expr =
               From the (pre-existing) variable naming, `expr` was seemingly assumed to be
               unnormalized to begin with. Note we also have `nexpr`, but used `expr` here. 
               By updating (1) to use an unnormalized expr, we avoid inferring the type of a 
-              normalized expression. *)
+              normalized expression, and so we do not throw an exception trying to infer the type 
+              of a generated name (e.g. `121_call`). *)
       Format.printf "Inferring type of %a\n"
         A.pp_print_expr expr;
       Chk.infer_type_expr info.context node_id expr |> unwrap |> fun (ty, _, _) -> ty ) in 
@@ -1932,7 +1933,7 @@ and mk_fresh_call ?(vmap=[]) info (id : NI.t) map pos cond restart args defaults
       in
       (*!! 2. We call abstract_expr on call_context, which (before my change in (1)) was already normalized, 
               but now is not normalized. *)
-      let info = { info with call_context = [] } in (* !! 2. I added this line, otherwise there is an infinite loop if the current expression (which we got from call_context) contains a call. I don't know if this works in general. *)
+      let info = { info with call_context = [] } in (* !! 2. I added this line, otherwise there is an infinite loop if the current expression (which we got from call_context) contains a call. I don't know if this works in general -- is the rest of the call_context still relevant here? Maybe we shouldn't throw out all of it, but only part? *)
       let nexpr, gids, warnings = abstract_expr false info (Some id) map conj in
       assert (warnings = []);
       match AH.id_of_expr nexpr with
@@ -2456,7 +2457,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     TernaryOp (pos, Ite, nexpr1, nexpr2, nexpr3), gids, warnings
   | TernaryOp (pos, LazyIte, expr1, expr2, expr3) ->
     let nexpr1, gids1, warnings1= normalize_expr ?guard info node_id map expr1 in
-    (*!! 1. call_context is normalized. I commented out the original line of code and am recording 
+    (*!! 1. call_context was normalized. I commented out the original line of code and am recording 
             the unnormalized expr. I think this is OK, as we will normalize later (see other comments). *)
     (*let info2 = { info with call_context = nexpr1 :: info.call_context } in*)
     let info2 = { info with call_context = expr1 :: info.call_context } in

--- a/tests/regression/success/Stack.lus
+++ b/tests/regression/success/Stack.lus
@@ -1,0 +1,94 @@
+
+const MAX_SIZE: subrange[10,*] of int;
+
+type Index = subtype { i: int | -1 <= i and i < MAX_SIZE };
+
+type Stack<T> = struct {
+  items: T^MAX_SIZE;
+  top_pos: Index;
+};
+
+function push<T>(s_in: Stack<T>; e: T) returns (s_out: Stack<T>);
+con
+  assume "Stack is not full" not is_full(s_in);
+  guarantee "Size has increased by one" size(s_out)=size(s_in)+1;
+  guarantee "The top element is 'e'" top(s_out)=e;
+noc
+var new_items: T^MAX_SIZE;
+let
+  new_items[i] = if i=s_in.top_pos+1 then e else s_in.items[i];
+  s_out = Stack@<T> {
+    items = new_items;
+    top_pos = s_in.top_pos + 1;
+  };
+tel
+
+function pop<T>(s_in: Stack<T>) returns (s_out: Stack<T>);
+con
+  assume "Stack is not empty" not is_empty(s_in);
+  guarantee "Size has decreased by one" size(s_out)=size(s_in)-1;
+noc
+let
+  s_out = Stack@<T> {
+    items = s_in.items;
+    top_pos = s_in.top_pos - 1;
+  };
+tel
+
+function empty_stack<T>() returns (s: Stack<T>);
+let
+  s = Stack@<T> {
+    items = choose@<T^MAX_SIZE>;
+    top_pos = -1;
+  };
+tel
+
+function is_empty<T>(s: Stack<T>) returns (r: bool);
+let
+   r = s.top_pos = -1;
+tel
+
+function is_full<T>(s: Stack<T>) returns (r: bool);
+let
+   r = s.top_pos = MAX_SIZE - 1;
+tel
+
+function size<T>(s: Stack<T>) returns (sz: int);
+let
+  sz = s.top_pos + 1;
+tel
+
+function top<T>(s: Stack<T>) returns (t: T);
+con
+  assume "Stack is not empty" not is_empty(s);
+noc
+let
+  t = s.items[s.top_pos];
+tel
+
+function imported equal<T>(s1,s2: Stack<T>) returns (r: bool);
+con
+  guarantee "Stacks are equal" r = 
+    (size(s1)=size(s2) and
+     forall (i: int) 0 <= i and i < size(s1) => s1.items[i] = s2.items[i]);
+noc
+
+node N(s1,s3:Stack<int>) returns (s2:Stack<int>; y: int);
+con
+  assume "s1 is not empty" not is_empty(s1) and not is_full(s1);
+noc
+var t1, t2: Stack<int>;
+let
+  t1 = push(empty_stack@<int>(), 1);
+  check "P1" top(t1)=1;
+
+  t2 = push(push(t1, 2), 3);
+  check "P2" top(pop(t2))=2;
+
+  s2 = if top(s1)=0 then push(s1, 1) else push(pop(s1), 3);
+  check "P3" top(s2)=1 or top(s2)=3;
+
+  y = if is_empty(s3) then 1 otherwise top(s3);
+  check "P4" y=1 or y=top(s3);
+  --%MAIN;
+tel


### PR DESCRIPTION
I learned about the crash bug (see new test case). It involves a bug with the normalization of lazy operators. I implemented a potential fix, but I don't know enough to tell if the fix is correct. So, I added comments explaining what I learned, and the fix I implemented. 

The comments should be read in order (start with `(*!! 1. <comment> *)`, then `(*!! 2. <comment> *)`, then `(*!! 3. <comment> *)`. Hopefully they provide enough description for you to understand the bug, how I fixed it, and why I am unsure whether the fix is correct.

For now, the PR still contains debug printing. I will remove it once we are confident in the fix (either this fix, or a different one).

If it doesn't make sense, let me know, and we can discuss it over Zoom.