### PR TITLE
Add support for map subtraction

### DIFF
--- a/doc/usr/source/2_input/11_maps.rst
+++ b/doc/usr/source/2_input/11_maps.rst
@@ -13,10 +13,13 @@ are all valid map literals.
 Type annotations are *required* for empty maps (e.g. ``map[]@<int, int>``)
 and optional for non-empty map literals (e.g. ``map[1 := 1]@<int, int>``).
 
-The built-in map operators are **map insertion/update** 
-(denoted by ``m[k1 := v1; ...; kn := vn]`` for map expression ``m``), 
-**map index access** (denoted by ``m[k]``), and
-**map (key) membership** (denoted by ``in``). 
+The built-in map operators are **map insertion/update**
+(denoted by ``m[k1 := v1; ...; kn := vn]`` for map expression ``m``),
+**map index access** (denoted by ``m[k]``),
+**map subtraction** (denoted by ``m - s`` for map expression ``m`` and set
+expression ``s`` whose elements have the same type as the keys of ``m``, which
+removes from ``m`` all keys contained in ``s``), and
+**map (key) membership** (denoted by ``in``).
 Indexing a map with ``m[k]`` returns the associated value for ``k`` in map ``m``. 
 If ``m`` does not have a binding for ``k``, 
 then the output of the operation is unconstrained.
@@ -29,14 +32,16 @@ See below for an example.
 
 .. code-block:: none
 
-   node N (inp: map<int, int>) returns (out, out2: map<int, int>) 
+   node N (inp: map<int, int>) returns (out, out2, out3: map<int, int>)
    let
-     out = inp[0 := 0; 1 := 1; 2 := 2]; 
+     out = inp[0 := 0; 1 := 1; 2 := 2];
      out2 = map[0 := 0; 1 := 1];
+     out3 = out - { 0, 1 };
 
      check 0 in out;
-     check out[0] = 0; 
+     check out[0] = 0;
      check forall (i: int) not (i in { 0, 1, 2 }) => out[i] = inp[i];
      check forall (i: int) not (i = 0 or i = 1) => not (i in out2);
+     check forall (i: int) (i in out3) = (i in out and not (i in { 0, 1 }));
    tel
 

--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -74,7 +74,13 @@ type t = {
     HString.t *
     LustreAst.lustre_type * 
     LustreAst.lustre_type) list;
