### PR TITLE
Fix FArray sort declaration in generated CPC proofs

### DIFF
--- a/src/certif/proof.ml
+++ b/src/certif/proof.ml
@@ -87,6 +87,7 @@ let cpc_proof_from_chan prefix in_ch =
 
 let s_define = HString.mk_hstring "define"
 let s_declare_const = HString.mk_hstring "declare-const"
+let s_declare_sort = HString.mk_hstring "declare-sort"
 let s_assume = HString.mk_hstring "assume"
 let s_assume_push = HString.mk_hstring "assume-push"
 let s_step = HString.mk_hstring "step"
@@ -98,8 +99,9 @@ let is_global_name (s : HString.t) : bool =
 let is_global_def = function
   | HS.List (HS.Atom kw :: HS.Atom name :: _) ->
       (HString.equal kw (s_define)
-      && is_global_name name) 
+      && is_global_name name)
       || HString.equal kw (s_declare_const)
+      || HString.equal kw (s_declare_sort)
   | _ -> false
 
 
@@ -108,6 +110,21 @@ let is_local_def = function
       HString.equal kw (HString.mk_hstring "define")
       && not (is_global_name name)
   | _ -> false
+
+(* Ethos only accepts SMT-LIB's declare-sort in reference files. In proof
+   files, a sort constructor of arity n must be declared as a constant of
+   type (-> Type ... Type) with n arguments *)
+let translate_sort_decl = function
+  | HS.List [HS.Atom kw; HS.Atom name; HS.Atom arity]
+    when HString.equal kw s_declare_sort ->
+      let n = int_of_string (HString.string_of_hstring arity) in
+      let ty = HS.Atom (HString.mk_hstring "Type") in
+      let ty_expr =
+        if n = 0 then ty
+        else HS.List (HS.Atom (HString.mk_hstring "->") :: List.init (n + 1) (fun _ -> ty))
+      in
+      HS.List [HS.Atom s_declare_const; HS.Atom name; ty_expr]
+  | sexpr -> sexpr
 
 let normalize_step = function
   | HS.List (HS.Atom kw :: tl)
@@ -119,7 +136,7 @@ let normalize_step = function
 let get_proof_defs (proof : cpc_step list) =
   let rec aux (acc_global_defs, acc_steps) = function
     | sexpr :: tl when is_global_def sexpr ->
-        aux (sexpr :: acc_global_defs, acc_steps) tl
+        aux (translate_sort_decl sexpr :: acc_global_defs, acc_steps) tl
     | sexpr :: tl when is_local_def sexpr ->
         aux (acc_global_defs, sexpr :: acc_steps) tl
      | sexpr :: tl ->


### PR DESCRIPTION
## Problem

For systems using Lustre maps or sets (encoded with the abstract `FArray` sort), the generated `kind_2_proof.cpc` was rejected by the Ethos checker:

```
Error: kind_2_proof.cpc:1.31: Could not find symbol FArray
```

Two issues in the proof assembly (`src/certif/proof.ml`):

1. `is_global_def` recognized `define` and `declare-const` commands (which are hoisted to the top of the assembled proof) but not `declare-sort`. As a result, `(declare-sort FArray 2)` was treated as a proof step: it appeared *after* the `declare-const` commands referencing `FArray`, and was duplicated once per sub-proof (base, induction, implication).

2. Even when placed first, Ethos only accepts `declare-sort` in reference (smt2) files, not in Eunoia proof files. The Eunoia way to declare a sort constructor is as a constant of type `Type`, as done in the CPC signatures (e.g. `(declare-const Array (-> Type Type Type))` in `Arrays.eo`).

## Fix

- Treat `declare-sort` as a global definition so it is hoisted ahead of its uses (this also deduplicates it, since only the base sub-proof's definitions are kept).
- Translate `(declare-sort S n)` to the Eunoia form `(declare-const S (-> Type ... Type))` with `n` argument types (or plain `Type` for arity 0) while collecting the definitions.

## Testing

For the following `map_subtraction.lus`:

```lustre
node N(m1: map<int,int>; s: set<int>) returns (m2: map<int,int>)
let
  m2 = m1 - s;
  check "P1" forall (k:int) (k in m2) = (k in m1 and not (k in s));
  check "P2" forall (k:int) (k in m2) => (m2[k] = m1[k]);
tel
```

`kind2 --proof true map_subtraction.lus` followed by `ethos_check.sh` on the generated `kind_2_proof.cpc` now reports `correct` (previously aborted with the error above). Also verified that proofs for a system without maps/sets still check as `correct`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)