### PR TITLE
Add GitHub Actions PR benchmark comparison (replace cluster webhook)

### DIFF
--- a/.github/workflows/kind2-ci.yml
+++ b/.github/workflows/kind2-ci.yml
@@ -3,6 +3,11 @@ name: Kind2 CI
 
 on: [push, pull_request]
 
+# A new push to a branch cancels this workflow's in-progress runs for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   kind2-build:
     strategy:

--- a/.github/workflows/kind2-docker.yml
+++ b/.github/workflows/kind2-docker.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main ]
     tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
 
+# Cancel a superseded build on a new push to main, but never cancel a tag
+# (release) build.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+
 jobs:
   build-and-publish:
     if: github.repository == 'kind2-mc/kind2'

--- a/.github/workflows/kind2-pr-benchmarks.yml
+++ b/.github/workflows/kind2-pr-benchmarks.yml
@@ -112,6 +112,15 @@ jobs:
           unzip -q $Z3_ZIP_NAME.zip
           sudo cp $Z3_ZIP_NAME/bin/z3 /usr/bin/
 
+      - name: Install cvc5
+        run: |
+          CVC5_VERSION=1.3.4
+          wget -q https://github.com/cvc5/cvc5/releases/download/cvc5-$CVC5_VERSION/cvc5-Linux-x86_64-static.zip
+          unzip -q cvc5-Linux-x86_64-static.zip
+          sudo cp "$(find . -path '*/bin/cvc5' -type f | head -1)" /usr/bin/cvc5
+          sudo chmod +x /usr/bin/cvc5
+          cvc5 --version | head -1
+
       - name: Checkout benchmarks
         uses: actions/checkout@v6
         with:
@@ -125,6 +134,11 @@ jobs:
       - name: Run benchmarks (${{ matrix.side }}, shard ${{ matrix.shard }})
         env:
           SHARD_INDEX: ${{ matrix.shard }}
+          # Use cvc5 as the SMT solver and cvc5's QE for IC3IA interpolation.
+          # cvc5's quantifier elimination stays within the input signature,
+          # avoiding the malformed output (non-linear terms / fresh constants)
+          # that Z3's qe2 can produce on some benchmarks.
+          KIND2_EXTRA_ARGS: "--smt_solver cvc5 --smt_itp_solver cvc5QE"
         run: |
           bash scripts/benchmarks/run-benchmarks.sh \
             "$PWD/kind2-bin/kind2" \

--- a/.github/workflows/kind2-pr-benchmarks.yml
+++ b/.github/workflows/kind2-pr-benchmarks.yml
@@ -28,7 +28,7 @@ env:
   BENCHMARKS_REF: main
   BENCHMARKS_SUBDIRS: "FMCAD08/Bool FMCAD08/Int FMCAD08/Real_Int"
   # Per-benchmark wall-clock timeout (seconds).
-  BENCH_TIMEOUT: "45"
+  BENCH_TIMEOUT: "60"
   # Number of shards each side's benchmark run is split into. MUST match the
   # length of the `shard` matrix list in the `benchmark` job below.
   SHARD_COUNT: "8"

--- a/.github/workflows/kind2-pr-benchmarks.yml
+++ b/.github/workflows/kind2-pr-benchmarks.yml
@@ -28,7 +28,7 @@ env:
   BENCHMARKS_REF: main
   BENCHMARKS_SUBDIRS: "FMCAD08/Bool FMCAD08/Int FMCAD08/Real_Int"
   # Per-benchmark wall-clock timeout (seconds).
-  BENCH_TIMEOUT: "60"
+  BENCH_TIMEOUT: "80"
   # Number of shards each side's benchmark run is split into. MUST match the
   # length of the `shard` matrix list in the `benchmark` job below.
   SHARD_COUNT: "8"

--- a/.github/workflows/kind2-pr-benchmarks.yml
+++ b/.github/workflows/kind2-pr-benchmarks.yml
@@ -28,7 +28,7 @@ env:
   BENCHMARKS_REF: main
   BENCHMARKS_SUBDIRS: "FMCAD08/Bool FMCAD08/Int FMCAD08/Real_Int"
   # Per-benchmark wall-clock timeout (seconds).
-  BENCH_TIMEOUT: "80"
+  BENCH_TIMEOUT: "120"
   # Number of shards each side's benchmark run is split into. MUST match the
   # length of the `shard` matrix list in the `benchmark` job below.
   SHARD_COUNT: "8"

--- a/.github/workflows/kind2-pr-benchmarks.yml
+++ b/.github/workflows/kind2-pr-benchmarks.yml
@@ -33,6 +33,10 @@ env:
   # length of the `shard` matrix list in the `benchmark` job below.
   SHARD_COUNT: "8"
   OCAML_VERSION: 4.14.2
+  # SMT solvers used by the benchmark run (Z3 as solver, MathSAT for
+  # interpolation). Bumping either version invalidates the solver cache.
+  Z3_VERSION: "4.15.3"
+  MATHSAT_VERSION: "5.6.17"
 
 jobs:
   build:
@@ -71,9 +75,36 @@ jobs:
           name: kind2-${{ matrix.side }}
           path: bin/kind2
 
