### PR TITLE
Default value adt fixes

### DIFF
--- a/src/lustre/lustreDesugarADTs.ml
+++ b/src/lustre/lustreDesugarADTs.ml
@@ -221,8 +221,11 @@ let rec default_value ctx adt_map pos ty =
   let ty = desugar_type pos ctx adt_map ty in
   match ty with
   | LA.Bool _ -> LA.Const (pos, LA.False)
-  | LA.Int _ | LA.SBitVector _ | LA.UBitVector _ ->
-    LA.Const (pos, LA.Num (HString.mk_hstring "0"))
+  | LA.Int _ -> LA.Const (pos, LA.Num (HString.mk_hstring "0"))
+  | LA.SBitVector (_, n) ->
+    LA.ConvOp (pos, LA.ToBV n, LA.Const (pos, LA.Num (HString.mk_hstring "0")))
+  | LA.UBitVector (_, n) ->
+    LA.ConvOp (pos, LA.ToUBV n, LA.Const (pos, LA.Num (HString.mk_hstring "0")))
   | LA.Real _ -> LA.Const (pos, LA.Dec (HString.mk_hstring "0.0"))
   | LA.EnumType (_, _, v :: _) -> LA.Ident (pos, v)
   | LA.EnumType (_, _, []) -> assert false

--- a/src/lustre/lustreExpr.ml
+++ b/src/lustre/lustreExpr.ml
@@ -3170,6 +3170,10 @@ let mk_array expr1 expr2 =
   let type_of_array t1 t2 = Type.mk_array t1 t2 in
   mk_binary (fun x _ -> x) type_of_array expr1 expr2
 
+let mk_const_array ty elem =
+  let t = Term.mk_const_array ty elem.expr_init in
+  { expr_init = t; expr_step = t; expr_type = ty }
+
 
 
 (* ********************************************************************** *)

--- a/src/lustre/lustreExpr.mli
+++ b/src/lustre/lustreExpr.mli
@@ -520,6 +520,8 @@ val unsafe_expr_of_term : Term.t -> expr
 
 val mk_array : t -> t -> t
 
+val mk_const_array : Type.t -> t -> t
+
 val mk_let : (Var.t * expr) list -> t -> t
 
 val apply_subst : (Var.t * expr) list -> t -> t

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -776,34 +776,87 @@ let field_name_to_index adt_map field_hs =
    ensures set/map array indices are consistent with ADT equality semantics:
    junk fields (payload of a non-selected constructor) never affect membership. *)
 let adt_canonicalize_key adt_map bindings =
-  let default_of_type ty =
+  let rec default_of_type ty =
     if Type.is_bool ty then E.t_false
     else if Type.is_real ty then E.mk_real Decimal.zero
+    else if Type.is_ubitvector ty then E.mk_to_ubv (Type.bitvectorsize ty) (E.mk_int Numeral.zero)
+    else if Type.is_bitvector ty then E.mk_to_bv (Type.bitvectorsize ty) (E.mk_int Numeral.zero)
+    else if Type.is_array ty then
+      E.mk_const_array ty (default_of_type (Type.elem_type_of_array ty))
     else match Type.node_of_type ty with
       | Type.Enum (l, _) -> E.mk_constr (Type.get_constr_of_num l) ty
       | _ -> E.mk_int Numeral.zero
   in
