### PR TITLE
Disallow calls to nodes/functions without outputs

### DIFF
--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -815,9 +815,6 @@ left_side:
   (* Parenthesized list *)
   | LPAREN; l = struct_item_list; RPAREN { A.StructDef (mk_pos $startpos, l) }
 
-  (* Empty list *)
-  | LPAREN; RPAREN { A.StructDef (mk_pos $startpos, []) }
-
 
 (* Item in a structured equation *)
 struct_item:

--- a/tests/regression/error/empty_lhs_in_if_block.lus
+++ b/tests/regression/error/empty_lhs_in_if_block.lus
@@ -1,0 +1,12 @@
+node F(x: int) returns ();
+let
+tel
+
+node N(c: bool) returns ();
+let
+  if c then
+    () = F(0);
+  else
+    () = F(1);
+  fi
+tel


### PR DESCRIPTION
Currently, calls to nodes/functions without outputs are only allowed on the right-hand side of an equation with an empty list of variables on the left-hand side. After this PR, Kind 2 no longer accepts an empty list of variables on the left-hand side, effectively disallowing calls to nodes/functions without outputs, which are not properly supported when they occur in if blocks or during slicing.