### PR TITLE
Support the `last` operator in frame blocks

### DIFF
--- a/src/ivcMcs.ml
+++ b/src/ivcMcs.ml
@@ -237,7 +237,7 @@ let rec minimize_node_call_args ue lst expr =
   in
   let rec aux expr =
     match expr with
-    | A.Const _ | A.Ident _ | A.ModeRef _ | A.EmptyMap _| A.EmptySet _
+    | A.Const _ | A.Ident _ | A.Last _ | A.ModeRef _ | A.EmptyMap _| A.EmptySet _
     -> expr
     | A.Call (pos, ty_args, ident, args) ->
       A.Call (pos, ty_args, ident, List.mapi (minimize_arg ident) args)
@@ -275,7 +275,7 @@ and ast_contains p ast =
   let rec aux ast =
     if p ast then true
     else match ast with
-    | A.Const _ | A.Ident _ | A.ModeRef _ | A.EmptyMap _ | A.EmptySet _
+    | A.Const _ | A.Ident _ | A.Last _ | A.ModeRef _ | A.EmptyMap _ | A.EmptySet _
       -> false
     | A.Call (_, _, _, args) ->
       List.map aux args

--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -133,6 +133,20 @@ let var_is_discarded_output var =
   String.split_on_char '_' (HString.string_of_hstring var)
   |> List.mem discarded_output
 
+(* String constant used in lustreDesugarLast.ml as a segment of the fresh local
+   variables introduced to desugar the 'last' operator (e.g. '0_glast_o'). The
+   leading numeric segment guarantees the generated names cannot clash with
+   user-written identifiers. These locals are invisible (Kind 2 generated). *)
+let last_local = "glast"
+
+(* Checks if a variable name corresponds to a 'last'-operator local. As with
+   [var_is_discarded_output], [LustreNodeGen.mk_ident] may move the leading
+   numeric segment to the end, so we look for [last_local] as a '_'-separated
+   segment, which matches both forms. *)
+let var_is_last_local var =
+  String.split_on_char '_' (HString.string_of_hstring var)
+  |> List.mem last_local
+
 let union_keys key id1 id2 = match key, id1, id2 with
   | _, None, None -> None
   | _, (Some v), None -> Some v

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -117,6 +117,13 @@ val discarded_output : string
 (** Checks if a variable name corresponds to a discarded call-statement result *)
 val var_is_discarded_output: HString.t -> bool
 
+(* String constant used as a segment of fresh locals introduced to desugar the
+   'last' operator (see lustreDesugarLast.ml). *)
+val last_local : string
+
+(** Checks if a variable name corresponds to a 'last'-operator local *)
+val var_is_last_local: HString.t -> bool
+
 val empty : unit -> t
 
 val union : t -> t -> t

--- a/src/lustre/lustreArrayDependencies.ml
+++ b/src/lustre/lustreArrayDependencies.ml
@@ -235,6 +235,8 @@ and process_expr ind_vars ctx (ns:AD.node_summary) proj indices expr =
     union_ (r e) graph
   (* Temporal operators *)
   | Pre _ -> empty_
+  (* 'last x' refers to the previous value of x: no instantaneous dependency *)
+  | Last _ -> empty_
   | Arrow (_, e1, e2) -> union_ (r e1) (r e2)
   | TypeAscription (_, e, _) -> r e
   (* Node calls *)

--- a/src/lustre/lustreAst.ml
+++ b/src/lustre/lustreAst.ml
@@ -136,6 +136,9 @@ type expr =
   (* Temporal operators *)
   | Pre of position * expr
   | Arrow of position * expr * expr
+  (* Previous value of a variable in a frame block (desugared early in the
+     pipeline by LustreDesugarLast) *)
+  | Last of position * ident
   (* Node calls *)
   | Call of position * lustre_type list * NI.t * expr list
   (* Type ascription *)
@@ -612,6 +615,9 @@ let rec pp_print_expr ppf =
         (pp_print_list pp_print_expr ",@ ") l 
 
     | Pre (p, e) -> p1 p "pre" e
+
+    | Last (p, i) ->
+      Format.fprintf ppf "%alast %a" ppos p pp_print_ident i
 
     | Arrow (p, e1, e2) -> p2 p "->" e1 e2
 

--- a/src/lustre/lustreAst.mli
+++ b/src/lustre/lustreAst.mli
@@ -171,6 +171,9 @@ and expr =
   (* Temporal operators *)
   | Pre of position * expr
   | Arrow of position * expr * expr
+  (* Previous value of a variable in a frame block (desugared early in the
+     pipeline by LustreDesugarLast) *)
+  | Last of position * ident
   (* Node calls *)
   | Call of position * lustre_type list * NI.t * expr list
   (* Type ascription *)

--- a/src/lustre/lustreAstDependencies.ml
+++ b/src/lustre/lustreAstDependencies.ml
@@ -439,7 +439,7 @@ let mk_graph_type_decl: LA.type_decl -> dependency_analysis_data
                             
 let rec get_node_call_from_expr: LA.expr -> (LA.ident * Lib.position) list
   = function
-  | Ident _ | EmptyMap (_, None) | EmptySet (_, None) -> []
+  | Ident _ | Last _ | EmptyMap (_, None) | EmptySet (_, None) -> []
   | EmptyMap (_, Some (kt, vt)) -> extract_node_calls_type kt @ extract_node_calls_type vt
   | EmptySet (_, Some ty) -> extract_node_calls_type ty
   | ModeRef (pos, ids) ->
@@ -775,6 +775,8 @@ let rec vars_with_flattened_nodes: node_summary -> int -> LA.expr -> LA.SI.t
 
   (* Temporal operators *)
   | Pre (_, _) -> SI.empty
+  (* 'last x' refers to the previous value of x: no instantaneous dependency *)
+  | Last _ -> SI.empty
   | Arrow (_, e1, e2) -> SI.union (r e1) (r e2)
   | TypeAscription (_, e, ty) -> SI.union (r e) (LH.vars_of_type ty)
 

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -146,7 +146,7 @@ let type_arity ty =
   | _ -> (0, 0)
 
 let rec expr_contains_call = function
-  | Ident (_, _) | ModeRef (_, _) | Const (_, _) -> false 
+  | Ident (_, _) | ModeRef (_, _) | Const (_, _) | Last (_, _) -> false
   | EmptySet (_, Some ty) -> 
     fold_lustre_ty expr_contains_call false (||) ty
   | EmptySet (_, None)
@@ -176,7 +176,7 @@ let rec expr_contains_call = function
     -> true
 
 let rec expr_contains_id id = function
-  | Ident (_, id2) -> id = id2
+  | Ident (_, id2) | Last (_, id2) -> id = id2
   | EmptyMap (_, None) | EmptySet (_, None)
   | ModeRef (_, _) | Const (_, _) -> false 
   | EmptyMap (_, Some (kt, vt)) -> 