-  List.map (fun (idx, e) ->
-    match List.rev idx with
-    | X.AdtPayloadIndex (ctor, _) :: prefix_rev ->
-      let prefix = List.rev prefix_rev in
-      let disc_info = StringMap.fold (fun type_name (info : LDAT.adt_info) acc ->
-        match acc with
-        | Some _ -> acc
-        | None ->
-          if StringMap.mem (HString.mk_hstring ctor) info.ctor_fields then
-            let disc_idx = prefix @ [X.AdtTagIndex (HString.string_of_hstring type_name)] in
-            (match List.assoc_opt disc_idx bindings with
-            | Some disc_e -> Some (disc_e, ctor, E.type_of_lustre_expr disc_e)
-            | None -> None)
-          else None
-      ) adt_map None in
-      (match disc_info with
-      | Some (disc_e, ctor, disc_ty) ->
-        let default = default_of_type (E.type_of_lustre_expr e) in
+  (* Collect all (prefix, ctor) pairs from AdtPayloadIndex occurrences in the
+     path. The result is innermost-first (longest prefix first), so that
+     fold_left wraps the innermost ITE first and the outermost last, producing
+     ite(outer=A, ite(inner=Y, e, default), default) for doubly-nested ADTs. *)
+  let rec collect_payload_levels acc prefix = function
+    | [] -> acc
+    | X.AdtPayloadIndex (ctor, _) as x :: rest ->
+      collect_payload_levels ((List.rev prefix, ctor) :: acc) (x :: prefix) rest
+    | x :: rest -> collect_payload_levels acc (x :: prefix) rest
+  in
+  let wrap_one_level bindings e (prefix, ctor) =
+    let disc_info = StringMap.fold (fun type_name (info : LDAT.adt_info) acc ->
+      match acc with
+      | Some _ -> acc
+      | None ->
+        if StringMap.mem (HString.mk_hstring ctor) info.ctor_fields then
+          let disc_idx = prefix @ [X.AdtTagIndex (HString.string_of_hstring type_name)] in
+          let disc_e_opt = match List.assoc_opt disc_idx bindings with
+            | Some _ as r -> r
+            | None ->
+              (* For array payloads, the discriminant binding has an ArrayVarIndex
+                 suffix (it is an element-level expression indexed into an array).
+                 Fall back to the first binding whose index starts with disc_idx. *)
+              (match List.find_opt (fun (idx, _) ->
+                let n = List.length disc_idx in
+                List.length idx > n &&
+                List.filteri (fun i _ -> i < n) idx = disc_idx
+              ) bindings with
+              | Some (_, e) -> Some e
+              | None -> None)
+          in
+          (match disc_e_opt with
+          | Some disc_e -> Some (disc_e, ctor, E.type_of_lustre_expr disc_e)
+          | None -> None)
+        else None
+    ) adt_map None in
+    match disc_info with
+    | Some (disc_e, ctor, disc_ty) ->
+      let e_ty = E.type_of_lustre_expr e in
+      (* When the discriminant is an array (Inner^N payload), the discriminant and
+         payload expressions are whole arrays. Build an element-wise ITE so that
+         junk fields for the wrong inner constructor are canonicalized per element.
+         Start from the original e to avoid mk_const_array with IntRange index types
+         (which do not parse as valid SMT-LIBv2 sorts in CVC5):
+         store(store(e, 0, ite(disc[0]=ctor, e[0], default)), 1, ite(disc[1]=ctor, e[1], default)). *)
+      if Type.is_array disc_ty && Flags.Arrays.smt () then
+        let disc_idx_ty = Type.index_type_of_array disc_ty in
+        let disc_elem_ty = Type.elem_type_of_array disc_ty in
+        let elem_ty = Type.elem_type_of_array e_ty in
+        let elem_default = default_of_type elem_ty in
+        (match Type.bounds_of_int_range disc_idx_ty with
+        | (_, Some upper) ->
+          let n = Numeral.to_int upper in
+          List.init n (fun i ->
+            let i_e = E.mk_of_expr ~as_type:disc_idx_ty (E.mk_int_expr (Numeral.of_int i)) in
+            let disc_i = E.mk_select disc_e i_e in
+            let e_i = E.mk_select e i_e in
+            (i_e, E.mk_ite (E.mk_eq disc_i (E.mk_constr ctor disc_elem_ty)) e_i elem_default)
+          ) |> List.fold_left (fun arr (i_e, v) -> E.mk_store arr i_e v) e
+        | _ -> e)
+      else if Type.is_array disc_ty then
+        e
+      else
+        let default = default_of_type e_ty in
         E.mk_ite (E.mk_eq disc_e (E.mk_constr ctor disc_ty)) e default
-      | None -> e)
-    | _ -> e
+    | None -> e
+  in
+  List.map (fun (idx, e) ->
+    let levels = collect_payload_levels [] [] idx in
+    List.fold_left (wrap_one_level bindings) e levels
   ) bindings
 
 let rec compile ctx gids adt_map scc_map decls =

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -804,8 +804,6 @@ let adt_canonicalize_key adt_map bindings =
       | None ->
         if StringMap.mem (HString.mk_hstring ctor) info.ctor_fields then
           let disc_idx = prefix @ [X.AdtTagIndex (HString.string_of_hstring type_name)] in
-          (* check_map_type rejects ArrayType as a key type, so disc_ty is
-             always an enum; array-payload ADT keys are unreachable. *)
           (match List.assoc_opt disc_idx bindings with
           | None -> assert false
           | Some disc_e -> Some (disc_e, ctor, E.type_of_lustre_expr disc_e))

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1392,10 +1392,7 @@ and compile_ast_expr
   and compile_map_index bounds expr k =
     let compiled_k = compile_ast_expr cstate ctx bounds map k in
     let bindings_k = X.bindings compiled_k in
-    let index_exprs =
-      if StringMap.is_empty cstate.adt_map then List.map snd bindings_k
-      else adt_canonicalize_key cstate.adt_map bindings_k
-    in
+    let index_exprs = adt_canonicalize_key cstate.adt_map bindings_k in
     let compiled_expr = compile_ast_expr cstate ctx bounds map expr in
     List.fold_left
       (fun acc index ->
@@ -2701,15 +2698,15 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
       let lhs_bounds = gen_lhs_bounds (AH.pos_of_expr nexpr1) true eq_lhs 1 in 
       let nexpr2 = compile_ast_expr cstate ctx lhs_bounds map nexpr2 in 
       let fresh_idx_e = compile_ast_expr cstate ctx lhs_bounds map fresh_idx in 
-      let nexpr2 = 
-        let nexpr2 = X.values nexpr2 in 
-        List.fold_left (fun (acc, acc_i) e -> 
+      let nexpr2 =
+        let nexpr2_vals = adt_canonicalize_key cstate.adt_map (X.bindings nexpr2) in
+        List.fold_left (fun (acc, acc_i) e ->
           X.add [X.TupleIndex acc_i] e acc, acc_i + 1
-        ) (X.empty, 0) nexpr2 |> fst 
+        ) (X.empty, 0) nexpr2_vals |> fst
       in
       let expr = compile_binary' E.mk_eq nexpr2 fresh_idx_e in
-      let cond_expr = 
-        X.singleton X.empty_index (List.fold_left E.mk_and E.t_true (X.values expr)) 
+      let cond_expr =
+        X.singleton X.empty_index (List.fold_left E.mk_and E.t_true (X.values expr))
       in
       let then_expr = A.GroupExpr (dummy_pos, TupleExpr, [Const (dummy_pos, True); nexpr3]) in 
       let else_expr = 
@@ -2796,12 +2793,9 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
          flattening so that the insertion position is consistent with membership
          checks (which also canonicalize via compile_map_index). *)
       let nexpr2 =
-        let nexpr2_vals =
-          if StringMap.is_empty cstate.adt_map then X.values nexpr2
-          else adt_canonicalize_key cstate.adt_map (X.bindings nexpr2)
-        in
+        let nexpr2_vals = adt_canonicalize_key cstate.adt_map (X.bindings nexpr2) in
         List.fold_left (fun (acc, acc_i) e ->
-          X.add [X.TupleIndex acc_i]  e acc, acc_i + 1
+          X.add [X.TupleIndex acc_i] e acc, acc_i + 1
         ) (X.empty, 0) nexpr2_vals |> fst
       in
       let expr = compile_binary' E.mk_eq nexpr2 fresh_idx_e in

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -2792,7 +2792,7 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
       (* Flatten nexpr2 to make the indices align (the compilation of map types in
          compile_ast_type flattens indices, so we need to do a corresponding flattening
          of nexpr2 to compile the equality between nexpr2 and fresh_idx_e).
-         For ADT element types, canonicalize junk payload fields to 0 before
+         For ADT element types, canonicalize junk payload fields to default values before
          flattening so that the insertion position is consistent with membership
          checks (which also canonicalize via compile_map_index). *)
       let nexpr2 =

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -804,54 +804,21 @@ let adt_canonicalize_key adt_map bindings =
       | None ->
         if StringMap.mem (HString.mk_hstring ctor) info.ctor_fields then
           let disc_idx = prefix @ [X.AdtTagIndex (HString.string_of_hstring type_name)] in
-          let disc_e_opt = match List.assoc_opt disc_idx bindings with
-            | Some _ as r -> r
-            | None ->
-              (* For array payloads, the discriminant binding has an ArrayVarIndex
-                 suffix (it is an element-level expression indexed into an array).
-                 Fall back to the first binding whose index starts with disc_idx. *)
-              (match List.find_opt (fun (idx, _) ->
-                let n = List.length disc_idx in
-                List.length idx > n &&
-                List.filteri (fun i _ -> i < n) idx = disc_idx
-              ) bindings with
-              | Some (_, e) -> Some e
-              | None -> None)
-          in
-          (match disc_e_opt with
-          | Some disc_e -> Some (disc_e, ctor, E.type_of_lustre_expr disc_e)
-          | None -> None)
+          (* check_map_type rejects ArrayType as a key type, so disc_ty is
+             always an enum; array-payload ADT keys are unreachable. *)
+          (match List.assoc_opt disc_idx bindings with
+          | None -> assert false
+          | Some disc_e -> Some (disc_e, ctor, E.type_of_lustre_expr disc_e))
         else None
     ) adt_map None in
     match disc_info with
     | Some (disc_e, ctor, disc_ty) ->
       let e_ty = E.type_of_lustre_expr e in
