### PR TITLE
Display named refinement types by name in property expressions

### DIFF
--- a/src/lustre/lustreDesugarADTs.ml
+++ b/src/lustre/lustreDesugarADTs.ml
@@ -531,12 +531,30 @@ let desugar_adts ctx type_and_const_decls node_contract_decls =
     ) ctx' type_and_const_decls' in
     (type_and_const_decls', node_contract_decls', ctx', adt_map)
 
+(* Canonical string key for a refinement type, used to recognize a refinement
+   type as an instance of a named refinement synonym for display.  The bound
+   variable is renamed to a fixed placeholder so that alpha-equivalent
+   refinements share a key; positions are ignored by the pretty-printer.
+   Returns None for non-refinement types. *)
+let ref_type_canonical_key ty =
+  match ty with
+  | LA.RefinementType (_, (_, id, base), pred) ->
+    let placeholder = LA.Ident (Lib.dummy_pos, HString.mk_hstring "$refvar") in
+    let pred = LH.substitute_naive id placeholder pred in
+    Some (Format.asprintf "%a | %a"
+            LA.pp_print_lustre_type base LA.pp_print_expr pred)
+  | _ -> None
+
 (* Rewrite a desugared expression back toward source-level ADT syntax.
    RecordExprs whose type name is in adt_map are reconstructed as ADTTerm nodes
    so that pp_print_expr renders them as "Ctor(arg1, arg2)" or just "Ctor".
-   This is the partial inverse of desugar_expr for the ADTTerm case. *)
-let rec rewrite_as_adt_terms adt_map expr =
-  let r e = rewrite_as_adt_terms adt_map e in
+   This is the partial inverse of desugar_expr for the ADTTerm case.
+   [ref_type_names] maps the canonical key (see [ref_type_canonical_key]) of a
+   named refinement synonym's flattened definition to its type name, so that a
+   refinement type printed in a quantifier renders as the synonym name (e.g.
+   "HostId") rather than its expansion. *)
+let rec rewrite_as_adt_terms ref_type_names adt_map expr =
+  let r e = rewrite_as_adt_terms ref_type_names adt_map e in
   let rlist = List.map r in
   let rilist = List.map (fun (i, e) -> (i, r e)) in
   let rloi = function
@@ -564,7 +582,11 @@ let rec rewrite_as_adt_terms adt_map expr =
     | LA.Map (pos, kt, vt) -> LA.Map (pos, rewrite_type kt, rewrite_type vt)
     | LA.Set (pos, t) -> LA.Set (pos, rewrite_type t)
     | LA.RefinementType (pos, (p2, id, t), e) ->
-      LA.RefinementType (pos, (p2, id, rewrite_type t), r e)
+      (* Collapse to the named refinement synonym when the type matches one. *)
+      (match ref_type_canonical_key ty with
+       | Some key when List.mem_assoc key ref_type_names ->
+         LA.UserType (pos, [], List.assoc key ref_type_names)
+       | _ -> LA.RefinementType (pos, (p2, id, rewrite_type t), r e))
     | LA.Bool _ | LA.Int _ | LA.Real _ | LA.SBitVector _ | LA.UBitVector _
     | LA.AbstractType _ | LA.History _ | LA.ADT _ -> ty
   in
@@ -619,5 +641,5 @@ let rec rewrite_as_adt_terms adt_map expr =
   | LA.AnyOp _ | LA.ChooseOp _ -> expr
   | LA.ADTTerm _ | LA.Match _ -> expr
 
-let string_of_expr_as_source adt_map expr =
-  LA.string_of_expr (rewrite_as_adt_terms adt_map expr)
+let string_of_expr_as_source ?(ref_type_names = []) adt_map expr =
+  LA.string_of_expr (rewrite_as_adt_terms ref_type_names adt_map expr)

