### PR TITLE
Fix exception on struct update of aggregate-element arrays

### DIFF
--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1360,33 +1360,45 @@ and compile_ast_expr
   and compile_struct_update expr1 index expr2 =
     let cexpr1 = compile_ast_expr cstate ctx bounds map expr1 in
     let cexpr2 = compile_ast_expr cstate ctx bounds map expr2 in
-    let rec aux accum = function
-      | [] -> List.rev accum
-      | A.MapIndex _ :: _ -> assert false 
-      | A.SetIndex _ :: _ -> assert false
-      | A.Label (_, index) :: tl ->
-        let index = HString.string_of_hstring index in
-        let accum' = X.RecordIndex index :: accum in
-        if X.mem_prefix (List.rev accum') cexpr1 then
-          aux accum' tl
-        else assert false (* guaranteed by type checker *)
-      | A.Index (_, index_expr) :: tl ->
-        let index_cexpr = compile_ast_expr cstate ctx bounds map index_expr in
-        let index = (index_cexpr |> X.values |> List.hd).expr_init in
-        let cexpr_sub = X.find_prefix accum cexpr1 in
-        let index_term = (index : E.expr :> Term.t ) in
-        let value = Term.numeral_of_term index_term |> Numeral.to_int in
-        let i = if Term.is_numeral index_term then
-            (match X.choose cexpr_sub with
-              | X.ArrayVarIndex _ :: _, _
-              | X.ArrayIntIndex _ :: _, _ -> X.ArrayIntIndex value
-              | X.TupleIndex _ :: _,_ -> X.TupleIndex (value, None)
-              | _ -> assert false (* guaranteed by type checker *))
-          else (match X.choose cexpr_sub with
-            | X.ArrayVarIndex _ :: _, _ -> X.ArrayVarIndex index
-            | _ -> assert false (* guaranteed by type checker *) )
-        in aux (i :: accum) tl
-      | A.GenericIndex _ :: _ -> assert false (* converted to another index in the normalizer *)
+    (* Struct update of an array whose elements are aggregates (records,
+       tuples, sets, maps, ...). The array dimension is encoded as the
+       *trailing* index of every leaf's path (see [compile_ast_type]), with
+       the aggregate structure appearing first. [struct_update_core] only
+       knows how to update when the array index is at the head of the path,
+       so we peel off the aggregate prefix, run the core update on the
+       trailing array dimension for each element value, and put the prefix
+       back. [cexpr2] (the replacement element) has the same aggregate
+       structure but without the trailing array index, so its leaf at a
+       given prefix is exactly the new element value to store. *)
+    let is_array_one_index = function
+      | X.ArrayVarIndex _ | X.ArrayIntIndex _ -> true
+      | _ -> false
+    in
+    let is_aggregate_array () =
+      match index with
+      | [A.Index _] ->
+        (match X.choose cexpr1 with
+         | key, _ ->
+           (match key with
+            (* Map-tagged tuple indices ([TupleIndex (_, Some _)]) mark a
+               map/set encoding, not a Lustre tuple; a plain
+               [TupleIndex (_, None)] is a genuine tuple and is handled by
+               the core (direct element replacement), so it is excluded
+               here. *)
+            | X.RecordIndex _ :: _
+            | X.SetMapIndex _ :: _
+            | X.ListIndex _ :: _
+            | X.AbstractTypeIndex _ :: _
+            | X.AdtTagIndex _ :: _
+            | X.AdtPayloadIndex _ :: _
+            | X.TupleIndex (_, Some _) :: _ ->
+              (* the array dimension must be the trailing index *)
+              (match List.rev key with
+               | last :: _ -> is_array_one_index last
+               | [] -> false)
+            | _ -> false)
+         | exception Not_found -> false)
+      | _ -> false
     in
     let rec mk_cond_indexes (acc, cpt) li ri =
       match li, ri with
@@ -1416,31 +1428,88 @@ and compile_ast_expr
       | _ :: ri' -> mk_store acc a ri' x
       | [] -> x
     in
-    let cindex = aux X.empty_index index in
-    let cexpr2' = X.fold (fun i v a -> X.add (cindex @ i) v a) cexpr2 X.empty in
-    let over_indices = fun i v a ->
-      try let v' = X.find i cexpr2' in X.add i v' a
-      with Not_found -> try
-        (match i with
-          | X.ArrayIntIndex _ :: _ | X.ArrayVarIndex _ :: _ -> ()
-          | _ -> raise Not_found);
-        let old_v = List.fold_left (fun (acc, cpt) i ->
-          let kt = match i with 
-          | X.ArrayIntIndex _ -> Type.t_int 
-          | X.ArrayVarIndex b -> E.type_of_expr b 
-          | _ -> assert false 
-          in
-          E.mk_select_and_push acc (E.mk_array_index_var cpt kt), cpt + 1
-        ) (v, 0) i |> fst
-        in let new_v = X.find cindex cexpr2' in
-        if Flags.Arrays.smt () then
-          let v' = mk_store [] v cindex new_v in X.add [] v' a
-        else
-          let v' = E.mk_ite (mk_cond_indexes ([], 0) i cindex) new_v old_v in
-          X.add [] v' a
-        with Not_found -> X.add i v a
+    let struct_update_core cexpr1 cexpr2 =
+      let rec aux accum = function
+        | [] -> List.rev accum
+        | A.MapIndex _ :: _ -> assert false
+        | A.SetIndex _ :: _ -> assert false
+        | A.Label (_, index) :: tl ->
+          let index = HString.string_of_hstring index in
+          let accum' = X.RecordIndex index :: accum in
+          if X.mem_prefix (List.rev accum') cexpr1 then
+            aux accum' tl
+          else assert false (* guaranteed by type checker *)
+        | A.Index (_, index_expr) :: tl ->
+          let index_cexpr = compile_ast_expr cstate ctx bounds map index_expr in
+          let index = (index_cexpr |> X.values |> List.hd).expr_init in
+          let cexpr_sub = X.find_prefix accum cexpr1 in
+          let index_term = (index : E.expr :> Term.t ) in
+          let i = if Term.is_numeral index_term then
+              let value = Term.numeral_of_term index_term |> Numeral.to_int in
+              (match X.choose cexpr_sub with
+                | X.ArrayVarIndex _ :: _, _
+                | X.ArrayIntIndex _ :: _, _ -> X.ArrayIntIndex value
+                | X.TupleIndex _ :: _,_ -> X.TupleIndex (value, None)
+                | _ -> assert false (* guaranteed by type checker *))
+            else (match X.choose cexpr_sub with
+              | X.ArrayVarIndex _ :: _, _ -> X.ArrayVarIndex index
+              | _ -> assert false (* guaranteed by type checker *) )
+          in aux (i :: accum) tl
+        | A.GenericIndex _ :: _ -> assert false (* converted to another index in the normalizer *)
+      in
+      let cindex = aux X.empty_index index in
+      let cexpr2' = X.fold (fun i v a -> X.add (cindex @ i) v a) cexpr2 X.empty in
+      let over_indices = fun i v a ->
+        try let v' = X.find i cexpr2' in X.add i v' a
+        with Not_found -> try
+          (match i with
+            | X.ArrayIntIndex _ :: _ | X.ArrayVarIndex _ :: _ -> ()
+            | _ -> raise Not_found);
+          let old_v = List.fold_left (fun (acc, cpt) i ->
+            let kt = match i with
+            | X.ArrayIntIndex _ -> Type.t_int
+            | X.ArrayVarIndex b -> E.type_of_expr b
+            | _ -> assert false
+            in
+            E.mk_select_and_push acc (E.mk_array_index_var cpt kt), cpt + 1
+          ) (v, 0) i |> fst
+          in let new_v = X.find cindex cexpr2' in
+          if Flags.Arrays.smt () then
+            let v' = mk_store [] v cindex new_v in X.add [] v' a
+          else
+            let v' = E.mk_ite (mk_cond_indexes ([], 0) i cindex) new_v old_v in
+            X.add [] v' a
+          with Not_found -> X.add i v a
+      in
+      X.fold over_indices cexpr1 X.empty
     in
-    X.fold over_indices cexpr1 X.empty
+    if is_aggregate_array () then
+      (* Peel off the aggregate prefix (everything but the trailing array
+         index), update the array dimension of each element with the core
+         logic, then restore the prefix. *)
+      let all_but_last key = match List.rev key with
+        | _ :: rev_prefix -> List.rev rev_prefix
+        | [] -> []
+      in
+      let prefixes =
+        X.fold
+          (fun key _ acc ->
+            let p = all_but_last key in
+            if List.exists (fun p' -> X.equal_index p p') acc then acc
+            else p :: acc)
+          cexpr1 []
+      in
+      List.fold_left
+        (fun result prefix ->
+          let sub1 = X.find_prefix prefix cexpr1 in
+          let elem = X.find prefix cexpr2 in
+          let elem_trie = X.singleton X.empty_index elem in
+          let sub_result = struct_update_core sub1 elem_trie in
+          X.fold (fun k v acc -> X.add (prefix @ k) v acc) sub_result result)
+        X.empty
+        prefixes
+    else
+      struct_update_core cexpr1 cexpr2
 
   and compile_array_ctor bounds expr size_expr =
     let array_size' = compile_ast_expr cstate ctx bounds map size_expr in

--- a/tests/regression/success/struct_update_aggregate_array.lus
+++ b/tests/regression/success/struct_update_aggregate_array.lus
@@ -1,0 +1,51 @@
+-- Regression test for a struct update (a[i := v]) of an array whose elements
+-- are aggregates: records, sets, or maps, e.g. responses[id := s] for
+-- responses : set<Request>^N.
+--
+-- Such an update used to raise an internal exception in lustreNodeGen:
+--   * a variable index raised Invalid_argument("numeral_of_term") because the
+--     numeral was extracted before the is_numeral guard; and
+--   * once that was fixed, both numeral and variable indices hit an
+--     "assert false", because the array dimension of an aggregate-element array
+--     is encoded as the *trailing* index of every leaf's path (the aggregate
+--     structure comes first), while the update logic assumed the array index
+--     was at the head of the path.
+--
+-- The update now peels off the aggregate prefix and stores into the trailing
+-- array dimension of each element value.
+
+-- Array of records, both a numeral and a variable index.
+type R = struct { a: int; b: int };
+
+node ArrayOfRecord(i: int; v: R) returns ();
+var arr_n, arr_v: R^3;
+let
+  arr_n = (R {a = 9; b = 8}^3)[1 := v];
+  arr_v = (R {a = 9; b = 8}^3)[i := v];
+
+  check "num-updated" arr_n[1].a = v.a and arr_n[1].b = v.b;
+  check "num-kept" arr_n[0].a = 9 and arr_n[0].b = 8 and arr_n[2].a = 9;
+  check "var-updated" (i >= 0 and i < 3) => (arr_v[i].a = v.a and arr_v[i].b = v.b);
+tel
+
+-- Array of sets, variable index.
+node ArrayOfSet(i: int; v: set<int>) returns ();
+var arr: set<int>^3;
+let
+  arr = ({}@<int>^3)[i := v];
+  check "set-updated"
+    (i >= 0 and i < 3) => (forall (x: int) (x in arr[i]) = (x in v));
+tel
+
+-- Array of maps, both a numeral and a variable index.
+node ArrayOfMap(i: int; v: map<int, int>) returns ();
+var arr_n, arr_v: map<int, int>^3;
+let
+  arr_n = (map[]@<int, int>^3)[1 := v];
+  arr_v = (map[]@<int, int>^3)[i := v];
+
+  check "map-num-updated" forall (k: int) arr_n[1][k] = v[k];
+  check "map-num-kept" forall (k: int) not (k in arr_n[0]);
+  check "map-var-updated"
+    (i >= 0 and i < 3) => (forall (k: int) arr_v[i][k] = v[k]);
+tel


### PR DESCRIPTION
## Problem

A struct update `a[i := v]` on an array whose **elements are aggregates** (records, sets, maps, ...) raises an internal exception during compilation. Minimal reproducer:

```
type R = struct { a: int; b: int };
node N(i: int; v: R) returns ();
var arr: R^3;
let
  arr = (R {a = 0; b = 0}^3)[i := v];
  check true;
tel
```

```
<Error> Error opening input file '...':
        Invalid_argument("numeral_of_term")
```

The same failure occurs for `set<T>^N` and `map<K, V>^N` (e.g. `responses[id := s]` for `responses : set<Request>^N`), and for numeral indices too.

## Cause

There are two issues in `compile_struct_update` ([`src/lustre/lustreNodeGen.ml`](../blob/main/src/lustre/lustreNodeGen.ml)):

1. `Term.numeral_of_term index_term` was evaluated **before** the `Term.is_numeral` guard, so a variable index raised `Invalid_argument("numeral_of_term")`.
2. The real gap: in the trie encoding produced by `compile_ast_type`, the array dimension of `T^N` is the **trailing** index of every leaf's path, with the aggregate structure (record fields, set/map `SetMapIndex`, map-tagged `TupleIndex`, ...) appearing **first**. The update logic assumed the array index was at the **head** of the path, so it hit `assert false` for every aggregate-element array — it only ever worked for scalar-element arrays and top-level tuples/records.

## Fix

The existing (correct) update logic is factored out into `struct_update_core`. For an aggregate-element array we peel off the aggregate prefix, run the core update on the trailing array dimension for each element value, then restore the prefix. `cexpr2` (the replacement element) has the same aggregate structure but without the trailing array index, so its leaf at a given prefix is exactly the new element value to store — letting the proven store/ite encoding be reused unchanged.

Genuine Lustre tuples (`TupleIndex (_, None)`) stay on the core path (direct element replacement); only map/set-tagged `TupleIndex (_, Some _)` entries are treated as aggregate arrays, since a tuple-of-arrays would otherwise be ambiguous.

## Tests

- `tests/regression/success/struct_update_aggregate_array.lus` — array-of-record, array-of-set, and array-of-map updates with both numeral and variable indices (all properties valid).
- Full regression suite passes (424 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)