+  # Download Z3 and MathSAT once and cache them, so the many benchmark shards
+  # (and future runs) restore the binaries instead of re-downloading them.
+  solvers:
+    if: ${{ !contains(github.event.pull_request.body, '%notest') }}
+    name: solvers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache SMT solvers
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ~/solver-bin
+          key: smt-solvers-z3-${{ env.Z3_VERSION }}-mathsat-${{ env.MATHSAT_VERSION }}
+
+      - name: Download SMT solvers (on cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/solver-bin
+          Z3_ZIP_NAME=z3-${Z3_VERSION}-x64-glibc-2.39
+          wget -q https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/$Z3_ZIP_NAME.zip
+          unzip -q $Z3_ZIP_NAME.zip
+          cp $Z3_ZIP_NAME/bin/z3 ~/solver-bin/
+          MATHSAT_DIR=mathsat-${MATHSAT_VERSION}-linux-x86_64
+          wget -q https://mathsat.fbk.eu/release/$MATHSAT_DIR.tar.gz
+          tar xzf $MATHSAT_DIR.tar.gz
+          cp $MATHSAT_DIR/bin/mathsat ~/solver-bin/
+
   benchmark:
     name: benchmark (${{ matrix.side }} ${{ matrix.shard }})
-    needs: build
+    needs: [build, solvers]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -104,20 +135,17 @@ jobs:
       - name: Make Kind 2 executable
         run: chmod +x kind2-bin/kind2
 
-      - name: Install Z3
-        run: |
-          Z3_VERSION=4.15.3
-          Z3_ZIP_NAME=z3-$Z3_VERSION-x64-glibc-2.39
-          wget -q https://github.com/Z3Prover/z3/releases/download/z3-$Z3_VERSION/$Z3_ZIP_NAME.zip
-          unzip -q $Z3_ZIP_NAME.zip
-          sudo cp $Z3_ZIP_NAME/bin/z3 /usr/bin/
+      - name: Restore SMT solvers (from cache)
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/solver-bin
+          key: smt-solvers-z3-${{ env.Z3_VERSION }}-mathsat-${{ env.MATHSAT_VERSION }}
+          fail-on-cache-miss: true
 
-      - name: Install MathSAT
+      - name: Install SMT solvers
         run: |
-          MATHSAT_DIR=mathsat-5.6.17-linux-x86_64
-          wget -q https://mathsat.fbk.eu/release/$MATHSAT_DIR.tar.gz
-          tar xzf $MATHSAT_DIR.tar.gz
-          sudo cp $MATHSAT_DIR/bin/mathsat /usr/bin/
+          sudo cp ~/solver-bin/z3 ~/solver-bin/mathsat /usr/bin/
+          z3 --version
           mathsat -version | head -1
 
       - name: Checkout benchmarks

--- a/.github/workflows/kind2-pr-benchmarks.yml
+++ b/.github/workflows/kind2-pr-benchmarks.yml
@@ -112,14 +112,13 @@ jobs:
           unzip -q $Z3_ZIP_NAME.zip
           sudo cp $Z3_ZIP_NAME/bin/z3 /usr/bin/
 
-      - name: Install cvc5
+      - name: Install MathSAT
         run: |
-          CVC5_VERSION=1.3.4
-          wget -q https://github.com/cvc5/cvc5/releases/download/cvc5-$CVC5_VERSION/cvc5-Linux-x86_64-static.zip
-          unzip -q cvc5-Linux-x86_64-static.zip
-          sudo cp "$(find . -path '*/bin/cvc5' -type f | head -1)" /usr/bin/cvc5
-          sudo chmod +x /usr/bin/cvc5
-          cvc5 --version | head -1
+          MATHSAT_DIR=mathsat-5.6.17-linux-x86_64
+          wget -q https://mathsat.fbk.eu/release/$MATHSAT_DIR.tar.gz
+          tar xzf $MATHSAT_DIR.tar.gz
+          sudo cp $MATHSAT_DIR/bin/mathsat /usr/bin/
+          mathsat -version | head -1
 
       - name: Checkout benchmarks
         uses: actions/checkout@v6
@@ -134,11 +133,10 @@ jobs:
       - name: Run benchmarks (${{ matrix.side }}, shard ${{ matrix.shard }})
         env:
           SHARD_INDEX: ${{ matrix.shard }}
-          # Use cvc5 as the SMT solver and cvc5's QE for IC3IA interpolation.
-          # cvc5's quantifier elimination stays within the input signature,
-          # avoiding the malformed output (non-linear terms / fresh constants)
-          # that Z3's qe2 can produce on some benchmarks.
-          KIND2_EXTRA_ARGS: "--smt_solver cvc5 --smt_itp_solver cvc5QE"
+          # Default options: Z3 as the SMT solver, MathSAT as the interpolating
+          # solver (auto-detected). MathSAT produces proper interpolants, so
+          # IC3IA never takes Z3's qe2 QE-interpolation path, avoiding the
+          # malformed output (non-linear terms / fresh constants) it can emit.
         run: |
           bash scripts/benchmarks/run-benchmarks.sh \
             "$PWD/kind2-bin/kind2" \

--- a/.github/workflows/kind2-pr-benchmarks.yml
+++ b/.github/workflows/kind2-pr-benchmarks.yml
@@ -5,9 +5,9 @@ name: Kind 2 PR Benchmarks
 # replaces the old remote-cluster webhook (webhook-handler + test_pr).
 #
 # Runs as its own workflow so it executes concurrently with the main Kind 2 CI.
-# The PR head and base legs run in parallel (matrix); within each leg the
-# benchmark set is run sequentially. Sharding a leg across a matrix is a
-# possible later optimization.
+# Pipeline: build each side (head/base) once, then fan the benchmark run out
+# across SHARD_COUNT shards per side (round-robin over the sorted file list),
+# then join every shard's results in a final compare job.
 
 on:
   pull_request:
@@ -27,41 +27,29 @@ env:
   BENCHMARKS_REPO: kind2-mc/kind2-benchmarks
   BENCHMARKS_REF: main
   BENCHMARKS_SUBDIRS: "FMCAD08/Bool FMCAD08/Int FMCAD08/Real_Int"
-  # Per-benchmark wall-clock timeout (seconds). Lowered from the cluster's 120s
-  # so the sequential run fits within a single GitHub-hosted job for now.
+  # Per-benchmark wall-clock timeout (seconds).
   BENCH_TIMEOUT: "45"
+  # Number of shards each side's benchmark run is split into. MUST match the
+  # length of the `shard` matrix list in the `benchmark` job below.
+  SHARD_COUNT: "8"
   OCAML_VERSION: 4.14.2
 
 jobs:
-  benchmark:
+  build:
     # Honor "%notest" in the PR description, matching the old cluster hook.
     if: ${{ !contains(github.event.pull_request.body, '%notest') }}
-    name: benchmark (${{ matrix.side }})
+    name: build (${{ matrix.side }})
     runs-on: ubuntu-latest
-    # GitHub-hosted jobs are capped at 6h; leave headroom.
-    timeout-minutes: 350
+    timeout-minutes: 120
     strategy:
-      # Build/benchmark head and base independently: a failure on one leg still
-      # lets the other finish, which aids diagnosis.
       fail-fast: false
       matrix:
         side: [head, base]
-
     steps:
       - name: Checkout Kind 2 (${{ matrix.side }})
         uses: actions/checkout@v6
         with:
           ref: ${{ matrix.side == 'head' && github.event.pull_request.head.sha || github.event.pull_request.base.sha }}
-
-      # Always drive the run with the PR head's copy of the harness, so the base
-      # leg works even when the base commit predates these scripts.
-      - name: Checkout benchmark harness (PR head)
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: _harness
-          sparse-checkout: scripts/benchmarks
-          sparse-checkout-cone-mode: false
 
       - name: Update package information
         run: sudo apt-get update -y
@@ -76,6 +64,45 @@ jobs:
         run: |
           opam install -y . --deps-only
           opam exec make build
+
+      - name: Upload Kind 2 binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: kind2-${{ matrix.side }}
+          path: bin/kind2
+
+  benchmark:
+    name: benchmark (${{ matrix.side }} ${{ matrix.shard }})
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      # Run every (side, shard) independently; a failure on one shard still lets
+      # the others finish, which aids diagnosis.
+      fail-fast: false
+      matrix:
+        side: [head, base]
+        # This list length MUST equal SHARD_COUNT above.
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+
+    steps:
+      # Drive the run with the PR head's copy of the harness, so it works even
+      # when the base commit predates these scripts.
+      - name: Checkout benchmark harness (PR head)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          sparse-checkout: scripts/benchmarks
+          sparse-checkout-cone-mode: false
+
+      - name: Download Kind 2 (${{ matrix.side }})
+        uses: actions/download-artifact@v7
+        with:
+          name: kind2-${{ matrix.side }}
+          path: kind2-bin
+
+      - name: Make Kind 2 executable
+        run: chmod +x kind2-bin/kind2
 
       - name: Install Z3
         run: |
@@ -95,19 +122,21 @@ jobs:
           # access (e.g. a fine-grained PAT stored as a secret):
           # token: ${{ secrets.BENCHMARKS_TOKEN }}
 
-      - name: Run benchmarks (${{ matrix.side }})
+      - name: Run benchmarks (${{ matrix.side }}, shard ${{ matrix.shard }})
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}
         run: |
-          bash _harness/scripts/benchmarks/run-benchmarks.sh \
-            "$PWD/bin/kind2" \
+          bash scripts/benchmarks/run-benchmarks.sh \
+            "$PWD/kind2-bin/kind2" \
             "${BENCH_TIMEOUT}" \
-            "$RUNNER_TEMP/${{ matrix.side }}.stat" \
+            "$RUNNER_TEMP/${{ matrix.side }}-${{ matrix.shard }}.stat" \
             benchmarks ${BENCHMARKS_SUBDIRS}
 
-      - name: Upload stat file
+      - name: Upload stat shard
         uses: actions/upload-artifact@v7
         with:
-          name: benchmark-stat-${{ matrix.side }}
-          path: ${{ runner.temp }}/${{ matrix.side }}.stat
+          name: benchmark-stat-${{ matrix.side }}-${{ matrix.shard }}
+          path: ${{ runner.temp }}/${{ matrix.side }}-${{ matrix.shard }}.stat
 
   compare:
     name: compare
@@ -121,16 +150,22 @@ jobs:
           sparse-checkout: scripts/benchmarks
           sparse-checkout-cone-mode: false
 
-      - name: Download stat files
+      - name: Download stat shards
         uses: actions/download-artifact@v7
         with:
           pattern: benchmark-stat-*
           merge-multiple: true
           path: stats
 
+      - name: Assemble per-side stat files
+        run: |
+          cat stats/head-*.stat > head.stat
+          cat stats/base-*.stat > base.stat
+          echo "head: $(wc -l < head.stat) rows, base: $(wc -l < base.stat) rows"
+
       - name: Compare results
         run: |
           bash scripts/benchmarks/compare-benchmarks.sh \
-            stats/head.stat \
-            stats/base.stat \
+            head.stat \
+            base.stat \
             "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/kind2-pr-benchmarks.yml
+++ b/.github/workflows/kind2-pr-benchmarks.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - name: Cache SMT solvers
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/solver-bin
           key: smt-solvers-z3-${{ env.Z3_VERSION }}-mathsat-${{ env.MATHSAT_VERSION }}
@@ -136,7 +136,7 @@ jobs:
         run: chmod +x kind2-bin/kind2
 
       - name: Restore SMT solvers (from cache)
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ~/solver-bin
           key: smt-solvers-z3-${{ env.Z3_VERSION }}-mathsat-${{ env.MATHSAT_VERSION }}

--- a/.github/workflows/kind2-pr-benchmarks.yml
+++ b/.github/workflows/kind2-pr-benchmarks.yml
@@ -1,0 +1,136 @@
+name: Kind 2 PR Benchmarks
+
+# Builds the pull request's Kind 2 and the base branch's Kind 2, benchmarks each
+# over a fixed set, and fails the check on a regression or soundness bug. This
+# replaces the old remote-cluster webhook (webhook-handler + test_pr).
+#
+# Runs as its own workflow so it executes concurrently with the main Kind 2 CI.
+# The PR head and base legs run in parallel (matrix); within each leg the
+# benchmark set is run sequentially. Sharding a leg across a matrix is a
+# possible later optimization.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+# A new push to the PR cancels an in-progress benchmark run for the same PR.
+concurrency:
+  group: kind2-pr-benchmarks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  # Benchmark set: the Lustre files under FMCAD08/{Bool,Int,Real_Int} on the
+  # main branch of kind2-mc/kind2-benchmarks. BENCHMARKS_SUBDIRS is a
+  # space-separated list of directories (relative to the repo root) to run.
+  BENCHMARKS_REPO: kind2-mc/kind2-benchmarks
+  BENCHMARKS_REF: main
+  BENCHMARKS_SUBDIRS: "FMCAD08/Bool FMCAD08/Int FMCAD08/Real_Int"
+  # Per-benchmark wall-clock timeout (seconds). Lowered from the cluster's 120s
+  # so the sequential run fits within a single GitHub-hosted job for now.
+  BENCH_TIMEOUT: "45"
+  OCAML_VERSION: 4.14.2
+
+jobs:
+  benchmark:
+    # Honor "%notest" in the PR description, matching the old cluster hook.
+    if: ${{ !contains(github.event.pull_request.body, '%notest') }}
+    name: benchmark (${{ matrix.side }})
+    runs-on: ubuntu-latest
+    # GitHub-hosted jobs are capped at 6h; leave headroom.
+    timeout-minutes: 350
+    strategy:
+      # Build/benchmark head and base independently: a failure on one leg still
+      # lets the other finish, which aids diagnosis.
+      fail-fast: false
+      matrix:
+        side: [head, base]
+
+    steps:
+      - name: Checkout Kind 2 (${{ matrix.side }})
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.side == 'head' && github.event.pull_request.head.sha || github.event.pull_request.base.sha }}
+
+      # Always drive the run with the PR head's copy of the harness, so the base
+      # leg works even when the base commit predates these scripts.
+      - name: Checkout benchmark harness (PR head)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: _harness
+          sparse-checkout: scripts/benchmarks
+          sparse-checkout-cone-mode: false
+
+      - name: Update package information
+        run: sudo apt-get update -y
+
+      - name: Set up OCaml ${{ env.OCAML_VERSION }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ env.OCAML_VERSION }}
+          cache-prefix: pr-benchmarks-${{ matrix.side }}
+
+      - name: Build Kind 2 (${{ matrix.side }})
+        run: |
+          opam install -y . --deps-only
+          opam exec make build
+
+      - name: Install Z3
+        run: |
+          Z3_VERSION=4.15.3
+          Z3_ZIP_NAME=z3-$Z3_VERSION-x64-glibc-2.39
+          wget -q https://github.com/Z3Prover/z3/releases/download/z3-$Z3_VERSION/$Z3_ZIP_NAME.zip
+          unzip -q $Z3_ZIP_NAME.zip
+          sudo cp $Z3_ZIP_NAME/bin/z3 /usr/bin/
+
+      - name: Checkout benchmarks
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.BENCHMARKS_REPO }}
+          ref: ${{ env.BENCHMARKS_REF }}
+          path: benchmarks
+          # If the benchmarks repository is private, provide a token with read
+          # access (e.g. a fine-grained PAT stored as a secret):
+          # token: ${{ secrets.BENCHMARKS_TOKEN }}
+
+      - name: Run benchmarks (${{ matrix.side }})
+        run: |
+          bash _harness/scripts/benchmarks/run-benchmarks.sh \
+            "$PWD/bin/kind2" \
+            "${BENCH_TIMEOUT}" \
+            "$RUNNER_TEMP/${{ matrix.side }}.stat" \
+            benchmarks ${BENCHMARKS_SUBDIRS}
+
+      - name: Upload stat file
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-stat-${{ matrix.side }}
+          path: ${{ runner.temp }}/${{ matrix.side }}.stat
+
+  compare:
+    name: compare
+    needs: benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout benchmark harness (PR head)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          sparse-checkout: scripts/benchmarks
+          sparse-checkout-cone-mode: false
+
+      - name: Download stat files
+        uses: actions/download-artifact@v7
+        with:
+          pattern: benchmark-stat-*
+          merge-multiple: true
+          path: stats
+
+      - name: Compare results
+        run: |
+          bash scripts/benchmarks/compare-benchmarks.sh \
+            stats/head.stat \
+            stats/base.stat \
+            "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/kind2-pr-benchmarks.yml
+++ b/.github/workflows/kind2-pr-benchmarks.yml
@@ -15,9 +15,9 @@ on:
 permissions:
   contents: read
 
-# A new push to the PR cancels an in-progress benchmark run for the same PR.
+# A new push to a branch cancels this workflow's in-progress runs for it.
 concurrency:
-  group: kind2-pr-benchmarks-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -1,0 +1,59 @@
+# PR benchmark comparison
+
+CI harness that replaces the remote-cluster webhook (`webhook-handler` +
+`test_pr`). On every pull request it builds Kind 2 at the PR head **and** at the
+base commit and benchmarks each over a fixed set — the two legs run **in
+parallel** (a `[head, base]` job matrix); within each leg the benchmark set runs
+sequentially. A final `compare` job joins the two stat files and fails the check
+if the PR introduces a **regression** or a **soundness bug**.
+
+Driven by [`.github/workflows/kind2-pr-benchmarks.yml`](../../.github/workflows/kind2-pr-benchmarks.yml).
+
+## Scripts
+
+- `run-benchmarks.sh <kind2_bin> <timeout_s> <out_stat> <bench_root> [subdir...]`
+  Runs `<kind2_bin>` over every `*.lus` under each `<bench_root>/<subdir>`
+  (or all of `<bench_root>` if no subdir is given) sequentially and writes one
+  line per benchmark to `<out_stat>`:
+  `<relative/path.lus> <Valid|Invalid|Timeout|Error|Mixed> <wall_seconds>`,
+  where the path is relative to `<bench_root>`. Uses Kind 2's `--timeout_wall`
+  (soft) wrapped in `timeout` (hard kill), and classifies output with the same
+  distinguished strings the cluster's `benchmark-stat` used for the `kind-2`
+  profile. Extra Kind 2 flags can be passed via `KIND2_EXTRA_ARGS`.
+
+- `compare-benchmarks.sh <head_stat> <base_stat> [summary_file]`
+  Joins the two stat files and writes a Markdown report (to
+  `$GITHUB_STEP_SUMMARY` in CI). Exit codes:
+  - `2` — soundness bug: base `Invalid` → head `Valid`
+  - `1` — regression: base `Valid` → head not `Valid`/`Timeout`, or
+           base `Invalid` → head not `Invalid`/`Timeout`
+  - `0` — no regressions
+
+  A head `Timeout` where the base solved the benchmark is reported for
+  information only, not treated as a regression (CI runner timing is noisy).
+
+## Configuration (must be set before enabling)
+
+The benchmark set is checked out from a **separate repository**. Edit the `env`
+block in the workflow:
+
+| Variable             | Meaning                                                      |
+|----------------------|--------------------------------------------------------------|
+| `BENCHMARKS_REPO`    | `owner/repo` holding the benchmark set                       |
+| `BENCHMARKS_REF`     | branch/tag/sha to pin                                        |
+| `BENCHMARKS_SUBDIRS` | space-separated dirs to run, relative to the repo root       |
+| `BENCH_TIMEOUT`      | per-benchmark wall timeout, seconds (default `45`)           |
+
+Currently set to `FMCAD08/Bool FMCAD08/Int FMCAD08/Real_Int` on the `main`
+branch of `kind2-mc/kind2-benchmarks`.
+
+If the benchmarks repo is private, uncomment `token:` in the *Checkout
+benchmarks* step and add a read-only PAT secret.
+
+## Later optimizations (not done yet)
+
+The PR head and base legs already run in parallel, but each leg runs its
+benchmark set sequentially. To speed a leg up, shard its file list across a
+sub-matrix (each shard runs a slice of the `*.lus`), then concatenate the shard
+stat files before the `compare` job — recovering more of the parallelism the
+4-node cluster provided.

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -2,10 +2,19 @@
 
 CI harness that replaces the remote-cluster webhook (`webhook-handler` +
 `test_pr`). On every pull request it builds Kind 2 at the PR head **and** at the
-base commit and benchmarks each over a fixed set — the two legs run **in
-parallel** (a `[head, base]` job matrix); within each leg the benchmark set runs
-sequentially. A final `compare` job joins the two stat files and fails the check
-if the PR introduces a **regression** or a **soundness bug**.
+base commit and benchmarks each over a fixed set, then fails the check if the PR
+introduces a **regression** or a **soundness bug**.
+
+Pipeline (`build` → `benchmark` → `compare`):
+
+1. **`build` (matrix: `side`)** — build Kind 2 at each side once; upload the
+   binary as an artifact.
+2. **`benchmark` (matrix: `side` × `shard`)** — download the binary and run one
+   shard of the benchmark set (round-robin over the sorted file list); upload
+   the shard's stat file. All `side × SHARD_COUNT` shards run in parallel.
+3. **`compare`** — concatenate the shard stat files per side, join head vs.
+   base, write a Markdown Step Summary (result counts per version + regressions,
+   soundness bugs, and improvements), and set the check's exit status.
 
 Driven by [`.github/workflows/kind2-pr-benchmarks.yml`](../../.github/workflows/kind2-pr-benchmarks.yml).
 
