### PR TITLE
Fix dropped domain guards in equality over nested map values

### DIFF
--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1174,13 +1174,19 @@ and compile_ast_expr
           | E.Unbound _ -> 
             acc
         ) E.t_true (List.combine idx_vars bounds) in
-        (* For map value equality we only consider m1[k] = m2[k] for k in the maps. 
-           `acc_guard` collects the constraints that k is in the map (if the equality is over maps) *)
-        let acc_guard' = List.fold_left (fun acc e -> 
-          let e = List.fold_left (fun acc arr_i -> 
+        (* For map value equality we only consider m1[k] = m2[k] for k in the maps.
+           `acc_guard` collects the constraints that k is in the map (if the equality is over maps).
+           A guard array may have fewer index positions than the current leaf (e.g. the
+           domain array of a map whose values are sets, which adds an element index), so
+           select each guard with only the prefix of index variables matching its arity. *)
+        let acc_guard' = List.fold_left (fun acc e ->
+          let guard_arity =
+            List.length (Type.all_index_types_of_array (E.type_of_lustre_expr e))
+          in
+          let e = List.fold_left (fun acc arr_i ->
             E.mk_select_and_push acc arr_i
-          ) e arr_is in
-          E.mk_and acc e 
+          ) e (fst (list_split guard_arity arr_is)) in
+          E.mk_and acc e
         ) E.t_true acc_guard in
         (* For equality:    forall (x: K) conditions =>  arr1[x]  = arr2[x] 
            For disequality: exists (x: K) conditions and arr1[x] <> arr2[x]. 

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1175,10 +1175,9 @@ and compile_ast_expr
             acc
         ) E.t_true (List.combine idx_vars bounds) in
         (* For map value equality we only consider m1[k] = m2[k] for k in the maps.
-           `acc_guard` collects the constraints that k is in the map (if the equality is over maps).
-           A guard array may have fewer index positions than the current leaf (e.g. the
-           domain array of a map whose values are sets, which adds an element index), so
-           select each guard with only the prefix of index variables matching its arity. *)
+          "acc_guard" collects the constraints that k is in the map (if the equality is over maps).
+          "guard_arity" (and its usage) ensures that we only use indices associated
+          with the map key type and not its value type (eg, consider map<int, set<int>>). *)
         let acc_guard' = List.fold_left (fun acc e ->
           let guard_arity =
             List.length (Type.all_index_types_of_array (E.type_of_lustre_expr e))

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -45,6 +45,7 @@ module SVS = StateVar.StateVarSet
 module TM = Type.TypeMap
 
 module Ctx = TypeCheckerContext
+module Chk = LustreTypeChecker
 
 module StringMap = HString.HStringMap
 
@@ -1114,6 +1115,54 @@ and compile_ast_expr
     let (mk_binary, mk_seq, const_expr, mk_quant, mk_comb) = match polarity with
       | true -> (E.mk_eq, E.mk_and, E.t_true, E.mk_forall, E.mk_impl)
       | false -> (E.mk_neq, E.mk_or, E.t_false, E.mk_exists, E.mk_and) in
