### PR TITLE
Address BV compression SMT encoding BV sort bug

### DIFF
--- a/src/induction/compress.ml
+++ b/src/induction/compress.ml
@@ -201,6 +201,29 @@ let only_bv trans_sys =
   | `Inferred l -> TermLib.FeatureSet.(mem BV l && not(mem IA l))
 
 
+(* Width of the bitvector encoding a state's temporal offset in
+   [equal_mod_input]. Must match the width used for the codomain of
+   [uf_distinct] below and the width used to build the constant in
+   [term_of_state]. *)
+let equal_mod_input_bv_width = Numeral.of_int 64
+
+(* [2^n] as a [Numeral.t] *)
+let rec pow2_numeral n =
+  if Numeral.equal n Numeral.zero then Numeral.one
+  else Numeral.mult (Numeral.of_int 2) (pow2_numeral (Numeral.pred n))
+
+(* Offsets at or beyond this value can no longer be told apart once
+   encoded as an [equal_mod_input_bv_width]-bit unsigned bitvector *)
+let equal_mod_input_bv_bound = pow2_numeral equal_mod_input_bv_width
+
+(* An offset that doesn't fit in [equal_mod_input_bv_width] bits cannot be
+   soundly used as a distinguishing tag: two different offsets could wrap
+   around to the same bitvector value, which would make the blocking clause
+   in [equal_mod_input] incorrectly force two genuinely distinct states to
+   coincide. Compression is only a search optimization, so it is always
+   safe to fall back to not compressing rather than risk that. *)
+let offset_fits_bv_width n = Numeral.lt n equal_mod_input_bv_bound
+
 (* Declare uninterpreted function symbol *)
 let init_equal_mod_input declare_fun trans_sys =
 
@@ -222,7 +245,9 @@ let init_equal_mod_input declare_fun trans_sys =
          (List.sort 
             StateVar.compare_state_vars
             (TransSys.state_vars trans_sys)))
-      (if only_bv trans_sys then Type.mk_ubv 64 else Type.t_int)
+      (if only_bv trans_sys then 
+         Type.mk_ubv (Numeral.to_int equal_mod_input_bv_width)
+       else Type.t_int)
   in
   
   declare_fun uf_distinct
@@ -257,7 +282,8 @@ let equal_mod_input only_bv unc_inputs accum s1 s2 =
       (* Count number of clauses *)
       Stat.incr Stat.ind_compress_equal_mod_input;
 
-      (* Blocking term to force states not equivalent *)
+      (* Blocking term to force states not equivalent, or [None] if
+         compression must be skipped for this pair due to BV overflow *)
       let term =
 
         (* Use uninterpreted function symbol or disjunction of equations? *)
@@ -282,9 +308,7 @@ let equal_mod_input only_bv unc_inputs accum s1 s2 =
             let term_of_state s =
               let n =
                 if only_bv then
-                  let n' = aux s in
-                  let width = Term.sufficiently_large_bit_width (n' |> Numeral.to_int) |> Numeral.of_int in
-                  Term.mk_ubv (Bitvector.num_to_ubv width n')
+                  Term.mk_ubv (Bitvector.num_to_ubv equal_mod_input_bv_width (aux s))
                 else
                   Term.mk_num (aux s)
               in
@@ -303,21 +327,34 @@ let equal_mod_input only_bv unc_inputs accum s1 s2 =
                  n]
             in              
 
-            (* Equation to force first state distinct from others *)
-            let t1 = term_of_state s1 in
+            if
+              only_bv &&
+              (not (offset_fits_bv_width (aux s1)) || not (offset_fits_bv_width (aux s2)))
+            then
 
-            (* Equation to force second state distinct from others *)
-            let t2 = term_of_state s2 in
+              None
 
-            (* Add conjunction of equations as blocking clause *)
-            Term.mk_and [t1; t2]
+            else
+
+              (
+
+                (* Equation to force first state distinct from others *)
+                let t1 = term_of_state s1 in
+
+                (* Equation to force second state distinct from others *)
+                let t2 = term_of_state s2 in
+
+                (* Add conjunction of equations as blocking clause *)
+                Some (Term.mk_and [t1; t2])
+
+              )
 
           )
 
         else
 
           (* Generate disjunction of disequalities and add to accumulator *)
-          (Term.mk_or
+          Some (Term.mk_or
 
              (List.fold_left2
                 (fun a (v1, _) (v2, _) -> 
@@ -339,10 +376,15 @@ let equal_mod_input only_bv unc_inputs accum s1 s2 =
 
       in
 
-      Debug.compress
-        "Compression clause@ %a" Term.pp_print_term term;
+      match term with
+      | Some term ->
 
-      term :: accum
+        Debug.compress
+          "Compression clause@ %a" Term.pp_print_term term;
+
+        term :: accum
+
+      | None -> accum
 
     )
 

--- a/tests/regression/success/bv_compression.lus
+++ b/tests/regression/success/bv_compression.lus
@@ -1,0 +1,40 @@
+
+node Sofar( X : bool ) returns ( Sofar : bool );
+let
+    Sofar = X -> X or pre Sofar;
+tel
+node excludes2( X1, X2 : bool ) returns ( excludes : bool );
+let
+    excludes = not ( X1 and X2 );
+tel
+node voiture(m,s: bool) returns
+(   toofast, stop, bump: bool;
+    dist, speed, time: int32;
+    move: bool; second, meter: bool );
+let
+  meter = false -> (m and not s);
+  second = false -> s;
+  move = true -> pre(move and not stop and not toofast and not bump);
+  dist = (int32 0) -> if move and meter then pre(dist)+(int32 1)
+			   else pre(dist);
+  speed = (int32 0) -> if not move or second then (int32 0)
+		else if move and meter then pre(speed) - (int32 1)
+		else pre(speed);
+  time = (int32 0) -> if second then pre(time) + (int32 1)
+		else pre(time);
+  toofast = speed >= (int32 3);
+  stop = time >= (int32 4);
+  bump = dist = (int32 10);
+tel
+node top(m, s : bool) returns (OK : bool);
+var toofast, stop, bump: bool;
+    dist, speed, time: int32;
+    move: bool; second, meter: bool;
+    env : bool;
+let
+  (toofast, stop, bump, dist, speed, time, move, second, meter) = voiture(m,s);
+  env = Sofar( excludes2( m, s ) and dist < (int32 32767));
+  OK = env => dist >= (int32 0);
+  --%MAIN;
+  --%PROPERTY OK;
+tel


### PR DESCRIPTION
We have had some recurring issues regarding compression of inductive counterexamples in bit vector SMT theories. Here are my thoughts regarding the latest iteration (bug illustrated in the new test case).

1. The problem compression addresses: we want to add constraints to eliminate loops in state (ie, the same state, by some notion of equivalence, to appear twice in a cex).
2. To achieve this end, we assert the constraint `f(state_i) = i` for every timestep `i` for an uninterpreted function `f`. This way, we can’t have the same state at different timesteps (because `f` is a mathematical function).
3. The bug is a type (bitvector width) mismatch between the codomain of `f` and the type of `i`, which should match but do not in our SMT encoding. We were trying to compute only the number of bits sufficient to store `i`. However, this `i` changes over time, and will not match a fixed return type for `f`. 
4. Naturally we could use an integer type for both `i` and codomain of `f`, but if we are in a BV-only logic we can’t do this. 
5. For some reason, when we extended Kind 2 for arbitrary-width bit vectors, we thought we needed to extend handling here, but the problems seem orthogonal. The type of `i` (and the codomain of `f`) are dependent on trace length, not on input types. (My guess - we noted a hardcoded `64` in the code base, thought it corresponded to the largest possible input BV type, and assumed it needed to be updated.)
6. So, to address the issue, we will conservatively both set the type of `i` and the return type of `f` to `(_ BitVec 64)`, as our traces in practice will not be long enough to overflow it. And even if they did overflow it, the sufficiently large bit width was not knowable a priori.
7. This being said, it is still theoretically possible in constraint `f(state) = i` for `i` to overflow. To prevent (even hypothetical) soundness bugs and to make the code understandable, I propose we add checks to ensure that `i` is not too large to overflow (ie, it can be stored with a 64-bit machine integer). If it is too large, we simply do not assert the constraint. We can no longer compress, but at least there is no soundness issue.