@@ -214,6 +214,7 @@ let rec expr_contains_id id = function
 (* Substitute t for var. AnyOp/ChooseOp is not supported due to introduction of bound variables. *)
 let rec substitute_naive (var:HString.t) t = function
   | Ident (_, i) as e -> if i = var then t else e
+  | Last (_, _) as e -> e
   | EmptyMap (_, None) | EmptySet (_, None)
   | ModeRef (_, _) as e -> e
   | EmptyMap (p, Some (kt, vt)) ->
@@ -280,9 +281,10 @@ let rec apply_subst_in_expr sigma = function
       | Some expr -> expr
       | None -> Ident (pos, i)
   )
+  | Last (_, _) as e -> e
   | EmptyMap (_, None) | EmptySet (_, None)
   | ModeRef (_, _) as e -> e
-  | EmptyMap (p, Some (kt, vt)) -> 
+  | EmptyMap (p, Some (kt, vt)) ->
     EmptyMap (p, Some (map_lustre_ty (apply_subst_in_expr sigma) kt, map_lustre_ty (apply_subst_in_expr sigma) vt))
   | EmptySet (p, Some ty) -> 
     EmptySet (p, Some (map_lustre_ty (apply_subst_in_expr sigma) ty))
@@ -358,8 +360,9 @@ let rec apply_type_subst_in_expr
   | AnyOp _ -> assert false (* Not supported due to introduction of bound variables *)
   | ChooseOp _ -> assert false (* Not supported due to introduction of bound variables *)
 
-  | Ident _ 
-  | ModeRef _  -> expr
+  | Ident _
+  | ModeRef _
+  | Last _ -> expr
   | RecordProject (pos, e, idx) -> RecordProject (pos, apply_type_subst_in_expr sigma e, idx)
   | Const (_, _) as e -> e
   | Extract (pos, e, idx1, idx2) -> Extract (pos, apply_type_subst_in_expr sigma e, idx1, idx2)
@@ -467,7 +470,9 @@ let rec apply_subst_in_type sigma = function
   | ty -> ty
     
 let rec has_unguarded_pre ung = function
-  | Const _ | Ident _ | ModeRef _  | EmptyMap (_, None) | EmptySet (_, None) -> false 
+  (* 'last x' is always guarded by its frame initialization *)
+  | Last _
+  | Const _ | Ident _ | ModeRef _  | EmptyMap (_, None) | EmptySet (_, None) -> false
 
   | EmptyMap (_, Some (kt, vt)) ->  
     fold_lustre_ty (has_unguarded_pre ung) false (||) kt || 
@@ -572,7 +577,9 @@ let has_unguarded_pre e =
   then raise Parser_error; u
 
 let rec has_unguarded_pre_no_warn ung = function
-  | Const _ | Ident _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> false 
+  (* 'last x' is always guarded by its frame initialization *)
+  | Last _
+  | Const _ | Ident _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> false
 
   | EmptyMap (_, Some (kt, vt)) -> 
     fold_lustre_ty (has_unguarded_pre_no_warn ung) false (||) kt || 
@@ -769,6 +776,9 @@ let rec has_pre_or_arrow = function
 
   | Pre (pos, _) -> Some pos
 
+  (* 'last x' denotes the previous value of x, i.e. it carries a 'pre' *)
+  | Last (pos, _) -> Some pos
+
   | TypeAscription (_, e, ty) -> (
     match has_pre_or_arrow e with
     | None -> fold_lustre_ty has_pre_or_arrow None (fun x1 x2 -> some_of_list [x1; x2]) ty
@@ -945,9 +955,9 @@ let mk_mode_ref_id ids =
 let rec vars_of_node_calls_h obs =
   let vars obs = vars_of_node_calls_h obs in
   function
-  | Ident (_, i) -> if obs then SI.singleton i else SI.empty
+  | Ident (_, i) | Last (_, i) -> if obs then SI.singleton i else SI.empty
   | ModeRef (_, is) -> if obs then SI.singleton (mk_mode_ref_id is) else SI.empty
-  | RecordProject (_, e, _) -> vars obs e 
+  | RecordProject (_, e, _) -> vars obs e
   | EmptyMap (_, None) | EmptySet (_, None) -> SI.empty   
   | EmptyMap (_, Some (kt, vt)) -> 
     SI.union (fold_lustre_ty (vars obs) SI.empty SI.union kt)
@@ -996,9 +1006,9 @@ let vars_of_node_calls = vars_of_node_calls_h false
 let rec vars_without_node_call_ids: expr -> iset =
   let vars = vars_without_node_call_ids in
   function
-  | Ident (_, i) -> SI.singleton i
+  | Ident (_, i) | Last (_, i) -> SI.singleton i
   | ModeRef (_, is) -> SI.singleton (mk_mode_ref_id is)
-  | RecordProject (_, e, _) -> vars e 
+  | RecordProject (_, e, _) -> vars e
   | EmptyMap (_, None) | EmptySet (_, None) -> SI.empty
   | EmptyMap (_, Some (kt, vt)) -> 
     SI.union (fold_lustre_ty vars SI.empty SI.union kt) 
@@ -1057,8 +1067,9 @@ let rec calls_of_expr: expr -> NI.Set.t =
              (NI.Set.flatten (calls_of_expr e :: List.map calls_of_expr es))
   (* Everything else *)
   | Ident _ -> NI.Set.empty
+  | Last _ -> NI.Set.empty
   | ModeRef _ -> NI.Set.empty
-  | RecordProject (_, e, _) -> calls_of_expr e 
+  | RecordProject (_, e, _) -> calls_of_expr e
   | Const _ -> NI.Set.empty
   | Extract (_, e, _, _)
   | UnaryOp (_,_,e) -> calls_of_expr e
@@ -1131,6 +1142,8 @@ let rec vars_without_node_call_ids_current: expr -> iset =
   | ChooseOp (_, (_, i, _), e) -> SI.diff (vars e) (SI.singleton i)
   (* Temporal operators *)
   | Pre _ -> SI.empty
+  (* 'last x' refers to the previous value of x, i.e. x under a 'pre' *)
+  | Last _ -> SI.empty
   | Arrow (_, e1, e2) ->  SI.union (vars e1) (vars e2)
   | TypeAscription (_, e, ty) ->
     SI.union (vars e) (fold_lustre_ty vars SI.empty SI.union ty)
@@ -1235,9 +1248,9 @@ let split_program: declaration list -> (declaration list * declaration list)
 let rec replace_with_constants: expr -> expr =
   let c p = Const(p, Num (HString.mk_hstring "42")) in
   function
-  | Ident(p, _) -> c p 
+  | Ident(p, _) | Last (p, _) -> c p
     | EmptySet (_, None) | EmptyMap (_, None)
-    | ModeRef _ as e -> e 
+    | ModeRef _ as e -> e
   | RecordProject (p, e, i) -> RecordProject (p, replace_with_constants e, i)  
   | EmptyMap (p, Some (kt, vt)) -> 
     EmptyMap (p, Some (map_lustre_ty replace_with_constants kt, map_lustre_ty replace_with_constants vt))
@@ -1326,9 +1339,10 @@ and is used inside abstract_pre_subexpressions *)
 
   
 let rec abstract_pre_subexpressions: expr -> expr = function
