### PR TITLE
Handle unconstrained ADT discriminant in clocked-call counterexamples

### DIFF
--- a/src/lustre/lustrePath.ml
+++ b/src/lustre/lustrePath.ml
@@ -1120,12 +1120,24 @@ let rec reconstruct_adt_at_step model bindings adt_map step root_index type_name
     (match List.nth_opt disc_vals step with
     | None -> assert false
     | Some (Model.Term t) when Type.is_enum disc_type ->
-      let ctor_name = Term.numeral_of_term t |> Type.get_constr_of_num in
-      let ctor_hs = HString.mk_hstring ctor_name in
-      let fields =
-        match G.HStringMap.find_opt ctor_hs adt_info.G.ctor_fields with
-        | None -> assert false | Some fs -> fs
+      (* The discriminant of a clocked node instance is unconstrained while its
+         clock is inactive, so its model value may be an arbitrary enum numeral
+         that does not name a constructor of this ADT (it may belong to another
+         enum, or to no enum at all). When that happens we cannot reconstruct a
+         meaningful value for this step, so display the unknown-value
+         placeholder "_" instead of failing. *)
+      let ctor_and_fields =
+        match Term.numeral_of_term t |> Type.get_constr_of_num with
+        | ctor_name ->
+          let ctor_hs = HString.mk_hstring ctor_name in
+          Option.map
+            (fun fields -> (ctor_name, fields))
+            (G.HStringMap.find_opt ctor_hs adt_info.G.ctor_fields)
+        | exception Not_found -> None
       in
+      (match ctor_and_fields with
+      | None -> "_"
+      | Some (ctor_name, fields) ->
       if fields = [] then ctor_name
       else
         let field_strs = List.mapi (fun j (_fname, field_kind) ->
@@ -1164,7 +1176,7 @@ let rec reconstruct_adt_at_step model bindings adt_map step root_index type_name
               ) bindings in
               reconstruct_compound_at_step model sub_bindings step)
         ) fields in
-        ctor_name ^ "(" ^ String.concat ", " field_strs ^ ")"
+        ctor_name ^ "(" ^ String.concat ", " field_strs ^ ")")
     | _ -> assert false)
 
 (* Reconstruct original ADT constructor values from hidden disc+payload fields.

--- a/tests/regression/falsifiable/adt_clocked_call_cex.lus
+++ b/tests/regression/falsifiable/adt_clocked_call_cex.lus
@@ -1,0 +1,30 @@
+-- Reconstructing a counterexample that includes a node instance called under a
+-- clock (a when-block) must not crash when the instance carries ADT-typed
+-- streams. While the clock is inactive the instance does not step, so its ADT
+-- discriminant state variables are unconstrained and may hold an arbitrary
+-- value that does not name a constructor of the ADT. Counterexample ADT
+-- reconstruction used to assume the discriminant was always a valid
+-- constructor and raised an assertion (or Not_found) failure otherwise. Here
+-- the property is falsified in a state where the clock is off, so 'Sub' is
+-- inactive at the counterexample step and its Option-typed streams must be
+-- reconstructed defensively.
+
+datatype Option = Some (int) | None;
+
+node Sub(o: Option) returns (out: Option);
+let
+  out = o;
+tel
+
+node main(b: bool; o: Option) returns (res: Option);
+let
+  frame (res)
+    res = None;
+  let
+    when b then
+      res = Sub(o);
+    end
+  tel
+
+  check "p" (match res with | Some(x): true | None: false end);
+tel


### PR DESCRIPTION
## Problem

Kind 2 aborts with a runtime error while printing a counterexample for a model that calls a node under a clock (a `when`-block) when that node carries ADT-typed streams:

```
<Error> Runtime error in invariant manager: File "src/lustre/lustrePath.ml", line 1127, characters 18-24: Assertion failed
```

(Depending on the model, the same root cause can instead surface as `Runtime error in invariant manager: Not_found`.)

This was found while investigating a report where the message was masked by an earlier type-checking error (see #1393); with that fixed, the model reaches counterexample reconstruction and crashes here.

## Root cause

A node instance called under a clock does not step while its clock is inactive, so its ADT discriminant state variables are unconstrained in the model. Their value can therefore be an arbitrary enum numeral that names a constructor of a *different* enum (→ `assert false` at the `ctor_fields` lookup) or of no enum at all (→ `Not_found` from `Type.get_constr_of_num`).

`reconstruct_adt_at_step` assumed the discriminant always named a constructor of the ADT being reconstructed, so it failed on these don't-care values instead of tolerating them.

## Fix

Resolve the constructor defensively in `reconstruct_adt_at_step`: if the discriminant value does not name a constructor of this ADT, display the unknown-value placeholder `"_"` for that step — consistent with how the surrounding code already renders other unknown values (e.g. inactive instances' non-ADT streams).

## Testing

- Added regression test `tests/regression/falsifiable/adt_clocked_call_cex.lus`, which deterministically triggers the runtime error on `develop` (exit 1) and produces the expected `falsifiable` result with the fix (exit 40). Verified under all three slicing modes.
- Full regression suite (409 tests) and OUnit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)