### PR TITLE
Filter out inline calls in CEX that are irrelevant to the property

### DIFF
--- a/src/inputSystem.ml
+++ b/src/inputSystem.ml
@@ -864,27 +864,10 @@ let slice_to_abstraction_and_property
     (* Slice Lustre subnode to property term *)
     | Lustre (main_subs, globals, ast) ->
 
-      let vars = match prop'.Property.prop_source with
-        | Property.Assumption _ ->
-          TransSys.state_vars trans_sys' |> SVar.StateVarSet.of_list
-        | _ ->
-          Term.state_vars_of_term prop'.Property.prop_term
-      in
-
-      let is_prop'_instantiated =
-        match prop'.Property.prop_source with
-        | Property.Instantiated _ -> true
-        | _ -> false
-      in
-
       let subsystem' =
         let sub = S.find_subsystem_of_list main_subs scope in
-        if is_prop'_instantiated then
-          LustreSlicing.slice_to_abstraction
-            (Flags.slice_nodes () == `On) analysis' sub
-        else
-          LustreSlicing.slice_to_abstraction_and_property
-            analysis' vars sub
+        LustreSlicing.slice_to_abstraction_and_property
+          analysis' prop' sub
       in
 
       Lustre ([subsystem'], globals, ast)

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -690,7 +690,7 @@ let keep_inline_call c prop =
       match prop.Property.prop_source with
       | Property.Instantiated ((_, pos), prop') ->
         pos = c.N.call_pos || check prop'
-      | Property.Assumption (_, (s, p)) when p = c.N.call_pos -> true
+      | Property.Assumption (_, (_, p)) when p = c.N.call_pos -> true
       | _ -> false
     in
     check prop

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -682,10 +682,24 @@ let roots_of_contract_ass = function
   let with_sofar_var = assumes <> [] in
   Contract.svars_of ~with_sofar_var contract
 
-let roots_of_inlined_calls calls =
+let keep_inline_call c prop =
+  match prop with
+  | None -> true
+  | Some prop ->
+    let rec check prop =
+      match prop.Property.prop_source with
+      | Property.Instantiated ((_, pos), prop') ->
+        pos = c.N.call_pos || check prop'
+      | Property.Assumption (_, (s, p)) when p = c.N.call_pos -> true
+      | _ -> false
+    in
+    check prop
+
+
+let roots_of_inlined_calls prop calls =
   List.fold_left
     (fun acc c ->
-      if c.N.call_inlined then
+      if c.N.call_inlined && keep_inline_call c prop then
         SVS.union acc (D.values c.call_outputs |> SVS.of_list)
       else
         acc
@@ -1010,6 +1024,7 @@ let rec slice_nodes
 (* Slice a node to its implementation, starting from the outputs,
    contracts and properties *)
 let root_and_leaves_of_impl  
+    property
     is_top
     roots
     ({ N.outputs; 
@@ -1053,7 +1068,7 @@ let root_and_leaves_of_impl
     |> SVS.union (
       if is_top then SVS.empty else D.values outputs |> SVS.of_list
     )
-    |> SVS.union (roots_of_inlined_calls calls)
+    |> SVS.union (roots_of_inlined_calls property calls)
 
     |> SVS.elements
   in
@@ -1067,6 +1082,7 @@ let root_and_leaves_of_impl
 (* Slice a node to its contracts, starting from contracts, stopping at
    outputs *)
 let root_and_leaves_of_contracts
+    property
     is_top
     roots
     ({ N.outputs;
@@ -1089,7 +1105,7 @@ let root_and_leaves_of_contracts
     match roots node false with
     | None ->
       roots_of_contract ~with_sofar_var:(not is_top) contract
-      |> SVS.union (roots_of_inlined_calls calls)
+      |> SVS.union (roots_of_inlined_calls property calls)
       |> SVS.union (roots_of_props_contract props)
       |> SVS.elements
     | Some r ->
@@ -1115,19 +1131,19 @@ let node_is_abstract analysis { N.node_id } =
    indicated by [abstraction_map]. Use the implementation if a node is
    not in the map. *)
 let root_and_leaves_of_abstraction_map 
-  is_top roots abstraction_map node
+  property is_top roots abstraction_map node
 =
   if node_is_abstract abstraction_map node
   then (* Node is to be abstract *)
-    root_and_leaves_of_contracts is_top roots node 
+    root_and_leaves_of_contracts property is_top roots node 
   else (* Node is to be concrete *)
-    root_and_leaves_of_impl is_top roots node
+    root_and_leaves_of_impl property is_top roots node
 
 
 (* Slice nodes to abstraction or implementation as indicated in
    [abstraction_map] *)
 let slice_to_abstraction'
-  ?(preserve_sig = false) analysis roots subsystem
+  ?(preserve_sig = false) ?property analysis roots subsystem
 =
 
   let { A.top } = A.info_of_param analysis in
@@ -1143,10 +1159,10 @@ let slice_to_abstraction'
 
     slice_nodes
       preserve_sig
-      (root_and_leaves_of_abstraction_map false roots analysis)
+      (root_and_leaves_of_abstraction_map property false roots analysis)
       nodes
       []
-      [root_and_leaves_of_abstraction_map true roots analysis (List.hd nodes)]
+      [root_and_leaves_of_abstraction_map property true roots analysis (List.hd nodes)]
 
   in
 
@@ -1206,7 +1222,7 @@ let slice_to_abstraction_and_property
     )
   in
   slice_to_abstraction'
-    ~preserve_sig:preserve_sig analysis roots subsystem
+    ~preserve_sig:preserve_sig ~property:prop analysis roots subsystem
 
 
   

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -1186,14 +1186,24 @@ let slice_to_abstraction
 (* Slice nodes to abstraction or implementation as indicated in
    [abstraction_map] *)
 let slice_to_abstraction_and_property
-  ?(preserve_sig = false) analysis vars subsystem
+  ?(preserve_sig = false) analysis prop subsystem
 =
-  let roots { N.contract } is_impl =
-    if is_impl then
-      Some vars
-    else
-      (* Always include at least roots of contract *)
-      Some (roots_of_contract_ass contract) 
+  let roots =
+    match prop.Property.prop_source with
+    | Property.Instantiated _
+    | Property.Assumption _ -> (fun _ _ -> None)
+    | _ -> (
+      let vars =
+        Term.state_vars_of_term prop.Property.prop_term
+      in
+      fun { N.contract } is_impl -> (
+        if is_impl then
+          Some vars
+        else
+          (* Always include at least roots of contract *)
+          Some (roots_of_contract_ass contract)
+        )
+    )
   in
   slice_to_abstraction'
     ~preserve_sig:preserve_sig analysis roots subsystem

--- a/src/lustre/lustreSlicing.mli
+++ b/src/lustre/lustreSlicing.mli
@@ -150,7 +150,7 @@ val slice_to_abstraction :
 
 val slice_to_abstraction_and_property :
     ?preserve_sig:bool ->
-    Analysis.param -> StateVar.StateVarSet.t ->
+    Analysis.param -> Property.t ->
     LustreNode.t SubSystem.t ->
     LustreNode.t SubSystem.t 
 

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2962,11 +2962,8 @@ let trans_sys_of_nodes
       S.slice_to_abstraction
         ~preserve_sig (slice_nodes == `On) analysis_param subsystem'
     | Some prop ->