-  | Ident _ 
+  | Ident _
+  | Last _
   | EmptySet (_, None) | EmptyMap (_, None)
-  | ModeRef _ as e -> e 
+  | ModeRef _ as e -> e
   | EmptyMap (p, Some (kt, vt)) -> 
     EmptyMap (p, Some (map_lustre_ty abstract_pre_subexpressions kt, map_lustre_ty abstract_pre_subexpressions vt))
   | EmptySet (p, Some ty) -> 
@@ -1420,7 +1434,12 @@ let rec replace_idents locals1 locals2 expr =
       | Some i2 -> Ident (pos, i2)
       | None -> Ident (pos, i)
   )
-  | Quantifier (a, b, tis, e) -> 
+  | Last (pos, i) -> (
+    match List.assoc_opt i (List.combine locals1 locals2) with
+      | Some i2 -> Last (pos, i2)
+      | None -> Last (pos, i)
+  )
+  | Quantifier (a, b, tis, e) ->
     (* Remove 'tis' from locals because they're bound in 'e' *)
     let locals = List.combine locals1 locals2 in 
     let is = List.map (fun (_, i, _) -> i) tis in
@@ -1895,6 +1914,7 @@ let hash depth_limit expr =
       | TypeAscription (_, e, _) ->
         let e_hash = r (depth + 1) e in
         Hashtbl.hash (30, e_hash)
+      | Last (_, x) -> Hashtbl.hash (31, HString.hash x)
   in
   r 0 expr
 
@@ -1911,6 +1931,7 @@ let rec rename_contract_vars = function
         Ident (p, id)
       else e
     with _ -> e)
+  | Last (_, _) as e -> e
   | EmptySet (_, None) | EmptyMap (_, None)
   | ModeRef (_, _) as e -> e
   | EmptyMap (p, Some (kt, vt)) ->
@@ -2005,7 +2026,8 @@ let rec constants_to_calls: ident list -> expr -> expr
     TypeAscription (p, r e, map_lustre_ty r ty)
   | Const _ as e -> e
   | ModeRef _ as e -> e
-    
+  | Last _ as e -> e
+
   | RecordProject (p, e, idx) -> RecordProject (p, r e, idx)
   | ConvOp (p, op, e) -> ConvOp (p, op, r e)
   | Extract (p, e, ub, lb) -> Extract (p, r e, ub, lb)

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -58,6 +58,7 @@ let pos_of_expr = function
   | Quantifier (pos, _, _, _)
   | When (pos , _ , _) | Condact (pos , _ , _ , _ , _, _)
   | Activate (pos , _ , _ , _ , _) | Merge (pos , _ , _ ) | Pre (pos , _)
+  | Last (pos, _)
   | RestartEvery (pos, _, _, _)
   | Arrow (pos , _, _) | Call (pos, _, _, _)
   | AnyOp (pos, _, _) | ChooseOp (pos, _, _) | Extract (pos, _, _, _)

--- a/src/lustre/lustreAstInlineConstants.ml
+++ b/src/lustre/lustreAstInlineConstants.ml
@@ -238,6 +238,7 @@ and push_pre is_guarded pos =
   let r e = push_pre is_guarded pos e in
   function
   | LA.Ident _ as e -> LA.Pre (pos, e)
+  | Last _ as e -> LA.Pre (pos, e)
   | ModeRef _ as e -> LA.Pre (pos, e)
   | EmptySet _ as e -> LA.Pre (pos, e)
   | EmptyMap _ as e -> LA.Pre (pos, e)

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -829,6 +829,7 @@ let desugar_history_in_expr ctx ctr_id prefix expr =
     | Some hist_varid ->
       StringSet.empty, IndexAccess(pos, Ident(pos, hist_varid), expr, Array)
   )
+  | Last _ -> StringSet.empty, expr
   | ModeRef _ -> StringSet.empty, expr
   | RecordProject (pos, e, idx) ->
     let vars, e' = r map e in
@@ -2156,6 +2157,8 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
   (* Variable renaming to ease handling contract scopes                       *)
   (* ************************************************************************ *)
   | Ident _ as e -> rename_id_expr info e, empty (), []
+  (* 'last' is desugared away before normalization *)
+  | Last _ as e -> e, empty (), []
   (* ************************************************************************ *)
   (* The remaining expr kinds are all just structurally recursive             *)
   (* ************************************************************************ *)

--- a/src/lustre/lustreDesugarFrameBlocks.ml
+++ b/src/lustre/lustreDesugarFrameBlocks.ml
@@ -115,6 +115,7 @@ let rec fill_ite_helper frame_pos node_id lhs fill e =
   | TypeAscription (p, e, ty) -> TypeAscription (p, r e, ty)
   | Const _ as e -> e
   | ModeRef _ as e -> e
+  | Last _ as e -> e
   | EmptyMap _ as e -> e
   | EmptySet _ as e -> e
   | RecordProject (p, e, id) -> RecordProject (p, r e, id)

