### PR TITLE
Support omitting equations and else/otherwise branches in when/cond blocks within frame blocks

### DIFF
--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -1193,6 +1193,71 @@ will also generate the two warnings as discussed in the previous paragraph.
       fi
    tel
 
+The ``last`` operator
+^^^^^^^^^^^^^^^^^^^^^
+Within a frame block, the expression ``last x`` (where ``x`` is a variable in
+scope) denotes the previous value of ``x``, initialized by the frame.
+That is, ``last x`` is equivalent to ``init_x -> pre x``, where ``init_x`` is the
+initialization given for ``x`` at the top of the frame block (or simply
+``pre x`` when ``x`` has no initialization).
+
+The ``last`` operator may only be used inside a frame block; using it elsewhere
+is an error.
+
+For example, in the following frame block ``last o`` refers to the value of
+``o`` at the previous timestep, initialized to ``i`` (the initialization of
+``o``):
+
+.. code-block:: none
+
+   frame (o)
+   o = i;
+   let
+      o = last o + 1;
+   tel
+
+Omitting equations in ``when`` blocks within frame blocks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Just as with ``if`` statements, a variable may be left undefined in some branches
+of a ``when`` block when the ``when`` block appears within a frame block.
+When the definition of a variable ``x`` is omitted in a branch, that branch
+behaves as if it contained the equation ``x = last x`` (i.e., ``x`` keeps its
+previous value, initialized by the frame). For example, the following two frame
+blocks are equivalent:
+
+.. code-block:: none
+
+   frame (o, c1, c2)
+   o = i; c1 = 0; c2 = 0;
+   let
+      when m then
+         o = last o + 1;
+         c1 = 1 -> pre c1 + 1;
+      else
+         o = last o - 1;
+         c2 = 1 -> pre c2 + 1;
+      end
+   tel
+
+.. code-block:: none
+
+   frame (o, c1, c2)
+   o = i; c1 = 0; c2 = 0;
+   let
+      when m then
+         o = last o + 1;
+         c1 = 1 -> pre c1 + 1;
+         c2 = last c2;
+      else
+         o = last o - 1;
+         c2 = 1 -> pre c2 + 1;
+         c1 = last c1;
+      end
+   tel
+
+Outside a frame block, every variable defined in any branch of a ``when`` block
+must still be defined in all branches.
+
 Restrictions
 ^^^^^^^^^^^^
 A frame block cannot be nested within an if statement or another frame block, as

--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -1196,10 +1196,23 @@ will also generate the two warnings as discussed in the previous paragraph.
 The ``last`` operator
 ^^^^^^^^^^^^^^^^^^^^^
 Within a frame block, the expression ``last x`` (where ``x`` is a variable in
-scope) denotes the previous value of ``x``, initialized by the frame.
-That is, ``last x`` is equivalent to ``init_x -> pre x``, where ``init_x`` is the
-initialization given for ``x`` at the top of the frame block (or simply
-``pre x`` when ``x`` has no initialization).
+scope) denotes the value of ``x`` at the *immediately preceding timestep*, with
+the value at the first timestep given by the frame's initialization of ``x`` (or
+left undefined when ``x`` has no initialization). ``last x`` always refers to the
+value of ``x`` one timestep earlier, regardless of any branch conditions under
+which it appears.
+
+.. warning::
+
+   ``last x`` is **not** the same as writing ``init_x -> pre x`` inside a branch
+   of a ``when`` (or ``cond``) block. When ``init_x -> pre x`` is written
+   directly inside a branch, the lazy branch semantics make ``pre x`` refer to
+   the value of ``x`` the *last time that branch was selected*, which may be
+   several timesteps earlier. In contrast, ``last x`` always refers to the value
+   of ``x`` at the immediately preceding timestep. (In a context that is
+   evaluated at every timestep — for example a plain frame-block equation outside
+   any ``when``/``cond`` branch — the two coincide, but ``last x`` is the
+   reliable way to express "value at the previous timestep" in all contexts.)
 
 The ``last`` operator may only be used inside a frame block; using it elsewhere
 is an error.

--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -1268,8 +1268,41 @@ blocks are equivalent:
       end
    tel
 
+Within a frame block, the ``else`` branch of a ``when`` block (and the
+``otherwise`` branch of a ``cond`` block) may also be omitted entirely. An
+omitted ``else``/``otherwise`` branch behaves as if it defined every frame block
+variable with ``x = last x``. For example, the following two frame blocks are
+equivalent:
+
+.. code-block:: none
+
+   frame (o, c1, c2)
+   o = i; c1 = 0; c2 = 0;
+   let
+      when m then
+         o = last o + 1;
+         c1 = 1 -> pre c1 + 1;
+      end
+   tel
+
+.. code-block:: none
+
+   frame (o, c1, c2)
+   o = i; c1 = 0; c2 = 0;
+   let
+      when m then
+         o = last o + 1;
+         c1 = 1 -> pre c1 + 1;
+      else
+         o = last o;
+         c1 = last c1;
+         c2 = last c2;
+      end
+   tel
+
 Outside a frame block, every variable defined in any branch of a ``when`` block
