### PR TITLE
Add proper support for nonrecursive ADT refinement types 

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -76,6 +76,7 @@ module AH = LustreAstHelpers
 module AIC = LustreAstInlineConstants
 module Ctx = TypeCheckerContext
 module Chk = LustreTypeChecker
+module LDAT = LustreDesugarADTs
 
 type error = [
   | `LustreAstNormalizerError
@@ -164,6 +165,7 @@ type info = {
   inlinable_funcs : LustreAst.node_decl NI.Map.t;
   call_context : LustreAst.expr list;
   inlined_expr_ctx : bool;
+  adt_map : LDAT.adt_map;
 }
 
 let add_ty_to_info info id ty =
@@ -413,7 +415,7 @@ let mk_fresh_dummy_index _ =
   let name = HString.concat2 prefix (HString.mk_hstring "_index") in
   name
 
-let rec mk_enum_expr ?(mk_enum=true) ctx node_id expr_type expr =
+let rec mk_enum_expr ?(mk_enum=true) adt_map ctx node_id expr_type expr =
   let rec mk ctx n expr_type expr = 
     let expr_type = Chk.expand_type_syn_reftype_history ctx expr_type |> unwrap in
     match expr_type with
@@ -441,19 +443,41 @@ let rec mk_enum_expr ?(mk_enum=true) ctx node_id expr_type expr =
          let i = i |> string_of_int |> HString.mk_hstring in
          mk ctx n ty (A.IndexAccess (dpos, expr, A.Const (p, A.Num i), A.Tuple))
       ) tys |> List.flatten
-    | RecordType (_, _, tys) ->
-      let mk_proj i = A.RecordProject (dpos, expr, i) in
-      let tys = List.filter (fun (_, _, ty) -> Ctx.type_contains_enum ctx ty) tys in
-      let tys = List.map (fun (_, i, ty) -> mk ctx n ty (mk_proj i)) tys in
-      List.fold_left (@) [] tys
-    | A.Set (_, kt) -> 
+    | RecordType (_, rname, tys) ->
+      (* If record type came from desugared ADT, the constraint only applies
+         if the constructor is selected *)
+      (match LDAT.HStringMap.find_opt rname adt_map with
+      | Some adt_info ->
+        let tag_expr = A.RecordProject (dpos, expr, adt_info.LDAT.disc_field) in
+        List.concat_map (fun (_, fname, ftype) ->
+          if not (Ctx.type_contains_enum ctx ftype) then []
+          else
+            let constraints = mk ctx n ftype (A.RecordProject (dpos, expr, fname)) in
+            if HString.equal fname adt_info.LDAT.disc_field || constraints = [] then constraints
+            else
+              let ctor_opt = LDAT.HStringMap.fold (fun ctor fields acc ->
+                match acc with Some _ -> acc | None ->
+                if List.exists (fun (fn, _) -> HString.equal fn fname) fields then Some ctor else None
+              ) adt_info.LDAT.ctor_fields None in
+              match ctor_opt with
+              | None -> constraints
+              | Some ctor ->
+                let guard = A.CompOp (dpos, A.Eq, tag_expr, A.Ident (dpos, ctor)) in
+                List.map (fun (c, is_orig) -> A.BinaryOp (dpos, A.Impl, guard, c), is_orig) constraints
+        ) tys
+      | None ->
+        let mk_proj i = A.RecordProject (dpos, expr, i) in
+        let tys = List.filter (fun (_, _, ty) -> Ctx.type_contains_enum ctx ty) tys in
+        let tys = List.map (fun (_, i, ty) -> mk ctx n ty (mk_proj i)) tys in
+        List.fold_left (@) [] tys)
+    | A.Set (_, kt) ->
       let idx_str = HString.concat2 (HString.mk_hstring "x") 
                                     (HString.mk_hstring (string_of_int n)) in
       let idx = A.Ident (dpos, idx_str) in
       let ctx = Ctx.add_ty ctx idx_str kt in
       let rexpr1 = mk ctx (succ n) kt idx in
       let key_in_map = A.BinaryOp (dpos, A.In Set, idx, expr) in
-      let enum_exprs = List.map fst (mk_enum_expr ctx node_id kt idx) in
+      let enum_exprs = List.map fst (mk_enum_expr adt_map ctx node_id kt idx) in
       let assumption1 = List.fold_left (fun acc e ->
           A.BinaryOp (dpos, A.And, acc, e)
         ) key_in_map enum_exprs
@@ -480,7 +504,7 @@ let rec mk_enum_expr ?(mk_enum=true) ctx node_id expr_type expr =
       let rexpr1 = mk ctx (succ n) kt idx in
       let rexpr2 = mk ctx (succ n) vt (A.IndexAccess (dpos, expr, idx, Map)) in
       let key_in_map = A.BinaryOp (dpos, A.In Map, idx, expr) in
-      let enum_exprs = List.map fst (mk_enum_expr ctx node_id kt idx) in
+      let enum_exprs = List.map fst (mk_enum_expr adt_map ctx node_id kt idx) in
       let assumption = List.fold_left (fun acc e ->
           A.BinaryOp (dpos, A.And, acc, e)
         ) key_in_map enum_exprs
@@ -512,7 +536,7 @@ let rec mk_enum_expr ?(mk_enum=true) ctx node_id expr_type expr =
       For example, x: [subtype { y: int | P1(y) }, subtype { y: int | P2(y) }] returns two expressions, 
       P1(x[0]) and P2(x[1]). *)
 and mk_ref_type_expr
- = fun ctx node_id expr expr_type ->
+ = fun adt_map ctx node_id expr expr_type ->
   let ty = Ctx.expand_type_syn ctx expr_type in
   match ty with 
   | A.RefinementType (_, (_, id2, _), ref_expr) -> 
@@ -520,20 +544,41 @@ and mk_ref_type_expr
        in terms of x instead of y *)
     let expr = AH.substitute_naive id2 expr ref_expr in 
     [expr]
-  | TupleType (pos, tys) 
+  | TupleType (pos, tys)
   | GroupType (pos, tys) -> List.mapi (fun i ty ->
       let i = i |> string_of_int |> HString.mk_hstring in
-      mk_ref_type_expr ctx node_id (A.IndexAccess (pos, expr, A.Const (pos, A.Num i), A.Tuple)) ty
+      mk_ref_type_expr adt_map ctx node_id (A.IndexAccess (pos, expr, A.Const (pos, A.Num i), A.Tuple)) ty
     ) tys |> List.flatten
-  | RecordType (p, _, tis) -> 
-    List.map (fun (_, id2, ty) -> 
-      let expr = A.RecordProject(p, expr, id2) in
-      mk_ref_type_expr ctx node_id expr ty
-    ) tis |> List.flatten
+  | RecordType (p, rname, tis) ->
+    (* If record type came from desugared ADT, the constraint only applies
+       if the constructor is selected *)
+    (match LDAT.HStringMap.find_opt rname adt_map with
+    | Some adt_info ->
+      let tag_expr = A.RecordProject (p, expr, adt_info.LDAT.disc_field) in
+      List.concat_map (fun (_, fname, ftype) ->
+        let fexpr = A.RecordProject (p, expr, fname) in
+        let constraints = mk_ref_type_expr adt_map ctx node_id fexpr ftype in
+        if HString.equal fname adt_info.LDAT.disc_field || constraints = [] then constraints
+        else
+          let ctor_opt = LDAT.HStringMap.fold (fun ctor fields acc ->
+            match acc with Some _ -> acc | None ->
+            if List.exists (fun (fn, _) -> HString.equal fn fname) fields then Some ctor else None
+          ) adt_info.LDAT.ctor_fields None in
+          match ctor_opt with
+          | None -> constraints
+          | Some ctor ->
+            let guard = A.CompOp (p, A.Eq, tag_expr, A.Ident (p, ctor)) in
+            List.map (fun c -> A.BinaryOp (p, A.Impl, guard, c)) constraints
+      ) tis
+    | None ->
+      List.map (fun (_, id2, ty) ->
+        let expr = A.RecordProject (p, expr, id2) in
+        mk_ref_type_expr adt_map ctx node_id expr ty
+      ) tis |> List.flatten)
   | ArrayType (_, (ty, len)) -> 
     let pos = AH.pos_of_expr expr in
     let dummy_index = mk_fresh_dummy_index () in
-    let exprs = mk_ref_type_expr ctx node_id (A.IndexAccess(pos, expr, Ident(pos, dummy_index), Array)) ty in
+    let exprs = mk_ref_type_expr adt_map ctx node_id (A.IndexAccess(pos, expr, Ident(pos, dummy_index), Array)) ty in
     List.map (fun expr ->
       let bound1 = 
         A.CompOp(pos, Lte, A.Const(pos, Num (HString.mk_hstring "0")), A.Ident(pos, dummy_index)) 
@@ -548,9 +593,9 @@ and mk_ref_type_expr
     let idx = A.Ident (pos, dummy_index) in
     let ctx = Ctx.add_ty ctx dummy_index ty in 
     let base_kt = Chk.expand_type_syn_reftype_history ctx ty |> Result.get_ok in 
-    let exprs1 = mk_ref_type_expr ctx node_id idx ty in
+    let exprs1 = mk_ref_type_expr adt_map ctx node_id idx ty in
     let key_in_map = A.BinaryOp (dpos, A.In Set, idx, expr) in
-    let enum_exprs = List.map fst (mk_enum_expr ctx node_id ty idx) in
+    let enum_exprs = List.map fst (mk_enum_expr adt_map ctx node_id ty idx) in
     let assumption1 = List.fold_left (fun acc e ->
         A.BinaryOp (dpos, A.And, acc, e)
       ) key_in_map enum_exprs
@@ -566,9 +611,9 @@ and mk_ref_type_expr
     let idx = A.Ident (pos, dummy_index) in
     let ctx = Ctx.add_ty ctx dummy_index kt in 
     let base_kt = Chk.expand_type_syn_reftype_history ctx kt |> Result.get_ok in 
-    let exprs1 = mk_ref_type_expr ctx node_id idx kt in
+    let exprs1 = mk_ref_type_expr adt_map ctx node_id idx kt in
     let key_in_map = A.BinaryOp (dpos, A.In Map, idx, expr) in
-    let enum_exprs = List.map fst (mk_enum_expr ctx node_id kt idx) in
+    let enum_exprs = List.map fst (mk_enum_expr adt_map ctx node_id kt idx) in
     let assumption = List.fold_left (fun acc e ->
         A.BinaryOp (dpos, A.And, acc, e)
       ) key_in_map enum_exprs
@@ -580,7 +625,7 @@ and mk_ref_type_expr
         A.Quantifier (dpos, A.Forall, [var], body e assumption)
       ) exprs1
     in
-    let exprs2 = mk_ref_type_expr ctx node_id (A.IndexAccess(pos, expr, Ident(pos, dummy_index), Map)) vt in
+    let exprs2 = mk_ref_type_expr adt_map ctx node_id (A.IndexAccess(pos, expr, Ident(pos, dummy_index), Map)) vt in
     let exprs2 =
       List.map (fun e -> 
         A.Quantifier (dpos, A.Forall, [var], body e assumption)
@@ -602,8 +647,8 @@ let mk_enum_reftype_constraints node_id info vars =
       (fun acc (_, id, ty) ->
         let expr = A.Ident(dpos, id) in
         let range_exprs =
-          List.map fst (mk_enum_expr info.context node_id ty expr) @
-          (mk_ref_type_expr info.context node_id expr ty)
+          List.map fst (mk_enum_expr info.adt_map info.context node_id ty expr) @
+          (mk_ref_type_expr info.adt_map info.context node_id expr ty)
         in
         range_exprs :: acc
       )
@@ -1001,7 +1046,7 @@ let get_inlinable_func_decls inlinable_funcs decls =
     NI.Map.empty
     decls
 
-let rec normalize ctx inlinable_funcs (decls:LustreAst.t) gids =
+let rec normalize adt_map ctx inlinable_funcs (decls:LustreAst.t) gids =
   let info = { context = ctx;
     inductive_variables = StringMap.empty;
     quantified_variables = [];
@@ -1013,7 +1058,8 @@ let rec normalize ctx inlinable_funcs (decls:LustreAst.t) gids =
     local_group_projection = -1;
     inlinable_funcs = get_inlinable_func_decls inlinable_funcs decls;
     call_context = [];
-    inlined_expr_ctx = false; }
+    inlined_expr_ctx = false;
+    adt_map; }
   in
   let over_declarations (nitems, accum, warnings_accum) item =
     clear_cache ();
@@ -1056,7 +1102,7 @@ let rec normalize ctx inlinable_funcs (decls:LustreAst.t) gids =
     (empty (), [])
 
   and mk_fresh_refinement_type_constraint source info map pos node_id expr expr_type =
-    let ref_type_exprs = mk_ref_type_expr info.context node_id expr expr_type in
+    let ref_type_exprs = mk_ref_type_expr info.adt_map info.context node_id expr expr_type in
     let gids, warnings = List.map (fun ref_type_expr ->
       i := !i + 1;
       let output_expr = AH.rename_contract_vars ref_type_expr in

--- a/src/lustre/lustreAstNormalizer.mli
+++ b/src/lustre/lustreAstNormalizer.mli
@@ -86,19 +86,24 @@ val mk_fresh_dummy_index : 'a -> HString.t
 
 val mk_enum_expr :
   ?mk_enum:bool ->
+  LustreDesugarADTs.adt_map ->
   TypeCheckerContext.tc_context ->
   NodeId.t option ->
   LustreAst.lustre_type ->
   LustreAst.expr ->
   (LustreAst.expr * bool) list
 
-val mk_ref_type_expr : TypeCheckerContext.tc_context ->
+val mk_ref_type_expr :
+  LustreDesugarADTs.adt_map ->
+  TypeCheckerContext.tc_context ->
   NodeId.t option ->
   LustreAst.expr ->
   LustreAst.lustre_type ->
   LustreAst.expr list
 
-val normalize : TypeCheckerContext.tc_context ->
+val normalize :
+  LustreDesugarADTs.adt_map ->
+  TypeCheckerContext.tc_context ->
   NodeId.Set.t ->
   LustreAst.t ->
   GeneratedIdentifiers.t NodeId.Map.t ->

--- a/src/lustre/lustreInput.ml
+++ b/src/lustre/lustreInput.ml
@@ -258,7 +258,7 @@ let type_check declarations =
 
     (* Step 22. Normalize AST: guard pres, abstract to locals where appropriate *)
     let* (normalized_decls, gids, warnings6) =
-      LAN.normalize inlined_global_ctx inlinable_funcs 
+      LAN.normalize adt_map inlined_global_ctx inlinable_funcs
                     (const_inlined_type_and_consts @ const_inlined_nodes_and_contracts) gids
     in
 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -3116,7 +3116,7 @@ and compile_const_decl ?(is_generated=false) cstate ctx map is_local scope = fun
         let ctx = Ctx.add_ty ctx i ty in
         let ref_type_exprs =
           if has_ref_type then
-            AN.mk_ref_type_expr ctx None (A.Ident(p, i)) ty
+            AN.mk_ref_type_expr cstate.adt_map ctx None (A.Ident(p, i)) ty
           else []
         in
         List.map (fun expr ->

--- a/tests/regression/success/adt_ref_type_2.lus
+++ b/tests/regression/success/adt_ref_type_2.lus
@@ -1,0 +1,31 @@
+type PostiveReal = subtype { r: real | r > 0.0 };
+
+datatype Shape = Circle (PostiveReal) | Rect (PostiveReal, PostiveReal);
+
+function area(s: Shape) returns (a: real);
+let
+   a =
+     match s with
+     | Circle (r): 3.14159 * r * r
+     | Rect (w, h): w * h
+   end;
+tel
+
+type PosInt = subrange [1,*] of int;
+
+datatype Labeled = Tag (PosInt, Shape) | Unlabeled (Shape);
+
+node top() returns ();
+var c1: Shape;
+    c2: Shape;
+    l1: Labeled;
+    l2: Labeled;
+let
+   c1 = Circle(2.0);
+   c2 = Rect(3.0, 4.0);
+   l1 = Tag(1, Circle(2.0));
+   l2 = Unlabeled(Rect(3.0, 4.0));
+
+   check "P1" area(c1) = 12.56636;
+   check "P2" area(c2) = 12.0;
+tel


### PR DESCRIPTION
Refinement type constraints for ADTs need to be conditioned on the selected constructor