--- a/src/lustre/lustreDesugarLast.ml
+++ b/src/lustre/lustreDesugarLast.ml
@@ -1,0 +1,276 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2026 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+ *)
+
+(** Desugars the [last] operator.
+
+    [last x], where [x] is a variable in scope, may only occur in an expression
+    within a frame block. It denotes the previous value of [x], initialized by
+    the frame.
+
+    For each frame block, every variable [x] referenced through [last] is
+    replaced by a fresh internal local variable [last_x] defined (on the base
+    clock, outside the frame block) by
+      [last_x = init_x -> pre x]
+    where [init_x] is the frame's initialization expression for [x] (or just
+    [pre x] when [x] has no initialization).
+
+    This mirrors the semantics of manually introducing such a local variable
+    (see the [when_last2.lus] example).
+ *)
+
+module A = LustreAst
+module R = Res
+module AH = LustreAstHelpers
+module GI = GeneratedIdentifiers
+
+let (let*) = R.(>>=)
+
+type error_kind =
+  | MisplacedLastError of HString.t
+  | UnknownIdentifier of HString.t
+
+let error_message = function
+  | MisplacedLastError id ->
+    "The 'last' operator can only be used within a frame block (found 'last "
+    ^ HString.string_of_hstring id ^ "')."
+  | UnknownIdentifier id ->
+    "Unknown identifier '" ^ HString.string_of_hstring id ^ "'"
+
+type error = [
+  | `LustreDesugarLastError of Lib.position * error_kind
+]
+
+let mk_error pos kind = Error (`LustreDesugarLastError (pos, kind))
+
+(* Counter for fresh last-variable names. The leading digit guarantees the
+   generated names cannot clash with user-written identifiers. *)
+let i = ref 0
+
+let mk_fresh_last_name x =
+  let name =
+    (string_of_int !i) ^ "_" ^ GI.last_local ^ "_" ^ (HString.string_of_hstring x)
+  in
+  i := !i + 1;
+  HString.mk_hstring name
+
+(** Returns the fresh local name associated with frame variable [x], creating it
+    (and recording it in [acc], together with the position of its first use) on
+    first use. [acc] preserves insertion order. *)
+let get_or_create acc pos x =
+  match List.assoc_opt x !acc with
+  | Some (n, _) -> n
+  | None -> let n = mk_fresh_last_name x in acc := !acc @ [(x, (n, pos))]; n
+
+(** Replaces every [last x] occurring in [e] with a reference to its fresh local
+    variable, recording the needed last-variables in [acc]. *)
+let rec replace_last acc e =
+  let r = replace_last acc in
+  match e with
+  | A.Last (pos, x) -> A.Ident (pos, get_or_create acc pos x)
+  | Ident _ | ModeRef _ | Const _
+  | EmptyMap (_, None) | EmptySet (_, None) -> e
+  | EmptyMap (p, Some (kt, vt)) -> EmptyMap (p, Some (kt, vt))
+  | EmptySet (p, Some ty) -> EmptySet (p, Some ty)
+  | RecordProject (pos, e, idx) -> RecordProject (pos, r e, idx)
+  | Extract (pos, e, idx1, idx2) -> Extract (pos, r e, idx1, idx2)
+  | UnaryOp (pos, op, e) -> UnaryOp (pos, op, r e)
+  | BinaryOp (pos, op, e1, e2) -> BinaryOp (pos, op, r e1, r e2)
+  | TernaryOp (pos, op, e1, e2, e3) -> TernaryOp (pos, op, r e1, r e2, r e3)
+  | ConvOp (pos, op, e) -> ConvOp (pos, op, r e)
+  | CompOp (pos, op, e1, e2) -> CompOp (pos, op, r e1, r e2)
+  | AnyOp (pos, ti, e) -> AnyOp (pos, ti, r e)
+  | ChooseOp (pos, ti, e) -> ChooseOp (pos, ti, r e)
+  | Quantifier (pos, q, tis, e) -> Quantifier (pos, q, tis, r e)
+  | RecordExpr (pos, ident, ps, expr_list) ->
+    RecordExpr (pos, ident, ps, List.map (fun (i, e) -> (i, r e)) expr_list)
+  | GroupExpr (pos, kind, expr_list) ->
+    GroupExpr (pos, kind, List.map r expr_list)
+  | StructUpdate (pos, e1, idx, Some e2) ->
+    StructUpdate (pos, r e1, idx, Some (r e2))
+  | StructUpdate (pos, e1, idx, None) ->
+    StructUpdate (pos, r e1, idx, None)
+  | ArrayConstr (pos, e1, e2) -> ArrayConstr (pos, r e1, r e2)
+  | IndexAccess (pos, e1, e2, kind) -> IndexAccess (pos, r e1, r e2, kind)
+  | When (pos, e, clock) -> When (pos, r e, clock)
+  | Condact (pos, e1, e2, id, expr_list1, expr_list2) ->
+    Condact (pos, r e1, r e2, id, List.map r expr_list1, List.map r expr_list2)
+  | Activate (pos, ident, e1, e2, expr_list) ->
+    Activate (pos, ident, r e1, r e2, List.map r expr_list)
+  | Merge (pos, ident, expr_list) ->
+    Merge (pos, ident, List.map (fun (i, e) -> (i, r e)) expr_list)
+  | RestartEvery (pos, ident, expr_list, e) ->
+    RestartEvery (pos, ident, List.map r expr_list, r e)
+  | Pre (pos, e) -> Pre (pos, r e)
+  | Arrow (pos, e1, e2) -> Arrow (pos, r e1, r e2)
+  | TypeAscription (pos, e, ty) -> TypeAscription (pos, r e, ty)
+  | Call (pos, ty_args, id, expr_list) ->
+    Call (pos, ty_args, id, List.map r expr_list)
+
+let replace_last_eq acc = function
+  | A.Assert (pos, e) -> A.Assert (pos, replace_last acc e)
+  | A.Equation (pos, lhs, e) -> A.Equation (pos, lhs, replace_last acc e)
+
+let replace_last_prop_kind acc = function
+  | A.Provided e -> A.Provided (replace_last acc e)
+  | k -> k
+
+(** Replaces [last] in all expressions reachable from the node item [ni]
+    (recursing into nested if/when/frame blocks). *)
+let rec replace_last_ni acc ni = match ni with
+  | A.Body eq -> A.Body (replace_last_eq acc eq)
+  | A.IfBlock (pos, e, nis1, nis2) ->
+    A.IfBlock (pos, replace_last acc e,
+               List.map (replace_last_ni acc) nis1,
+               List.map (replace_last_ni acc) nis2)
+  | A.WhenBlock (pos, e, nis1, nis2) ->
+    A.WhenBlock (pos, replace_last acc e,
+                 List.map (replace_last_ni acc) nis1,
+                 List.map (replace_last_ni acc) nis2)
+  | A.FrameBlock (pos, vars, nes, nis) ->
+    A.FrameBlock (pos, vars, List.map (replace_last_eq acc) nes,
+                  List.map (replace_last_ni acc) nis)
+  | A.AnnotProperty (pos, name, e, k) ->
+    A.AnnotProperty (pos, name, replace_last acc e, replace_last_prop_kind acc k)
+  | A.AnnotMain _ | A.Auto _ -> ni
+
+(* {1 Detecting misplaced last operators} *)
+
+let rec find_last_expr e = match e with
+  | A.Last (pos, x) -> Some (pos, x)
+  | Ident _ | ModeRef _ | Const _
+  | EmptyMap _ | EmptySet _ -> None
+  | RecordProject (_, e, _) | Extract (_, e, _, _)
+  | UnaryOp (_, _, e) | ConvOp (_, _, e)
+  | AnyOp (_, _, e) | ChooseOp (_, _, e) | Quantifier (_, _, _, e)
+  | When (_, e, _) | Pre (_, e) | TypeAscription (_, e, _) -> find_last_expr e
+  | BinaryOp (_, _, e1, e2) | CompOp (_, _, e1, e2)
+  | ArrayConstr (_, e1, e2) | IndexAccess (_, e1, e2, _)
+  | Arrow (_, e1, e2) -> find_last_first [e1; e2]
+  | TernaryOp (_, _, e1, e2, e3) -> find_last_first [e1; e2; e3]
+  | RecordExpr (_, _, _, l) | Merge (_, _, l) ->
+    find_last_first (List.map snd l)
+  | GroupExpr (_, _, l) | Call (_, _, _, l) -> find_last_first l
+  | StructUpdate (_, e1, _, Some e2) -> find_last_first [e1; e2]
+  | StructUpdate (_, e1, _, None) -> find_last_expr e1
+  | Condact (_, e1, e2, _, l1, l2) -> find_last_first ([e1; e2] @ l1 @ l2)
+  | Activate (_, _, e1, e2, l) -> find_last_first ([e1; e2] @ l)
+  | RestartEvery (_, _, l, e) -> find_last_first (e :: l)
+
+and find_last_first = function
+  | [] -> None
+  | e :: es -> (match find_last_expr e with Some r -> Some r | None -> find_last_first es)
+
+let find_last_eq = function
+  | A.Assert (_, e) | A.Equation (_, _, e) -> find_last_expr e
+
+(** Looks for a (misplaced) [last] in a node item that is not a frame block,
+    descending into nested if/when blocks but not frame blocks (which handle
+    [last] themselves). *)
+let rec find_last_ni ni = match ni with
+  | A.Body eq -> find_last_eq eq
+  | A.IfBlock (_, e, nis1, nis2) | A.WhenBlock (_, e, nis1, nis2) ->
+    (match find_last_expr e with
+     | Some r -> Some r
+     | None -> find_last_nis (nis1 @ nis2))
+  | A.FrameBlock _ -> None
+  | A.AnnotProperty (_, _, e, A.Provided e2) ->
+    (match find_last_expr e with Some r -> Some r | None -> find_last_expr e2)
+  | A.AnnotProperty (_, _, e, _) -> find_last_expr e
+  | A.AnnotMain _ | A.Auto _ -> None
+
+and find_last_nis nis =
+  List.fold_left
+    (fun acc ni -> match acc with Some _ -> acc | None -> find_last_ni ni)
+    None nis
+
+(* {1 Type lookup} *)
+
+(* Build a lookup table from variable name to declared type using the node's
+   inputs, outputs and (variable) locals. *)
+let mk_type_lookup cctds ctds nlds =
+  let inputs = List.map (fun (_, id, ty, _, _) -> (id, ty)) cctds in
+  let outputs = List.map (fun (_, id, ty, _) -> (id, ty)) ctds in
+  let locals = List.filter_map (function
+    | A.NodeVarDecl (_, (_, id, ty, _)) -> Some (id, ty)
+    | A.NodeConstDecl _ -> None) nlds
+  in
+  inputs @ outputs @ locals
+
+(** Generates, for each recorded last-variable, its fresh local declaration and
+    defining equation [last_x = init_x -> pre x]. *)
+let gen_last_defs f_pos type_lookup nes last_vars =
+  R.seq (List.map (fun (x, (last_name, pos)) ->
+    match List.assoc_opt x type_lookup with
+    | None -> mk_error pos (UnknownIdentifier x)
+    | Some ty ->
+      let pre_x = A.Pre (f_pos, A.Ident (f_pos, x)) in
+      (* Initialization from the frame block, if any. *)
+      let init = List.find_map (function
+        | A.Equation (_, A.StructDef (_, [A.SingleIdent (_, id)]), e) when id = x -> Some e
+        | A.Equation (_, A.StructDef (_, [A.ArrayDef (_, id, _)]), e) when id = x -> Some e
+        | _ -> None) nes
+      in
+      let rhs = match init with
+        | Some init -> A.Arrow (AH.pos_of_expr init, init, pre_x)
+        | None -> pre_x
+      in
+      let decl = A.NodeVarDecl (f_pos, (f_pos, last_name, ty, A.ClockTrue)) in
+      let eq =
+        A.Body (A.Equation (f_pos,
+          A.StructDef (f_pos, [A.SingleIdent (f_pos, last_name)]), rhs))
+      in
+      R.ok (decl, eq)
+  ) last_vars)
+
+(* {1 Node processing} *)
+
+(** Processes a single (top-level) node item, returning the new local
+    declarations, the (possibly several) replacement node items, after
+    desugaring any [last] operators. *)
+let desugar_node_item type_lookup ni = match ni with
+  | A.FrameBlock (pos, vars, nes, nis) ->
+    let acc = ref [] in
+    let nes = List.map (replace_last_eq acc) nes in
+    let nis = List.map (replace_last_ni acc) nis in
+    let* defs = gen_last_defs pos type_lookup nes !acc in
+    let decls = List.map fst defs in
+    let last_eqs = List.map snd defs in
+    R.ok (decls, last_eqs @ [A.FrameBlock (pos, vars, nes, nis)])
+  | _ ->
+    (match find_last_ni ni with
+     | Some (pos, x) -> mk_error pos (MisplacedLastError x)
+     | None -> R.ok ([], [ni]))
+
+let desugar_node_decl (node_id, b, opac, nps, cctds, ctds, nlds, nis, co) =
+  let type_lookup = mk_type_lookup cctds ctds nlds in
+  let* res = R.seq (List.map (desugar_node_item type_lookup) nis) in
+  let decls, nis = List.split res in
+  let decls = List.flatten decls in
+  let nis = List.flatten nis in
+  R.ok (node_id, b, opac, nps, cctds, ctds, decls @ nlds, nis, co)
+
+(** Desugars the [last] operator in a declaration list. *)
+let desugar_last decls =
+  R.seq (List.map (fun decl -> match decl with
+    | A.NodeDecl (s, nd) ->
+      let* nd = desugar_node_decl nd in
+      R.ok (A.NodeDecl (s, nd))
+    | A.FuncDecl (s, nd, attrs) ->
+      let* nd = desugar_node_decl nd in
+      R.ok (A.FuncDecl (s, nd, attrs))
+    | _ -> R.ok decl
+  ) decls)

