### PR TITLE
Support lexicographic decreases measures (tuples)

### DIFF
--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -42,7 +42,8 @@ type error_kind = Unknown of string
   | EquationWidthsUnequal
   | ContractDependencyOnCurrentOutput of SI.t
   | CyclicDependency of HString.t list
-  | ImportedCyclicDependency of (HString.t list * NI.t) 
+  | ImportedCyclicDependency of (HString.t list * NI.t)
+  | MismatchedDecreasesArity of HString.t list
 
 let error_message error = match error with
   | Unknown s -> s
@@ -67,8 +68,13 @@ let error_message error = match error with
         ^ Lib.string_of_t LA.pp_print_ident imported_node_name in
 
     "Potential cyclic dependency detected in definition of identifiers: "
-    ^ (Lib.string_of_t (Lib.pp_print_list LA.pp_print_ident " -> ") ids) ^ 
+    ^ (Lib.string_of_t (Lib.pp_print_list LA.pp_print_ident " -> ") ids) ^
     " (Hint: " ^ helping_message ^ ")"
+  | MismatchedDecreasesArity ids ->
+    "Mutually recursive functions must declare decrease measures of the same "
+    ^ "arity for the lexicographic termination check to be well defined, but "
+    ^ "mismatching arities were found among: "
+    ^ (Lib.string_of_t (Lib.pp_print_list LA.pp_print_ident ", ") ids)
 
 type error = [
   | `LustreAstDependenciesError of Lib.position * error_kind
@@ -1208,6 +1214,44 @@ let sort_and_check_contract_eqns: dependency_analysis_data
    2. Ensures the assumptions do not use the current value
       of the output streams. *)
 
+(* The arity of a function's decrease measure: the number of components of the
+   tuple (a single, non-tuple measure has arity 1). Returns [None] for any
+   declaration without a decreases clause. *)
+let decreases_arity = function
+  | LA.FuncDecl (_, (_, _, _, _, _, _, _, _, Some (_, citems)), _) ->
+    List.fold_left
+      (fun acc item -> match item with
+        | LA.Decreases (_, LA.GroupExpr (_, LA.ExprList, es)) -> Some (List.length es)
+        | LA.Decreases (_, _) -> Some 1
+        | _ -> acc)
+      None citems
+  | _ -> None
+
+(* All functions of a mutually recursive group must declare a decrease measure
+   of the same arity, otherwise their measures cannot be compared
+   lexicographically against each other. *)
+let check_decreases_arity ad decl_map scc =
+  let arities =
+    List.filter_map
+      (fun id ->
+        match IMap.find_opt id decl_map with
+        | Some (Some decl) ->
+          (match decreases_arity decl with Some n -> Some (id, n) | None -> None)
+        | _ -> None)
+      scc
+  in
+  match arities with
+  | [] | [_] -> R.ok ()
+  | (_, n0) :: _ ->
+    if List.for_all (fun (_, n) -> n = n0) arities then R.ok ()
+    else
+      let pos =
+        match find_id_pos ad.id_pos_data (List.hd scc) with
+        | Some p -> p
+        | None -> assert false
+      in
+      graph_error pos (MismatchedDecreasesArity (List.map fst arities))
+
 let topological_sort_with_rec_funs decl_map ad =
   let sccs =
     (* Topological ordered *)
@@ -1235,6 +1279,7 @@ let topological_sort_with_rec_funs decl_map ad =
         acc
         scc
     in
+    let* () = check_decreases_arity ad decl_map scc in
     let scc_map' =
       List.fold_left (fun acc id -> IMap.add id scc_id acc) scc_map scc
     in

--- a/src/lustre/lustreAstDependencies.mli
+++ b/src/lustre/lustreAstDependencies.mli
@@ -51,6 +51,7 @@ type error_kind = Unknown of string
   | ContractDependencyOnCurrentOutput of LA.SI.t
   | CyclicDependency of HString.t list
   | ImportedCyclicDependency of (HString.t list * NodeId.t)
+  | MismatchedDecreasesArity of HString.t list
 
 type error = [
   | `LustreAstDependenciesError of Lib.position * error_kind

--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -151,7 +151,10 @@ type contract = C.t
 
 type func_info = {
   uf_symbols : UfSymbol.t StateVar.StateVarMap.t;
-  rec_info: (int * E.expr) option;
+  (* SCC identifier together with the decrease measure of the function: a
+     non-empty list of expressions interpreted lexicographically (a single
+     element is the ordinary, non-lexicographic case). *)
+  rec_info: (int * E.expr list) option;
   is_lemma: bool;
 }
 

--- a/src/lustre/lustreNode.mli
+++ b/src/lustre/lustreNode.mli
@@ -153,7 +153,7 @@ type equation = equation_lhs * LustreExpr.t
 
 type func_info = {
   uf_symbols : UfSymbol.t StateVar.StateVarMap.t;
-  rec_info: (int * LustreExpr.expr) option;
+  rec_info: (int * LustreExpr.expr list) option;
   is_lemma: bool;
 }
 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1868,13 +1868,15 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
         if is_rec then
           match StringMap.find_opt internal_node_name_hstring scc_map with
           | Some scc_id -> (
-            let decreases_expr = 
+            let decreases_expr =
               match get_decreases_expr contract with
               | Some expr -> (
+                (* A tuple of measures compiles to several indexed bindings,
+                   one per lexicographic component, in declaration order. *)
                 let nexpr = compile_ast_expr cstate ctx [] map expr in
                 match X.bindings nexpr with
-                | [_, expr] -> E.init_expr expr
-                | _ -> assert false
+                | [] -> assert false
+                | bindings -> List.map (fun (_, e) -> E.init_expr e) bindings
               )
               | None -> assert false
             in
@@ -3024,7 +3026,7 @@ and compile_declaration_phase1:
   | A.ContractNodeDecl _ -> cstate
   | A.NodeParamInst _ -> assert false
 
-and get_decreases_expr contract = 
+and get_decreases_expr contract =
   match contract with
   | Some (_, contract) -> (
     let over_decrease_clause = fun acc decl ->
@@ -3035,6 +3037,13 @@ and get_decreases_expr contract =
     List.fold_left over_decrease_clause None contract
   )
   | None -> None
+
+(* The individual components of a decrease measure. A tuple of measures is
+   represented as an expression list; a single measure is its own component. *)
+and decreases_measures expr =
+  match expr with
+  | A.GroupExpr (_, A.ExprList, es) -> es
+  | e -> [e]
 
 (* Inline the abstractions introduced by normalization back to their
    source-level expressions, so that recovered expressions are written in terms
@@ -3091,7 +3100,34 @@ and mk_rec_decrease_expr pos callee_formals args callee_decreases caller_decreas
         (fun acc ph arg -> LustreAstHelpers.substitute_naive ph arg acc)
         to_placeholders placeholders args
     in
-    Some (A.string_of_expr (A.CompOp (pos, A.Lt, substituted, caller_decreases)))
+    (* Render the decrease constraint. For a single measure this is just
+       "callee < caller". For a tuple of measures it is the lexicographic
+       ordering: the i-th component strictly decreases while all preceding
+       components are equal. *)
+    let callee_ms = decreases_measures substituted in
+    let caller_ms = decreases_measures caller_decreases in
+    if List.length callee_ms <> List.length caller_ms then None
+    else
+      let lt c d = A.CompOp (pos, A.Lt, c, d) in
+      let eq c d = A.CompOp (pos, A.Eq, c, d) in
+      let conj a b = A.BinaryOp (pos, A.And, a, b) in
+      let disj a b = A.BinaryOp (pos, A.Or, a, b) in
+      let rec lex = function
+        | [], [] -> None
+        | [c], [d] -> Some (lt c d)
+        | c :: cs, d :: ds -> (
+          let rest =
+            match lex (cs, ds) with
+            | Some tl -> conj (eq c d) tl
+            | None -> eq c d
+          in
+          Some (disj (lt c d) rest)
+        )
+        | _ -> None
+      in
+      (match lex (callee_ms, caller_ms) with
+       | Some e -> Some (A.string_of_expr e)
+       | None -> None)
 
 and compile_declaration_phase2:
   compiler_state -> GI.t NI.Map.t -> Ctx.tc_context -> int StringMap.t ->

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -609,9 +609,16 @@ assumption_vars:
   }
 
 decreases_clause:
-  DECREASES ; e = expr; SEMICOLON
+  DECREASES ; es = separated_nonempty_list(COMMA, expr); SEMICOLON
   {
-    A.Decreases (mk_pos $startpos, e)
+    let pos = mk_pos $startpos in
+    (* A single measure is kept as a plain expression; a tuple of measures is
+       represented as an expression list, interpreted lexicographically. *)
+    let e = match es with
+      | [e] -> e
+      | _ -> A.GroupExpr (pos, A.ExprList, es)
+    in
+    A.Decreases (pos, e)
   }
 
 contract_item:

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -405,14 +405,17 @@ let bounded_check call_pos caller_rf =
   let prop_name =
     Format.asprintf "bounded_check%a" pp_print_line_and_column call_pos
   in
+  (* Lexicographic termination requires the measure to be bounded below, i.e.
+     each component is non-negative. *)
   let prop_term =
-    let caller_rf_term =
-      E.base_term_of_expr TransSys.prop_base caller_rf
-    in
-    Term.mk_leq [Term.mk_num Numeral.zero; caller_rf_term]
+    List.map (fun e ->
+      Term.mk_leq [Term.mk_num Numeral.zero; E.base_term_of_expr TransSys.prop_base e])
+      caller_rf
+    |> Term.mk_and
   in
   let prop_expr =
-    Format.asprintf "(0 <= %a)" (E.pp_print_expr false) caller_rf
+    List.map (fun e -> Format.asprintf "(0 <= %a)" (E.pp_print_expr false) e) caller_rf
+    |> String.concat " and "
   in
   let prop_status = P.PropUnknown in
   let prop_source = P.TerminationCheck call_pos in
@@ -428,17 +431,32 @@ let decrease_check call_pos svar_map src_expr caller_rf callee_rf =
   let prop_name =
     Format.asprintf "decrease_check%a" pp_print_line_and_column call_pos
   in
-  let callee_rf_term =
-    E.base_term_of_expr TransSys.prop_base callee_rf |> lift_term svar_map
+  let callee_rf_terms =
+    List.map (fun e ->
+      E.base_term_of_expr TransSys.prop_base e |> lift_term svar_map) callee_rf
   in
+  let caller_rf_terms =
+    List.map (E.base_term_of_expr TransSys.prop_base) caller_rf
+  in
+  (* The measure strictly decreases in the lexicographic order: some component
+     decreases while all earlier components stay equal. For a single component
+     this reduces to the ordinary "callee < caller". When the two measures have
+     different arities (possible for mutually recursive functions), their common
+     prefix is compared. *)
   let prop_term =
-    let caller_rf_term =
-      E.base_term_of_expr TransSys.prop_base caller_rf
+    let rec lex cs ds =
+      match cs, ds with
+      | [c], [d] -> Term.mk_lt [c; d]
+      | c :: cs', d :: ds' ->
+        Term.mk_or [
+          Term.mk_lt [c; d];
+          Term.mk_and [Term.mk_eq [c; d]; lex cs' ds']
+        ]
+      | _ -> assert false
     in
-    Term.mk_lt [
-      callee_rf_term;
-      caller_rf_term
-    ]
+    let n = min (List.length callee_rf_terms) (List.length caller_rf_terms) in
+    let take l = List.filteri (fun i _ -> i < n) l in
+    lex (take callee_rf_terms) (take caller_rf_terms)
   in
   (* Prefer the source-level rendering reconstructed during node generation
      (e.g. "n - 1 < n"); fall back to the normalized term otherwise. *)
@@ -446,9 +464,7 @@ let decrease_check call_pos svar_map src_expr caller_rf callee_rf =
     match src_expr with
     | Some e -> e
     | None ->
-      Format.asprintf "%a < %a"
-        (E.pp_print_term_as_expr false) callee_rf_term
-        (E.pp_print_expr false) caller_rf
+      Format.asprintf "%a" (E.pp_print_term_as_expr false) prop_term
   in
   let prop_status = P.PropUnknown in
   let prop_source = P.TerminationCheck call_pos in

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -2178,7 +2178,18 @@ and check_contract_node_eqn: (LA.SI.t * LA.SI.t) -> tc_context -> NI.t -> LA.con
       let* e, warnings = check_type_expr ctx (Some nname) e (Bool pos) in 
       R.ok (LA.Guarantee (pos, id, b, e), warnings)
     | Decreases (pos, e) ->
-      let* e, warnings = check_type_expr ctx (Some nname) e (Int pos) in
+      (* A decreases measure is a single integer expression, or a tuple of
+         integer expressions interpreted lexicographically. Every component
+         must be of integer type. *)
+      let* e, warnings = (match e with
+        | LA.GroupExpr (gpos, LA.ExprList, es) ->
+          let* res = R.seq (List.map (fun e ->
+            check_type_expr ctx (Some nname) e (Int pos)) es)
+          in
+          let es, warnings = List.split res in
+          R.ok (LA.GroupExpr (gpos, LA.ExprList, es), List.flatten warnings)
+        | _ -> check_type_expr ctx (Some nname) e (Int pos))
+      in
       R.ok (LA.Decreases (pos, e), warnings)
     | Mode (pos, id, reqs, ensures) ->
       let* reqs, warnings1 = R.seq (List.map (fun (a, b, e)  -> 

--- a/tests/regression/error/decreases_arity_mismatch.lus
+++ b/tests/regression/error/decreases_arity_mismatch.lus
@@ -1,0 +1,22 @@
+-- Two mutually recursive functions whose decrease measures have different
+-- arities (a pair vs. a single value). They cannot be compared
+-- lexicographically against each other, so this must be rejected.
+function rec isEven(m, n: int) returns (r: bool);
+(*@contract
+  assume m >= 0 and n >= 0;
+  guarantee true;
+  decreases m, n;
+*)
+let
+  r = when n <= 0 then true else isOdd(n - 1);
+tel
+
+function rec isOdd(n: int) returns (r: bool);
+(*@contract
+  assume n >= 0;
+  guarantee true;
+  decreases n;
+*)
+let
+  r = when n <= 0 then false else isEven(0, n - 1);
+tel

--- a/tests/regression/falsifiable/decreases_tuple_increasing.lus
+++ b/tests/regression/falsifiable/decreases_tuple_increasing.lus
@@ -1,0 +1,12 @@
+-- A lexicographic decreases measure that does not actually decrease: the first
+-- component stays equal while the second strictly increases, so the
+-- decrease_check must be falsified.
+function rec f(m, n: int) returns (r: int);
+(*@contract
+  assume m >= 0 and n >= 0;
+  guarantee r >= 0;
+  decreases m, n;
+*)
+let
+  r = when m <= 0 then 0 else f(m, n + 1);
+tel

--- a/tests/regression/success/ackermann.lus
+++ b/tests/regression/success/ackermann.lus
@@ -1,0 +1,14 @@
+-- The Ackermann function terminates by the lexicographic ordering of the
+-- pair (m, n): each recursive call either decreases m, or keeps m equal and
+-- decreases n.
+function rec ack(m, n: int) returns (r: int);
+(*@contract
+  assume m >= 0 and n >= 0;
+  guarantee "nonneg" r >= 0;
+  decreases m, n;
+*)
+let
+  r = when m <= 0 then n + 1
+      else when n <= 0 then ack(m - 1, 1)
+      else ack(m - 1, ack(m, n - 1));
+tel


### PR DESCRIPTION
Accept a decreases annotation that is a tuple of integer expressions, e.g. "decreases m, n;", and generate the termination check based on the lexicographic ordering of the tuple. A single measure keeps its previous behavior.

- Parser: accept a comma-separated list of measures (a single one stays a plain expression; multiple are an ExprList group).
- Type checker: require every tuple component to be of integer type.
- Node generation: compile each component, render the source-level decrease constraint as the lexicographic comparison.
- TransSys: decrease_check becomes the lexicographic strict-decrease term; bounded_check requires every component to be non-negative.
- Dependencies: reject mutually recursive functions whose measures differ in arity, since they cannot be compared lexicographically.

Add regression tests: lexicographic Ackermann (success), a tuple that does not decrease (falsifiable), and a mutual-recursion arity mismatch (error).