### PR TITLE
Fix proof certificate generation for systems with maps and sets

### DIFF
--- a/src/certif/certifChecker.ml
+++ b/src/certif/certifChecker.ml
@@ -242,6 +242,12 @@ let rec split_cmp acc cmp = function
 
 (* Preprocessing of terms for proof producing version of cvc5 *)
 let preproc term =
+  (* Encode select operators over unbounded arrays (Lustre maps and sets) as
+     applications of their uninterpreted select functions when the builtin
+     theory of arrays is disabled, as done for terms sent to solvers (the
+     select symbol is not printable in that mode). No-op when --smt_arrays
+     is on or the term contains no select. *)
+  let term = Term.convert_select term in
   Term.map (fun _ t -> match Term.node_of_term t with
       | Term.T.Node (cmp, (_::_::_::_ as l)) ->
         begin match Symbol.node_of_symbol cmp with
@@ -1266,8 +1272,11 @@ let add_logic ?(compliant=false) fmt sys =
 
   
 let add_arrays fmt =
-  (* Add farray declaration *)
-  fprintf fmt "(declare-sort FArray 2)@.";
+  (* Add farray declaration (only meaningful when the builtin theory of
+     arrays is disabled; with --smt_arrays the certificate uses the native
+     Array sort) *)
+  if not (Flags.Arrays.smt ()) then
+    fprintf fmt "(declare-sort FArray 2)@.";
   (* Add select functions *)
   declare_selects fmt
 
@@ -1321,6 +1330,21 @@ let export_system_defs
       add_section fmt "Constant constraints";
       List.iter (fun c -> assert_expr fmt c) constraints
     )
+  ) ;
+
+  (* Declaring uninterpreted function symbols (e.g. those introduced for
+     imported functions), as done for solvers by
+     TransSys.declare_sorts_ufs_const *)
+  let ufs =
+    TS.fold_subsystems ~include_top:true (fun acc t ->
+      List.fold_left (fun acc uf -> UfSymbol.UfSymbolSet.add uf acc)
+        acc (TS.get_ufs t)
+    ) UfSymbol.UfSymbolSet.empty sys
+    |> UfSymbol.UfSymbolSet.elements
+  in
+  if ufs <> [] then (
+    add_section fmt "Uninterpreted function symbols";
+    List.iter (declare_const fmt) ufs
   ) ;
 
   (* Declaring function symbols *)

--- a/src/certif/proof.ml
+++ b/src/certif/proof.ml
@@ -32,6 +32,10 @@ let cvc5_proof_args () =
     [
       "--lang=smt2";
       "--simplification=none";
+      (* Resort to full effort quantifier instantiation techniques instead of
+         answering unknown; without it, certificates with quantified
+         constraints (e.g. from Lustre maps and sets) are not provable *)
+      "--full-saturate-quant";
       "--dump-proofs";
       "--proof-format-mode=cpc";
     ]

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -1000,6 +1000,9 @@ let declare_init_flag_of_bounds { init_flag_state_var } declare lbound ubound =
   |> Var.declare_vars declare 
 
 
+(* Return other function symbols *)
+let get_ufs { ufs } = ufs
+
 (* Declare other functions symbols *)
 let declare_ufs { ufs } declared declare =
   List.fold_left 

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -520,6 +520,12 @@ val assert_global_constraints : t -> (Term.t -> unit) -> unit
 *)
 val uf_defs : t -> pred_def list
 
+(** Return the uninterpreted function symbols declared in this system (e.g.
+    the symbols introduced for imported functions), excluding the
+    uninterpreted symbols of state variables and the init and trans
+    predicates. *)
+val get_ufs : t -> UfSymbol.t list
+
 (** {1 Properties} *)
 
 val property_of_name : t -> string -> Property.t


### PR DESCRIPTION
Independent of #1395/#1396 (different subsystem; applies directly to `develop`).

## Problem

`--proof true` (and `--certif true`) fail on Lustre models that use maps or sets. Three independent issues stack:

1. **Internal assertion failure** during the certification post-analysis:
   ```
   <Error> Caught File "src/smt/genericSMTLIBDriver.ml", line 856 ... Assertion failed in post-analysis treatment.
   ```
   The certificate writer prints terms to the certificate files directly, without the `Term.convert_select` encoding that the live-solver path applies (`SMTSolver`, `TransSys`). Raw `select` symbols over unbounded arrays (the encoding of maps and sets) are not printable when the builtin theory of arrays is disabled, so the generic SMT-LIB printer asserts.

2. **Unparsable certificates for models with imported functions**: the uninterpreted symbols introduced for imported functions (`...__function_of_inputs`) were never declared in the certificate files. cvc5 rejects them with `Symbol '...' not declared as a variable`.

3. **Unprovable induction certificates**: cvc5 is invoked for proof production with `--simplification=none` and no quantifier instantiation options, and answers `unknown` on induction certificates containing quantified map/set constraints, which surfaces as `Failure: Expected 'unsat' at beginning of CPC proof`.

## Fix

- Apply `Term.convert_select` in the certificate term preprocessing (`certifChecker.preproc`), the shared funnel for both `assert` and `define-fun` printing. No-op with `--smt_arrays true` or for select-free terms.
- Declare the system's and subsystems' uninterpreted function symbols in the certificate, mirroring `TransSys.declare_sorts_ufs_const`; adds a `TransSys.get_ufs` accessor.
- Pass `--full-saturate-quant` to the cvc5 proof-production command, as the regular cvc5 driver does.
- Declare the `FArray` sort in certificates only when the builtin theory of arrays is disabled (with `--smt_arrays`, certificates use the native `Array` sort).

## Testing

Verified against this base in both directions with a model combining a constrained map constant, a map-typed state variable, and an imported function with a contract: unpatched `develop` crashes with the assertion failure above; with the fix, Kind 2 generates all split proofs (`base.cpc`, `induction.cpc`, `implication.cpc`) and the combined `kind_2_proof.cpc`, in both array modes. On a branch with extended syntax, proof generation was further exercised on a suite of distributed-protocol models (two-phase commit with imported contract functions, client-server, distributed lock, ring leader election, quorum leader election), all generating complete proofs. There is currently no proof-generation test infrastructure under `tests/`, so no automated test is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)