-must still be defined in all branches.
+must still be defined in all branches, and the ``else``/``otherwise`` branch
+cannot be omitted.
 
 Restrictions
 ^^^^^^^^^^^^

--- a/src/lustre/lustreDesugarIfBlocks.ml
+++ b/src/lustre/lustreDesugarIfBlocks.ml
@@ -446,21 +446,25 @@ let extract_equations_from_if node_id ctx ib in_frame_block =
 (** Helper function for 'desugar_node_item' that converts WhenBlocks to a list
     of lazy ITEs (if-then-otherwise). Same steps as extract_equations_from_if
     but uses tree_to_lazy_ite to produce LazyIte expressions. *)
-let extract_equations_from_when node_id ctx wb =
+let extract_equations_from_when node_id ctx wb in_frame_block =
   update_if_position_info node_id wb;
   let* tree_map = when_block_to_trees wb in
   let (lhss_poss, trees) = LhsMap.bindings (tree_map) |> List.split in
   let trees = List.map simplify_tree trees in
-  (* For when blocks, always enforce that every variable defined in any branch
-     is defined in all branches, regardless of context. *)
+  (* Outside a frame block, every variable defined in any branch must be defined
+     in all branches. Inside a frame block, an omitted definition is filled with
+     an oracle (later guarded by 'last x', i.e. 'init_x -> pre x'), so undefined
+     branches are allowed. *)
   let* () =
-    let lhss = List.map fst lhss_poss in
-    R.seq_ (List.map2 (fun lhs tree ->
-      if has_leaf_none tree && not (is_discarded_lhs lhs) then
-        let (var, pos) = get_lhs_var lhs in
-        mk_error pos (MissingDefinitionInBranchError var)
-      else R.ok ()
-    ) lhss trees)
+    if in_frame_block then R.ok ()
+    else
+      let lhss = List.map fst lhss_poss in
+      R.seq_ (List.map2 (fun lhs tree ->
+        if has_leaf_none tree && not (is_discarded_lhs lhs) then
+          let (var, pos) = get_lhs_var lhs in
+          mk_error pos (MissingDefinitionInBranchError var)
+        else R.ok ()
+      ) lhss trees)
   in
   let lhs_poss = List.map (fun (A.StructDef (pos, _), _) -> pos) lhss_poss in
   let rhs_poss = List.map snd lhss_poss in
@@ -484,7 +488,7 @@ let extract_equations_from_when node_id ctx wb =
 *)
 let rec desugar_node_item node_id ctx in_frame_block ni = match ni with
   | A.IfBlock _ as ib -> extract_equations_from_if node_id ctx ib in_frame_block
-  | A.WhenBlock _ as wb -> extract_equations_from_when node_id ctx wb
+  | A.WhenBlock _ as wb -> extract_equations_from_when node_id ctx wb in_frame_block
   | A.FrameBlock (pos, vars, nes, nis) ->
     let* res = R.seq (List.map (desugar_node_item node_id ctx true) nis) in
     let decls, nis, gids = split_and_flatten3 res in

--- a/src/lustre/lustreParser.mly
+++ b/src/lustre/lustreParser.mly
@@ -844,19 +844,23 @@ node_if_block:
 
 
 node_when_block:
-  | WHEN; e = expr; THEN; 
+  | WHEN; e = expr; THEN;
       l1 = nonempty_list(node_item);
-    ELSE; 
+    END;
+    { A.WhenBlock (mk_pos $startpos, e, l1, []) }
+  | WHEN; e = expr; THEN;
+      l1 = nonempty_list(node_item);
+    ELSE;
       l2 = nonempty_list(node_item);
     END;
     { A.WhenBlock (mk_pos $startpos, e, l1, l2) }
   | COND;
       BAR; c1 = node_cond_case_colon;
       cs = list(bar_node_cond_case_colon);
