### PR TITLE
Drive match-arm temporal expressions by their guard clock

### DIFF
--- a/src/lustre/lustreGenNodes.ml
+++ b/src/lustre/lustreGenNodes.ml
@@ -56,14 +56,17 @@ fun ctx node_name e ->
         | _ -> true
     ) inputs in
     let inputs_call = List.map (fun str -> A.Ident (pos, str)) inputs in
-    let input_decls = List.map (fun input ->
-      let ty = match Ctx.lookup_ty ctx input with
-        | Some ty -> ty
-        | None -> assert false
-      in
+    let input_tys = List.map (fun input -> Ctx.lookup_ty ctx input) inputs in
+    (* If the type of any free variable cannot be determined here (e.g. a
+       match-arm pattern variable that is only substituted by a later pass),
+       skip the abstraction and leave the branch unchanged. *)
+    if List.exists Option.is_none input_tys then e, []
+    else
+    let input_decls = List.map2 (fun input ty ->
+      let ty = match ty with Some ty -> ty | None -> assert false in
       let is_const = match Ctx.lookup_const ctx input with Some _ -> true | None -> false in
       (pos, input, ty, A.ClockTrue, is_const)
-    ) inputs in
+    ) inputs input_tys in
     (* The output type is the type of the branch expression. If the type cannot
        be inferred here, leave the branch unchanged and let the later
        type-checking pass report the error. *)
@@ -350,10 +353,17 @@ fun ctx node_name fun_ids expr ->
     let expr_list, gen_nodes = List.map rec_call expr_list |> List.split in
     Call (pos, ty_args, id, expr_list), List.flatten gen_nodes_ty @ List.flatten gen_nodes
   | Match (pos, e, arms, ty_opt) ->
+    (* Each match arm body is evaluated under the clock determined by the
+       scrutinee matching the arm's pattern (the match is desugared into a
+       lazy if-then-else chain later in the pipeline). When a body is a
+       temporal expression (it uses '->' or 'pre'), abstract it into a call
+       to a fresh internal node so that its temporal behavior is driven by
+       that clock, just as is done for when-then-else branches. *)
     let e, gen_nodes1 = rec_call e in
     let arms, gen_nodes2 = List.map (fun (pat, arm_e) ->
       let arm_e, gen_nodes = rec_call arm_e in
-      (pat, arm_e), gen_nodes
+      let arm_e, gen_nodes' = abstract_temporal_branch ctx node_name arm_e in
+      (pat, arm_e), gen_nodes @ gen_nodes'
     ) arms |> List.split in
     Match (pos, e, arms, ty_opt), gen_nodes1 @ List.flatten gen_nodes2
   | ADTTerm (pos, ty_args, ctor, args) ->

--- a/tests/regression/falsifiable/match_temporal_expr1.lus
+++ b/tests/regression/falsifiable/match_temporal_expr1.lus
@@ -1,0 +1,21 @@
+datatype Flag = F | T;
+
+node two(m: Flag) returns (c1, c2: int);
+let
+  c1 =
+    match m with
+    | T : 1 -> pre c2 + 1
+    | F : 0 -> pre c2 + 1
+    end
+    ;
+
+  c2 = 10 -> if not (pre c2 = 99) then 99 else 22;
+tel
+
+node main() returns (c1, c2: int);
+var d: Flag;
+let
+  d = T ->  if pre d = T then F else T;
+  c1, c2 = two(d);
+  check "P1" not (c1 = 23 and c2 = 22);
+tel


### PR DESCRIPTION
## Summary
- A `match m with ...` expression with **temporal arm bodies** (using `->` or `pre`) did not behave like the equivalent `when m then ... else ...` expression. Its temporal operators ticked on the **base clock** instead of the arm's guard clock, producing incorrect results — e.g. a falsifiable property was reported as valid.

## Details
- The branches of a `when`-then-else expression are clocked: a temporal branch is abstracted into a call to a fresh internal node (`abstract_temporal_branch` in `lustreGenNodes`) so its temporal behavior is driven by the guard.
- `Match` is desugared into a lazy if-then-else chain, but that desugaring runs *after* `lustreGenNodes`. At `lustreGenNodes` time the node is still a `Match`, and its arm bodies were recursed into but never abstracted — so the fix is to apply the same `abstract_temporal_branch` treatment to match-arm bodies.
- Also hardened `abstract_temporal_branch` to skip the abstraction (instead of failing with `assert false`) when a free variable's type cannot be resolved. This can happen for constructor payload pattern variables that are only substituted into the arm body by a later pass.

## Tests
- Added `tests/regression/falsifiable/match_temporal_expr1.lus`, the `match` analogue of `when_temporal_expr1.lus`. The property is now correctly reported invalid, with the same counterexample as the `when` version.
- Full regression suite: 1128 passed.

## Note
- Match arms whose temporal body references a constructor **payload** variable (e.g. `Some(x): pre x`) are still not clocked, since the payload's type isn't known at `lustreGenNodes` time; such an arm keeps its prior base-clock behavior (no crash). However, this case should be rejected since **payload** variables are not streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)