### PR TITLE
Fix non-termination in counterexample equation ordering

### DIFF
--- a/src/lustre/lustreNode.ml
+++ b/src/lustre/lustreNode.ml
@@ -942,24 +942,36 @@ let ordered_equations_of_node { equations } stateful init =
     List.exists (fun ((sv, _), _) -> StateVar.equal_state_vars svar sv) eqs
   in
 
-  let rec loop postponed ordered = function
+  let rec loop made_progress postponed ordered = function
     | eq :: tail ->
       if svars_of eq |> SVS.for_all (is_known ordered) then
         (* We have ordered all the state vars the lhs of the equation mentions.
            Prepending to ordered. *)
-        loop postponed (eq :: ordered) tail
+        loop true postponed (eq :: ordered) tail
       else
         (* We are missing some equations, postponing the ordering of this
            equation. *)
-        loop (eq :: postponed) ordered tail
+        loop made_progress (eq :: postponed) ordered tail
     | [] -> (
       match postponed with
       | [] -> List.rev ordered
-      | _ -> loop [] ordered postponed
+      | _ ->
+        if made_progress then
+          (* At least one equation was ordered in this pass; some of the
+             postponed equations may now be ready, so make another pass. *)
+          loop false [] ordered postponed
+        else
+          (* No equation could be ordered in this pass, meaning the remaining
+             equations depend on state vars that are neither stateful nor
+             defined by any equation (e.g. results of recursive function
+             instances during counterexample reconstruction). There is no
+             valid order for them, so keep them as-is instead of looping
+             forever. *)
+          List.rev_append ordered postponed
     )
   in
 
-  loop [] [] equations
+  loop false [] [] equations
 
 (** Returns the equation for a state variable if any. *)
 let equation_of_svar { equations } svar =


### PR DESCRIPTION
## Problem

When a node's main property fails through a recursive function call, Kind 2 can hang instead of reporting the counterexample.

Reproducer (`sum` is a recursive function whose `sum is non-negative` guarantee is genuinely false since `sum(0) = 0`):

```
function rec sum(n:int) returns (m:int);
con
  guarantee "sum is non-negative" m > 0;
  guarantee "sum-formula" (n>=0) => m = n * (n + 1) / 2;
  decreases n;
noc
let
  m = when n<=0 then 0 else n + sum(n-1);
tel

lemma double(n: int)
con
  guarantee "sum-double" n>=0 => sum(2 * n) = 2 * sum(n) + n * n;
  decreases n;
noc
let
  when n>0 then double(n-1); else auto; end
tel
```

- `kind2 --lus_main sum ...` reports the counterexample for `sum is non-negative` as expected.
- `kind2 --lus_main double ...` hangs: the inherited subproperty `sum is non-negative` is disproved, but counterexample reconstruction never terminates (segfaulting in deep term traversal under the default stack, and leaving the engine processes running so Kind 2 never exits).

## Cause

`ordered_equations_of_node` topologically sorts a node's equations by their dependencies, postponing any equation whose state vars are not yet known. When an equation depends on a state var that is neither stateful nor defined by any equation in the node, that equation can never become known: the postponed set stops shrinking and the loop spins forever.

This occurs during counterexample reconstruction for recursive function instances, where an equation references the result of a recursive call that is not represented as a local equation / stateful var of the reconstructed node.

## Fix

Track whether any equation was ordered during a pass. If a full pass orders nothing while equations remain, no valid order exists for them, so return them as-is instead of looping forever.

## Testing

- `--lus_main double` now terminates and prints the full counterexample with its call trace; `--lus_main sum` is unchanged.
- `dune build @runtest` passes.
- Full regression suite: 1200 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)