-  set_insertions: (HString.t * 
+  map_subtractions: (HString.t *
+    LustreAst.expr *
+    LustreAst.expr *
+    HString.t *
+    LustreAst.lustre_type *
+    LustreAst.lustre_type) list;
+  set_insertions: (HString.t *
     LustreAst.expr * 
     LustreAst.expr * 
     HString.t *
@@ -138,6 +144,7 @@ let union ids1 ids2 = {
     empty_maps = ids1.empty_maps @ ids2.empty_maps;
     empty_sets = ids1.empty_sets @ ids2.empty_sets;
     map_element_updates = ids1.map_element_updates @ ids2.map_element_updates;
+    map_subtractions = ids1.map_subtractions @ ids2.map_subtractions;
     set_binops = ids1.set_binops @ ids2.set_binops;
     set_insertions = ids1.set_insertions @ ids2.set_insertions;
     expanded_variables = StringSet.union ids1.expanded_variables ids2.expanded_variables;
@@ -169,6 +176,7 @@ let empty () = {
   empty_maps = [];
   empty_sets = [];
   map_element_updates = [];
+  map_subtractions = [];
   set_binops = [];
   set_insertions = [];
   expanded_variables = StringSet.empty;

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -74,7 +74,13 @@ type t = {
     HString.t * 
     LustreAst.lustre_type * 
     LustreAst.lustre_type) list;
-  set_insertions: (HString.t * 
+  map_subtractions: (HString.t *
+    LustreAst.expr *
+    LustreAst.expr *
+    HString.t *
+    LustreAst.lustre_type *
+    LustreAst.lustre_type) list;
+  set_insertions: (HString.t *
     LustreAst.expr * 
     LustreAst.expr * 
     HString.t * 

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2446,7 +2446,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
       normalize_expr ?guard info node_id map (A.BinaryOp (pos, A.Union, expr1, expr2))
     | Set _, Times -> 
       normalize_expr ?guard info node_id map (A.BinaryOp (pos, A.Intersection, expr1, expr2))
-    | Set _, Minus ->
+    | Set _, Minus | Map _, Minus ->
       normalize_expr ?guard info node_id map (A.BinaryOp (pos, A.Difference, expr1, expr2))
     | _ ->  
       let nexpr1, gids1, warnings1 = normalize_expr ?guard info node_id map expr1 in
@@ -2465,23 +2465,38 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
     let _, _, warnings2 = normalize_expr ?guard info node_id map expr2 in 
     i := !i + 1; 
     let prefix = HString.mk_hstring (string_of_int !i) in 
-    let name1 = HString.concat2 prefix (HString.mk_hstring "_set_binop") in 
     let name2 = HString.concat2 prefix (HString.mk_hstring "_idx") in 
-    let ty = match Chk.infer_type_expr info.context node_id expr1 with 
+    let ty1 = match Chk.infer_type_expr info.context node_id expr1 with 
     | Ok (ty, _, _) -> (
       match Chk.expand_type_syn_reftype_history_subrange info.context ty with 
-      | Ok (Set (_, ty)) -> ty 
+      | Ok ty -> ty
       | _ -> assert false
     )
     | Error _ -> assert false 
-    in 
-    let gids3 = { (empty ()) with   
-      set_binops = [ name1, nexpr1, nexpr2, name2, op, ty ]; 
-      locals = StringMap.add name2 ty (StringMap.singleton name1 (A.Set (pos, ty)));
-    } in 
-    let nexpr = A.Ident (pos, name1) in 
-    let gids = List.fold_left union (empty ()) [gids1; gids2; gids3] in 
-    nexpr, gids, warnings1 @ warnings2
+    in
+    (match op, ty1 with
+    | A.Difference, A.Map (_, kt, vt) ->
+      (* Map subtraction: remove from the map all keys contained in the set *)
+      let name1 = HString.concat2 prefix (HString.mk_hstring "_map_subtraction") in
+      let kt = Chk.expand_type_syn_reftype_history_subrange info.context kt |> Result.get_ok in
+      let vt = Chk.expand_type_syn_reftype_history_subrange info.context vt |> Result.get_ok in
+      let gids3 = { (empty ()) with
+        map_subtractions = [ name1, nexpr1, nexpr2, name2, kt, vt ];
+        locals = StringMap.add name2 kt (StringMap.singleton name1 (A.Map (pos, kt, vt)));
+      } in
+      let nexpr = A.Ident (pos, name1) in
+      let gids = List.fold_left union (empty ()) [gids1; gids2; gids3] in
+      nexpr, gids, warnings1 @ warnings2
+    | _ ->
+      let name1 = HString.concat2 prefix (HString.mk_hstring "_set_binop") in
+      let ty = match ty1 with Set (_, ty) -> ty | _ -> assert false in
+      let gids3 = { (empty ()) with
+        set_binops = [ name1, nexpr1, nexpr2, name2, op, ty ];
+        locals = StringMap.add name2 ty (StringMap.singleton name1 (A.Set (pos, ty)));
+      } in
+      let nexpr = A.Ident (pos, name1) in
+      let gids = List.fold_left union (empty ()) [gids1; gids2; gids3] in
+      nexpr, gids, warnings1 @ warnings2)
   | BinaryOp (pos, op, expr1, expr2) ->
     let nexpr1, gids1, warnings1 = normalize_expr ?guard info node_id map expr1 in
     let nexpr2, gids2, warnings2 = normalize_expr ?guard info node_id map expr2 in

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -2431,6 +2431,31 @@ and compile_node_decl gids_map is_function opac cstate ctx node_id ext params in
     List.fold_left over_map_element_updates [] gids.GI.map_element_updates
   in
   let gequations = gequations @ map_element_update_eqs in
+  let map_subtraction_eqs =
+    let over_map_subtractions acc (id, nexpr1, nexpr2, fresh_idx_name, _, _) =
+      (* Desugar to lhs[i] = (i in nexpr1 and not (i in nexpr2), nexpr1[i]),
+         i.e. a key is kept iff it is in the map and not in the subtracted set *)
+      let fresh_idx = A.Ident (dummy_pos, fresh_idx_name) in
+      let eq_lhs = compile_map_or_set_def id fresh_idx_name false in
+      let lhs_bounds = gen_lhs_bounds (AH.pos_of_expr nexpr1) true eq_lhs 1 in
+      let present_expr =
+        A.BinaryOp (dummy_pos, A.And,
+          A.BinaryOp (dummy_pos, In Map, fresh_idx, nexpr1),
+          A.UnaryOp (dummy_pos, A.Not,
+            A.BinaryOp (dummy_pos, In Set, fresh_idx, nexpr2)))
+      in
+      let value_expr = A.IndexAccess (dummy_pos, nexpr1, fresh_idx, Map) in
+      let expr = A.GroupExpr (dummy_pos, TupleExpr, [present_expr; value_expr]) in
+      let eq_rhs = compile_ast_expr cstate ctx lhs_bounds map expr in
+      (* Format.fprintf Format.std_formatter "lhs: %a@.rhs: %a@.@.\n"
+        (X.pp_print_index_trie true StateVar.pp_print_state_var) eq_lhs
+        (X.pp_print_index_trie true (E.pp_print_lustre_expr true)) eq_rhs; *)
+      let map_subtraction_eqs = expand_tuple Lib.dummy_pos eq_lhs eq_rhs in
+      map_subtraction_eqs @ acc
+    in
+    List.fold_left over_map_subtractions [] gids.GI.map_subtractions
+  in
+  let gequations = gequations @ map_subtraction_eqs in
   (* ****************************************************************** *)
   (* Sets                                                               *)
   (* ****************************************************************** *)

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1674,6 +1674,12 @@ and infer_type_binary_op: tc_context -> NI.t option -> Lib.position
       if same_elem_ty
       then R.ok (ty2, e1, e2, warnings1 @ warnings2)
       else type_error pos (ExpectedNumberOrSetTypes (ty1, ty2))
+    | Map (_, kt, _), Set (_, st) ->
+      (* Map subtraction: remove from the map all keys contained in the set *)
+      let* same_elem_ty = eq_lustre_type ctx kt st in
+      if same_elem_ty
+      then R.ok (ty1, e1, e2, warnings1 @ warnings2)
+      else type_error pos (ExpectedNumberOrSetTypes (ty1, ty2))
     | _ ->
       let* is_num = are_args_num ctx pos ty1 ty2 in
       if is_num

--- a/tests/regression/success/map_subtraction.lus
+++ b/tests/regression/success/map_subtraction.lus
@@ -1,0 +1,6 @@
+node N(m1: map<int,int>; s: set<int>) returns (m2: map<int,int>)
+let
+  m2 = m1 - s;
+  check "P1" forall (k:int) (k in m2) = (k in m1 and not (k in s));
+  check "P2" forall (k:int) (k in m2) => (m2[k] = m1[k]);
+tel


### PR DESCRIPTION
Implement the map subtraction operator `m - s`, which removes from a map all keys contained in a set whose element type matches the map's key type.