--- a/src/lustre/lustreDesugarADTs.ml
+++ b/src/lustre/lustreDesugarADTs.ml
@@ -648,11 +648,22 @@ let rewrite_as_adt_terms ref_type_names adt_map expr =
     | LA.Map (pos, kt, vt) -> LA.Map (pos, rewrite_type kt, rewrite_type vt)
     | LA.Set (pos, t) -> LA.Set (pos, rewrite_type t)
     | LA.RefinementType (pos, (p2, id, t), e) ->
-      (* Collapse to the named refinement synonym when the type matches one. *)
+      (* Collapse to the named refinement synonym when the type matches one
+          unambiguously. Distinct synonyms can share a canonical key (e.g. two
+          separately-declared "subtype { i: int | i > 0 }" aliases): in that
+          case we cannot tell which name the quantifier's type came from, so we
+          fall back to the expansion rather than guess and risk showing the
+          wrong name. *)
       (match ref_type_canonical_key ty with
-       | Some key when List.mem_assoc key ref_type_names ->
-         LA.UserType (pos, [], List.assoc key ref_type_names)
-       | _ -> LA.RefinementType (pos, (p2, id, rewrite_type t), r e))
+        | Some key ->
+          (match List.filter (fun (k, _) -> String.equal k key) ref_type_names
+                |> List.map snd
+                |> List.sort_uniq HString.compare
+          with
+          | [name] -> LA.UserType (pos, [], name)
+          | [] | _ :: _ :: _ ->
+            LA.RefinementType (pos, (p2, id, rewrite_type t), r e))
+        | None -> LA.RefinementType (pos, (p2, id, rewrite_type t), r e))
     | LA.Bool _ | LA.Int _ | LA.Real _ | LA.SBitVector _ | LA.UBitVector _
     | LA.AbstractType _ | LA.History _ | LA.ADT _ -> ty
   in

--- a/src/lustre/lustreDesugarADTs.mli
+++ b/src/lustre/lustreDesugarADTs.mli
@@ -52,4 +52,12 @@ val desugar_adts :
   LustreAst.declaration list ->
   LustreAst.declaration list * LustreAst.declaration list * TypeCheckerContext.tc_context * adt_map
 
