### PR TITLE
Normalization bug

### DIFF
--- a/kind2.install
+++ b/kind2.install
@@ -10,5 +10,4 @@ doc: [
   "_build/install/default/doc/kind2/CHANGES.md"
   "_build/install/default/doc/kind2/LICENSE.rst"
   "_build/install/default/doc/kind2/README.rst"
-  "_build/install/default/doc/kind2/odoc-config.sexp"
 ]

--- a/kind2.install
+++ b/kind2.install
@@ -10,4 +10,5 @@ doc: [
   "_build/install/default/doc/kind2/CHANGES.md"
   "_build/install/default/doc/kind2/LICENSE.rst"
   "_build/install/default/doc/kind2/README.rst"
+  "_build/install/default/doc/kind2/odoc-config.sexp"
 ]

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -495,10 +495,10 @@ let rec mk_enum_range_expr ?(force_prop = false) ?(mk_enum=true) ?(mk_range=true
       let body = fun e -> A.BinaryOp (dpos, A.Impl, assumption, e) in
       List.map (fun (e, is_original) -> A.Quantifier (dpos, A.Forall, [var], body e), is_original) rexpr
     | TupleType (p, tys) ->
-      let mk_proj i = A.IndexAccess (dpos, expr, A.Const (p, A.Num (i |> string_of_int |> HString.mk_hstring)), A.Tuple) in
-      let tys = List.filter (fun ty -> Ctx.type_contains_enum_or_subrange ctx ty) tys in
-      let tys = List.mapi (fun i ty -> mk ctx n ty (mk_proj i)) tys in
-      List.fold_left (@) [] tys
+      List.mapi (fun i ty ->
+         let i = i |> string_of_int |> HString.mk_hstring in
+         mk ctx n ty (A.IndexAccess (dpos, expr, A.Const (p, A.Num i), A.Tuple))
+      ) tys |> List.flatten
     | RecordType (_, _, tys) ->
       let mk_proj i = A.RecordProject (dpos, expr, i) in
       let tys = List.filter (fun (_, _, ty) -> Ctx.type_contains_enum_or_subrange ctx ty) tys in

--- a/tests/regression/success/hop.lus
+++ b/tests/regression/success/hop.lus
@@ -1,0 +1,7 @@
+type Action = enum { Shell, Command, PortForward };
+
+node Top () returns ()
+let
+  check (exists (e: [int, Action]) e = e);
+tel
+


### PR DESCRIPTION
Before this PR, `mk_enum_range_expr` filtered out non-enum/subrange types within tuple types during normalization (see line 499 before the changes). I don't know why it was implemented this way, but it causes an assert failure in the new test case. 

I updated the logic to exactly mirror `mk_ref_type_expr`.