### PR TITLE
Fix internal Type_mismatch in equality over maps with collection values

### DIFF
--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1174,13 +1174,19 @@ and compile_ast_expr
           | E.Unbound _ -> 
             acc
         ) E.t_true (List.combine idx_vars bounds) in
-        (* For map value equality we only consider m1[k] = m2[k] for k in the maps. 
-           `acc_guard` collects the constraints that k is in the map (if the equality is over maps) *)
-        let acc_guard' = List.fold_left (fun acc e -> 
-          let e = List.fold_left (fun acc arr_i -> 
+        (* For map value equality we only consider m1[k] = m2[k] for k in the maps.
+           `acc_guard` collects the constraints that k is in the map (if the equality is over maps).
+           A guard array may have fewer index positions than the current leaf (e.g. the
+           domain array of a map whose values are sets, which adds an element index), so
+           select each guard with only the prefix of index variables matching its arity. *)
+        let acc_guard' = List.fold_left (fun acc e ->
+          let guard_arity =
+            List.length (Type.all_index_types_of_array (E.type_of_lustre_expr e))
+          in
+          let e = List.fold_left (fun acc arr_i ->
             E.mk_select_and_push acc arr_i
-          ) e arr_is in
-          E.mk_and acc e 
+          ) e (fst (list_split guard_arity arr_is)) in
+          E.mk_and acc e
         ) E.t_true acc_guard in
         (* For equality:    forall (x: K) conditions =>  arr1[x]  = arr2[x] 
            For disequality: exists (x: K) conditions and arr1[x] <> arr2[x]. 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1175,10 +1175,9 @@ and compile_ast_expr
             acc
         ) E.t_true (List.combine idx_vars bounds) in
         (* For map value equality we only consider m1[k] = m2[k] for k in the maps.
-           `acc_guard` collects the constraints that k is in the map (if the equality is over maps).
-           A guard array may have fewer index positions than the current leaf (e.g. the
-           domain array of a map whose values are sets, which adds an element index), so
-           select each guard with only the prefix of index variables matching its arity. *)
+          "acc_guard" collects the constraints that k is in the map (if the equality is over maps).
+          "guard_arity" (and its usage) ensures that we only use indices associated
+          with the map key type and not its value type (eg, consider map<int, set<int>>). *)
         let acc_guard' = List.fold_left (fun acc e ->
           let guard_arity =
             List.length (Type.all_index_types_of_array (E.type_of_lustre_expr e))

--- a/tests/regression/success/repro_map_of_sets_clocked.lus
+++ b/tests/regression/success/repro_map_of_sets_clocked.lus
@@ -1,0 +1,32 @@
+-- Minimal reproduction of a frontend bug (now fixed): a map-of-sets state
+-- variable assigned by a node call under a `when` clock inside a frame
+-- block made Kind 2 fail with an internal LustreExpr.Type_mismatch
+-- (reported as "Error opening input file").
+--
+-- Cause: the clocked call generates "held value consistent with clocked
+-- call" definitions containing structural equality over the map value.
+-- LustreNodeGen.compile_equality selected the map's domain guard array
+-- with the full index-variable list of the current value leaf; for
+-- map<int,set<int>> the value leaf has two index positions (key and set
+-- element) while the domain guard has one, so the second select hit a
+-- Bool and LustreExpr.type_of_select raised Type_mismatch. Fixed by
+-- selecting each guard with only the prefix of index variables matching
+-- its own arity (lustreNodeGen.ml, compile_equality). This file is kept
+-- as a regression test; it verifies on the fixed build.
+node Sub(st: map<int,set<int>>) returns (st_after: map<int,set<int>>);
+let
+  st_after = st;
+tel
+node Top(go: bool) returns (ok: bool);
+var st: map<int,set<int>>;
+let
+  frame (st)
+    st = map[]@<int,set<int>>;
+  let
+    when go then
+      st = Sub(last st);
+    end
+  tel
+  ok = true;
+  check "c" ok;
+tel

--- a/tests/regression/success/repro_map_of_sets_clocked.lus
+++ b/tests/regression/success/repro_map_of_sets_clocked.lus
@@ -1,18 +1,3 @@
--- Minimal reproduction of a frontend bug (now fixed): a map-of-sets state
--- variable assigned by a node call under a `when` clock inside a frame
--- block made Kind 2 fail with an internal LustreExpr.Type_mismatch
--- (reported as "Error opening input file").
---
--- Cause: the clocked call generates "held value consistent with clocked
--- call" definitions containing structural equality over the map value.
--- LustreNodeGen.compile_equality selected the map's domain guard array
--- with the full index-variable list of the current value leaf; for
--- map<int,set<int>> the value leaf has two index positions (key and set
--- element) while the domain guard has one, so the second select hit a
--- Bool and LustreExpr.type_of_select raised Type_mismatch. Fixed by
--- selecting each guard with only the prefix of index variables matching
--- its own arity (lustreNodeGen.ml, compile_equality). This file is kept
--- as a regression test; it verifies on the fixed build.
 node Sub(st: map<int,set<int>>) returns (st_after: map<int,set<int>>);
 let
   st_after = st;


### PR DESCRIPTION
## Problem

Structural equality over a value of type `map<K, set<E>>` makes Kind 2 exit with an internal error, misleadingly reported on the input-file channel:

```
<Error> Error opening input file '...': LustreExpr.Type_mismatch
```

A typical trigger is a map-of-sets state variable assigned by a node call under a `when` clock inside a frame block: the clocked-call machinery generates held-value consistency definitions containing exactly such an equality (see the added regression test for a 13-line reproduction).

## Cause

`LustreNodeGen.compile_equality` compiles equality over an indexed type leaf-by-leaf, and guards map-value leaves with the map's domain (presence) arrays collected in `acc_guard`. Each guard was selected with the **full** index-variable list of the current leaf. For `map<K, set<E>>` the value leaf has two index positions (key and set element) while the domain guard has one, so the second select is applied to a `Bool` term and `LustreExpr.type_of_select` raises `Type_mismatch`.

## Fix

Select each guard with only the prefix of index variables matching its own arity. Leaves whose guards have the same number of index positions (all previously working cases) compile exactly as before.

## Testing

- Added `tests/regression/success/repro_map_of_sets_clocked.lus`; it fails with the internal error on unpatched `develop` and verifies with the fix (both checked locally against this base).
- Exercised at scale on a set of distributed-protocol models (quorum-based leader election with `map<HostId, set<HostId>>` state, two-phase commit, sharded KV, Paxos): all verify with the fix, with results identical to equivalent formulations that avoid map-of-sets state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)