### PR TITLE
Ensure all variables in If block are fully defined

### DIFF
--- a/src/lustre/lustreDesugarIfBlocks.ml
+++ b/src/lustre/lustreDesugarIfBlocks.ml
@@ -26,6 +26,8 @@ module Ctx = TypeCheckerContext
 
 type error_kind = 
   | MisplacedNodeItemError of A.node_item
+  | MissingElseBranchError
+  | MissingDefinitionInBranchError of HString.t
 
 let error_message error = match error with
   | MisplacedNodeItemError ni -> (match ni with
@@ -36,6 +38,10 @@ let error_message error = match error with
     (* Other node items are allowed *)
     | _ -> assert false
   )
+  | MissingElseBranchError ->
+    "If blocks outside of frame blocks must have an else branch."
+  | MissingDefinitionInBranchError id ->
+    "Variable '" ^ HString.string_of_hstring id ^ "' must be defined in all branches of the if block."
 
 type error = [
   | `LustreDesugarIfBlocksError of Lib.position * error_kind
@@ -73,6 +79,29 @@ let mk_error pos kind = Error (`LustreDesugarIfBlocksError (pos, kind))
 let unwrap = function 
 | Ok r -> r 
 | Error _ -> assert false
+
+(** Checks that an if block (outside of a frame block) has an else branch,
+    and recursively checks nested if blocks. *)
+let rec check_if_block_has_else ni = match ni with
+  | A.IfBlock (pos, _, _, []) -> mk_error pos MissingElseBranchError
+  | A.IfBlock (_, _, then_nis, else_nis) ->
+    let if_blocks = List.filter_map (fun item -> match item with
+      | A.IfBlock _ -> Some item
+      | _ -> None) (then_nis @ else_nis) in
+    R.seq_ (List.map check_if_block_has_else if_blocks)
+  | _ -> assert false
+
+(** Checks whether a cond_tree contains any Leaf None (undefined branch). *)
+let rec has_leaf_none = function
+  | Leaf None -> true
+  | Leaf (Some _) -> false
+  | Node (l, _, r) -> has_leaf_none l || has_leaf_none r
+
+(** Extracts the variable name and position from an equation LHS. *)
+let get_lhs_var lhs = match lhs with
+  | A.StructDef (pos, [SingleIdent (_, i)]) -> (i, pos)
+  | A.StructDef (pos, [ArrayDef (_, i, _)]) -> (i, pos)
+  | _ -> assert false
 
 (** Create a new oracle for use with if blocks. *)
 let mk_fresh_ib_oracle pos expr_type =
@@ -302,13 +331,32 @@ let split_and_flatten3 ls =
     4. Filling in the ITE expressions with oracles where variables are undefined.
     5. Returning lists of new local declarations, generated equations, and gids
     *)
-let extract_equations_from_if node_id ctx ib =
+let extract_equations_from_if node_id ctx ib in_frame_block =
+  (* When outside a frame block, enforce that else branches are present and
+     that every variable defined in one branch is defined in all branches. *)
+  let* () =
+    if in_frame_block then R.ok ()
+    else check_if_block_has_else ib
+  in
   (* Keep track of where the if block variables are defined so that the position can
      be displayed in post analysis, eg ivcMcs.ml *)
   update_if_position_info node_id ib;
   let* tree_map = if_block_to_trees ib in
   let (lhss_poss, trees) = LhsMap.bindings (tree_map) |> List.split in
   let trees = List.map simplify_tree trees in  
+  (* When outside a frame block, every variable defined in any branch must be
+     defined in all branches (no Leaf None allowed). *)
+  let* () =
+    if in_frame_block then R.ok ()
+    else
+      let lhss = List.map fst lhss_poss in
+      R.seq_ (List.map2 (fun lhs tree ->
+        if has_leaf_none tree then
+          let (var, pos) = get_lhs_var lhs in
+          mk_error pos (MissingDefinitionInBranchError var)
+        else R.ok ()
+      ) lhss trees)
+  in
   let lhs_poss = List.map (fun (A.StructDef (pos, _), _) -> pos) lhss_poss in
   let rhs_poss = List.map snd lhss_poss in
   let lhss = List.map fst lhss_poss in
@@ -331,10 +379,10 @@ let extract_equations_from_if node_id ctx ib =
     local declarations (if we introduce new local variables), the converted
     node_item list in the form of ITEs, and any gids).
 *)
-let rec desugar_node_item node_id ctx ni = match ni with
-  | A.IfBlock _ as ib -> extract_equations_from_if node_id ctx ib
+let rec desugar_node_item node_id ctx in_frame_block ni = match ni with
+  | A.IfBlock _ as ib -> extract_equations_from_if node_id ctx ib in_frame_block
   | A.FrameBlock (pos, vars, nes, nis) -> 
-    let* res = R.seq (List.map (desugar_node_item node_id ctx) nis) in
+    let* res = R.seq (List.map (desugar_node_item node_id ctx true) nis) in
     let decls, nis, gids = split_and_flatten3 res in
     R.ok (decls, [A.FrameBlock(pos, vars, nes, nis)], gids)
   | _ -> R.ok ([], [ni], [GI.empty ()])