-      OTHERWISE; COLON;
-      l_else = nonempty_list(node_item);
+      l_else = option(cond_otherwise);
     END;
     {
+      let l_else = match l_else with Some l -> l | None -> [] in
       let cases = c1 :: cs in
       let nested = List.fold_right
         (fun (cond, l_then) l_otherwise ->
@@ -868,6 +872,10 @@ node_when_block:
       | [A.WhenBlock _ as wb] -> wb
       | _ -> assert false
     }
+
+
+cond_otherwise:
+  | OTHERWISE; COLON; l = nonempty_list(node_item) { l }
 
 
 bar_node_cond_case_colon:

--- a/tests/ounit/lustre/lustreSyntaxChecks/cond_no_otherwise_in_frame.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/cond_no_otherwise_in_frame.lus
@@ -1,0 +1,14 @@
+node two(m: bool; i: int) returns (o, c1, c2: int);
+let
+  frame (o, c1, c2)
+    o = i;
+    c1 = 0;
+    c2 = 0;
+  let
+    cond
+      | m:
+        o = last o + 1;
+        c1 = 1 -> pre c1 + 1;
+    end
+  tel
+tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/when_block_omitted_in_frame.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/when_block_omitted_in_frame.lus
@@ -1,0 +1,16 @@
+node two(m: bool; i: int) returns (o, c1, c2: int);
+let
+  frame (o, c1, c2)
+    o = i;
+    c1 = 0;
+    c2 = 0;
+  let
+    when m then
+      o = last o + 1;
+      c1 = 1 -> pre c1 + 1;
+    else
+      o = last o - 1;
+      c2 = 1 -> pre c2 + 1;
+    end
+  tel
+tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/when_no_else_in_frame.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/when_no_else_in_frame.lus
@@ -1,0 +1,13 @@
+node two(m: bool; i: int) returns (o, c1, c2: int);
+let
+  frame (o, c1, c2)
+    o = i;
+    c1 = 0;
+    c2 = 0;
+  let
+    when m then
+      o = last o + 1;
+      c1 = 1 -> pre c1 + 1;
+    end
+  tel
+tel

--- a/tests/ounit/lustre/lustreSyntaxChecks/when_no_else_outside_frame.lus
+++ b/tests/ounit/lustre/lustreSyntaxChecks/when_no_else_outside_frame.lus
@@ -1,0 +1,7 @@
+node test(x: int) returns (y, z: int);
+let
+  z = 0;
+  when (x > 0) then
+    y = 1;
+  end
+tel

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -869,4 +869,16 @@ let _ = run_test_tt_main ("frontend LustreDesugarFrameBlocks and LustreDesugarIf
     match load_file "./lustreSyntaxChecks/when_block_omitted_in_frame.lus" with
     | Ok _ -> true
     | _ -> false);
+  mk_test "When block with omitted else branch within frame block is accepted" (fun () ->
+    match load_file "./lustreSyntaxChecks/when_no_else_in_frame.lus" with
+    | Ok _ -> true
+    | _ -> false);
+  mk_test "Cond block with omitted otherwise branch within frame block is accepted" (fun () ->
+    match load_file "./lustreSyntaxChecks/cond_no_otherwise_in_frame.lus" with
+    | Ok _ -> true
+    | _ -> false);
+  mk_test "When block with omitted else branch outside frame block" (fun () ->
+    match load_file "./lustreSyntaxChecks/when_no_else_outside_frame.lus" with
+    | Error (`LustreDesugarIfBlocksError (_, MissingDefinitionInBranchError _)) -> true
+    | _ -> false);
 ])

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -865,4 +865,8 @@ let _ = run_test_tt_main ("frontend LustreDesugarFrameBlocks and LustreDesugarIf
     match load_file "./lustreSyntaxChecks/when_block_missing_definition.lus" with
     | Error (`LustreDesugarIfBlocksError (_, MissingDefinitionInBranchError _)) -> true
     | _ -> false);
+  mk_test "When block variable omitted in branch within frame block is accepted" (fun () ->
+    match load_file "./lustreSyntaxChecks/when_block_omitted_in_frame.lus" with
+    | Ok _ -> true
+    | _ -> false);
 ])

--- a/tests/regression/falsifiable/cond_no_otherwise_in_frame.lus
+++ b/tests/regression/falsifiable/cond_no_otherwise_in_frame.lus
@@ -1,0 +1,25 @@
+
+node two(m: bool; i: int) returns (o, c1, c2: int);
+let
+  frame (o, c1, c2)
+    o = i;
+    c1 = 0;
+    c2 = 0;
+  let
+    -- Omitting the 'otherwise' branch of a cond block within a frame block is
+    -- accepted, with the same 'x = last x' semantics as an omitted when 'else'.
+    cond
+      | m:
+        o = last o + 1;
+        c1 = 1 -> pre c1 + 1;
+    end
+  tel
+tel
+
+node main() returns (o, c1, c2: int);
+var d: bool;
+let
+  d = true -> not (pre d);
+  o, c1, c2 = two(d, 0);
+  check "P1" not (o = 5 and c1 = 5 and c2 = 0);
+tel