-      let vars =
-        Term.state_vars_of_term prop.P.prop_term
-      in
       S.slice_to_abstraction_and_property
-        ~preserve_sig analysis_param vars subsystem'
+        ~preserve_sig analysis_param prop subsystem'
   else
     subsystem'
   in

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -805,7 +805,10 @@ let call_terms_of_node_call mk_fresh_state_var globals
 
         (* Property is instantiated *)
         let prop_source =
-          P.Instantiated (I.to_scope (NI.get_internal_name call_node_id |> I.of_hstring), p)
+          let called_scope =
+            I.to_scope (NI.get_internal_name call_node_id |> I.of_hstring)
+          in
+          P.Instantiated ((called_scope, call_pos), p)
         in
 
         (* Property status is unknown *)

--- a/src/nativeInput.ml
+++ b/src/nativeInput.ml
@@ -275,7 +275,7 @@ let prop_source_of_sexpr prop_term = function
       let rec prop = {Property.prop_name = p; prop_source = source;
                       prop_term; prop_status = Property.PropUnknown;
                       prop_kind = Invariant; }
-      and source = Property.Instantiated (scope, prop) in
+      and source = Property.Instantiated ((scope, Lib.dummy_pos), prop) in
       source
     else assert false
 
@@ -652,7 +652,7 @@ let pp_print_prop_source sys ppf = function
   | Property.Generated (_, state_vars, _) ->
     Format.fprintf ppf ":generated@ (@[<v>%a@])"
     (pp_print_list (pp_print_state_var sys) "@ ") state_vars  
-  | Property.Instantiated (scope, prop) ->
+  | Property.Instantiated ((scope, _), prop) ->
     let name = prop.Property.prop_name in
     Format.fprintf ppf ":subsystem@ %s" (String.concat "." (scope @ [name]))
   | Property.Candidate _ ->

--- a/src/property.ml
+++ b/src/property.ml
@@ -81,7 +81,7 @@ and prop_source =
 
      Reference the instantiated property by the [scope] of the subsystem and
      the name of the property *)
-  | Instantiated of Scope.t * t
+  | Instantiated of (Scope.t * Lib.position) * t
 
   (* Contract assumption that a caller has to prove.
 
@@ -146,7 +146,7 @@ let pp_print_prop_source ppf = function
      Format.fprintf ppf "subrange constraint"
   | Candidate _ ->
      Format.fprintf ppf "candidate invariant"
-  | Instantiated (scope,_) ->
+  | Instantiated ((scope, _),_) ->
      Format.fprintf
        ppf
        "instantiated from %s"

--- a/src/property.mli
+++ b/src/property.mli
@@ -71,7 +71,7 @@ and prop_source =
   | Generated of Lib.position option * StateVar.t list * generated_source
   (** Property was generated, for example, from a subrange constraint *)
 
-  | Instantiated of Scope.t * t
+  | Instantiated of (Scope.t * Lib.position) * t
   (** Property is an instance of a property in a called node.
 
      Reference the instantiated property by the [scope] of the subsystem and

--- a/tests/regression/falsifiable/inline_call_cex.lus
+++ b/tests/regression/falsifiable/inline_call_cex.lus
@@ -1,0 +1,12 @@
+transparent function F(inp: int) returns (out: int)
+con
+  assume inp > 0;
+noc
+let
+  out = inp + 1;
+tel
+
+node N() returns ()
+let
+  check "P1" forall (i: int) F(i) < i;
+tel


### PR DESCRIPTION
In fact, this is more general: it also filters out inline calls when using IC3IA if the property is not related to the call. This is fine since these calls are introduced for the sole purpose of checking proof obligations (as the original call has been replaced by the expression).