### PR TITLE
Render named types instead of desugared inline definitions in output

### DIFF
--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -36,9 +36,6 @@ open ProcessCall
 
 (* |===| Helpers. *)
 
-(** TSys name formatter. *)
-let fmt_sys = TSys.pp_print_trans_sys_name
-
 (* |===| Helpers to run stuff. *)
 
 (** Child processes forked.

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -610,8 +610,12 @@ let analyze msg_setup save_results ignore_props stop_if_falsified slice_to_prop 
   Stat.start_timer Stat.analysis_time ;
 
   ( if TSys.has_real_property sys |> not && not ignore_props then
+      let node_name =
+        ISys.get_node_user_name in_sys (TSys.scope_of_trans_sys sys)
+      in
       KEvent.log L_note
-        "System %a has no property, skipping verification step." fmt_sys sys
+        "System %a has no property, skipping verification step."
+        (LustreIdent.pp_print_ident true) node_name
     else
       let props = TSys.props_list_of_bound sys Num.zero in
       (* Issue analysis start notification. *)

--- a/src/lustre/lustreDesugarADTs.ml
+++ b/src/lustre/lustreDesugarADTs.ml
@@ -517,6 +517,28 @@ let rec rewrite_as_adt_terms adt_map expr =
     | LA.SetIndex (p, e) -> LA.SetIndex (p, r e)
     | LA.GenericIndex (p, e) -> LA.GenericIndex (p, r e)
   in
+  (* Rewrite a desugared type back toward its source-level named form so that,
+     e.g., a quantifier over an ADT prints as "Message" rather than the inline
+     record definition, and an enum prints by its declared type name.  Record
+     and enum types always carry their declared type name, so a bare UserType
+     with that name renders correctly. *)
+  let rec rewrite_type ty =
+    match ty with
+    | LA.RecordType (pos, name, _) -> LA.UserType (pos, [], name)
+    | LA.EnumType (pos, name, _) -> LA.UserType (pos, [], name)
+    | LA.UserType (pos, args, name) ->
+      LA.UserType (pos, List.map rewrite_type args, name)
+    | LA.TupleType (pos, ts) -> LA.TupleType (pos, List.map rewrite_type ts)
+    | LA.GroupType (pos, ts) -> LA.GroupType (pos, List.map rewrite_type ts)
+    | LA.ArrayType (pos, (t, e)) -> LA.ArrayType (pos, (rewrite_type t, r e))
+    | LA.TArr (pos, t1, t2) -> LA.TArr (pos, rewrite_type t1, rewrite_type t2)
+    | LA.Map (pos, kt, vt) -> LA.Map (pos, rewrite_type kt, rewrite_type vt)
+    | LA.Set (pos, t) -> LA.Set (pos, rewrite_type t)
+    | LA.RefinementType (pos, (p2, id, t), e) ->
+      LA.RefinementType (pos, (p2, id, rewrite_type t), r e)
+    | LA.Bool _ | LA.Int _ | LA.Real _ | LA.SBitVector _ | LA.UBitVector _
+    | LA.AbstractType _ | LA.History _ | LA.ADT _ -> ty
+  in
   match expr with
   | LA.RecordExpr (pos, type_name, [], fields) when HStringMap.mem type_name adt_map ->
     let info = HStringMap.find type_name adt_map in
@@ -550,14 +572,17 @@ let rec rewrite_as_adt_terms adt_map expr =
   | LA.When (p, e, c) -> LA.When (p, r e, c)
   | LA.Pre (p, e) -> LA.Pre (p, r e)
   | LA.Arrow (p, e1, e2) -> LA.Arrow (p, r e1, r e2)
-  | LA.TypeAscription (p, e, ty) -> LA.TypeAscription (p, r e, ty)
-  | LA.Call (p, ty_args, id, es) -> LA.Call (p, ty_args, id, rlist es)
+  | LA.TypeAscription (p, e, ty) -> LA.TypeAscription (p, r e, rewrite_type ty)
+  | LA.Call (p, ty_args, id, es) ->
+    LA.Call (p, List.map rewrite_type ty_args, id, rlist es)
   | LA.Merge (p, id, flds) -> LA.Merge (p, id, rilist flds)
   | LA.Activate (p, id, e1, e2, es) -> LA.Activate (p, id, r e1, r e2, rlist es)
   | LA.Condact (p, e1, e2, id, es1, es2) ->
     LA.Condact (p, r e1, r e2, id, rlist es1, rlist es2)
   | LA.RestartEvery (p, id, es, e) -> LA.RestartEvery (p, id, rlist es, r e)
-  | LA.Quantifier (p, k, idents, e) -> LA.Quantifier (p, k, idents, r e)
+  | LA.Quantifier (p, k, idents, e) ->
+    let idents = List.map (fun (ip, id, ty) -> (ip, id, rewrite_type ty)) idents in
+    LA.Quantifier (p, k, idents, r e)
   | LA.Extract (p, e, ub, lb) -> LA.Extract (p, r e, ub, lb)
   | LA.AnyOp _ | LA.ChooseOp _ -> expr
   | LA.ADTTerm _ | LA.Match _ -> expr

--- a/src/lustre/lustreInstantiatePolyNodes.ml
+++ b/src/lustre/lustreInstantiatePolyNodes.ml
@@ -132,6 +132,7 @@ let rec gen_poly_decl: Ctx.tc_context -> GI.t NI.Map.t -> NI.t option -> (A.decl
   let pp_print_ty_arg ppf = function
     | A.RecordType (_, n, _) -> HString.pp_print_hstring ppf n
     | A.ADT (_, n, _) -> HString.pp_print_hstring ppf n
+    | A.EnumType (_, n, _) -> HString.pp_print_hstring ppf n
     | ty -> A.pp_print_lustre_type ppf ty
   in
   let user_name = Format.asprintf

--- a/tests/regression/success/two_phase_commit.lus
+++ b/tests/regression/success/two_phase_commit.lus
@@ -111,11 +111,11 @@ let
   frame (sentMsgs)
     sentMsgs = {}@<Message>;
   let
-    if IsSome@<Message>(send) then
-      sentMsgs = prevSentMsgs + {GetValue@<Message>(send)};
+    if IsSome(send) then
+      sentMsgs = prevSentMsgs + {GetValue(send)};
     fi
   tel
-  recv = any { m: Option<Message> | IsSome@<Message>(m) => GetValue@<Message>(m) in prevSentMsgs };
+  recv = any { m: Option<Message> | IsSome(m) => GetValue(m) in prevSentMsgs };
 tel
 
 function imported AllVotesCollected(votes: map<HostId,Vote>) returns (r: bool);
@@ -135,15 +135,15 @@ node Coordinator(my_turn: bool; nw_recv: Option<Message>)
 var sender: HostId;
     vote: Vote;
 let
-  sender = GetMsgSender(GetValue@<Message>(nw_recv));
-  vote = GetMsgVote(GetValue@<Message>(nw_recv));
+  sender = GetMsgSender(GetValue(nw_recv));
+  vote = GetMsgVote(GetValue(nw_recv));
   frame (votes, nw_send, decision)
     decision = None@<Decision>;
     votes = map[]@<HostId,Vote>;
     nw_send = None@<Message>;
   let
     if (my_turn) then
-      if (IsSome@<Message>(nw_recv) and IsVoteMsg(GetValue@<Message>(nw_recv))) then
+      if (IsSome(nw_recv) and IsVoteMsg(GetValue(nw_recv))) then
         votes = map[]@<HostId,Vote> -> (pre votes)[sender := vote];
         if AllVotesCollected(votes) then
           decision = Some(GetDecision(votes));
@@ -172,13 +172,13 @@ let
     nw_send = None@<Message>;
   let
     if (my_turn) then
-      if (IsSome@<Message>(nw_recv) and IsVoteReqMsg(GetValue@<Message>(nw_recv))) then
+      if (IsSome(nw_recv) and IsVoteReqMsg(GetValue(nw_recv))) then
         nw_send = Some(VoteMsg(id, Preference[id]));
         if Preference[id] = No then
           decision = Some(Abort);
         fi
-      elsif (IsSome@<Message>(nw_recv) and IsDecisionMsg(GetValue@<Message>(nw_recv))) then
-        decision = Some(GetMsgDecision(GetValue@<Message>(nw_recv)));
+      elsif (IsSome(nw_recv) and IsDecisionMsg(GetValue(nw_recv))) then
+        decision = Some(GetMsgDecision(GetValue(nw_recv)));
         nw_send = None@<Message>;
       else
         nw_send = None@<Message>;
@@ -198,7 +198,7 @@ function imported AllWithDecisionAgreeWithThisOne(
 );
 (*@contract
   guarantee r = (
-    (IsSome@<Decision>(coord_decision) => GetValue@<Decision>(coord_decision) = decision) and
+    (IsSome(coord_decision) => GetValue(coord_decision) = decision) and
     (forall (i: HostId) i in partic_decision => partic_decision[i] = decision)
   );
 *)
@@ -245,10 +245,10 @@ let
     Participant(tk_holder.class = Participant, tk_holder.id, network_recv);
 
   partic_decision = map[]@<HostId,Decision> ->
-    if tk_holder.class = Coordinator or not IsSome@<Decision>(decision_id) then
+    if tk_holder.class = Coordinator or not IsSome(decision_id) then
       pre partic_decision
     else
-      (pre partic_decision)[tk_holder.id := GetValue@<Decision>(decision_id)];
+      (pre partic_decision)[tk_holder.id := GetValue(decision_id)];
 
   if tk_holder.class = Coordinator then
     network_send = coord_send;
@@ -274,10 +274,10 @@ let
       GetDecision(votes) = GetMsgDecision(msg));
 
   check "Participant Commit Decision Agree With Decision Msg"
-    IsSome@<Decision>(decision_id) and GetValue@<Decision>(decision_id) = Commit =>
+    IsSome(decision_id) and GetValue(decision_id) = Commit =>
       DecisionMsg(Commit) in sentMsgs;
 
   check "Participant Decision Agree With Participant Preferences"
-    ((forall (idx: HostId) Preference[idx]=Yes) and IsSome@<Decision>(decision_id)) =>
-      GetValue@<Decision>(decision_id) = Commit;
+    ((forall (idx: HostId) Preference[idx]=Yes) and IsSome(decision_id)) =>
+      GetValue(decision_id) = Commit;
 tel


### PR DESCRIPTION
## Problem

When desugared ADTs (and other named types) appear in user-facing output, they were rendered as their inline desugared structure instead of the declared type name. For example, running kind2 on a two-phase-commit model produced:

- Property summary quantifiers:
  ```
  forall
    (msg:
       Message { Message_tag: enum { VoteReqMsg, VoteMsg, DecisionMsg };
                 VoteMsg_0: int;
                 VoteMsg_1: enum { Yes, No };
                 DecisionMsg_0: enum { Commit, Abort } })
    ...
  ```
- Analysis subsystem list: `IsSome<enum { Commit, Abort }>` instead of `IsSome<Decision>`.
- Under `--modular`, the "no property" note: `System IsSome.poly_1 has no property, ...` instead of `System IsSome<Decision> has no property, ...`.

## Changes

- **`lustreDesugarADTs`**: when reconstructing source-level syntax for property expressions (`rewrite_as_adt_terms`), also rewrite desugared *types* back to their named form. Record and enum types always carry their declared type name, so a quantifier over an ADT now prints as `Message`, and enum type args print by name. Applies to quantifier binders, call type args, and type ascriptions; recurses through arrays, tuples, maps, sets, and refinement types (covers ADT-desugared records, user records, and enums).
- **`lustreInstantiatePolyNodes`**: print enum type args by their declared name in monomorphized instance names, matching the existing record/ADT handling (`IsSome<Decision>` instead of `IsSome<enum { ... }>`).
- **`kind2Flow`**: the "system has no property" note now uses the node's user-facing name rather than the internal scope name, so polymorphic instances render as `IsSome<Decision>`, `IsSome<Message>`, etc. Non-Lustre inputs fall back to the internal name as before.
- Minor cleanup of `tests/regression/success/two_phase_commit.lus`.

## Testing

- `dune build @runtest` passes.
- Full regression suite (`tests/run`): 1218 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)