### PR TITLE
Tie recursive function instances to their functional UF

### DIFF
--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2438,9 +2438,23 @@ let rec trans_sys_of_node' options globals top_name analysis_param
           `trans`. *)
           let function_ufs, function_constraints_at_0 =
             match comp_type with
-            | Function { uf_symbols } when options.add_functional_constraints -> (
+            | Function { uf_symbols; rec_info } when options.add_functional_constraints -> (
+              (* For a recursive function we tie the outputs of *every*
+                 instance (expanded or abstracted) to the global functional
+                 UF, not just the abstracted leaves whose outputs are
+                 undefined. On an expanded instance the output is also
+                 constrained by the body equation, so this forces the UF to
+                 satisfy the function's defining equation at that argument
+                 (one unrolling). Without it the recurrence is only known for
+                 the inlined interior and is lost at the uninterpreted leaf,
+                 so calls to the function at arguments separated by the
+                 induction's shift never relate (see Even_Odd lemma). *)
+              let constrained_outputs =
+                if rec_info <> None then D.values outputs
+                else undefined_outputs
+              in
               let function_ufs =
-                undefined_outputs |> List.map (fun sv ->
+                constrained_outputs |> List.map (fun sv ->
                   match SVM.find_opt sv uf_symbols with
                   | Some uf -> uf
                   | None -> assert false
@@ -2455,7 +2469,7 @@ let rec trans_sys_of_node' options globals top_name analysis_param
                   let inputs = D.values inputs in
                   List.map (fun input -> term_0_of input) inputs
                 in
-                undefined_outputs
+                constrained_outputs
                 |> List.map (fun output ->
                   let uf = SVM.find output uf_symbols in
                   Term.mk_eq [

--- a/tests/regression/success/even_odd_sum_props.lus
+++ b/tests/regression/success/even_odd_sum_props.lus
@@ -1,0 +1,35 @@
+type Nat = subrange [0,*] of int;
+
+function rec IsEven(n: Nat) returns (e: bool);
+con
+  decreases n;
+noc
+let
+  e = when n = 0 then true else IsOdd(n - 1);
+tel
+
+function rec IsOdd(n: Nat) returns (o: bool);
+con
+  decreases n;
+noc
+let
+  o = when n = 0 then false else IsEven(n - 1);
+tel
+
+lemma EvenOddSumProperties(a, b: Nat)
+con
+  guarantee "Sum of odds is even"
+    IsOdd(a) and IsOdd(b) ==> IsEven(a + b);
+
+  guarantee "Sum of even and odd is odd"
+    IsEven(a) and IsOdd(b) ==> IsOdd(a + b);
+
+  decreases a;
+noc
+let
+  when a > 0 then
+    EvenOddSumProperties(a - 1, b);
+  else
+    auto;
+  end
+tel


### PR DESCRIPTION
## Problem

Inductive lemmas over mutually recursive functions get stuck. The motivating example proves the even/odd sum properties by induction:

```
function rec IsEven(n: Nat) returns (e: bool); con decreases n; noc
let e = when n = 0 then true else IsOdd(n - 1); tel

function rec IsOdd(n: Nat) returns (o: bool); con decreases n; noc
let o = when n = 0 then false else IsEven(n - 1); tel

lemma EvenOddSumProperties(a, b: Nat)
con
  guarantee "Sum of odds is even"        IsOdd(a) and IsOdd(b) ==> IsEven(a + b);
  guarantee "Sum of even and odd is odd" IsEven(a) and IsOdd(b) ==> IsOdd(a + b);
  decreases a;
noc
let when a > 0 then EvenOddSumProperties(a - 1, b); else auto; end tel
```

Both guarantees come back `unknown` and Kind 2 never terminates — BMC and k-induction keep increasing `k` forever (IC3 is disabled because the system contains an abstract function).

## Root cause

Recursive function calls are inlined to a fixed depth and the deepest call is abstracted to the **bare** functional UF (`IsEven.e.__function_of_inputs`, `IsOdd.o.__function_of_inputs`). The defining equation `E(n) = ite(n=0, true, O(n-1))` was asserted only for the finitely-inlined interior instances, **never for the uninterpreted leaf symbols themselves**. So the even/odd recurrence holds for the inlined interior but breaks at the abstraction boundary. Because the induction on `a` shifts arguments by one (a parity flip), the goal's calls and the inductive hypothesis's calls reduce to the uninterpreted leaves at arguments on opposite sides of that broken boundary, with no axiom to bridge them — the solver is free to satisfy the IH while falsifying the goal.

The inductive hypothesis itself (the `EvenOddSumProperties(a-1, b)` recursive call) *is* supplied correctly; the missing piece was purely the recurrence on the UF symbols.

## Fix

Emit the functional-consistency constraint `output = f.__function_of_inputs(inputs)` for **every** instance of a recursive function, not just the abstracted leaves whose outputs are undefined. On an expanded instance the output is also constrained by the body equation, so tying it to the global UF forces the UF to satisfy the function's own defining equation at that argument (one unrolling), e.g.:

```smt2
(= IsOdd.usr.o@0 (ite (= IsOdd.usr.n@0 0) false IsOdd.res.call_8@0))   ; body
(= IsOdd.usr.o@0 (IsOdd.o.__function_of_inputs IsOdd.usr.n@0))          ; new: tie to UF
```

which together give `uf_O(n) = ite(n=0, false, uf_E(n-1))`. With the recurrence holding everywhere the UF appears, the parity bridges and the lemma closes in a single inductive step.

Non-recursive functions are unaffected (still only their undefined outputs are tied).

## Result

| Property | Before | After |
|---|---|---|
| `Sum of odds is even` | `unknown` (hangs) | **valid (k=1)** |
| `Sum of even and odd is odd` | `unknown` (hangs) | **valid (k=1)** |

Run terminates in ~2.4s instead of never.

## Testing

- Adds `tests/regression/success/even_odd_sum_props.lus`.
- Full regression suite: **1197 passed** (every test × 3 slicing modes).
- Dune unit tests: all OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)