@@ -19,7 +28,8 @@ Driven by [`.github/workflows/kind2-pr-benchmarks.yml`](../../.github/workflows/
   where the path is relative to `<bench_root>`. Uses Kind 2's `--timeout_wall`
   (soft) wrapped in `timeout` (hard kill), and classifies output with the same
   distinguished strings the cluster's `benchmark-stat` used for the `kind-2`
-  profile. Extra Kind 2 flags can be passed via `KIND2_EXTRA_ARGS`.
+  profile. Extra Kind 2 flags can be passed via `KIND2_EXTRA_ARGS`. Set
+  `SHARD_COUNT`/`SHARD_INDEX` (env) to run only one round-robin shard of the set.
 
 - `compare-benchmarks.sh <head_stat> <base_stat> [summary_file]`
   Joins the two stat files and writes a Markdown report (to
@@ -43,17 +53,21 @@ block in the workflow:
 | `BENCHMARKS_REF`     | branch/tag/sha to pin                                        |
 | `BENCHMARKS_SUBDIRS` | space-separated dirs to run, relative to the repo root       |
 | `BENCH_TIMEOUT`      | per-benchmark wall timeout, seconds (default `45`)           |
+| `SHARD_COUNT`        | shards per side; **must** match the `shard` matrix length    |
 
 Currently set to `FMCAD08/Bool FMCAD08/Int FMCAD08/Real_Int` on the `main`
 branch of `kind2-mc/kind2-benchmarks`.
 
+To change the shard count, edit **both** `SHARD_COUNT` and the `shard: [...]`
+matrix list in the `benchmark` job so their lengths agree.
+
 If the benchmarks repo is private, uncomment `token:` in the *Checkout
 benchmarks* step and add a read-only PAT secret.
 
-## Later optimizations (not done yet)
+## Tuning
 
-The PR head and base legs already run in parallel, but each leg runs its
-benchmark set sequentially. To speed a leg up, shard its file list across a
-sub-matrix (each shard runs a slice of the `*.lus`), then concatenate the shard
-stat files before the `compare` job — recovering more of the parallelism the
-4-node cluster provided.
+Wall-clock time is dominated by the slowest shard. Increasing `SHARD_COUNT`
+shortens each shard but adds fixed per-job overhead (checkout + Z3 install) and
+consumes more concurrent runners. The `Int` subset dominates the set, and the
+~60 benchmarks that hit the timeout are spread across shards by the round-robin
+split.

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -25,7 +25,9 @@ Driven by [`.github/workflows/kind2-pr-benchmarks.yml`](../../.github/workflows/
   (or all of `<bench_root>` if no subdir is given) sequentially and writes one
   line per benchmark to `<out_stat>`:
   `<relative/path.lus> <Valid|Invalid|Timeout|Error|Mixed> <wall_seconds>`,
-  where the path is relative to `<bench_root>`. Uses Kind 2's `--timeout_wall`
+  where the path is relative to `<bench_root>` (plus a 4th `<shard>` column when
+  sharding, so the comparison can name the job whose log holds an errored
+  benchmark's output). Uses Kind 2's `--timeout_wall`
   (soft) wrapped in `timeout` (hard kill), and classifies output with the same
   distinguished strings the cluster's `benchmark-stat` used for the `kind-2`
   profile. Extra Kind 2 flags can be passed via `KIND2_EXTRA_ARGS`. Set
@@ -41,6 +43,8 @@ Driven by [`.github/workflows/kind2-pr-benchmarks.yml`](../../.github/workflows/
 
   A head `Timeout` where the base solved the benchmark is reported for
   information only, not treated as a regression (CI runner timing is noisy).
+  The Errors table names the shard job (`benchmark (head <N>)`) whose log
+  contains each errored benchmark's Kind 2 output.
 
 ## Configuration (must be set before enabling)
 

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -36,10 +36,13 @@ Driven by [`.github/workflows/kind2-pr-benchmarks.yml`](../../.github/workflows/
 - `compare-benchmarks.sh <head_stat> <base_stat> [summary_file]`
   Joins the two stat files and writes a Markdown report (to
   `$GITHUB_STEP_SUMMARY` in CI). Exit codes:
-  - `2` — soundness bug: base `Invalid` → head `Valid`
-  - `1` — regression: base `Valid` → head not `Valid`/`Timeout`, or
-           base `Invalid` → head not `Invalid`/`Timeout`
-  - `0` — no regressions
+  - `2` — soundness bug: the head flips a property between `Valid` and `Invalid`
+          vs. the base, in either direction — base `Invalid` → head `Valid`
+          (unsound for verification) or base `Valid` → head `Invalid` (unsound
+          for falsification)
+  - `1` — regression: base `Valid`/`Invalid` → head `Error` (a solved benchmark
+          the PR can no longer solve, other than a noisy `Timeout`)
+  - `0` — no regressions or soundness bugs
 
   A head `Timeout` where the base solved the benchmark is reported for
   information only, not treated as a regression (CI runner timing is noisy).

--- a/scripts/benchmarks/compare-benchmarks.sh
+++ b/scripts/benchmarks/compare-benchmarks.sh
@@ -91,7 +91,14 @@ improvements=()
 errors=()
 
 while read -r name hr hw br bw; do
-  if [ "$br" = "Invalid" ] && [ "$hr" = "Valid" ]; then
+  # A property that flips between Valid and Invalid vs. the base is a soundness
+  # discrepancy in one direction or the other:
+  #   base Invalid -> head Valid  : the PR proves a falsifiable property
+  #                                 (unsound for verification).
+  #   base Valid   -> head Invalid: the PR reports a counterexample for a valid
+  #                                 property (unsound for falsification).
+  if { [ "$br" = "Invalid" ] && [ "$hr" = "Valid" ]; } \
+     || { [ "$br" = "Valid" ] && [ "$hr" = "Invalid" ]; }; then
     soundness+=("$name|$br|$hr")
   elif [ "$br" = "Valid" ] && [ "$hr" != "Valid" ] && [ "$hr" != "Timeout" ]; then
     regressions+=("$name|$br|$hr")
@@ -112,7 +119,7 @@ done < "$joined"
 # Errors fail the check independently of regressions/soundness; the headline
 # shows the most severe issue but every applicable table is rendered below.
 if [ "${#soundness[@]}" -gt 0 ]; then
-  verdict=":x: **Soundness bug** — the PR reports a property Valid that the base found Invalid."
+  verdict=":x: **Soundness bug** — the PR flips ${#soundness[@]} property(ies) between Valid and Invalid vs. the base."
   exit_code=2
 elif [ "${#regressions[@]}" -gt 0 ]; then
   verdict=":x: **Regression** — the PR changes ${#regressions[@]} result(s) for the worse."

--- a/scripts/benchmarks/compare-benchmarks.sh
+++ b/scripts/benchmarks/compare-benchmarks.sh
@@ -53,14 +53,21 @@ done
 
 emit() { printf '%s\n' "$*" >> "$SUMMARY"; }
 
-# Sort by benchmark name so `join` lines up head and base rows.
-sort -k1,1 -o "$HEAD_STAT" "$HEAD_STAT"
-sort -k1,1 -o "$BASE_STAT" "$BASE_STAT"
+# Head shard per benchmark, from the optional 4th column that sharded CI runs
+# write (see run-benchmarks.sh). Lets the Errors table point at the job whose
+# log holds an errored benchmark's output. Absent for unsharded/local runs.
+declare -A head_shard
+while read -r s_name _s_res _s_wall s_shard _rest; do
+  [ -n "${s_shard:-}" ] && head_shard["$s_name"]="$s_shard"
+done < "$HEAD_STAT"
 
-joined=$(mktemp)
-trap 'rm -f "$joined"' EXIT
+# Normalize to <name result wall> so the join is robust to the extra column.
+h3=$(mktemp); b3=$(mktemp); joined=$(mktemp)
+trap 'rm -f "$h3" "$b3" "$joined"' EXIT
+awk '{ print $1, $2, $3 }' "$HEAD_STAT" | sort -k1,1 > "$h3"
+awk '{ print $1, $2, $3 }' "$BASE_STAT" | sort -k1,1 > "$b3"
 # Output columns: name headRes headWall baseRes baseWall
-join -j1 "$HEAD_STAT" "$BASE_STAT" > "$joined"
+join -j1 "$h3" "$b3" > "$joined"
 
 n_head=$(wc -l < "$HEAD_STAT")
 n_base=$(wc -l < "$BASE_STAT")
@@ -97,7 +104,7 @@ while read -r name hr hw br bw; do
   # Any error from the PR's binary is a problem in its own right, whether or not
   # the base also errored on it — an error must never count as a pass.
   if [ "$hr" = "Error" ]; then
-    errors+=("$name|$br|$hr")
+    errors+=("$name|$br|$hr|${head_shard[$name]:-}")
   fi
 done < "$joined"
 
@@ -158,12 +165,27 @@ emit_table() {
   emit ""
 }
 
+# The Errors table has an extra column naming the shard job whose log holds each
+# benchmark's Kind 2 output (dumped there under a "::group::" by run-benchmarks.sh).
+emit_errors_table() {
+  emit "### :boom: Errors (PR head)"
+  emit "| Benchmark | Base | PR head | Output in job |"
+  emit "|---|---|---|---|"
+  local row name base head shard job
+  for row in "$@"; do
+    IFS='|' read -r name base head shard <<< "$row"
+    if [ -n "$shard" ]; then job="\`benchmark (head $shard)\`"; else job="—"; fi
+    emit "| \`$name\` | $base | $head | $job |"
+  done
+  emit ""
+}
+
 if [ "${#soundness[@]}" -gt 0 ]; then
   emit_table ":rotating_light: Soundness bugs" "${soundness[@]}"
 fi
 emit_table "Regressions" "${regressions[@]}"
 if [ "${#errors[@]}" -gt 0 ]; then
-  emit_table ":boom: Errors (PR head)" "${errors[@]}"
+  emit_errors_table "${errors[@]}"
 fi
 emit_table "Improvements (Timeout → solved)" "${improvements[@]}"
 

--- a/scripts/benchmarks/compare-benchmarks.sh
+++ b/scripts/benchmarks/compare-benchmarks.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+#########################################################################
+# This file is part of the Kind 2 model checker.                        #
+#                                                                       #
+# Copyright (c) 2024 by the Board of Trustees of the University of Iowa #
+#                                                                       #
+# Licensed under the Apache License, Version 2.0 (the "License"); you   #
+# may not use this file except in compliance with the License.  You     #
+# may obtain a copy of the License at                                   #
+#                                                                       #
+# http://www.apache.org/licenses/LICENSE-2.0                            #
+#                                                                       #
+# Unless required by applicable law or agreed to in writing, software   #
+# distributed under the License is distributed on an "AS IS" BASIS,     #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       #
+# implied. See the License for the specific language governing          #
+# permissions and limitations under the License.                        #
+#########################################################################
+
+# Compare two stat files produced by run-benchmarks.sh (PR head vs. base),
+# write a Markdown summary (to $GITHUB_STEP_SUMMARY when running in CI), and
+# exit non-zero when the head introduces a regression or a soundness bug.
+#
+# The comparison mirrors the cluster's test_pr logic:
+#   - Soundness bug:  base = Invalid  ->  head = Valid          (exit 2)
+#   - Regression:     base = Valid    ->  head != Valid/Timeout (exit 1)
+#                     base = Invalid  ->  head != Invalid/Timeout (exit 1)
+# A head Timeout where the base solved the benchmark is NOT treated as a
+# regression (timing on shared CI runners is noisy); it is reported for
+# information only.
+#
+# Usage:
+#   compare-benchmarks.sh <head_stat> <base_stat> [summary_file]
+
+set -u
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $(basename "$0") <head_stat> <base_stat> [summary_file]" >&2
+  exit 3
+fi
+
+HEAD_STAT=$1
+BASE_STAT=$2
+SUMMARY=${3:-/dev/stdout}
+
+for f in "$HEAD_STAT" "$BASE_STAT"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: stat file '$f' does not exist." >&2
+    exit 3
+  fi
+done
+
+emit() { printf '%s\n' "$*" >> "$SUMMARY"; }
+
+# Sort by benchmark name so `join` lines up head and base rows.
+sort -k1,1 -o "$HEAD_STAT" "$HEAD_STAT"
+sort -k1,1 -o "$BASE_STAT" "$BASE_STAT"
+
+joined=$(mktemp)
+trap 'rm -f "$joined"' EXIT
+# Output columns: name headRes headWall baseRes baseWall
+join -j1 "$HEAD_STAT" "$BASE_STAT" > "$joined"
+
+n_head=$(wc -l < "$HEAD_STAT")
+n_base=$(wc -l < "$BASE_STAT")
+n_common=$(wc -l < "$joined")
+
+regressions=()
+soundness=()
+improvements=()
+head_total=0
+base_total=0
+
+while read -r name hr hw br bw; do
+  head_total=$(awk "BEGIN { printf \"%.2f\", $head_total + $hw }")
+  base_total=$(awk "BEGIN { printf \"%.2f\", $base_total + $bw }")
+
+  if [ "$br" = "Invalid" ] && [ "$hr" = "Valid" ]; then
+    soundness+=("$name|$br|$hr")
+  elif [ "$br" = "Valid" ] && [ "$hr" != "Valid" ] && [ "$hr" != "Timeout" ]; then
+    regressions+=("$name|$br|$hr")
+  elif [ "$br" = "Invalid" ] && [ "$hr" != "Invalid" ] && [ "$hr" != "Timeout" ]; then
+    regressions+=("$name|$br|$hr")
+  elif [ "$br" = "Timeout" ] && { [ "$hr" = "Valid" ] || [ "$hr" = "Invalid" ]; }; then
+    improvements+=("$name|$br|$hr")
+  fi
+done < "$joined"
+
+# ---- Overall verdict & exit code -------------------------------------------
+if [ "${#soundness[@]}" -gt 0 ]; then
+  verdict=":x: **Soundness bug** — the PR reports a property Valid that the base found Invalid."
+  exit_code=2
+elif [ "${#regressions[@]}" -gt 0 ]; then
+  verdict=":x: **Regression** — the PR changes ${#regressions[@]} result(s) for the worse."
+  exit_code=1
+else
+  verdict=":white_check_mark: **No regressions** — the PR conforms with the base branch."
+  exit_code=0
+fi
+
+# ---- Markdown report --------------------------------------------------------
+emit "## Kind 2 benchmark comparison (PR head vs. base)"
+emit ""
+emit "$verdict"
+emit ""
+emit "| | Benchmarks | Total wall time |"
+emit "|---|---:|---:|"
+emit "| PR head | $n_head | ${head_total}s |"
+emit "| Base    | $n_base | ${base_total}s |"
+emit ""
+if [ "$n_head" -ne "$n_common" ] || [ "$n_base" -ne "$n_common" ]; then
+  emit "> :warning: Only $n_common benchmark(s) ran under **both** binaries; unmatched benchmarks are excluded from the comparison."
+  emit ""
+fi
+
+emit_table() {
+  # $1 = title, remaining args = "name|base|head" rows
+  local title=$1; shift
+  emit "### $title"
+  if [ "$#" -eq 0 ]; then
+    emit "_None._"
+    emit ""
+    return
+  fi
+  emit "| Benchmark | Base | PR head |"
+  emit "|---|---|---|"
+  local row
+  for row in "$@"; do
+    emit "| \`${row%%|*}\` | $(echo "$row" | cut -d'|' -f2) | $(echo "$row" | cut -d'|' -f3) |"
+  done
+  emit ""
+}
+
+if [ "${#soundness[@]}" -gt 0 ]; then
+  emit_table ":rotating_light: Soundness bugs" "${soundness[@]}"
+fi
+emit_table "Regressions" "${regressions[@]}"
+emit_table "Improvements (Timeout → solved)" "${improvements[@]}"
+
+exit "$exit_code"

--- a/scripts/benchmarks/compare-benchmarks.sh
+++ b/scripts/benchmarks/compare-benchmarks.sh
@@ -66,16 +66,23 @@ n_head=$(wc -l < "$HEAD_STAT")
 n_base=$(wc -l < "$BASE_STAT")
 n_common=$(wc -l < "$joined")
 
+# Per-category counts and total wall time, computed directly from each stat file.
+count_cat() { awk -v c="$2" '$2 == c { n++ } END { print n + 0 }' "$1"; }
+total_wall() { awk '{ t += $3 } END { printf "%.1f", t + 0 }' "$1"; }
+
+h_valid=$(count_cat "$HEAD_STAT" Valid);     b_valid=$(count_cat "$BASE_STAT" Valid)
+h_invalid=$(count_cat "$HEAD_STAT" Invalid); b_invalid=$(count_cat "$BASE_STAT" Invalid)
+h_timeout=$(count_cat "$HEAD_STAT" Timeout); b_timeout=$(count_cat "$BASE_STAT" Timeout)
+h_error=$(count_cat "$HEAD_STAT" Error);     b_error=$(count_cat "$BASE_STAT" Error)
+h_mixed=$(count_cat "$HEAD_STAT" Mixed);     b_mixed=$(count_cat "$BASE_STAT" Mixed)
+head_total=$(total_wall "$HEAD_STAT")
+base_total=$(total_wall "$BASE_STAT")
+
 regressions=()
 soundness=()
 improvements=()
-head_total=0
-base_total=0
 
 while read -r name hr hw br bw; do
-  head_total=$(awk "BEGIN { printf \"%.2f\", $head_total + $hw }")
-  base_total=$(awk "BEGIN { printf \"%.2f\", $base_total + $bw }")
-
   if [ "$br" = "Invalid" ] && [ "$hr" = "Valid" ]; then
     soundness+=("$name|$br|$hr")
   elif [ "$br" = "Valid" ] && [ "$hr" != "Valid" ] && [ "$hr" != "Timeout" ]; then
@@ -104,10 +111,17 @@ emit "## Kind 2 benchmark comparison (PR head vs. base)"
 emit ""
 emit "$verdict"
 emit ""
-emit "| | Benchmarks | Total wall time |"
+emit "| Result | PR head | Base |"
 emit "|---|---:|---:|"
-emit "| PR head | $n_head | ${head_total}s |"
-emit "| Base    | $n_base | ${base_total}s |"
+emit "| Valid | $h_valid | $b_valid |"
+emit "| Invalid | $h_invalid | $b_invalid |"
+emit "| Timeout | $h_timeout | $b_timeout |"
+emit "| Error | $h_error | $b_error |"
+if [ "$h_mixed" -gt 0 ] || [ "$b_mixed" -gt 0 ]; then
+  emit "| Mixed | $h_mixed | $b_mixed |"
+fi
+emit "| **Total** | $n_head | $n_base |"
+emit "| **Wall time** | ${head_total}s | ${base_total}s |"
 emit ""
 if [ "$n_head" -ne "$n_common" ] || [ "$n_base" -ne "$n_common" ]; then
   emit "> :warning: Only $n_common benchmark(s) ran under **both** binaries; unmatched benchmarks are excluded from the comparison."

--- a/scripts/benchmarks/compare-benchmarks.sh
+++ b/scripts/benchmarks/compare-benchmarks.sh
@@ -81,6 +81,7 @@ base_total=$(total_wall "$BASE_STAT")
 regressions=()
 soundness=()
 improvements=()
+errors=()
 
 while read -r name hr hw br bw; do
   if [ "$br" = "Invalid" ] && [ "$hr" = "Valid" ]; then
@@ -92,14 +93,25 @@ while read -r name hr hw br bw; do
   elif [ "$br" = "Timeout" ] && { [ "$hr" = "Valid" ] || [ "$hr" = "Invalid" ]; }; then
     improvements+=("$name|$br|$hr")
   fi
+
+  # Any error from the PR's binary is a problem in its own right, whether or not
+  # the base also errored on it — an error must never count as a pass.
+  if [ "$hr" = "Error" ]; then
+    errors+=("$name|$br|$hr")
+  fi
 done < "$joined"
 
 # ---- Overall verdict & exit code -------------------------------------------
+# Errors fail the check independently of regressions/soundness; the headline
+# shows the most severe issue but every applicable table is rendered below.
 if [ "${#soundness[@]}" -gt 0 ]; then
   verdict=":x: **Soundness bug** — the PR reports a property Valid that the base found Invalid."
   exit_code=2
 elif [ "${#regressions[@]}" -gt 0 ]; then
   verdict=":x: **Regression** — the PR changes ${#regressions[@]} result(s) for the worse."
+  exit_code=1
+elif [ "${#errors[@]}" -gt 0 ]; then
+  verdict=":x: **Some error occurred during testing** — the PR's Kind 2 errored on ${#errors[@]} benchmark(s); see logs."
   exit_code=1
 else
   verdict=":white_check_mark: **No regressions** — the PR conforms with the base branch."
@@ -150,6 +162,9 @@ if [ "${#soundness[@]}" -gt 0 ]; then
   emit_table ":rotating_light: Soundness bugs" "${soundness[@]}"
 fi
 emit_table "Regressions" "${regressions[@]}"
+if [ "${#errors[@]}" -gt 0 ]; then
+  emit_table ":boom: Errors (PR head)" "${errors[@]}"
+fi
 emit_table "Improvements (Timeout → solved)" "${improvements[@]}"
 
 exit "$exit_code"

--- a/scripts/benchmarks/run-benchmarks.sh
+++ b/scripts/benchmarks/run-benchmarks.sh
@@ -106,6 +106,10 @@ if [ "$SHARD_COUNT" -gt 1 ]; then
     | awk -v n="$SHARD_COUNT" -v k="$SHARD_INDEX" 'NR % n == k')
 fi
 
+# When sharding, tag each stat line with this shard's index (4th column) so the
+# comparison can point at the job whose log holds an errored benchmark's output.
+if [ "$SHARD_COUNT" -gt 1 ]; then shard_field=" $SHARD_INDEX"; else shard_field=""; fi
+
 total=${#FILES[@]}
 if [ "$total" -eq 0 ]; then
   echo "ERROR: no *.lus benchmarks found under: ${SEARCH_DIRS[*]} (shard ${SHARD_INDEX}/${SHARD_COUNT})" >&2
@@ -141,7 +145,7 @@ for f in "${FILES[@]}"; do
   else res=Mixed
   fi
 
-  printf '%s %s %s\n' "$rel" "$res" "$wall" >> "$OUT_STAT"
+  printf '%s %s %s%s\n' "$rel" "$res" "$wall" "$shard_field" >> "$OUT_STAT"
   printf '[%d/%d] %-8s %6ss  %s\n' "$i" "$total" "$res" "$wall" "$rel"
 
   # Surface the Kind 2 output for errored benchmarks so "see logs" is actionable.

--- a/scripts/benchmarks/run-benchmarks.sh
+++ b/scripts/benchmarks/run-benchmarks.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+#########################################################################
+# This file is part of the Kind 2 model checker.                        #
+#                                                                       #
+# Copyright (c) 2024 by the Board of Trustees of the University of Iowa #
+#                                                                       #
+# Licensed under the Apache License, Version 2.0 (the "License"); you   #
+# may not use this file except in compliance with the License.  You     #
+# may obtain a copy of the License at                                   #
+#                                                                       #
+# http://www.apache.org/licenses/LICENSE-2.0                            #
+#                                                                       #
+# Unless required by applicable law or agreed to in writing, software   #
+# distributed under the License is distributed on an "AS IS" BASIS,     #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       #
+# implied. See the License for the specific language governing          #
+# permissions and limitations under the License.                        #
+#########################################################################
+
+# Run a single Kind 2 binary over every *.lus file under one or more benchmark
+# directories, sequentially, and write a stat file with one line per benchmark:
+#
+#     <relative/path.lus> <Result> <wall_seconds>
+#
+# where <Result> is one of Valid, Invalid, Timeout, Error, Mixed. The relative
+# path is taken with respect to <bench_root>, so selecting several subdirs of a
+# common root yields distinct, stable names (e.g. Bool/x.lus, Int/y.lus).
+#
+# This replaces the cluster's TreeLimitedRun + run-benchmark.sh + benchmark-stat
+# trio: we rely on Kind 2's own --timeout_wall for the soft limit, wrap it in
+# `timeout` as a hard kill, and classify the output using the same distinguished
+# strings benchmark-stat used for the "kind-2" profile.
+#
+# Usage:
+#   run-benchmarks.sh <kind2_bin> <timeout_seconds> <out_stat> <bench_root> [subdir...]
+#
+# If no subdir is given, all *.lus under <bench_root> are run.
+# Extra Kind 2 flags can be passed via the KIND2_EXTRA_ARGS environment variable.
+
+set -u
+
+if [ "$#" -lt 4 ]; then
+  echo "Usage: $(basename "$0") <kind2_bin> <timeout_seconds> <out_stat> <bench_root> [subdir...]" >&2
+  exit 2
+fi
+
+KIND2_BIN=$1
+TIMEOUT=$2
+OUT_STAT=$3
+BENCH_ROOT=$4
+shift 4
+SUBDIRS=("$@")
+
+# Optional extra Kind 2 flags (space-separated) via the environment.
+read -r -a EXTRA_ARGS <<< "${KIND2_EXTRA_ARGS:-}"
+
+if [ ! -x "$KIND2_BIN" ]; then
+  echo "ERROR: Kind 2 binary '$KIND2_BIN' not found or not executable." >&2
+  exit 2
+fi
+if [ ! -d "$BENCH_ROOT" ]; then
+  echo "ERROR: benchmark root '$BENCH_ROOT' does not exist." >&2
+  exit 2
+fi
+
+# Directories to search: each given subdir under the root, or the whole root.
+SEARCH_DIRS=()
+if [ "${#SUBDIRS[@]}" -eq 0 ]; then
+  SEARCH_DIRS=("$BENCH_ROOT")
+else
+  for sub in "${SUBDIRS[@]}"; do
+    d="$BENCH_ROOT/$sub"
+    if [ ! -d "$d" ]; then
+      echo "ERROR: benchmark subdir '$d' does not exist." >&2
+      exit 2
+    fi
+    SEARCH_DIRS+=("$d")
+  done
+fi
+
+# Distinguished strings, matching benchmark-stat's "kind-2" profile. With
+# `--color false`, Kind 2 emits these tags verbatim at the start of a line.
+VALID_PAT='^<Success> Property'
+INVALID_PAT='^<Failure>'
+ERROR_PAT='^<Error>'
+
+# Hard kill a bit after Kind 2's own wall-clock timeout, in case it fails to
+# stop itself (e.g. a wedged solver child process).
+HARD_TIMEOUT=$((TIMEOUT + 15))
+
+: > "$OUT_STAT"
+
+# Deterministic ordering so head/base stat files line up and diffs are stable.
+mapfile -t FILES < <(find "${SEARCH_DIRS[@]}" -type f -iname '*.lus' | sort)
+
+total=${#FILES[@]}
+if [ "$total" -eq 0 ]; then
+  echo "ERROR: no *.lus benchmarks found under: ${SEARCH_DIRS[*]}" >&2
+  exit 2
+fi
+
+echo "Running $total benchmark(s) with '$KIND2_BIN' (timeout ${TIMEOUT}s)"
+
+out_file=$(mktemp)
+trap 'rm -f "$out_file"' EXIT
+
+i=0
+for f in "${FILES[@]}"; do
+  i=$((i + 1))
+  rel=${f#"$BENCH_ROOT"/}
+
+  start=$(date +%s.%N)
+  timeout "$HARD_TIMEOUT" "$KIND2_BIN" -v --color false \
+    --timeout_wall "$TIMEOUT" "${EXTRA_ARGS[@]}" "$f" > "$out_file" 2>&1
+  end=$(date +%s.%N)
+  wall=$(awk "BEGIN { printf \"%.2f\", $end - $start }")
+
+  # grep -c prints a count and exits 1 when there are no matches; that is fine,
+  # we only read the printed count and never rely on the exit status.
+  n_valid=$(grep -c "$VALID_PAT" "$out_file")
+  n_invalid=$(grep -c "$INVALID_PAT" "$out_file")
+  n_error=$(grep -c "$ERROR_PAT" "$out_file")
+
+  if   [ "$n_error"   -gt 0 ]; then res=Error
+  elif [ "$n_valid"   -gt 0 ] && [ "$n_invalid" -eq 0 ]; then res=Valid
+  elif [ "$n_invalid" -gt 0 ] && [ "$n_valid"   -eq 0 ]; then res=Invalid
+  elif [ "$n_valid"   -eq 0 ] && [ "$n_invalid" -eq 0 ]; then res=Timeout
+  else res=Mixed
+  fi
+
+  printf '%s %s %s\n' "$rel" "$res" "$wall" >> "$OUT_STAT"
+  printf '[%d/%d] %-8s %6ss  %s\n' "$i" "$total" "$res" "$wall" "$rel"
+done
+
+echo "Wrote $OUT_STAT"

--- a/scripts/benchmarks/run-benchmarks.sh
+++ b/scripts/benchmarks/run-benchmarks.sh
@@ -94,9 +94,21 @@ HARD_TIMEOUT=$((TIMEOUT + 15))
 # Deterministic ordering so head/base stat files line up and diffs are stable.
 mapfile -t FILES < <(find "${SEARCH_DIRS[@]}" -type f -iname '*.lus' | sort)
 
+# Optional round-robin sharding so several jobs can split the set. With
+# SHARD_COUNT>1, this job runs only the files whose position in the sorted list
+# satisfies (position mod SHARD_COUNT == SHARD_INDEX). Round-robin spreads
+# adjacent (often similarly hard) benchmarks across shards for balance.
+# SHARD_COUNT<=1 (the default) runs everything.
+SHARD_COUNT=${SHARD_COUNT:-1}
+SHARD_INDEX=${SHARD_INDEX:-0}
+if [ "$SHARD_COUNT" -gt 1 ]; then
+  mapfile -t FILES < <(printf '%s\n' "${FILES[@]}" \
+    | awk -v n="$SHARD_COUNT" -v k="$SHARD_INDEX" 'NR % n == k')
+fi
+
 total=${#FILES[@]}
 if [ "$total" -eq 0 ]; then
-  echo "ERROR: no *.lus benchmarks found under: ${SEARCH_DIRS[*]}" >&2
+  echo "ERROR: no *.lus benchmarks found under: ${SEARCH_DIRS[*]} (shard ${SHARD_INDEX}/${SHARD_COUNT})" >&2
   exit 2
 fi
 

--- a/scripts/benchmarks/run-benchmarks.sh
+++ b/scripts/benchmarks/run-benchmarks.sh
@@ -143,6 +143,15 @@ for f in "${FILES[@]}"; do
 
   printf '%s %s %s\n' "$rel" "$res" "$wall" >> "$OUT_STAT"
   printf '[%d/%d] %-8s %6ss  %s\n' "$i" "$total" "$res" "$wall" "$rel"
+
+  # Surface the Kind 2 output for errored benchmarks so "see logs" is actionable.
+  # `::group::`/`::endgroup::` make it a collapsible section in the CI job log
+  # (and are harmless plain text elsewhere).
+  if [ "$res" = "Error" ]; then
+    echo "::group::Kind 2 output for errored benchmark: $rel"
+    cat "$out_file"
+    echo "::endgroup::"
+  fi
 done
 
 echo "Wrote $OUT_STAT"


### PR DESCRIPTION
## What

Replaces the remote-cluster PR benchmark webhook (`webhook-handler` + `test_pr`) with a self-contained GitHub Actions workflow that, on every pull request, builds Kind 2 at the PR head **and** at the base commit, benchmarks each over a fixed set, and fails the check on a **regression** or **soundness bug**.

## Workflow (`.github/workflows/kind2-pr-benchmarks.yml`)

Pipeline `build → benchmark → compare`, running concurrently with the main CI:

1. **build** (`head`, `base`) — build each side once, upload the binary.
2. **solvers** — download Z3 + MathSAT once and cache them (keyed by version), so shards don't re-download.
3. **benchmark** (`side × shard`) — 8 shards/side in parallel; each restores the cached binaries and runs a round-robin slice of the set. Runs with default options (Z3 solver, MathSAT interpolation).
4. **compare** — join the shard stats and write a Markdown Step Summary (per-result counts, regressions, soundness bugs, errors with a pointer to the shard job whose log holds the Kind 2 output).

Honors `%notest` in the PR body, matching the old hook.

## Classification (`scripts/benchmarks/`)

- **Soundness bug** (exit 2): a property flips between `Valid` and `Invalid` vs. the base, either direction — `Invalid→Valid` (unsound for verification) or `Valid→Invalid` (unsound for falsification).
- **Regression** (exit 1): a solved benchmark the PR can no longer solve (→ `Error`); or any `Error` from the PR's binary.
- A `Timeout` where the base solved is reported for information only (CI timing is noisy).

## Benchmark set

`FMCAD08/{Bool,Int,Real_Int}` on the `main` branch of `kind2-mc/kind2-benchmarks` (checked out at run time). Per-benchmark wall timeout 120s; both are `env` knobs.

## Solver choice

Uses default options: Z3 as the SMT solver, **MathSAT** auto-detected for interpolation. MathSAT produces proper interpolants, so IC3IA never takes Z3's `qe2` QE-interpolation path — which can emit malformed output (non-linear terms / fresh constants) on some benchmarks (reported upstream as Z3Prover/z3#10170 and #10172). MathSAT was also the fastest of the tried configs.

## Also included

Per-branch `concurrency` with `cancel-in-progress` so a new push cancels the branch's still-running workflows:
- `kind2-ci.yml` and the new benchmark workflow — per branch.
- `kind2-docker.yml` — only for `main` pushes, never for tag/release builds.

(These CI-hygiene changes are bundled here for convenience; happy to split them into a separate PR if preferred. The commit history is iterative — squash-merge recommended.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)