@@ -344,13 +392,13 @@ let rec desugar_node_item node_id ctx ni = match ni with
 let desugar_node_decl ctx decl = match decl with
   | A.FuncDecl (s, (node_id, b, opac, nps, cctds, ctds, nlds, nis, co)) ->
     let ctx = Chk.add_full_node_ctx ctx node_id nps cctds ctds nlds in
-    let* nis = R.seq (List.map (desugar_node_item node_id ctx) nis) in
+    let* nis = R.seq (List.map (desugar_node_item node_id ctx false) nis) in
     let new_decls, nis, gids = split_and_flatten3 nis in
     let gids = List.fold_left GI.union (GI.empty ()) gids in
     R.ok (A.FuncDecl (s, (node_id, b, opac, nps, cctds, ctds, new_decls @ nlds, nis, co)), NI.Map.singleton node_id gids)
   | A.NodeDecl (s, (node_id, b, opac, nps, cctds, ctds, nlds, nis, co)) ->
     let ctx = Chk.add_full_node_ctx ctx node_id nps cctds ctds nlds in
-    let* nis = R.seq (List.map (desugar_node_item node_id ctx) nis) in
+    let* nis = R.seq (List.map (desugar_node_item node_id ctx false) nis) in
     let new_decls, nis, gids = split_and_flatten3 nis in
     let gids = List.fold_left GI.union (GI.empty ()) gids in
     R.ok (A.NodeDecl (s, (node_id, b, opac, nps, cctds, ctds, new_decls @ nlds, nis, co)), NI.Map.singleton node_id gids)

--- a/src/lustre/lustreDesugarIfBlocks.mli
+++ b/src/lustre/lustreDesugarIfBlocks.mli
@@ -33,6 +33,8 @@
 
 type error_kind = 
   | MisplacedNodeItemError of LustreAst.node_item
+  | MissingElseBranchError
+  | MissingDefinitionInBranchError of HString.t
 
 val error_message : error_kind -> string
 

--- a/tests/ounit/lustre/lustreSyntaxChecks/if_block_missing_definition.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/if_block_missing_definition.lus
@@ -1,0 +1,10 @@
+node test(x: int) returns (y, z: int);
+let
+  if (x > 0)
+  then
+    y = 1;
+    z = 2;
+  else
+    y = 3;
+  fi
+tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/if_block_missing_else.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/if_block_missing_else.lus
@@ -1,0 +1,7 @@
+node test(x: int) returns (y: int);
+let
+  if (x > 0)
+  then
+    y = 1;
+  fi
+tel

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -860,7 +860,15 @@ let _ = run_test_tt_main ("frontend LustreDesugarFrameBlocks and LustreDesugarIf
   mk_test "Uninitialized node item inside frame block 2" (fun () ->
     match load_file "./lustreSyntaxChecks/uninitialized_node_item_frame2.lus" with
     | Error (`LustreSyntaxChecksError (_, MisplacedVarInFrameBlock _)) -> true
-    | _ -> false);  
+    | _ -> false);
+  mk_test "If block outside frame block missing else branch" (fun () ->
+    match load_file "./lustreSyntaxChecks/if_block_missing_else.lus" with
+    | Error (`LustreDesugarIfBlocksError (_, MissingElseBranchError)) -> true
+    | _ -> false);
+  mk_test "If block outside frame block variable missing in branch" (fun () ->
+    match load_file "./lustreSyntaxChecks/if_block_missing_definition.lus" with
+    | Error (`LustreDesugarIfBlocksError (_, MissingDefinitionInBranchError _)) -> true
+    | _ -> false);
 ])
 
 (* *************************************************************************** *)

--- a/tests/regression/falsifiable/sym_subrange_bug.lus
+++ b/tests/regression/falsifiable/sym_subrange_bug.lus
@@ -8,5 +8,7 @@ node N(c: bool; r: R) returns (s: set<R>);
 let
   if c then
     s = {r} + {r};
+  else
+    s = any@<set<int>>;
   fi
 tel

--- a/tests/regression/success/imperative_if_oracle.lus
+++ b/tests/regression/success/imperative_if_oracle.lus
@@ -14,6 +14,7 @@ let
     y2 = 10;
   else 
     y1 = 6;
+    y2 = any@<int>;
   fi
   p1 = any@<bool>;
   p3 = any@<bool>;

--- a/tests/regression/success/imperative_if_oracle2.lus
+++ b/tests/regression/success/imperative_if_oracle2.lus
@@ -12,6 +12,7 @@ let
     y2 = 10;
   else 
     y1 = 6;
+    y2 = any@<int>;
   fi
   y3 = any@<int>;
 tel

--- a/tests/regression/success/imperative_if_oracle3.lus
+++ b/tests/regression/success/imperative_if_oracle3.lus
@@ -31,5 +31,10 @@ let
     y2 = '(44, false, true);
     y3 = r2 { v3 = 22; v4 = r1 { v1 = true; v2 = 45; v3 = true }};
     y4[i] = if i = 0 then 0 else (y4[i-1] + 1);
+  else
+    y1 = any@<int^2>;
+    y2 = any@<[int, bool, bool]>;
+    y3 = any@<r2>;
+    y4[i] = any@<int>;
   fi
 tel


### PR DESCRIPTION
We recently changed Kind 2 to disallow undefined output variables (PR #1303). To align with this behavior, this PR enforces that, outside a frame block, `if` blocks must include an `else` branch and that any variable defined in one branch must be defined in all branches.

Assisted by VS Code Copilot.