-val string_of_expr_as_source : adt_map -> LustreAst.expr -> string
+(* Canonical string key of a refinement type, or None if it is not one.  Used to
+   build the [ref_type_names] map passed to [string_of_expr_as_source]: the key of
+   a named refinement synonym's flattened definition maps to the synonym name. *)
+val ref_type_canonical_key : LustreAst.lustre_type -> string option
+
+(* [ref_type_names] maps refinement-type canonical keys to synonym names so that a
+   quantified refinement type prints as the synonym name rather than its expansion. *)
+val string_of_expr_as_source :
+  ?ref_type_names:(string * HString.t) list -> adt_map -> LustreAst.expr -> string

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -79,6 +79,9 @@ type compiler_state = {
     StateVar.StateVarHashtbl.t;
   global_constraints: LustreExpr.t list;
   adt_map : LDAT.adt_map;
+  (* Maps the canonical key of a named refinement synonym's flattened definition
+     to its type name, so refinement types can be displayed by name. *)
+  ref_type_names : (string * HString.t) list;
 }
 
 (*
@@ -144,6 +147,7 @@ let empty_compiler_state () = {
   state_var_bounds = SVT.create 7;
   global_constraints = [];
   adt_map = StringMap.empty;
+  ref_type_names = [];
 }
 
 (*
@@ -672,7 +676,7 @@ let expand_tuple pos lhs rhs =
   expand_tuple' pos [] []
     (X.bindings lhs) (X.bindings rhs)
 
-let compile_contract_item gids map count scope kind pos name expr =
+let compile_contract_item cstate gids map count scope kind pos name expr =
     let scope = List.map (fun (i, s) -> i, HString.string_of_hstring s) scope in
     let ident = extract_normalized expr in
     let state_var = H.find !map.state_var ident in
@@ -682,8 +686,11 @@ let compile_contract_item gids map count scope kind pos name expr =
     in
     let sexpr =
       let key = HString.mk_hstring (LustreAst.string_of_expr expr) in
-      try LustreAst.string_of_expr (GI.StringMap.find key gids.GI.expr_source_map)
-      with Not_found -> LustreAst.string_of_expr expr
+      let source =
+        try GI.StringMap.find key gids.GI.expr_source_map with Not_found -> expr
+      in
+      LDAT.string_of_expr_as_source
+        ~ref_type_names:cstate.ref_type_names cstate.adt_map source
     in
     let contract_sv = C.mk_svar pos count name state_var scope sexpr in
     N.add_state_var_def state_var (N.ContractItem (pos, contract_sv, kind));
@@ -1862,12 +1869,12 @@ and compile_contract_variables cstate gids ctx map contract_scope node_scope con
     let over_modes (pos, id, reqs, enss) =
       let id' = HString.string_of_hstring id in
       let reqs = List.mapi
-        (fun i (p, n, e) -> 
-          compile_contract_item gids map (i + 1) contract_scope N.Require p n e)
+        (fun i (p, n, e) ->
+          compile_contract_item cstate gids map (i + 1) contract_scope N.Require p n e)
         reqs in
       let enss = List.mapi
-        (fun i (p, n, e) -> 
-          compile_contract_item gids map (i + 1) contract_scope N.Ensure p n e)
+        (fun i (p, n, e) ->
+          compile_contract_item cstate gids map (i + 1) contract_scope N.Ensure p n e)
         enss in
       let contract_scope =
         List.map (fun (_, i) -> HString.string_of_hstring i) contract_scope
@@ -1949,7 +1956,7 @@ and compile_contract cstate gids ctx map contract_scope node_scope contract =
       let i = !map.assume_count in
       map := {!map with assume_count = i + 1 };
       let kind = if soft then N.WeakAssumption else N.Assumption in
-      compile_contract_item gids map (i + 1) contract_scope kind pos name expr
+      compile_contract_item cstate gids map (i + 1) contract_scope kind pos name expr
     in List.map over_assumes assumes
   in
   let guarantees = 
@@ -1957,7 +1964,7 @@ and compile_contract cstate gids ctx map contract_scope node_scope contract =
       let i = !map.guarantee_count in
       map := {!map with guarantee_count = i + 1 };
       let kind = if soft then N.WeakGuarantee else N.Guarantee in
-      compile_contract_item gids map (i + 1) contract_scope kind pos name expr
+      compile_contract_item cstate gids map (i + 1) contract_scope kind pos name expr
     in List.map over_guarantees guarantees
       |> List.map (fun g -> g, false)
   in assumes @ assumes2,
@@ -2539,7 +2546,8 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
       let src_expr_str =
         let key = HString.mk_hstring (LustreAst.string_of_expr expr) in
         let desugared = try GI.StringMap.find key gids.GI.expr_source_map with Not_found -> expr in
-        LDAT.string_of_expr_as_source cstate.adt_map desugared
+        LDAT.string_of_expr_as_source
+          ~ref_type_names:cstate.ref_type_names cstate.adt_map desugared
       in
       let name, src =
         match name_opt with
@@ -3081,7 +3089,10 @@ and compile_node_decl scc_map gids_map rec_decreases_map is_function is_rec is_l
           (a, ac, (contract_sv, false) :: g, gc + 1, p)
         | None, Some gen_src ->
           let src = Property.Generated (Some pos, [sv], gen_src) in
-          let rexpr_str = LDAT.string_of_expr_as_source cstate.adt_map rexpr in
+          let rexpr_str =
+            LDAT.string_of_expr_as_source
+              ~ref_type_names:cstate.ref_type_names cstate.adt_map rexpr
+          in
           (a, ac, g, gc, (sv, name, src, Property.Invariant, rexpr_str) :: p)
         | _ -> assert false
     in
@@ -3295,8 +3306,15 @@ and compile_type_decl pos ctx cstate = function
     let empty_map = ref (empty_identifier_maps None) in
     let t = compile_ast_type cstate ctx empty_map ltype in
     let type_alias = StringMap.add ident t cstate.type_alias in
+    (* Record named refinement synonyms so refinement types can be displayed by
+       name. The declaration's type is already flattened at this point, matching
+       the form quantifier annotations take in property expressions. *)
+    let ref_type_names = match LDAT.ref_type_canonical_key ltype with
+      | Some key -> (key, ident) :: cstate.ref_type_names
+      | None -> cstate.ref_type_names
+    in
     { cstate with
-      type_alias }
+      type_alias; ref_type_names }
   | A.FreeType (_, ident) ->
     let empty_map = ref (empty_identifier_maps None) in
     let t = compile_ast_type cstate ctx empty_map (A.AbstractType (pos, ident)) in

--- a/tests/regression/success/quantifier_named_refinement.lus
+++ b/tests/regression/success/quantifier_named_refinement.lus
@@ -1,0 +1,23 @@
+-- Property/contract expressions that quantify over a named refinement type
+-- should print the type by name (e.g. "HostId") rather than its expanded form.
+
+const N: subrange [1,*] of int;
+type Nat = subtype { i : int | 0 <= i };
+type HostId = subtype { i : Nat | i < N };
+
+-- Contract guarantee quantifying over a named refinement type (guarantee path).
+node checker(a: bool) returns (ok: bool);
+(*@contract
+  guarantee "g" (forall (h: HostId) (0 <= h));
+*)
+let
+  ok = a;
+tel
+
+node main(a: bool) returns (ok: bool);
+let
+  ok = checker(a);
+  -- User properties quantifying over named refinement types (property path).
+  check "hostid" forall (h: HostId) (0 <= h);
+  check "nat"    forall (n: Nat) (0 <= n);
+tel


### PR DESCRIPTION
## Problem

A quantifier over a **named refinement type** was displayed using the expanded, flattened refinement instead of the type name. For example, with `type HostId = subtype { i : Nat | i < N };`, a property `forall (h: HostId) ...` printed as:

```
forall (h: subtype { i: int | ((0 <= i) and (i < N)) }) (0 <= h)
```

instead of:

```
forall (h: HostId) (0 <= h)
```

This is **not ADT-specific** — it affects any quantifier whose bound-variable annotation is a named refinement synonym.

## Why the name is lost

The synonym name disappears very early: the type checker's `check_type_well_formed` expands type synonyms in type annotations for well-formedness, and the flattened refinement is **semantically required** downstream (it carries the quantifier's guard — dropping the flattening makes valid properties invalid). So the name cannot be preserved through the pipeline; it can only be restored at the display layer.

## Change

Recognize a refinement type as an instance of a named refinement synonym and render it by name:

- `ref_type_canonical_key` computes a canonical string for a refinement type (bound variable normalized to a fixed placeholder, positions ignored by the pretty-printer).
- `compile_type_decl` records each named refinement synonym's already-flattened definition → its name in a new `cstate.ref_type_names`. The flattened *type declaration* matches the flattened form quantifier annotations take, and normalization leaves `TypeDecl`s untouched, so the forms line up.
- `string_of_expr_as_source` collapses a refinement type back to its synonym name when the canonical keys match; anonymous refinements (no matching synonym) are left expanded.

This is applied to all display paths — user properties, generated `SubType` constraints, and contract assumptions/guarantees. `compile_contract_item` now also routes through `string_of_expr_as_source`, which additionally gives contracts consistent ADT rendering.

These are display-only changes (`prop_expr` / contract `src_expr`); the verification terms are untouched.

## Result

```
forall (h: HostId) (0 <= h)
```

Contract guarantees/assumptions collapse too, e.g.:

```
forall (hostid: HostId) (Preference[hostid] = Yes) => ...
```

## Testing

New regression test `tests/regression/success/quantifier_named_refinement.lus` exercises both the property and contract paths. The full regression suite passes (421 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)