### PR TITLE
Add option to limit printed container elements

### DIFF
--- a/src/flags.ml
+++ b/src/flags.ml
@@ -3107,8 +3107,21 @@ module Global = struct
     )
 
   let real_precision () = !real_precision
+  let default_arr_elements_printed = 5
+  let arr_elements_printed = ref default_arr_elements_printed
+  
+  (* Array printing *)
+  let _ = add_spec
+    "--max_array_elements_printed"
+    (Arg.Int (fun n -> arr_elements_printed := n))
+    (fun fmt ->
+      Format.fprintf fmt
+        "Specifices number of elements to print when printing array-like types in pretty-print output.@ \
+        Default: %d"
+        default_arr_elements_printed
+    )
 
-
+  let arr_elements_printed () = !arr_elements_printed
   (* Log invariants. *)
   let log_invs_default = false
   let log_invs = ref log_invs_default
@@ -3731,6 +3744,7 @@ type slice_nodes = Global.slice_nodes
 
 let output_dir = Global.output_dir
 let include_dirs = Global.include_dirs
+let arr_elements_printed = Global.arr_elements_printed
 let log_invs = Global.log_invs
 let print_invs = Global.print_invs
 let print_cex = Global.print_cex

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -3116,7 +3116,7 @@ module Global = struct
     (Arg.Int (fun n -> arr_elements_printed := n))
     (fun fmt ->
       Format.fprintf fmt
-        "Specifices number of elements to print when printing array-like types in pretty-print output.@ \
+        "Specifices number of elements to print when printing array-like types in pretty-print output. Set to -1 to always print all elements.@ \
         Default: %d"
         default_arr_elements_printed
     )

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -3116,7 +3116,8 @@ module Global = struct
     (Arg.Int (fun n -> arr_elements_printed := n))
     (fun fmt ->
       Format.fprintf fmt
-        "Specifices number of elements to print when printing array-like types in pretty-print output. Set to -1 to always print all elements.@ \
+        "Maximum number of elements to print for each array, map, or set in plain-text output.@ \
+        Set to -1 to always print all elements.@ \
         Default: %d"
         default_arr_elements_printed
     )

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -3112,7 +3112,7 @@ module Global = struct
   
   (* Array printing *)
   let _ = add_spec
-    "--max_array_elements_printed"
+    "--print_container_limit"
     (Arg.Int (fun n -> arr_elements_printed := n))
     (fun fmt ->
       Format.fprintf fmt

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -165,6 +165,8 @@ val include_dirs : unit -> string list
 type real_precision = [`Rational | `Float]
 val real_precision : unit -> real_precision
 
+val arr_elements_printed : unit -> int
+
 (** Minimizes and logs invariants as contracts. *)
 val log_invs : unit -> bool
 

--- a/src/model.ml
+++ b/src/model.ml
@@ -172,7 +172,9 @@ let pp_print_map_as_array as_type ppf m =
         incr num_printed;
         first := false;
       )) m;
-    if !over_printed then Format.fprintf ppf ", ...";
+    if !over_printed then
+      Format.fprintf ppf "%s..."
+        (if !num_printed >= 1 then ", " else "");
     for _ = 1 to dim do
       Format.fprintf ppf "]@]";
     done

--- a/src/model.ml
+++ b/src/model.ml
@@ -143,7 +143,10 @@ let pp_print_map_as_array as_type ppf m =
       Format.fprintf ppf "[@[<hov 0>";
     done;
     let first = ref true in
+    let num_printed = ref 0 in
+    let over_printed = ref false in
     MIL.iter (fun l v ->
+        if !num_printed >= 5 then over_printed := true else (
         Array.blit current 0 prev 0 dim;
         Array.blit (Array.of_list l) 0 current 0 dim;
         let cpt = ref 0 in
@@ -165,8 +168,10 @@ let pp_print_map_as_array as_type ppf m =
         in
         Format.fprintf ppf "%*s%a"
           (val_width - w) "" (pp_print_value_term ty) v;
+        incr num_printed;
         first := false;
-      ) m;
+      )) m;
+    if !over_printed then Format.fprintf ppf ", ...";
     for _ = 1 to dim do
       Format.fprintf ppf "]@]";
     done

--- a/src/model.ml
+++ b/src/model.ml
@@ -145,8 +145,9 @@ let pp_print_map_as_array as_type ppf m =
     let first = ref true in
     let num_printed = ref 0 in
     let over_printed = ref false in
+    let max_printed = Flags.arr_elements_printed () in
     MIL.iter (fun l v ->
-        if !num_printed >= 5 then over_printed := true else (
+        if !num_printed >= max_printed then over_printed := true else (
         Array.blit current 0 prev 0 dim;
         Array.blit (Array.of_list l) 0 current 0 dim;
         let cpt = ref 0 in

--- a/src/model.ml
+++ b/src/model.ml
@@ -147,7 +147,7 @@ let pp_print_map_as_array as_type ppf m =
     let over_printed = ref false in
     let max_printed = Flags.arr_elements_printed () in
     MIL.iter (fun l v ->
-        if !num_printed >= max_printed then over_printed := true else (
+        if (!num_printed >= max_printed) && max_printed != -1 then over_printed := true else (
         Array.blit current 0 prev 0 dim;
         Array.blit (Array.of_list l) 0 current 0 dim;
         let cpt = ref 0 in


### PR DESCRIPTION
Add option `--print_container_limit`, which is set to 5 by default, that controls how many elements of a container is printed. This applies to sets, maps, and arrays. It does not apply to tuples nor records since those are flattened in the pretty print output.

This option has no effect on JSON output.