-      (* When the discriminant is an array (Inner^N payload), the discriminant and
-         payload expressions are whole arrays. Build an element-wise ITE so that
-         junk fields for the wrong inner constructor are canonicalized per element.
-         Start from the original e to avoid mk_const_array with IntRange index types
-         (which do not parse as valid SMT-LIBv2 sorts in CVC5):
-         store(store(e, 0, ite(disc[0]=ctor, e[0], default)), 1, ite(disc[1]=ctor, e[1], default)). *)
-      if Type.is_array disc_ty && Flags.Arrays.smt () then
-        let disc_idx_ty = Type.index_type_of_array disc_ty in
-        let disc_elem_ty = Type.elem_type_of_array disc_ty in
-        let elem_ty = Type.elem_type_of_array e_ty in
-        let elem_default = default_of_type elem_ty in
-        (match Type.bounds_of_int_range disc_idx_ty with
-        | (_, Some upper) ->
-          let n = Numeral.to_int upper in
-          List.init n (fun i ->
-            let i_e = E.mk_of_expr ~as_type:disc_idx_ty (E.mk_int_expr (Numeral.of_int i)) in
-            let disc_i = E.mk_select disc_e i_e in
-            let e_i = E.mk_select e i_e in
-            (i_e, E.mk_ite (E.mk_eq disc_i (E.mk_constr ctor disc_elem_ty)) e_i elem_default)
-          ) |> List.fold_left (fun arr (i_e, v) -> E.mk_store arr i_e v) e
-        | _ -> e)
-      else if Type.is_array disc_ty then
-        e
-      else
-        let default = default_of_type e_ty in
-        E.mk_ite (E.mk_eq disc_e (E.mk_constr ctor disc_ty)) e default
+      (* Should hold due to restrictions of set element and map 
+         key types in the type checker *)
+      assert (not (Type.is_array disc_ty));
+      let default = default_of_type e_ty in
+      E.mk_ite (E.mk_eq disc_e (E.mk_constr ctor disc_ty)) e default
     | None -> e
   in
   List.map (fun (idx, e) ->

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -2698,15 +2698,15 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
       let lhs_bounds = gen_lhs_bounds (AH.pos_of_expr nexpr1) true eq_lhs 1 in 
       let nexpr2 = compile_ast_expr cstate ctx lhs_bounds map nexpr2 in 
       let fresh_idx_e = compile_ast_expr cstate ctx lhs_bounds map fresh_idx in 
-      let nexpr2 =
+      let nexpr2 = 
         let nexpr2_vals = adt_canonicalize_key cstate.adt_map (X.bindings nexpr2) in
         List.fold_left (fun (acc, acc_i) e ->
           X.add [X.TupleIndex acc_i] e acc, acc_i + 1
-        ) (X.empty, 0) nexpr2_vals |> fst
+        ) (X.empty, 0) nexpr2_vals |> fst 
       in
       let expr = compile_binary' E.mk_eq nexpr2 fresh_idx_e in