+    (* Map-value leaves must be compared only at keys present in the map. The
+       trie fold below can associate the domain (presence) array of an
+       outermost map with the leaves of its value, but maps nested deeper
+       (inside map values, tuples, records or ADT payloads) contribute domain
+       arrays that cannot be recognized from trie indices alone: a map's
+       domain/value pair is encoded with plain tuple indices, which are
+       ambiguous with actual tuples. Compute the association from the source
+       type of the operands instead: collect, for every map in the type, the
+       trie prefix of its value subtree together with the prefix of its domain
+       leaf. A leaf under a value prefix is then guarded by the corresponding
+       domain array (of the first operand). Falls back to the legacy
+       first-leaf guard if the type of neither operand can be inferred. *)
+    let guard_pairs_opt =
+      let rec collect ty prefix acc =
+        match Ctx.expand_type_syn ctx ty with
+        | A.Map (_, _, vty) ->
+          let acc = (prefix @ [X.TupleIndex 1], prefix @ [X.TupleIndex 0]) :: acc in
+          collect vty (prefix @ [X.TupleIndex 1]) acc
+        | A.TupleType (_, tys) ->
+          List.fold_left (fun (k, acc) t ->
+            succ k, collect t (prefix @ [X.TupleIndex k]) acc) (0, acc) tys
+          |> snd
+        | A.GroupType (_, tys) ->
+          List.fold_left (fun (k, acc) t ->
+            succ k, collect t (prefix @ [X.ListIndex k]) acc) (0, acc) tys
+          |> snd
+        | A.RecordType (_, _, fields) ->
+          List.fold_left (fun acc (_, i, t) ->
+            collect t (prefix @ [field_name_to_index cstate.adt_map i]) acc)
+            acc fields
+        | A.ArrayType (_, (t, _)) ->
+          (* array dimensions are appended after the trailing map dimensions,
+             so the structural prefix of the element type is unchanged *)
+          collect t prefix acc
+        | A.RefinementType (_, (_, _, t), _) -> collect t prefix acc
+        | _ -> acc
+      in
+      match Chk.infer_type_expr ctx None expr1 with
+      | Ok (ty, _, _) -> Some (collect ty [] [])
+      | Error _ ->
+        (match Chk.infer_type_expr ctx None expr2 with
+         | Ok (ty, _, _) -> Some (collect ty [] [])
+         | Error _ -> None)
+    in
+    let is_index_prefix p i =
+      List.length p <= List.length i
+      && X.compare_indexes p (fst (list_split (List.length p) i)) = 0
+    in
     let expr1 = compile_ast_expr cstate ctx bounds map expr1 in
     let expr2 = compile_ast_expr cstate ctx bounds map expr2 in
     let eqs = X.map2 (fun _ e1 e2 -> (e1, e2)) expr1 expr2 in
@@ -1175,10 +1224,25 @@ and compile_ast_expr
             acc
         ) E.t_true (List.combine idx_vars bounds) in
         (* For map value equality we only consider m1[k] = m2[k] for k in the maps.
-           `acc_guard` collects the constraints that k is in the map (if the equality is over maps).
-           A guard array may have fewer index positions than the current leaf (e.g. the
-           domain array of a map whose values are sets, which adds an element index), so
-           select each guard with only the prefix of index variables matching its arity. *)
+           The guards of this leaf are the domain arrays of all its enclosing maps,
+           located from the source type (see guard_pairs_opt above); without type
+           information, fall back to the domain array of the outermost map collected
+           by the fold in `acc_guard`. A guard array may have fewer index positions
+           than the current leaf (e.g. the domain array of a map whose values are
+           sets or maps, which add further index positions), so select each guard
+           with only the prefix of index variables matching its arity. *)
+        let leaf_guards = match guard_pairs_opt with
+          | Some pairs ->
+            List.filter_map (fun (value_prefix, domain_prefix) ->
+              if is_index_prefix value_prefix i then
+                match X.bindings (X.find_prefix domain_prefix eqs) with
+                | [(_, (g1, _))] -> Some g1
+                | _ -> None
+                | exception Not_found -> None
+              else None
+            ) pairs
+          | None -> acc_guard
+        in
         let acc_guard' = List.fold_left (fun acc e ->
           let guard_arity =
             List.length (Type.all_index_types_of_array (E.type_of_lustre_expr e))
@@ -1187,7 +1251,7 @@ and compile_ast_expr
             E.mk_select_and_push acc arr_i
           ) e (fst (list_split guard_arity arr_is)) in
           E.mk_and acc e
