### PR TITLE
Fix assertion on structural equality of container-valued map entries

### DIFF
--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1186,8 +1186,19 @@ and compile_ast_expr
          for structural equality *)
       | ty when Type.is_array ty ->
         let sv = state_var_of_expr e1 in
-        let bounds = SVT.find !map.bounds sv in
         let idx_tys = Type.all_index_types_of_array ty in
+        (* [bounds] are recorded for the whole state variable [sv], so they cover
+           all of its array/map/set dimensions. When [e1] is a sub-selection of
+           [sv] (e.g. a map value [m\[k\]] whose type is itself a set or array),
+           the outer, already-indexed dimensions are not part of [e1]'s type.
+           Those dimensions come first (dimensions are ordered outer-to-inner), so
+           drop the leading ones and keep the [List.length idx_tys] bounds that
+           correspond to [e1]'s own remaining dimensions. *)
+        let bounds =
+          let all_bounds = SVT.find !map.bounds sv in
+          let drop = List.length all_bounds - List.length idx_tys in
+          if drop > 0 then snd (list_split drop all_bounds) else all_bounds
+        in
         assert (List.length bounds = List.length idx_tys);
         let idx_vars = List.map (Var.mk_fresh_var) idx_tys in
         let arr_is = List.map E.mk_free_var idx_vars in

--- a/tests/regression/success/map_value_container_equality.lus
+++ b/tests/regression/success/map_value_container_equality.lus
@@ -1,0 +1,21 @@
+-- Regression test for structural equality of a map value that is itself a
+-- container (a set or an array), e.g. m[c] = <set> for m : map<K, set<V>>.
+--
+-- Compiling such an equality used to raise an internal assertion failure
+-- (lustreNodeGen, "List.length bounds = List.length idx_tys"): the bounds
+-- recorded for the whole map state variable cover both the key dimension and the
+-- value's inner dimensions, but the indexed value m[c] only has the inner ones.
+-- The already-indexed (outer) dimensions are now dropped before pairing bounds
+-- with the value's index types.
+
+node M1() returns (m: map<int,set<int>>);
+let
+  m = any { x : map<int,set<int>> | forall (c: int) x[c] = {}@<int> };
+  check "empty" forall (c: int) not (0 in m[c]);
+tel
+
+node M2() returns (m: map<int,int^2>);
+let
+  m = any { x : map<int,int^2> | forall (c: int) x[c] = [0, 0] };
+  check "zeros" forall (c: int) m[c][0] = 0;
+tel


### PR DESCRIPTION
## Problem

Compiling a structural equality whose operand is a **map value that is itself a container** (a set or an array) — e.g. `m[c] = <set>` for `m : map<K, set<V>>` — raises an internal assertion failure:

```
File "src/lustre/lustreNodeGen.ml", line 1191: Assertion failed
```

Minimal reproducer:

```
node M() returns (m: map<int,set<int>>);
let
  m = any { x : map<int,set<int>> | forall (c: int) x[c] = {}@<int> };
tel
```

(`map<int,int^2>` with `x[c] = [0,0]` triggers it too.) Whole-map equality (`m1 = m2`) is unaffected.

## Cause

The `bounds` recorded for a state variable describe *all* of its array/map/set dimensions. For a `map<K, set<V>>` state variable that includes both the key dimension and the set's inner dimension, but an indexed value `m[c]` only has the inner dimension — so the recorded bounds had more entries than the value's index types (`List.length bounds ≠ List.length idx_tys`), which fails the assertion (and the subsequent `List.combine`).

## Fix

The indexed-out dimensions are always the outer (leading) ones, so drop the leading `len bounds − len idx_tys` bounds and keep the ones that correspond to the value's own remaining dimensions. This also preserves the `Bound`/`Unbound` distinction, so genuine array dimensions still get their in-range guards (verified with the `map<int,int^2>` case) while map/set dimensions correctly get none.

## Tests

- `tests/regression/success/map_value_container_equality.lus` — covers `map<int,set<int>>` and `map<int,int^2>` value equalities.

Full regression suite and OUnit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)