### PR TITLE
Fix assertion failure when formatting ADT counterexamples

### DIFF
--- a/src/lustre/lustrePath.ml
+++ b/src/lustre/lustrePath.ml
@@ -1230,7 +1230,8 @@ let adt_streams_from_bindings (adt_map : G.adt_map) model node bindings =
         if is_top_level then Some (index, sv, type_name, root_index)
         else None
       | _ -> None
-      | exception Not_found -> assert false
+      (* A state var with no recorded source is not a discriminant; skip it. *)
+      | exception Not_found -> None
     ) bindings in
     List.filter_map (fun (_disc_index, disc_sv, type_name, root_index) ->
       (* Derive the user-visible stream name by stripping ".disc_field" from


### PR DESCRIPTION
## Problem

Running a model with ADT variables that produces a counterexample can crash with:

```
<Error> Runtime error in invariant manager: File "src/lustre/lustrePath.ml", line 1233, characters 31-37: Assertion failed
```

## Cause

`adt_streams_from_bindings` scans a node's input/output/local bindings for ADT discriminant state vars by calling `N.get_state_var_source node sv`. That function raises `Not_found` for any state var with no recorded source. The exception was handled with `assert false`, which crashed the invariant manager while it was formatting a counterexample.

## Fix

A state var without a recorded source is simply not a discriminant, so it should be skipped (`None`) rather than triggering an assertion. This is consistent with the other call sites of `get_state_var_source` in the same file, which already treat `Not_found` gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)