--- a/tests/regression/falsifiable/when_last_omitted.lus
+++ b/tests/regression/falsifiable/when_last_omitted.lus
@@ -1,0 +1,28 @@
+
+node two(m: bool; i: int) returns (o, c1, c2: int);
+let
+  frame (o, c1, c2)
+    o = i;
+    c1 = 0;
+    c2 = 0;
+  let
+    -- Omitting an equation in a when branch within a frame block is accepted.
+    -- An omitted variable x in a branch behaves as 'x = last x', so this node
+    -- is equivalent to when_last.lus.
+    when m then
+      o = last o + 1;
+      c1 = 1 -> pre c1 + 1;
+    else
+      o = last o - 1;
+      c2 = 1 -> pre c2 + 1;
+    end
+  tel
+tel
+
+node main() returns (o, c1, c2: int);
+var d: bool;
+let
+  d = true -> not (pre d);
+  o, c1, c2 = two(d, 0);
+  check "P1" not (o = 0 and c1 = 5 and c2 = 5);
+tel

--- a/tests/regression/falsifiable/when_no_else_in_frame.lus
+++ b/tests/regression/falsifiable/when_no_else_in_frame.lus
@@ -1,0 +1,26 @@
+
+node two(m: bool; i: int) returns (o, c1, c2: int);
+let
+  frame (o, c1, c2)
+    o = i;
+    c1 = 0;
+    c2 = 0;
+  let
+    -- Omitting the 'else' branch of a when block within a frame block is
+    -- accepted. Each frame variable behaves as 'x = last x' in the omitted
+    -- branch, so c2 (never defined here) stays at its initialization (0), and o
+    -- and c1 stutter when m is false.
+    when m then
+      o = last o + 1;
+      c1 = 1 -> pre c1 + 1;
+    end
+  tel
+tel
+
+node main() returns (o, c1, c2: int);
+var d: bool;
+let
+  d = true -> not (pre d);
+  o, c1, c2 = two(d, 0);
+  check "P1" not (o = 5 and c1 = 5 and c2 = 0);
+tel


### PR DESCRIPTION
## Summary

This branch extends frame blocks so that `when`/`cond` blocks behave like `if`
statements with respect to omitted definitions. Inside a frame block, an omitted
definition for a variable `x` behaves as `x = last x` (i.e. `x` keeps its value
from the previous timestep, initialized by the frame).

Two related capabilities are added:

1. **Omitting equations in branches.** A variable may be left undefined in some
   branches of a `when` block (and therefore a `cond` block) when the block
   appears within a frame block. The omitted branch behaves as `x = last x`.
2. **Omitting the `else`/`otherwise` branch.** The `else` branch of a `when`
   block (and the `otherwise` branch of a `cond` block) may be omitted entirely
   within a frame block. The omitted branch behaves as if every frame variable
   were defined with `x = last x`. This mirrors the existing support for `if`
   blocks with no `else` branch.

Outside a frame block, the previous rules still hold: every variable defined in
any branch must be defined in all branches, and the `else`/`otherwise` branch
cannot be omitted.

## Changes

- **`src/lustre/lustreDesugarIfBlocks.ml`**: `extract_equations_from_when` now
  takes an `in_frame_block` flag. Inside a frame block, undefined branches are
  allowed and filled with oracles that the frame-block desugaring later replaces
  with `init_x -> pre x` (the meaning of `last x`), reusing the exact mechanism
  already used for `if` blocks. Outside a frame block, the
  `MissingDefinitionInBranchError` check is unchanged.
- **`src/lustre/lustreParser.mly`**: added a `when ... then ... end` production
  (no `else`) and made the `otherwise` clause of `cond` blocks optional. No new
  grammar conflicts.
- **`doc/usr/source/2_input/1_lustre.rst`**: documented the previously
  undocumented `last` operator (including a warning that `last x` is *not* the
  same as writing `init_x -> pre x` inside a lazy branch), and documented
  omitting equations and the `else`/`otherwise` branch within frame blocks.

## Tests

- `tests/regression/falsifiable/`: `when_last_omitted.lus`,
  `when_no_else_in_frame.lus`, `cond_no_otherwise_in_frame.lus`.
- `tests/ounit/lustre/`: positive tests for omitted branches/equations accepted
  within frame blocks, and a negative test confirming an omitted `else` outside a
  frame block is still rejected.

The `when_last_omitted.lus` example produces results identical to the existing
`tests/regression/falsifiable/when_last.lus` (same counterexample, invalid after
9 steps).
