### PR TITLE
Remove the explicit check for missing else branches

### DIFF
--- a/src/lustre/lustreDesugarIfBlocks.ml
+++ b/src/lustre/lustreDesugarIfBlocks.ml
@@ -26,7 +26,6 @@ module Ctx = TypeCheckerContext
 
 type error_kind = 
   | MisplacedNodeItemError of A.node_item
-  | MissingElseBranchError
   | MissingDefinitionInBranchError of HString.t
 
 let error_message error = match error with
@@ -38,10 +37,8 @@ let error_message error = match error with
     (* Other node items are allowed *)
     | _ -> assert false
   )
-  | MissingElseBranchError ->
-    "If blocks outside of frame blocks must have an else branch."
   | MissingDefinitionInBranchError id ->
-    "Variable '" ^ HString.string_of_hstring id ^ "' must be defined in all branches of the if block."
+    "Variable '" ^ HString.string_of_hstring id ^ "' must be defined in every branch, including implicit ones."
 
 type error = [
   | `LustreDesugarIfBlocksError of Lib.position * error_kind
@@ -79,17 +76,6 @@ let mk_error pos kind = Error (`LustreDesugarIfBlocksError (pos, kind))
 let unwrap = function 
 | Ok r -> r 
 | Error _ -> assert false
-
-(** Checks that an if block (outside of a frame block) has an else branch,
-    and recursively checks nested if blocks. *)
-let rec check_if_block_has_else ni = match ni with
-  | A.IfBlock (pos, _, _, []) -> mk_error pos MissingElseBranchError
-  | A.IfBlock (_, _, then_nis, else_nis) ->
-    let if_blocks = List.filter_map (fun item -> match item with
-      | A.IfBlock _ -> Some item
-      | _ -> None) (then_nis @ else_nis) in
-    R.seq_ (List.map check_if_block_has_else if_blocks)
-  | _ -> assert false
 
 (** Checks whether a cond_tree contains any Leaf None (undefined branch). *)
 let rec has_leaf_none = function
@@ -332,12 +318,6 @@ let split_and_flatten3 ls =
     5. Returning lists of new local declarations, generated equations, and gids
     *)
 let extract_equations_from_if node_id ctx ib in_frame_block =
-  (* When outside a frame block, enforce that else branches are present and
-     that every variable defined in one branch is defined in all branches. *)
-  let* () =
-    if in_frame_block then R.ok ()
-    else check_if_block_has_else ib
-  in
   (* Keep track of where the if block variables are defined so that the position can
      be displayed in post analysis, eg ivcMcs.ml *)
   update_if_position_info node_id ib;

--- a/src/lustre/lustreDesugarIfBlocks.mli
+++ b/src/lustre/lustreDesugarIfBlocks.mli
@@ -33,7 +33,6 @@
 
 type error_kind = 
   | MisplacedNodeItemError of LustreAst.node_item
-  | MissingElseBranchError
   | MissingDefinitionInBranchError of HString.t
 
 val error_message : error_kind -> string

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -863,7 +863,7 @@ let _ = run_test_tt_main ("frontend LustreDesugarFrameBlocks and LustreDesugarIf
     | _ -> false);
   mk_test "If block outside frame block missing else branch" (fun () ->
     match load_file "./lustreSyntaxChecks/if_block_missing_else.lus" with
-    | Error (`LustreDesugarIfBlocksError (_, MissingElseBranchError)) -> true
+    | Error (`LustreDesugarIfBlocksError (_, MissingDefinitionInBranchError _)) -> true
     | _ -> false);
   mk_test "If block outside frame block variable missing in branch" (fun () ->
     match load_file "./lustreSyntaxChecks/if_block_missing_definition.lus" with


### PR DESCRIPTION
If an `if` block does not have an `else` branch, either `MissingDefinitionInBranchError` is raised or no variable is defined.