### PR TITLE
Keep free constants in typing context under CONTRACTCK

### DIFF
--- a/src/lustre/lustreConstantsToFunctions.ml
+++ b/src/lustre/lustreConstantsToFunctions.ml
@@ -250,22 +250,22 @@ let gen_const_functions ctx decls =
         let node_type = NI.FreeConstant in
         let node_id = NI.mk_node_id ~node_type id in
         let ops = [s.start_pos, id, ty, A.ClockTrue] in
-        let func_ty = A.TArr (p, GroupType (p, []), ty) in 
-        let acc_ctx = Ctx.remove_const acc_ctx id in
-        let acc_ctx = Ctx.add_ty_node acc_ctx node_id func_ty true in 
+        let func_ty = A.TArr (p, GroupType (p, []), ty) in
+        let acc_ctx = Ctx.add_ty_node acc_ctx node_id func_ty true in
         let acc_ctx = Ctx.add_node_param_attr acc_ctx node_id [] in
         let acc_decls =
           acc_decls @ [A.FuncDecl (s, (node_id, true, Default, [], [], ops, [], [], None), { is_lemma = false; is_rec = false })]
         in
-        let acc_decls, acc_new_func_ids =
+        let acc_decls, acc_new_func_ids, acc_ctx =
           (* If type does not contain generated identifiers, and we are only generating
              an imported function for realizability checking, then we don't need to
              convert references to this constant to calls, so we keep original declaration,
-             and we don't include the id in new_func_ids *)
+             we don't include the id in new_func_ids, and the identifier must remain a
+             constant in the typing context *)
           if not contains_gids then
-            acc_decls @ [decl], acc_new_func_ids
+            acc_decls @ [decl], acc_new_func_ids, acc_ctx
           else
-            acc_decls, id :: acc_new_func_ids
+            acc_decls, id :: acc_new_func_ids, Ctx.remove_const acc_ctx id
         in
         acc_decls, acc_new_func_ids, acc_ctx
       else 

--- a/tests/lustre/realizability_constants_3.lus
+++ b/tests/lustre/realizability_constants_3.lus
@@ -1,0 +1,14 @@
+-- A free constant whose type does not generate identifiers must stay a
+-- constant in the typing context when CONTRACTCK generates the imported
+-- function used to check its realizability. Otherwise, normalizing a
+-- quantifier over a refinement type mentioning the constant fails.
+
+const N: int;
+
+type HostId = subtype { i : int | i < N };
+
+node M(x: bool) returns (y: bool);
+let
+  y = x;
+  check "P" forall (i: HostId) i < N;
+tel


### PR DESCRIPTION
`./bin/kind2 --enable CONTRACTCK` crashed with an assertion failure in the AST normalizer on inputs combining a free constant, a refinement type mentioning it, and a quantifier over that type:

```lustre
const N: int;
type HostId = subtype { i : int | i < N };

node Sys(x: bool) returns (y: bool);
let
  y = x;
  check "P" forall (i: HostId) i >= 0;
tel
```

```
<Error> Error opening input file 'm1.lus':
        File "src/lustre/lustreAstNormalizer.ml", line 109, characters 4-10: Assertion failed
```

Without `--enable CONTRACTCK` the same file is accepted.

## Cause

`gen_const_functions` converts free constants into zero-argument imported functions in two situations:

- the constant's type induces generated identifiers (`contains_gids`) — references to the constant *are* rewritten into calls and the original declaration is dropped;
- `CONTRACTCK` is enabled — an imported function is generated only so the constant's realizability can be checked; the original declaration is kept and references are deliberately left alone.

`Ctx.remove_const` was applied in both cases. In the second one, the normalizer ends up with a context where the identifier is no longer a constant while the AST still refers to it as one. Type checking a quantifier whose bound variable has a refinement type mentioning the constant then fails with `Illegal variable 'N' in type of constant`, and `unwrap` in `lustreAstNormalizer.ml` turns that `Error` into `assert false`.

## Fix

Remove the constant from the typing context only when its references are actually converted to calls.

## Testing

- The reproducer above and a larger model that originally surfaced the bug now analyze cleanly.
- `make test`: 425 passed.
- `tests/lustre/realizability_constants_1.lus` still passes under CONTRACTCK. Added `tests/lustre/realizability_constants_3.lus` covering this case.

Note: `tests/lustre/realizability_constants_2.lus` hangs under `--enable CONTRACTCK`, but this was verified to be pre-existing on `main` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)