### PR TITLE
Fix lost activation clock for multi-assignment calls in when blocks

### DIFF
--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -23,7 +23,15 @@ module StringMap = HString.HStringMap
 
 module StringSet = HString.HStringSet
 
-type source = Local | Input | Output | Ghost
+type source =
+  | Local
+  | Input
+  | Output
+  | Ghost
+  | ClockedOutput of LustreAst.expr
+  (* Output of an equation pulled out of a when-block branch; the expression is
+     the (polarity-adjusted) conjunction of the enclosing when-block guards.
+     Node calls in such an equation must be activated on that clock. *)
 
 type t = {
   node_args : (HString.t (* abstracted variable name *)

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -23,7 +23,15 @@
 module StringMap = HString.HStringMap
 module StringSet = HString.HStringSet
 
-type source = Local | Input | Output | Ghost
+type source =
+  | Local
+  | Input
+  | Output
+  | Ghost
+  | ClockedOutput of LustreAst.expr
+  (** Output of an equation pulled out of a when-block branch; the expression is
+      the (polarity-adjusted) conjunction of the enclosing when-block guards.
+      Node calls in such an equation must be activated on that clock. *)
 
 type t = {
   node_args : (HString.t (* abstracted variable name *)

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -216,7 +216,8 @@ let pp_print_generated_identifiers ppf gids =
     | Local -> "local"
     | Input -> "input"
     | Output -> "output"
-    | Ghost -> "ghost")
+    | Ghost -> "ghost"
+    | ClockedOutput _ -> "clocked output")
   in
   let pp_print_refinement_type_constraint ppf (source, pos, id, rexpr, _) =
     Format.fprintf ppf "(%a, %a, %a, %a)"
@@ -1150,6 +1151,27 @@ let rec normalize adt_map ctx inlinable_funcs (decls:LustreAst.t) gids =
       | Some Ghost -> 
         let nexpr, gids, warnings = normalize_expr info (Some node_id) gids_map expr in
         gids, warnings, (info.quantified_variables, info.contract_scope, lhs, nexpr, None)
+      (* Equation pulled out of a when-block branch: normalize it under the
+         when-block guard so that node calls are activated on that clock, as
+         they would have been had the call remained inside the branch. *)
+      | Some (ClockedOutput guard) ->
+        let info =
+          { info with context = ctx; interpretation = StringMap.empty; contract_scope = [] }
+        in
+        let nguard, gids0, warnings0 =
+          normalize_expr info (Some node_id) gids_map guard
+        in
+        let info = { info with call_context = nguard :: info.call_context } in
+        let neq, gids, warnings =
+          normalize_equation info node_id gids_map (A.Equation (Lib.dummy_pos, lhs, expr))
+        in
+        let nexpr =
+          match neq with
+          | A.Equation (_, _, nexpr) -> nexpr
+          | _ -> assert false
+        in
+        union gids0 gids, warnings0 @ warnings,
+        (info.quantified_variables, info.contract_scope, lhs, nexpr, None)
       | Some _ -> 
         let info =
           { info with context = ctx; interpretation = StringMap.empty; contract_scope = [] }

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -3001,7 +3001,7 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
       let constraint_kind, generated_source = match source with
       | GI.Input -> Some N.Assumption, None
       | Local -> None, Some Property.Body
-      | Output -> Some N.Guarantee, None
+      | Output | ClockedOutput _ -> Some N.Guarantee, None
       | Ghost -> if is_extern then None, Some Property.Contract else Some N.Guarantee, None
     in
     let name = create_constraint_name_pos pos in

--- a/src/lustre/lustreRemoveMultAssign.ml
+++ b/src/lustre/lustreRemoveMultAssign.ml
@@ -43,12 +43,17 @@ let mk_fresh_temp_var ty =
   name, gids2
 
 
-(** Takes in an equation LHS and returns 
+(** Takes in an equation LHS and returns
     * updated gids with temp variables,
-    * equations setting original variable equal to temp variables, 
+    * equations setting original variable equal to temp variables,
     * updated context
+
+    [source] records where the pulled-out equation comes from: [GI.Output] for
+    equations in if/frame blocks, and [GI.ClockedOutput guard] for equations in
+    when-block branches, so that node calls in the equation are activated on
+    the when-block guard.
    *)
-let create_new_eqs ctx lhs expr = 
+let create_new_eqs ctx source lhs expr =
   let rhs_pos = AH.pos_of_expr expr in
   let convert_struct_item = (function
     | A.SingleIdent (p, i) as si -> 
@@ -102,8 +107,8 @@ let create_new_eqs ctx lhs expr =
       let arrayids_original = get_array_ids ss in
       let arrayids_new = get_array_ids sis in
       let expr = LAH.replace_idents arrayids_original arrayids_new expr in
-      let gids2 = { (GI.empty ()) with 
-        equations = [([], [], A.StructDef(pos, sis), expr, Some GI.Output)];
+      let gids2 = { (GI.empty ()) with
+        equations = [([], [], A.StructDef(pos, sis), expr, Some source)];
       } in
       let eqs = List.map (fun x -> A.Body x) eqs in
         (
@@ -112,32 +117,45 @@ let create_new_eqs ctx lhs expr =
           gids2::gids
         )
 
-let remove_mult_assign_from_ni ctx ni = 
-  let rec helper ctx ni = (
-    match ni with 
-      | A.Body (Equation (_, lhs, expr)) -> 
+let remove_mult_assign_from_ni ctx ni =
+  (* [wguard] is the (polarity-adjusted) conjunction of the enclosing
+     when-block guards, if any. Equations pulled out of a when-block branch
+     must remember it so that their node calls are activated on that clock. *)
+  let conj_guard wguard e = match wguard with
+    | None -> Some e
+    | Some g -> Some (A.BinaryOp (AH.pos_of_expr e, A.And, e, g))
+  in
+  let rec helper ctx wguard ni = (
+    match ni with
+      | A.Body (Equation (_, lhs, expr)) ->
         let lhs_vars = AH.defined_vars_with_pos ni in
         (* If there is no multiple assignment, we don't alter the node item,
           otherwise, we must remove the multiple assignment. *)
-        if (List.length lhs_vars = 1) 
+        if (List.length lhs_vars = 1)
         then [ni], []
-        else create_new_eqs ctx lhs expr
-      
-      | IfBlock (pos, e, l1, l2) -> 
-        let nis1, gids1 = List.map (helper ctx) l1 |> List.split in
-        let nis2, gids2 = List.map (helper ctx) l2 |> List.split in
+        else
+          let source = match wguard with
+            | None -> GI.Output
+            | Some g -> GI.ClockedOutput g
+          in
+          create_new_eqs ctx source lhs expr
+
+      | IfBlock (pos, e, l1, l2) ->
+        let nis1, gids1 = List.map (helper ctx wguard) l1 |> List.split in
+        let nis2, gids2 = List.map (helper ctx wguard) l2 |> List.split in
         (* nis1 and nis3 are the temp variables need to get pulled outside the if block *)
         [A.IfBlock (pos, e, List.flatten nis1, List.flatten nis2)], List.flatten gids1 @ List.flatten gids2
 
       | WhenBlock (pos, e, l1, l2) ->
-        let nis1, gids1 = List.map (helper ctx) l1 |> List.split in
-        let nis2, gids2 = List.map (helper ctx) l2 |> List.split in
+        let not_e = A.UnaryOp (AH.pos_of_expr e, A.Not, e) in
+        let nis1, gids1 = List.map (helper ctx (conj_guard wguard e)) l1 |> List.split in
+        let nis2, gids2 = List.map (helper ctx (conj_guard wguard not_e)) l2 |> List.split in
         [A.WhenBlock (pos, e, List.flatten nis1, List.flatten nis2)], List.flatten gids1 @ List.flatten gids2
 
-      | FrameBlock (pos, vars, nes, nis) -> 
-        let nes = List.map (fun x -> A.Body x) nes in 
-        let nis1, gids1 = List.map (helper ctx) nes |> List.split in
-        let nis2, gids2 = List.map (helper ctx) nis |> List.split in
+      | FrameBlock (pos, vars, nes, nis) ->
+        let nes = List.map (fun x -> A.Body x) nes in
+        let nis1, gids1 = List.map (helper ctx wguard) nes |> List.split in
+        let nis2, gids2 = List.map (helper ctx wguard) nis |> List.split in
         let nis1 = nis1 |> List.flatten |> List.map 
           (fun x -> match x with | A.Body (Equation _ as e) -> e | _ -> assert false) in
         (* nis1 and nis3 are the temp variables need to get pulled outside the if block *)
@@ -151,7 +169,7 @@ let remove_mult_assign_from_ni ctx ni =
       | A.AnnotMain _
       | A.Auto _ -> [ni], []
   ) in
-  let (nis, gids) = helper ctx ni in
+  let (nis, gids) = helper ctx None ni in
   let gids = List.fold_left GI.union (GI.empty ()) gids in
   (* Calling 'remove_mult_assign_from_ib' on an if or frame block (which is always
      the case) will mean that nis2 will always have length 1. *)

--- a/tests/regression/success/when_multi_assign_clock.lus
+++ b/tests/regression/success/when_multi_assign_clock.lus
@@ -1,0 +1,31 @@
+-- A node call assigned through a multiple assignment inside a when-block
+-- branch must be activated on the when-block guard, exactly like a call
+-- assigned through a single assignment: the called node instance only steps
+-- when the guard is true, and its state is frozen otherwise.
+--
+-- 'a' counts the activations of TwoCounters, so it must agree with 'ticks',
+-- which counts the steps where the guard is true.
+
+node TwoCounters() returns (a, b: int);
+let
+  a = 1 -> pre a + 1;
+  b = 2 * a;
+tel
+
+node Main(c: bool) returns (a, b: int);
+var ticks: int;
+let
+  ticks = (if c then 1 else 0) -> pre ticks + (if c then 1 else 0);
+
+  frame (a, b)
+    a = 0;
+    b = 0;
+  let
+    when c then
+      a, b = TwoCounters();
+    end
+  tel
+
+  check "P1" c => a = ticks;
+  check "P2" c => b = 2 * a;
+tel


### PR DESCRIPTION
## Problem

A node call assigned through a multiple assignment inside a when-block branch, e.g.

```
when c then
  x, y, z = N(...);
end
```

was compiled differently from a call assigned through a single assignment. `LustreRemoveMultAssign` pulls the equation out of the branch into a generated equation over fresh locals, and that equation was normalized with an empty call context: the call ran on the base clock every step, and the when-block merely sampled its outputs. A single-assignment call, in contrast, stays inside the branch and is correctly activated on the when-block guard (its state is frozen while the guard is false).

The two forms should have the same semantics, and the divergence is observable: a counter node assigned through a multiple assignment counted base-clock steps instead of activations of the guard.

## Changes

- `GeneratedIdentifiers`: new `ClockedOutput` equation source recording the (polarity-adjusted) conjunction of the enclosing when-block guards on equations pulled out of when-block branches.
- `LustreRemoveMultAssign`: threads the enclosing when-block guards (with negation for else branches, and conjunction for nested when blocks) and tags pulled-out equations with `ClockedOutput` instead of `Output`.
- `LustreAstNormalizer`: normalizes `ClockedOutput` equations with the guard pushed as the call context, so node calls in them receive the same activation condition they would have had inside the branch.

## Verification

- New regression test `tests/regression/success/when_multi_assign_clock.lus`: a two-output counter node assigned through a multiple assignment in a when-block branch must count guard activations. The property was falsifiable before this change and is valid now.
- `dune build @runtest` passes (215 tests).
- When/frame/activate-related regression subset passes (90 tests); the full regression suite (1218 tests) passes with this change combined with the follow-up branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)