-      let cond_expr =
-        X.singleton X.empty_index (List.fold_left E.mk_and E.t_true (X.values expr))
+      let cond_expr = 
+        X.singleton X.empty_index (List.fold_left E.mk_and E.t_true (X.values expr)) 
       in
       let then_expr = A.GroupExpr (dummy_pos, TupleExpr, [Const (dummy_pos, True); nexpr3]) in 
       let else_expr = 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -771,6 +771,41 @@ let field_name_to_index adt_map field_hs =
   | Some idx -> idx
   | None -> X.RecordIndex field_str
 
+(* For each AdtPayloadIndex (ctor, _) entry in a compiled key binding list,
+   replace the payload expression with `ite(tag = ctor, expr, default_val)`.  This
+   ensures set/map array indices are consistent with ADT equality semantics:
+   junk fields (payload of a non-selected constructor) never affect membership. *)
+let adt_canonicalize_key adt_map bindings =
+  let default_of_type ty =
+    if Type.is_bool ty then E.t_false
+    else if Type.is_real ty then E.mk_real Decimal.zero
+    else match Type.node_of_type ty with
+      | Type.Enum (l, _) -> E.mk_constr (Type.get_constr_of_num l) ty
+      | _ -> E.mk_int Numeral.zero
+  in
+  List.map (fun (idx, e) ->
+    match List.rev idx with
+    | X.AdtPayloadIndex (ctor, _) :: prefix_rev ->
+      let prefix = List.rev prefix_rev in
+      let disc_info = StringMap.fold (fun type_name (info : LDAT.adt_info) acc ->
+        match acc with
+        | Some _ -> acc
+        | None ->
+          if StringMap.mem (HString.mk_hstring ctor) info.ctor_fields then
+            let disc_idx = prefix @ [X.AdtTagIndex (HString.string_of_hstring type_name)] in
+            (match List.assoc_opt disc_idx bindings with
+            | Some disc_e -> Some (disc_e, ctor, E.type_of_lustre_expr disc_e)
+            | None -> None)
+          else None
+      ) adt_map None in
+      (match disc_info with
+      | Some (disc_e, ctor, disc_ty) ->
+        let default = default_of_type (E.type_of_lustre_expr e) in
+        E.mk_ite (E.mk_eq disc_e (E.mk_constr ctor disc_ty)) e default
+      | None -> e)
+    | _ -> e
+  ) bindings
+
 let rec compile ctx gids adt_map scc_map decls =
   let over_decls_1 cstate decl = compile_declaration_phase1 cstate ctx decl in
   let output = List.fold_left over_decls_1 ({ (empty_compiler_state ()) with adt_map }) decls in
