### PR TITLE
Capitalize positions

### DIFF
--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -1238,7 +1238,7 @@ let pp_print_line_and_column ppf { pos_lnum; pos_cnum } =
 
   if pos_lnum >= 0 && pos_cnum >= 0 then
 
-    fprintf ppf "[l%dc%d]" pos_lnum pos_cnum
+    fprintf ppf "[L%dC%d]" pos_lnum pos_cnum
 
   else
 


### PR DESCRIPTION
Capitalize position labels so that they are easier to read.

`[l12c34]` --> `[L12C34]`