--- a/src/lustre/lustreDesugarLast.mli
+++ b/src/lustre/lustreDesugarLast.mli
@@ -1,0 +1,35 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2026 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+ *)
+
+(** Desugars the [last] operator (only allowed within frame blocks).
+
+    @author Kind 2 development team *)
+
+type error_kind =
+  | MisplacedLastError of HString.t
+  | UnknownIdentifier of HString.t
+
+val error_message : error_kind -> string
+
+type error = [
+  | `LustreDesugarLastError of Lib.position * error_kind
+]
+
+(** Replaces each [last x] occurring in a frame block with a fresh local
+    variable initialized by the frame and equal to [pre x] afterwards. Returns
+    an error if [last] is used outside of a frame block. *)
+val desugar_last : LustreAst.t -> (LustreAst.t, [> error]) result

--- a/src/lustre/lustreErrors.ml
+++ b/src/lustre/lustreErrors.ml
@@ -31,6 +31,7 @@ type error = [
   | `LustreConstantsToFunctionsError of Lib.position * LustreConstantsToFunctions.error_kind
   | `LustreGenRefTypeImpNodesError of Lib.position * LustreGenRefTypeImpNodes.error_kind
   | `LustreDesugarFrameBlocksError of Lib.position * LustreDesugarFrameBlocks.error_kind
+  | `LustreDesugarLastError of Lib.position * LustreDesugarLast.error_kind
 ]
 
 let error_position error = match error with
@@ -46,6 +47,7 @@ let error_position error = match error with
   | `LustreConstantsToFunctionsError (pos, _) -> pos
   | `LustreGenRefTypeImpNodesError (pos, _) -> pos
   | `LustreDesugarFrameBlocksError (pos, _) -> pos
+  | `LustreDesugarLastError (pos, _) -> pos
 
 let error_message error = match error with
   | `LustreArrayDependencies (_, kind) -> LustreArrayDependencies.error_message kind
@@ -60,3 +62,4 @@ let error_message error = match error with
   | `LustreConstantsToFunctionsError (_, kind) -> LustreConstantsToFunctions.error_message kind 
   | `LustreGenRefTypeImpNodesError (_, kind) -> LustreGenRefTypeImpNodes.error_message kind
   | `LustreDesugarFrameBlocksError (_, kind) -> LustreDesugarFrameBlocks.error_message kind
+  | `LustreDesugarLastError (_, kind) -> LustreDesugarLast.error_message kind

--- a/src/lustre/lustreErrors.mli
+++ b/src/lustre/lustreErrors.mli
@@ -32,6 +32,7 @@ type error = [
   | `LustreConstantsToFunctionsError of Lib.position * LustreConstantsToFunctions.error_kind
   | `LustreGenRefTypeImpNodesError of Lib.position * LustreGenRefTypeImpNodes.error_kind
   | `LustreDesugarFrameBlocksError of Lib.position * LustreDesugarFrameBlocks.error_kind
+  | `LustreDesugarLastError of Lib.position * LustreDesugarLast.error_kind
 ]
 
 val error_position : [< error] -> Lib.position

--- a/src/lustre/lustreFlattenRefinementTypes.ml
+++ b/src/lustre/lustreFlattenRefinementTypes.ml
@@ -148,9 +148,9 @@ let rec flatten_ref_types_expr: TypeCheckerContext.tc_context -> A.expr -> A.exp
   | EmptyMap (p, Some (kt, vt)) ->
     EmptyMap (p, Some (flatten_ref_type ctx kt, flatten_ref_type ctx vt))
   (* Everything else *)
-  | Ident _ | EmptyMap (_, None) | EmptySet (_, None)
-  | ModeRef _ as e -> e 
-  | RecordProject (p, e, i) -> RecordProject (p, rec_call e, i)  
+  | Ident _ | Last _ | EmptyMap (_, None) | EmptySet (_, None)
+  | ModeRef _ as e -> e
+  | RecordProject (p, e, i) -> RecordProject (p, rec_call e, i)
   | Const _ as e -> e
   | UnaryOp (p, op, e) -> UnaryOp (p, op, rec_call e)
   | BinaryOp (p, op, e1, e2) -> BinaryOp (p, op, rec_call e1, rec_call e2) 

--- a/src/lustre/lustreGenNodes.ml
+++ b/src/lustre/lustreGenNodes.ml
@@ -227,6 +227,7 @@ fun ctx node_name fun_ids expr ->
     A.Call(pos, ty_vars, name, inputs_call), gen_nodes @ ty_gen_nodes @ [generated_node]
 
   | Ident _ as e -> e, []
+  | Last _ as e -> e, []
   | ModeRef (_, _) as e -> e, []
   | A.EmptySet (pos, None) -> A.EmptySet (pos, None), []
   | A.EmptySet (pos, Some ty) ->

--- a/src/lustre/lustreGenRefTypeImpNodes.ml
+++ b/src/lustre/lustreGenRefTypeImpNodes.ml
@@ -64,7 +64,8 @@ let rec expr_contains_mode_ref expr =
   let r = expr_contains_mode_ref in 
   match expr with 
   | A.ModeRef (_, _) -> true
-  | Ident (_, _) 
+  | Ident (_, _)
+  | Last (_, _)
   | Const (_, _)
   | EmptySet _
   | EmptyMap _ -> false

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -39,6 +39,7 @@ module LAN = LustreAstNormalizer
 module LS = LustreSyntaxChecks
 module LDI = LustreDesugarIfBlocks
 module LDF = LustreDesugarFrameBlocks
+module LDL = LustreDesugarLast
 module LNC = LustreNameCalls
 module RMA = LustreRemoveMultAssign
 module LAD = LustreArrayDependencies
@@ -63,6 +64,7 @@ type error = [
   | `LustreConstantsToFunctionsError of Lib.position * LustreConstantsToFunctions.error_kind
   | `LustreGenRefTypeImpNodesError of Lib.position * LustreGenRefTypeImpNodes.error_kind
   | `LustreDesugarFrameBlocksError of Lib.position * LustreDesugarFrameBlocks.error_kind
+  | `LustreDesugarLastError of Lib.position * LustreDesugarLast.error_kind
 ]
 
 let (let*) = Res.(>>=)
@@ -149,6 +151,11 @@ let fail_or_warn warning =
 
 let type_check declarations =
   let tc_res = (
+    (* Step 0. Desugar the 'last' operator (only allowed within frame blocks).
+       Done before syntax checks and type checking so that the rest of the
+       pipeline never sees 'last'. *)
+    let* declarations = LDL.desugar_last declarations in
+
     (* Step 1. Basic syntax checks on declarations  *)
     let* warnings1, declarations = LS.syntax_check declarations in
 

--- a/src/lustre/lustreInput.mli
+++ b/src/lustre/lustreInput.mli
@@ -121,6 +121,7 @@ type error = [
   | `LustreConstantsToFunctionsError of Lib.position * LustreConstantsToFunctions.error_kind
   | `LustreGenRefTypeImpNodesError of Lib.position * LustreGenRefTypeImpNodes.error_kind
   | `LustreDesugarFrameBlocksError of Lib.position * LustreDesugarFrameBlocks.error_kind
+  | `LustreDesugarLastError of Lib.position * LustreDesugarLast.error_kind
 ]
 
 (** [of_file only_parse f] parse Lustre model from file [f], and

--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -379,10 +379,10 @@ and gen_poly_decls_expr: Ctx.tc_context -> GI.t NI.Map.t -> NI.t option -> (A.de
       ctx, gids, acc_exprs @ [expr], decls @ acc_decls, node_decls_map
     ) (ctx, gids, [], [], node_decls_map) exprs in 
     ctx, gids, Call (pos, [], node_id, exprs), decls, node_decls_map
-  | Ident _ | EmptyMap (_, None) | EmptySet (_, None)
+  | Ident _ | Last _ | EmptyMap (_, None) | EmptySet (_, None)
   | Const _
   | ModeRef _ -> ctx, gids, expr, [], node_decls_map
-  | RecordProject (p, expr, id) -> 
+  | RecordProject (p, expr, id) ->
     let ctx, gids, expr, decls, node_decls_map = rec_call expr in 
     ctx, gids, RecordProject (p, expr, id), decls, node_decls_map
   | ConvOp (p, op, expr) -> 

--- a/src/lustre/lustreLexer.mll
+++ b/src/lustre/lustreLexer.mll
@@ -326,6 +326,7 @@ let keyword_table = mk_hashtbl [
   (* Temporal operators *)
   "pre", PRE ;
   "fby", FBY ;
+  "last", LAST ;
 
   (* Block annotation contract stuff. *)
   "mode", MODE;

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1916,6 +1916,9 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
       | A.NodeVarDecl (_, (_, i, ast_type, A.ClockTrue)) ->
         let ident = mk_ident i
         and index_types = compile_ast_type cstate ctx map ast_type in
+        (* Locals introduced to desugar the 'last' operator are Kind 2
+           generated and therefore invisible (not shown in counterexamples). *)
+        let source = if GI.var_is_last_local i then N.Generated else N.Local in
         let over_indices = fun index index_type accum ->
           let possible_state_var = mk_state_var
             ~is_input:false
@@ -1924,7 +1927,7 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
             ident
             index
             index_type
-            (Some N.Local)
+            (Some source)
           in
           match possible_state_var with
           | Some state_var -> X.add index state_var accum

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1271,6 +1271,7 @@ and compile_ast_expr
   (* Identifiers                                                        *)
   (* ****************************************************************** *)
   | A.Ident (_, ident) -> compile_id_string bounds ident
+  | A.Last _ -> assert false (* desugared in lustreDesugarLast *)
   | A.ModeRef (_, path) -> compile_mode_reference path
   (* ****************************************************************** *)
   (* Constants                                                          *)

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -212,6 +212,7 @@ let mk_span start_pos end_pos =
 
 (* Tokens for temporal operators *)
 %token PRE
+%token LAST
 %token FBY
 %token ARROW
 
@@ -241,8 +242,9 @@ let mk_span start_pos end_pos =
 %left BVOR
 %left BVAND
 %nonassoc LSH RSH
-%nonassoc PRE 
-%nonassoc INT REAL 
+%nonassoc PRE
+%nonassoc LAST
+%nonassoc INT REAL
 %nonassoc NOT
 %nonassoc BVNOT 
 %left CARET 
@@ -1336,6 +1338,8 @@ pexpr(Q):
     
   (* A temporal operation *)
   | PRE; e = pexpr(Q) { A.Pre (mk_pos $startpos, e) }
+  (* The 'last' operator (only valid inside frame blocks; desugared away early) *)
+  | LAST; i = ident { A.Last (mk_pos $startpos, i) }
   | FBY LPAREN; pexpr(Q) COMMA; NUMERAL; COMMA; pexpr(Q) RPAREN
     { let pos = mk_pos $startpos in
       fail_at_position pos "Unsupported operator: fby" }

--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -274,6 +274,7 @@ let ctx_add_lazy_vars_from_guard ctx guard_expr =
 let rec has_stateful_op ctx =
 function
 | LA.Pre _ | Arrow _ -> true
+| Last _ -> true
 
 | RestartEvery _
 | AnyOp _ -> true
@@ -773,7 +774,7 @@ let rec expr_only_supported_in_merge observer expr =
     Res.seq_ (List.map (fun (_, e) -> match e with
       | LA.When (_, e, _) | e -> r true e)
       e)
-  | Ident _ | Const _ | ModeRef _ | EmptyMap _ | EmptySet _ -> Ok ()
+  | Ident _ | Last _ | Const _ | ModeRef _ | EmptyMap _ | EmptySet _ -> Ok ()
   | RecordProject (_, e, _)
   | UnaryOp (_, _, e)
   | ConvOp (_, _, e)
@@ -1306,9 +1307,9 @@ and check_expr: context -> (context -> LA.expr -> ([> warning] list, ([> error] 
       Res.ok (warnings1 @ warnings2) 
     | EmptySet (_, Some ty) -> 
       check_ty ctx f ty
-    | Ident _ | ModeRef _ | Const _ | EmptyMap _ | EmptySet _ -> Ok ([])
+    | Ident _ | Last _ | ModeRef _ | Const _ | EmptyMap _ | EmptySet _ -> Ok ([])
   in
-  let* warnings1 = res in 
+  let* warnings1 = res in
   let* warnings2 = check expr in 
   Ok (warnings1 @ warnings2)
 

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -342,10 +342,10 @@ let no_mismatched_clock is_bool e =
         | _ -> type_error pos (IllegalClockExprInActivate c)
       in
       clocks_match_result pos clk_exp clock
-    | Ident _ | Const _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> Ok ()
+    | Ident _ | Last _ | Const _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> Ok ()
     | EmptyMap (_, Some (kt, vt)) ->
       (LH.fold_lustre_ty (check_clocks clock) (R.ok ()) (>>) kt) >>
-      (LH.fold_lustre_ty (check_clocks clock) (R.ok ()) (>>) vt) 
+      (LH.fold_lustre_ty (check_clocks clock) (R.ok ()) (>>) vt)
     | EmptySet (_, Some ty) -> 
       LH.fold_lustre_ty (check_clocks clock) (R.ok ()) (>>) ty
     | RecordProject (_, e, _) | UnaryOp (_, _, e)
@@ -386,9 +386,9 @@ let no_mismatched_clock is_bool e =
           let* _ = check_clocks (ClockPos clock) e1 in
           check_clocks (ClockNeg clock) e2
         | _ -> Ok ())
-    | Ident _ | Const _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> Ok ()
-    | EmptyMap (_, Some (kt, vt)) -> 
-      (LH.fold_lustre_ty check_merge (R.ok ()) (>>) kt) >> 
+    | Ident _ | Last _ | Const _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> Ok ()
+    | EmptyMap (_, Some (kt, vt)) ->
+      (LH.fold_lustre_ty check_merge (R.ok ()) (>>) kt) >>
       (LH.fold_lustre_ty check_merge (R.ok ()) (>>) vt)
     | EmptySet (_, Some ty) -> 
       LH.fold_lustre_ty check_merge (R.ok ()) (>>) ty
@@ -564,6 +564,7 @@ let rec infer_const_attr ctx exp =
   (* Temporal operators *)
   | Pre (_, e) ->
     List.map (fun _ -> error exp "pre operator") (r e)
+  | Last _ -> [error exp "last operator"]
   | Arrow (_, e1, _) ->
     List.map (fun _ -> error exp "arrow operator") (r e1)
   | TypeAscription (_, e, ty) ->
@@ -715,10 +716,10 @@ let rec instantiate_type_variables_expr: tc_context -> NI.t -> tc_type list -> L
     ) tis) in 
     let* e = call e in 
     R.ok (LA.Quantifier (pos, q, tis, e))
-  | Ident _ | EmptyMap (_, None) | EmptySet (_, None) 
+  | Ident _ | Last _ | EmptyMap (_, None) | EmptySet (_, None)
   | ModeRef _ -> R.ok expr
-  | RecordProject (pos, e, idx) -> 
-    let* e = call e in 
+  | RecordProject (pos, e, idx) ->
+    let* e = call e in
     R.ok (LA.RecordProject (pos, e, idx))
   | Const (_, _) as e -> R.ok e
   | Extract (pos, e, idx1, idx2) -> 
@@ -951,7 +952,12 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
   (* Identifiers *)
   | LA.Ident (pos, i) ->
     (match (lookup_ty ctx i) with
-    | None -> type_error pos (UnboundIdentifier i) 
+    | None -> type_error pos (UnboundIdentifier i)
+    | Some ty -> R.ok (ty, e, []))
+  (* 'last x' has the same type as 'x' (desugared away before this point) *)
+  | LA.Last (pos, i) ->
+    (match (lookup_ty ctx i) with
+    | None -> type_error pos (UnboundIdentifier i)
     | Some ty -> R.ok (ty, e, []))
   | LA.ModeRef (pos, ids) ->      
     let lookup_mode_ty ctx (ids:HString.t list) =
@@ -1533,8 +1539,9 @@ and check_type_expr: tc_context -> NI.t option -> LA.expr -> tc_type -> (LA.expr
   | GroupExpr (pos, _, _) 
   | StructUpdate (pos, _, _, _) 
   | RecordExpr (pos, _, _, _) 
-  | Pre (pos, _) 
-  | When (pos, _, _) 
+  | Pre (pos, _)
+  | Last (pos, _)
+  | When (pos, _, _)
   | Call (pos, _, _, _) as e ->
     let* inf_ty, e, warnings = infer_type_expr ctx nname e in
     R.ifM (eq_lustre_type ctx inf_ty exp_ty)
@@ -2499,7 +2506,7 @@ and check_no_index_access ctx nname ty e =
     | Some (LA.Ident _, _, _) -> R.ok () (* Free constant *)
     | Some (e, _, _) -> r e (* Defined constant *)
   )
-  | Const _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> R.ok ()
+  | Last _ | Const _ | ModeRef _ | EmptyMap (_, None) | EmptySet (_, None) -> R.ok ()
   | EmptyMap (_, Some (kt, vt)) ->
     LH.fold_lustre_ty (check_no_index_access ctx nname ty) (R.ok ()) (>>) kt >>
     LH.fold_lustre_ty (check_no_index_access ctx nname ty) (R.ok ()) (>>) vt
@@ -2630,12 +2637,13 @@ and expr_contains_set_binop ctx ni expr =
       add_ty acc id ty 
     ) ctx tis in 
     expr_contains_set_binop ctx ni e 
-  | Ident _  -> false 
+  | Ident _  -> false
+  | Last _ -> false
   | EmptyMap (_, None) | EmptySet (_, None)
-  | ModeRef (_, _) | Const (_, _) -> false 
-  | EmptyMap (_, Some (kt, vt)) -> 
-    LH.fold_lustre_ty r false (||) kt || 
-    LH.fold_lustre_ty r false (||) vt 
+  | ModeRef (_, _) | Const (_, _) -> false
+  | EmptyMap (_, Some (kt, vt)) ->
+    LH.fold_lustre_ty r false (||) kt ||
+    LH.fold_lustre_ty r false (||) vt
   | EmptySet (_, Some ty) -> LH.fold_lustre_ty r false (||) ty
   | RecordProject (_, e, _) | UnaryOp (_, _, e)
   | ConvOp (_, _, e) | When (_, e, _) | Pre (_, e) 

--- a/src/lustre/typeCheckerContext.ml
+++ b/src/lustre/typeCheckerContext.ml
@@ -838,12 +838,12 @@ let rec ty_vars_of_expr ctx node_name expr =
   (* Quantified expressions *)
   | Quantifier (_, _, qs, e) -> 
     SI.diff (call e) (SI.flatten (List.map (fun (_, _, ty) -> ty_vars_of_type ctx node_name ty) qs)) 
-  | Ident (_, id) -> (
+  | Ident (_, id) | Last (_, id) -> (
     match lookup_ty ctx id with
     | None -> SI.empty (* e.g. any bound variable *)
     | Some ty -> ty_vars_of_type ctx node_name ty
   )
-  | EmptyMap (_, None) | EmptySet (_, None) 
+  | EmptyMap (_, None) | EmptySet (_, None)
   | ModeRef _ -> SI.empty
   | RecordProject (_, e, _) -> call e
   | TypeAscription (_, e, ty) ->
@@ -918,8 +918,8 @@ let node_id_is_node = fun ctx node_id ->
 let rec expr_contains_node_call ctx expr = 
   let r = expr_contains_node_call ctx in
   match expr with
-  | LA.Ident (_, _) | ModeRef (_, _) | Const (_, _) -> false 
-  | EmptySet (_, Some ty) -> 
+  | LA.Ident (_, _) | Last (_, _) | ModeRef (_, _) | Const (_, _) -> false
+  | EmptySet (_, Some ty) ->
     LH.fold_lustre_ty r false (||) ty
   | EmptySet (_, None)
   | EmptyMap (_, None) -> false

--- a/tests/regression/error/last_outside_frame.lus
+++ b/tests/regression/error/last_outside_frame.lus
@@ -1,0 +1,5 @@
+-- The 'last' operator may only be used within a frame block.
+node n(i: int) returns (o: int);
+let
+  o = last i + 1;
+tel

--- a/tests/regression/falsifiable/when_last.lus
+++ b/tests/regression/falsifiable/when_last.lus
@@ -1,0 +1,27 @@
+
+node two(m: bool; i: int) returns (o, c1, c2: int);
+let
+  frame (o, c1, c2)
+    o = i;
+    c1 = 0;
+    c2 = 0;
+  let
+    when m then
+      o = last o + 1;
+      c1 = 1 -> pre c1 + 1;
+      c2 = last c2;
+    else
+      o = last o - 1;
+      c2 = 1 -> pre c2 + 1;
+      c1 = last c1;
+    end
+  tel
+tel
+
+node main() returns (o, c1, c2: int);
+var d: bool;
+let
+  d = true -> not (pre d);
+  o, c1, c2 = two(d, 0);
+  check "P1" not (o = 0 and c1 = 5 and c2 = 5);
+tel


### PR DESCRIPTION
## Summary
- Add a **`last x`** operator that may only appear within a **frame block**. It denotes the previous value of `x`, initialized by the frame.
- Semantics: `last x` is equivalent to introducing a fresh local `last_x = init_x -> pre x`, where `init_x` is the frame's initialization for `x` (falling back to `pre x` when `x` has no initialization). This matches the manually-desugared reference behavior.

## Details
- New `Last` expression node (lexer keyword, parser rule `last <ident>`, AST + pretty-printer).
- New **`LustreDesugarLast`** pass, run *before* syntax checks and type checking, so the rest of the pipeline never sees `last`. For each frame block it introduces the fresh `last_x` local(s) (defined on the base clock, outside the frame) and rewrites every `last x` to a reference to it. Repeated uses of `last x` share one local.
- The generated locals are marked as **Kind 2 generated**, so they are not shown in counterexamples.
- A `Last` case is added to every exhaustive traversal over `expr` (treated as equivalent to `pre x`) so the strict build stays warning-free.
- Misuse is reported with a positioned error:
  - `last` outside a frame block -> *"The 'last' operator can only be used within a frame block ..."*
  - `last x` on an unknown identifier -> *"Unknown identifier 'x'"* (pointing at the use site).

## Tests
- `tests/regression/falsifiable/when_last.lus` — `last` inside `when` branches of a frame block.
- `tests/regression/error/last_outside_frame.lus` — rejects `last` outside a frame block.
- Full regression suite passes (1050 passed)