@@ -1356,7 +1391,11 @@ and compile_ast_expr
 
   and compile_map_index bounds expr k =
     let compiled_k = compile_ast_expr cstate ctx bounds map k in
-    let index_exprs = X.values compiled_k in
+    let bindings_k = X.bindings compiled_k in
+    let index_exprs =
+      if StringMap.is_empty cstate.adt_map then List.map snd bindings_k
+      else adt_canonicalize_key cstate.adt_map bindings_k
+    in
     let compiled_expr = compile_ast_expr cstate ctx bounds map expr in
     List.fold_left
       (fun acc index ->
@@ -2748,16 +2787,22 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
       let fresh_idx = A.Ident (dummy_pos, fresh_idx_name) in 
       let eq_lhs = compile_map_or_set_def id fresh_idx_name false in 
       let lhs_bounds = gen_lhs_bounds (AH.pos_of_expr nexpr1) true eq_lhs 1 in
-      let nexpr2 = compile_ast_expr cstate ctx lhs_bounds map nexpr2 in 
-      let fresh_idx_e = compile_ast_expr cstate ctx lhs_bounds map fresh_idx in 
-      (* Flatten nexpr2 to make the indices align (the compilation of map types in 
-         compile_ast_type flattens indices, so we need to do a corresponding flattening 
-         of nexpr2 to compile the equality between nexpr2 and fresh_idx_e) *)
+      let nexpr2 = compile_ast_expr cstate ctx lhs_bounds map nexpr2 in
+      let fresh_idx_e = compile_ast_expr cstate ctx lhs_bounds map fresh_idx in
+      (* Flatten nexpr2 to make the indices align (the compilation of map types in
+         compile_ast_type flattens indices, so we need to do a corresponding flattening
+         of nexpr2 to compile the equality between nexpr2 and fresh_idx_e).
+         For ADT element types, canonicalize junk payload fields to 0 before
+         flattening so that the insertion position is consistent with membership
+         checks (which also canonicalize via compile_map_index). *)
       let nexpr2 =
-        let nexpr2 = X.values nexpr2 in 
-        List.fold_left (fun (acc, acc_i) e -> 
+        let nexpr2_vals =
+          if StringMap.is_empty cstate.adt_map then X.values nexpr2
+          else adt_canonicalize_key cstate.adt_map (X.bindings nexpr2)
+        in
+        List.fold_left (fun (acc, acc_i) e ->
           X.add [X.TupleIndex acc_i]  e acc, acc_i + 1
-        ) (X.empty, 0) nexpr2 |> fst 
+        ) (X.empty, 0) nexpr2_vals |> fst
       in
       let expr = compile_binary' E.mk_eq nexpr2 fresh_idx_e in
       let cond_expr = 

--- a/tests/regression/success/adt_bv_real_junk.lus
+++ b/tests/regression/success/adt_bv_real_junk.lus
@@ -1,0 +1,12 @@
+datatype D = A (int8) | B (real) | C (uint16);
+
+function isA(d: D) returns (r: bool);
+let r = match d with | A(_) : true | _ : false end; tel
+
+node main(v: int8; w: real; u: uint16) returns (ok: bool);
+var d: D;
+let
+  d = A(v);
+  ok = isA(d);
+  check ok;
+tel

--- a/tests/regression/success/adt_set_array_payload_membership.lus
+++ b/tests/regression/success/adt_set_array_payload_membership.lus
@@ -1,0 +1,9 @@
+datatype D = A (int) | B (bool);
+
+node main(n: int) returns (ok: bool);
+var s: set<D>;
+let
+  s = {A(n)} -> pre s + {A(n)};
+  ok = A(n) in s;
+  check ok;
+tel

--- a/tests/regression/success/adt_set_bv_payload.lus
+++ b/tests/regression/success/adt_set_bv_payload.lus
@@ -1,0 +1,12 @@
+datatype D = A (int) | B (uint16);
+
+function isA(d: D) returns (r: bool);
+let r = match d with | A(_) : true | _ : false end; tel
+
+node main() returns (ok: bool);
+var s: set<D>;
+let
+  s = {}@<D>;
+  ok = true;
+  check forall (d: D) (d in s) => isA(d);
+tel

--- a/tests/regression/success/adt_set_doubly_nested_payload.lus
+++ b/tests/regression/success/adt_set_doubly_nested_payload.lus
@@ -1,0 +1,13 @@
+datatype Inner = X (int) | Y (bool);
+datatype Outer = A (Inner) | B (real);
+
+function isB(o: Outer) returns (r: bool);
+let r = match o with | A(_) : false | B(_) : true end; tel
+
+node main() returns (ok: bool);
+var s: set<Outer>;
+let
+  s = {}@<Outer>;
+  ok = true;
+  check forall (o: Outer) (o in s) => isB(o);
+tel

--- a/tests/regression/success/adt_set_nested_record_payload.lus
+++ b/tests/regression/success/adt_set_nested_record_payload.lus
@@ -1,0 +1,14 @@
+type Vote = enum {Yes, No};
+type Pair = struct { v: Vote };
+datatype Message = VoteReqMsg | VoteMsg (Pair) | DecisionMsg (bool);
+
+function IsDecisionMsg(m: Message) returns (r: bool);
+let r = match m with | DecisionMsg(_) : true | _ : false end; tel
+
+node main() returns (ok: bool);
+var s: set<Message>;
+let
+  s = {}@<Message>;
+  ok = true;
+  check forall (msg: Message) (msg in s) => IsDecisionMsg(msg);
+tel

--- a/tests/regression/success/two_phase_commit.lus
+++ b/tests/regression/success/two_phase_commit.lus
@@ -1,0 +1,283 @@
+
+type Nat = subrange [0,*] of int;
+type Pos = subrange [1,*] of int;
+
+datatype Option<T> = Some (T) | None;
+
+transparent function IsSome<T>(o: Option<T>) returns (r: bool);
+let
+  r = match o with
+    | Some(_) : true
+    | None : false
+  end;
+tel
+
+transparent function IsNone<T>(o: Option<T>) returns (r: bool);
+let
+  r = match o with
+    | Some(_) : false
+    | None : true
+  end;
+tel
+
+transparent function GetValue<T>(o: Option<T>) returns (v: T);
+let
+  v = match o with
+    | Some(value) : value
+    | None : choose@<T>
+  end;
+tel
+
+node imported nondet() returns (r: bool);
+
+type Vote = enum {Yes, No};
+
+type Decision = enum {Commit, Abort};
+
+type HostId = int;
+
+type HostClass = enum { Coordinator, Participant, NoHost };
+
+type Token_Holder = struct {
+  class: HostClass;
+  id: HostId;
+};
+
+const Preference : subtype { m : map<HostId,Vote> | forall (h:HostId) h in m };
+
+datatype Message =
+  | VoteReqMsg
+  | VoteMsg (HostId, Vote)
+  | DecisionMsg (Decision);
+
+function IsVoteReqMsg(m: Message) returns (r: bool);
+let
+  r = match m with
+    | VoteReqMsg : true
+    | _ : false
+  end;
+tel
+
+function IsVoteMsg(m: Message) returns (r: bool);
+let
+  r = match m with
+    | VoteMsg(_, _) : true
+    | _ : false
+  end;
+tel
+
+function IsDecisionMsg(m: Message) returns (r: bool);
+let
+  r = match m with
+    | DecisionMsg(_) : true
+    | _ : false
+  end;
+tel
+
+transparent function GetMsgSender(m: Message) returns (sender: HostId);
+let
+  sender =
+    match m with
+    | VoteMsg(s, v) : s
+    | _ : 0
+  end;
+tel
+
+transparent function GetMsgVote(m: Message) returns (vote: Vote);
+let
+  vote =
+    match m with
+    | VoteMsg(s, v) : v
+    | _ : No
+  end;
+tel
+
+transparent function GetMsgDecision(m: Message) returns (decision: Decision);
+let
+  decision =
+    match m with
+    | DecisionMsg(d) : d
+    | _ : Abort
+  end;
+tel
+
+type MsgSet = set<Message>;
+
+node Network(send: Option<Message>) returns 
+  (recv: Option<Message>; sentMsgs: MsgSet);
+var prevSentMsgs: MsgSet;
+let
+  prevSentMsgs = {}@<Message> -> pre sentMsgs;
+  frame (sentMsgs)
+    sentMsgs = {}@<Message>;
+  let
+    if IsSome@<Message>(send) then
+      sentMsgs = prevSentMsgs + {GetValue@<Message>(send)};
+    fi
+  tel
+  recv = any { m: Option<Message> | IsSome@<Message>(m) => GetValue@<Message>(m) in prevSentMsgs };
+tel
+
+function imported AllVotesCollected(votes: map<HostId,Vote>) returns (r: bool);
+(*@contract
+  guarantee r = (forall (i: HostId) i in votes);
+*)
+
+function imported GetDecision(votes: map<HostId,Vote>) returns (d: Decision);
+(*@contract
+  guarantee (forall (i: HostId) votes[i]=Yes) = (d = Commit);
+  guarantee (not (forall (i: HostId) votes[i]=Yes)) = (d = Abort);
+*)
+
+node Coordinator(my_turn: bool; nw_recv: Option<Message>)
+  returns (nw_send: Option<Message>; decision: Option<Decision>;
+           votes: map<HostId,Vote>);
+var sender: HostId;
+    vote: Vote;
+let
+  sender = GetMsgSender(GetValue@<Message>(nw_recv));
+  vote = GetMsgVote(GetValue@<Message>(nw_recv));
+  frame (votes, nw_send, decision)
+    decision = None@<Decision>;
+    votes = map[]@<HostId,Vote>;
+    nw_send = None@<Message>;
+  let
+    if (my_turn) then
+      if (IsSome@<Message>(nw_recv) and IsVoteMsg(GetValue@<Message>(nw_recv))) then
+        votes = map[]@<HostId,Vote> -> (pre votes)[sender := vote];
+        if AllVotesCollected(votes) then
+          decision = Some(GetDecision(votes));
+          nw_send = Some(DecisionMsg(GetDecision(votes)));
+        else
+          nw_send = None@<Message>;
+        fi
+      else
+        if (nondet()) then
+          nw_send = Some(VoteReqMsg);
+        else
+          nw_send = None@<Message>;
+        fi
+      fi
+    else
+      nw_send = None@<Message>;
+    fi
+  tel
+tel
+
+node Participant(my_turn: bool; id: HostId; nw_recv: Option<Message>)
+  returns (nw_send: Option<Message>; decision: Option<Decision>);
+let
+  frame (nw_send, decision)
+    decision = None@<Decision>;
+    nw_send = None@<Message>;
+  let
+    if (my_turn) then
+      if (IsSome@<Message>(nw_recv) and IsVoteReqMsg(GetValue@<Message>(nw_recv))) then
+        nw_send = Some(VoteMsg(id, Preference[id]));
+        if Preference[id] = No then
+          decision = Some(Abort);
+        fi
+      elsif (IsSome@<Message>(nw_recv) and IsDecisionMsg(GetValue@<Message>(nw_recv))) then
+        decision = Some(GetMsgDecision(GetValue@<Message>(nw_recv)));
+        nw_send = None@<Message>;
+      else
+        nw_send = None@<Message>;
+      fi
+    else
+      nw_send = None@<Message>;
+    fi
+  tel
+tel
+
+function imported AllWithDecisionAgreeWithThisOne(
+  coord_decision: Option<Decision>;
+  partic_decision: map<HostId,Decision>;
+  decision: Decision
+) returns (
+  r: bool
+);
+(*@contract
+  guarantee r = (
+    (IsSome@<Decision>(coord_decision) => GetValue@<Decision>(coord_decision) = decision) and
+    (forall (i: HostId) i in partic_decision => partic_decision[i] = decision)
+  );
+*)
+
+node DistributedSystem(tk_holder: Token_Holder) returns (
+  coord_decision: Option<Decision>; partic_decision: map<HostId,Decision>
+);
+(*@contract
+  assume "No one's turn initially, then always somebody's turn"
+    tk_holder.class = NoHost -> tk_holder.class <> NoHost;
+
+  guarantee "SafetyAC1"
+    AllWithDecisionAgreeWithThisOne(
+      coord_decision, partic_decision, Commit)
+    or
+    AllWithDecisionAgreeWithThisOne(
+      coord_decision, partic_decision, Abort);
+
+  guarantee "SafetyAC3" (
+    (exists (hostid:HostId) Preference[hostid] = No)
+    =>
+    AllWithDecisionAgreeWithThisOne(
+      coord_decision, partic_decision, Abort)
+  );
+
+  guarantee "SafetyAC4" (
+    (forall (hostid:HostId) Preference[hostid] = Yes)
+    =>
+    AllWithDecisionAgreeWithThisOne(
+      coord_decision, partic_decision, Commit)
+  );
+*)
+var coord_send, partic_send: Option<Message>;
+var network_send, network_recv: Option<Message>;
+var decision_id: Option<Decision>;
+var votes: map<HostId,Vote>; -- probe
+var sentMsgs: MsgSet; -- probe
+
+let
+  coord_send, coord_decision, votes =
+    Coordinator(tk_holder.class = Coordinator, network_recv);
+
+  partic_send, decision_id =
+    Participant(tk_holder.class = Participant, tk_holder.id, network_recv);
+
+  partic_decision = map[]@<HostId,Decision> ->
+    if tk_holder.class = Coordinator or not IsSome@<Decision>(decision_id) then
+      pre partic_decision
+    else
+      (pre partic_decision)[tk_holder.id := GetValue@<Decision>(decision_id)];
+
+  if tk_holder.class = Coordinator then
+    network_send = coord_send;
+  elsif tk_holder.class = Participant then
+    network_send = partic_send;
+  else -- tk_holder.class = NoHost
+    network_send = None@<Message>;
+  fi
+
+  network_recv, sentMsgs = Network(network_send);
+
+  check "Vote Messages Agree With Participant Preferences"
+    forall (msg: Message) (msg in sentMsgs and IsVoteMsg(msg)) =>
+      GetMsgVote(msg) = Preference[GetMsgSender(msg)];
+
+  check "Coordinator State Supported By Vote"
+    forall (idx:HostId) idx in votes => 
+      VoteMsg(idx, votes[idx]) in sentMsgs;
+
+  check "Decision Msgs Agree With Decision"
+    forall (msg: Message) (msg in sentMsgs and IsDecisionMsg(msg)) =>
+      (AllVotesCollected(votes) and
+      GetDecision(votes) = GetMsgDecision(msg));
+
+  check "Participant Commit Decision Agree With Decision Msg"
+    IsSome@<Decision>(decision_id) and GetValue@<Decision>(decision_id) = Commit =>
+      DecisionMsg(Commit) in sentMsgs;
+
+  check "Participant Decision Agree With Participant Preferences"
+    ((forall (idx: HostId) Preference[idx]=Yes) and IsSome@<Decision>(decision_id)) =>
+      GetValue@<Decision>(decision_id) = Commit;
+tel


### PR DESCRIPTION
Two bug fixes 

First, a straightforward bug fix in `default_value` in ``lustreDesugarADTs.ml``

Second --- 
Say we have `t = C(0)`, and `t' = C(0)`, but `t` and `t'` have different junk fields. Say we have set `s`. When determining `t in s` or `t' in s`, clearly only the non-junk fields should be considered. But, our encoding is a mapping from all the fields to a boolean value. So, in my opinion, the cleanest thing to do is to canonicalize junk fields to a default value -- when compiling `t in s` for ADT expression `t`, we essentially compute `s[t_tag][canonicalize(t_field0)][canonicalize(t_field1)]...`, where canonicalize is just an ITE: `if constructor_selected then t_fieldn else default_value`. Then clearly, we have to also update set insertion analogously.
To be clear, what we were doing before this PR is ``s[t_tag][t_field0][t_field1]...``, the same thing but without the ``canonicalize`` ITE