-        ) E.t_true acc_guard in
+        ) E.t_true leaf_guards in
         (* For equality:    forall (x: K) conditions =>  arr1[x]  = arr2[x] 
            For disequality: exists (x: K) conditions and arr1[x] <> arr2[x]. 
            For arrays, `conditions` are that the index is in range. 
@@ -2062,6 +2126,22 @@ and compile_node_io cstate ctx node_id params inputs outputs =
 
 and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_lemma opac cstate ctx node_id ext params locals items contract =
   let gids = NI.Map.find node_id gids_map in
+  (* Extend the typing context with the normalizer-generated locals of this
+     node so that source types of equality operands appearing in generated
+     equations can be inferred in compile_equality (used to locate the domain
+     guards of map-value comparisons) *)
+  let ctx =
+    let ctx =
+      GI.StringMap.fold (fun id ty acc -> Ctx.add_ty acc id ty)
+        gids.GI.locals ctx
+    in
+    let ctx =
+      List.fold_left (fun acc (id, _, ty, _) -> Ctx.add_ty acc id ty)
+        ctx gids.GI.node_args
+    in
+    List.fold_left (fun acc (id, ty) -> Ctx.add_ty acc id ty)
+      ctx gids.GI.free_constants
+  in
   (* Source decreases measure of this node, used as the right-hand side of the
      decrease constraint rendered for recursive calls. *)
   let node_decreases = get_decreases_expr contract in
@@ -3435,11 +3515,16 @@ and compile_declaration_phase2:
   match decl with
   | A.TypeDecl _ -> cstate
   | A.ConstDecl _ -> cstate
-  | A.FuncDecl (_, (i, ext, opac, params, _, _, locals, items, contract), { is_rec; is_lemma }) -> (
+  | A.FuncDecl (_, (i, ext, opac, params, inputs, outputs, locals, items, contract), { is_rec; is_lemma }) -> (
+    (* Extend the typing context with the node interface and locals so that
+       source types of equality operands can be inferred in compile_equality
+       (used to locate the domain guards of map-value comparisons) *)
+    let ctx = Chk.add_full_node_ctx ctx i params inputs outputs locals in
     let cstate = compile_node_decl scc_map gids rec_decreases_map true is_rec is_lemma opac cstate ctx i ext params locals items contract in
     { cstate with local_constants = StringMap.empty }
   )
-  | A.NodeDecl (_, (i, ext, opac, params, _, _, locals, items, contract)) ->
+  | A.NodeDecl (_, (i, ext, opac, params, inputs, outputs, locals, items, contract)) ->
+    let ctx = Chk.add_full_node_ctx ctx i params inputs outputs locals in
     let cstate = compile_node_decl scc_map gids rec_decreases_map false false false opac cstate ctx i ext params locals items contract in
     { cstate with local_constants = StringMap.empty }
   (* All contract node declarations are recorded and normalized in gids,

--- a/tests/regression/success/map_value_equality_nested_guards.lus
+++ b/tests/regression/success/map_value_equality_nested_guards.lus
@@ -1,0 +1,25 @@
+-- Regression test: equality over maps whose values contain further maps
+-- (directly or inside tuples) must compare value entries only at keys
+-- present in the enclosing maps. The domain guards of nested maps used to
+-- be dropped — only the outermost map's domain array guarded the
+-- comparison — so structurally equal nested maps could compare unequal
+-- due to junk at keys outside the inner domains. Also checks that an
+-- actual tuple in a map value is not mistaken for a map's internal
+-- domain/value pair encoding.
+type P = [bool, int];
+node Top(x: int) returns (ok: bool);
+var n1, n2, n3: map<int, map<int,int>>;
+var t1, t2, t3: map<int, P>;
+let
+  n1 = (map[]@<int,map<int,int>>)[x := (map[]@<int,int>)[0 := 1]];
+  n2 = (map[]@<int,map<int,int>>)[x := (map[]@<int,int>)[0 := 1]];
+  n3 = (map[]@<int,map<int,int>>)[x := (map[]@<int,int>)[0 := 2]];
+  t1 = (map[]@<int,P>)[x := '(true, 5)];
+  t2 = (map[]@<int,P>)[x := '(true, 5)];
+  t3 = (map[]@<int,P>)[x := '(false, 5)];
+  ok = true;
+  check "nested map equality" (n1 = n2);
+  check "nested map disequality" (not (n1 = n3));
+  check "tuple value equality" (t1 = t2);
+  check "tuple value disequality" (not (t1 = t3));
+tel

--- a/tests/regression/success/repro_map_of_sets_clocked.lus
+++ b/tests/regression/success/repro_map_of_sets_clocked.lus
@@ -1,0 +1,32 @@
+-- Minimal reproduction of a frontend bug (now fixed): a map-of-sets state
+-- variable assigned by a node call under a `when` clock inside a frame
+-- block made Kind 2 fail with an internal LustreExpr.Type_mismatch
+-- (reported as "Error opening input file").
+--
+-- Cause: the clocked call generates "held value consistent with clocked
+-- call" definitions containing structural equality over the map value.
+-- LustreNodeGen.compile_equality selected the map's domain guard array
+-- with the full index-variable list of the current value leaf; for
+-- map<int,set<int>> the value leaf has two index positions (key and set
+-- element) while the domain guard has one, so the second select hit a
+-- Bool and LustreExpr.type_of_select raised Type_mismatch. Fixed by
+-- selecting each guard with only the prefix of index variables matching
+-- its own arity (lustreNodeGen.ml, compile_equality). This file is kept
+-- as a regression test; it verifies on the fixed build.
+node Sub(st: map<int,set<int>>) returns (st_after: map<int,set<int>>);
+let
+  st_after = st;
+tel
+node Top(go: bool) returns (ok: bool);
+var st: map<int,set<int>>;
+let
+  frame (st)
+    st = map[]@<int,set<int>>;
+  let
+    when go then
+      st = Sub(last st);
+    end
+  tel
+  ok = true;
+  check "c" ok;
+tel

--- a/tests/regression/success/repro_map_of_sets_clocked.lus
+++ b/tests/regression/success/repro_map_of_sets_clocked.lus
@@ -1,18 +1,3 @@
--- Minimal reproduction of a frontend bug (now fixed): a map-of-sets state
--- variable assigned by a node call under a `when` clock inside a frame
--- block made Kind 2 fail with an internal LustreExpr.Type_mismatch
--- (reported as "Error opening input file").
---
--- Cause: the clocked call generates "held value consistent with clocked
--- call" definitions containing structural equality over the map value.
--- LustreNodeGen.compile_equality selected the map's domain guard array
--- with the full index-variable list of the current value leaf; for
--- map<int,set<int>> the value leaf has two index positions (key and set
--- element) while the domain guard has one, so the second select hit a
--- Bool and LustreExpr.type_of_select raised Type_mismatch. Fixed by
--- selecting each guard with only the prefix of index variables matching
--- its own arity (lustreNodeGen.ml, compile_equality). This file is kept
--- as a regression test; it verifies on the fixed build.
 node Sub(st: map<int,set<int>>) returns (st_after: map<int,set<int>>);
 let
   st_after = st;


### PR DESCRIPTION
Stacked on #1395 (it relies on the guard-arity handling introduced there); this branch is based on `fix-map-value-equality-guard-arity` and GitHub should retarget it to `main` automatically when #1395 merges.

## Problem

Structural equality over maps whose values contain further maps evaluates incorrectly: two structurally equal values of type `map<int, map<int,int>>` compare as **unequal** (falsifiable at k=0). The same applies to maps nested deeper inside tuples, records or ADT payloads in a map's value type.

## Cause

`LustreNodeGen.compile_equality` guards each map-value leaf so that entries are compared only at keys present in the map. The guards are collected by the trie fold, which can recognize only the **first** leaf as a domain (presence) array — a map's domain/value pair is encoded with plain tuple indices, which are ambiguous with actual tuples, so deeper domain arrays cannot be identified from trie indices alone. Inner value leaves were therefore compared at keys outside the inner domains, where the SMT arrays contain unconstrained junk.

## Fix

Compute the guard association from the **source type** of the equality operands: for every map in the (alias-expanded) type, collect the trie prefix of its value subtree together with the prefix of its domain leaf; a leaf under a value prefix is guarded by the domain arrays of all its enclosing maps. Actual tuples are distinguished from the map pair encoding by the type itself, so e.g. a `bool` field of a real tuple inside a map value is never mistaken for a domain guard. To make operand types inferable also in normalizer-generated equations (e.g. the held-value consistency definitions of clocked calls), the typing context is extended with the node interface, locals, and generated locals. If the type of neither operand can be inferred, the previous first-leaf guard is kept as a fallback.

## Testing

- Added `tests/regression/success/map_value_equality_nested_guards.lus` covering nested-map equality and disequality plus the real-tuple-in-map-value disambiguation; it fails on this base without the fix (`nested map equality` falsifiable at k=0) and passes with it. ADT payloads containing maps are also fixed but not expressible with the current `main` grammar; equivalent probes pass on a branch with the extended ADT payload syntax.
- The regression suite cases from #1395 still pass, and a set of distributed-protocol models exercising map/set-heavy state (two-phase commit, quorum leader election, sharded KV, Paxos) verify with results unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)