### PR TITLE
Filter spurious non-linear atoms from Z3 QE interpolants in IC3IA

### DIFF
--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -448,6 +448,21 @@ let refine fwd solver sys predicates cubes =
     |> Term.TermSet.elements
     |> List.iteri (fun i t -> Format.printf "ATOM%d: %a@." i Term.pp_print_term t);*)
 
+    (* Z3's quantifier elimination can return non-linear atoms (e.g. a product
+       of two integer variables) even when its input is linear; cvc5 does not.
+       For a linear transition system such atoms are spurious, and adding them
+       as predicates would make the SMT solver reject later queries with
+       "logic does not support non-linear arithmetic". Drop them here. *)
+    let atoms =
+      match TransSys.get_logic sys with
+      | `Inferred l when not (TermLib.FeatureSet.mem TermLib.NA l) ->
+        Term.TermSet.filter
+          (fun a ->
+            not (TermLib.FeatureSet.mem TermLib.NA (TermLib.logic_of_term [] a)))
+          atoms
+      | _ -> atoms
+    in
+
     add_predicates solver predicates atoms
   )
 


### PR DESCRIPTION
## Problem

When only Z3 is available, IC3IA uses Z3's quantifier elimination (`(apply (then qe-light qe2))`) for interpolation. Z3's QE can return an atom containing a **product of two variables** even when its input formula is linear (cvc5 never does this — confirmed with a cvc5 developer).

IC3IA turns the interpolant's atoms into abstraction predicates and asserts them into a solver declared with a **linear** logic (`QF_LIA`), so Z3 rejects the query:

```
<Error> Runtime failure in property directed reachability (IA): SMT solver failed:
        "line ...: logic does not support nonlinear arithmetic"
```

The property is still proved by other engines (the run exits 0), but IC3IA emits a spurious `<Error>` and the engine process dies. Because it depends on which interpolating solver `--smt_itp_solver detect` picks, it only shows up in Z3-only environments (e.g. CI that installs just Z3); with MathSAT/SMTInterpol installed, a proper linear interpolant is produced and the issue is invisible.

### Root cause (evidence)

From the QE solver's SMT trace, the input to `(apply (then qe-light qe2))` is linear (only `(* (- 1) var)` terms), but Z3's returned goal contains e.g. `(* (- 1) %f93@0 %f94@0)` — a genuine variable×variable product. Kind 2 parses Z3's QE output verbatim, so the non-linear atom flows into `add_predicates` and then into the main `QF_LIA` solver.

Tracked in Z3 issue #10170: https://github.com/Z3Prover/z3/issues/10170

## Fix

In `refine` (`src/ic3ia/IC3IA.ml`), after collecting the QE interpolant's atoms, drop any atom whose logic contains non-linear arithmetic **when the transition system is linear**. This never asserts a non-linear term for a linear problem; it is a no-op for genuinely non-linear systems and for cvc5/MathSAT/SMTInterpol interpolants.

## Verification

- Builds cleanly, including the strict (warnings-as-errors) profile.
- The benchmarks that previously errored (`FMCAD08/Int/misc/ticket3i_*`) now prove `Valid` with no `<Error>`, both with `--enable IC3IA --smt_itp_solver Z3qe` and with only Z3 on `PATH`.
- Swept all 86 `FMCAD08/Int/misc` files under IC3IA/Z3qe: 0 non-linear errors, 0 `<Error>`.
- Default interpolator path unchanged.

## Note on testing

This does not fit `tests/regression`: that harness only checks Kind 2's exit code (unchanged here — exit 0 both before and after, since the `<Error>` was a non-fatal engine crash) and has no per-test flag mechanism to force `--enable IC3IA --smt_itp_solver Z3qe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)