### PR TITLE
Share evaluation of if/when-block guards containing node calls

### DIFF
--- a/doc/usr/source/2_input/1_lustre.rst
+++ b/doc/usr/source/2_input/1_lustre.rst
@@ -960,6 +960,35 @@ as well as writing ``if`` statements that do not have any ``else`` or ``elsif`` 
    y1 = if condition1 then expr1 else (if condition2 then expr3 else expr5);
    y2 = if condition1 then expr2 else (if condition2 then expr4 else expr6);
 
+Although this desugaring gives each assigned variable its own copy of the
+conditions, the conditions are evaluated only *once* per timestep: all
+variables assigned by the same block see the same condition values, and
+therefore take the same branch. The distinction matters when a condition
+contains a call to a node whose outputs are not uniquely determined by its
+inputs — for example, an imported node with an underspecified (or no)
+contract, or a node whose definition uses the ``any`` operator. Such a call
+is evaluated once per timestep for the whole block, and the resulting value
+is shared by all the equations generated from the block. In the following
+example, the property ``"agree"`` is invariant because ``y1`` and ``y2``
+always take the same branch:
+
+.. code-block:: none
+
+   node imported nondet() returns (b: bool);
+
+   node example() returns (y1, y2: int);
+   let
+      if nondet() then
+         y1 = 1; y2 = 1;
+      else
+         y1 = 2; y2 = 2;
+      fi
+      check "agree" y1 = y2;
+   tel
+
+The same rule applies to the guards of the ``when`` and ``cond`` blocks
+below, and to blocks appearing inside frame conditions (where a variable
+left undefined in a branch holds its previous value).
 
 When blocks
 ^^^^^^^^^^^
@@ -1003,7 +1032,15 @@ cases.
 
 As for ``if`` blocks, ``when`` blocks are statement-level syntax sugar.
 For each assigned variable, the blocks above correspond to nested lazy
-``when ... then ... else ...`` expressions.
+``when ... then ... else ...`` expressions. As with ``if`` blocks, each
+guard is evaluated at most once per timestep, and its value — including any
+nondeterministic choice made by a node call appearing in the guard — is
+shared by all the variables assigned by the block. Consistent with the lazy
+branch semantics, the guard of a nested ``when`` block is itself part of
+the enclosing branch: it is evaluated only when that branch is selected,
+and node calls appearing in it are activated on the enclosing guards (their
+internal state only advances at timesteps where the enclosing branch is
+selected).
 
 Current restrictions for ``when`` blocks are:
 
@@ -1228,6 +1265,36 @@ For example, in the following frame block ``last o`` refers to the value of
    let
       o = last o + 1;
    tel
+
+The initialization of a frame block variable is evaluated only *once*, at
+the first timestep, and every reference to it denotes that same evaluation:
+the value a variable holds when the frame initialization applies and the
+value ``last x`` denotes at the first timestep are guaranteed to be the
+same. The distinction matters when the initialization expression is not
+uniquely determined — for example, an ``any`` operator or a call to an
+imported node. In the following example, the initial value of ``x`` is an
+arbitrary non-negative integer *chosen once*: at the first timestep, if
+``m`` is false, ``x`` keeps that value, and if ``m`` is true, ``x`` is that
+same value plus one — there are never two independent choices, one for
+``x`` and another for ``last x``. The property ``"nonneg"`` is invariant:
+
+.. code-block:: none
+
+   node count (m: bool) returns (x: int);
+   let
+      frame (x)
+      x = any { v: int | v >= 0 };
+      let
+         when m then
+            x = last x + 1;
+         end
+      tel
+      check "nonneg" x >= 0;
+   tel
+
+The same guarantee applies element-wise to array initializations (for
+example, ``x[i] = any { v: int | v >= 0 }`` makes one shared choice per
+element).
 
 Omitting equations in ``when`` blocks within frame blocks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/lustre/generatedIdentifiers.ml
+++ b/src/lustre/generatedIdentifiers.ml
@@ -165,6 +165,13 @@ let clocked_call_output = "wbcall"
    the node call activated on the when-block guard (e.g. '2_wbtie'). *)
 let clocked_call_tie = "wbtie"
 
+(* String constant used in lustreRemoveMultAssign.ml as the suffix of the fresh
+   boolean locals capturing an if/when-block guard that contains a node call
+   (e.g. '3_bguard'). Node calls are instantiated per syntactic occurrence and
+   the desugaring of blocks duplicates guards, so a guard with a
+   nondeterministic call must be bound to a single local first. *)
+let block_guard = "bguard"
+
 (* Checks if a variable name corresponds to a 'last'-operator local. As with
    [var_is_discarded_output], [LustreNodeGen.mk_ident] may move the leading
    numeric segment to the end, so we look for [last_local] as a '_'-separated

--- a/src/lustre/generatedIdentifiers.mli
+++ b/src/lustre/generatedIdentifiers.mli
@@ -150,6 +150,11 @@ val clocked_call_output : string
    the when-block guard (see lustreDesugarIfBlocks.ml). *)
 val clocked_call_tie : string
 
+(* String constant used as the suffix of the fresh boolean locals capturing an
+   if/when-block guard that contains a node call
+   (see lustreRemoveMultAssign.ml). *)
+val block_guard : string
+
 val empty : unit -> t
 
 val union : t -> t -> t

--- a/src/lustre/lustreRemoveMultAssign.ml
+++ b/src/lustre/lustreRemoveMultAssign.ml
@@ -117,14 +117,79 @@ let create_new_eqs ctx source lhs expr =
           gids2::gids
         )
 
+(* [wguard] is the (polarity-adjusted) conjunction of the enclosing when-block
+   guards, if any. Equations pulled out of a when-block branch (and abstracted
+   guards of nested when blocks) must remember it so that their node calls are
+   activated on that clock. *)
+let conj_guard wguard e = match wguard with
+  | None -> Some e
+  | Some g -> Some (A.BinaryOp (AH.pos_of_expr e, A.And, e, g))
+
+(* Node calls are instantiated per syntactic occurrence, and the desugaring of
+   if/when blocks (both here, in the [ClockedOutput] sources of pulled-out
+   equations, and in lustreDesugarIfBlocks.ml, where each variable defined by a
+   block gets its own copy of the guards in its ITE) duplicates block guards. A
+   nondeterministic node call in a guard would thus get an independent instance
+   in each copy, allowing variables assigned in the same branch to disagree on
+   which branch was taken. Bind any guard containing a node call to a fresh
+   local first, so that every copy of the guard refers to the same call
+   instance. Function calls are deterministic (a single UF application) and
+   safe to duplicate.
+
+   The guard of a when block nested inside another when block is evaluated
+   lazily: its node calls are activated on the enclosing guards (in the
+   normalizer, the conditions of nested LazyIte expressions are normalized
+   under the call context of the outer ones). The equation binding such a
+   guard must preserve this, so it is generated with a [ClockedOutput] source
+   on the enclosing (polarity-adjusted) guard conjunction [wguard]. *)
+let abstract_guard ctx wguard cond =
+  if AH.calls_of_expr cond |> NI.Set.exists (Ctx.node_id_is_node ctx) then
+    let pos = AH.pos_of_expr cond in
+    i := !i + 1;
+    let name = HString.mk_hstring (string_of_int !i ^ "_" ^ GI.block_guard) in
+    let source = match wguard with
+      | None -> GI.Local
+      | Some g -> GI.ClockedOutput g
+    in
+    let gids = { (GI.empty ()) with
+      GI.locals = GI.StringMap.singleton name (A.Bool pos);
+      GI.equations =
+        [([], [], A.StructDef (pos, [A.SingleIdent (pos, name)]),
+          cond, Some source)];
+    } in
+    A.Ident (pos, name), gids
+  else cond, GI.empty ()
+
+let rec abstract_block_guards ctx wguard ni = match ni with
+  | A.IfBlock (pos, cond, nis1, nis2) ->
+    let cond, gids = abstract_guard ctx wguard cond in
+    let nis1, gids1 =
+      List.map (abstract_block_guards ctx wguard) nis1 |> List.split in
+    let nis2, gids2 =
+      List.map (abstract_block_guards ctx wguard) nis2 |> List.split in
+    A.IfBlock (pos, cond, nis1, nis2),
+    List.fold_left GI.union gids (gids1 @ gids2)
+  | A.WhenBlock (pos, cond, nis1, nis2) ->
+    (* [cond] below is the abstracted guard when abstraction applies, so the
+       clocks of nested guards refer to the shared instance. *)
+    let cond, gids = abstract_guard ctx wguard cond in
+    let not_cond = A.UnaryOp (AH.pos_of_expr cond, A.Not, cond) in
+    let nis1, gids1 =
+      List.map (abstract_block_guards ctx (conj_guard wguard cond)) nis1
+      |> List.split in
+    let nis2, gids2 =
+      List.map (abstract_block_guards ctx (conj_guard wguard not_cond)) nis2
+      |> List.split in
+    A.WhenBlock (pos, cond, nis1, nis2),
+    List.fold_left GI.union gids (gids1 @ gids2)
+  | A.FrameBlock (pos, vars, nes, nis) ->
+    let nis, gidss =
+      List.map (abstract_block_guards ctx wguard) nis |> List.split in
+    A.FrameBlock (pos, vars, nes, nis),
+    List.fold_left GI.union (GI.empty ()) gidss
+  | _ -> ni, GI.empty ()
+
 let remove_mult_assign_from_ni ctx ni =
-  (* [wguard] is the (polarity-adjusted) conjunction of the enclosing
-     when-block guards, if any. Equations pulled out of a when-block branch
-     must remember it so that their node calls are activated on that clock. *)
-  let conj_guard wguard e = match wguard with
-    | None -> Some e
-    | Some g -> Some (A.BinaryOp (AH.pos_of_expr e, A.And, e, g))
-  in
   let rec helper ctx wguard ni = (
     match ni with
       | A.Body (Equation (_, lhs, expr)) ->
@@ -177,10 +242,12 @@ let remove_mult_assign_from_ni ctx ni =
   ni, gids
 
 let desugar_node_item ctx ni = match ni with
-  | A.IfBlock _ 
+  | A.IfBlock _
   | A.WhenBlock _
-  | A.FrameBlock _ -> 
-    remove_mult_assign_from_ni ctx ni 
+  | A.FrameBlock _ ->
+    let ni, gids1 = abstract_block_guards ctx None ni in
+    let ni, gids2 = remove_mult_assign_from_ni ctx ni in
+    ni, GI.union gids1 gids2
   | _ -> ni, GI.empty ()
 
 (** Remove multiple assignment from if and frame blocks in a single declaration. *)

--- a/tests/regression/success/block_guard_nondet.lus
+++ b/tests/regression/success/block_guard_nondet.lus
@@ -1,0 +1,59 @@
+-- A block guard is evaluated once per timestep: although the desugaring of
+-- if/when blocks gives each assigned variable its own copy of the guards, a
+-- nondeterministic node call in a guard is bound to a single shared local
+-- (see lustreRemoveMultAssign.ml), so all variables assigned by the block
+-- take the same branch.
+node imported nondet() returns (b: bool);
+
+node if_block() returns (ok: bool);
+var x, y: int;
+let
+  frame (x, y)
+    x = 0;
+    y = 0;
+  let
+    if nondet() then
+      x = 1;
+      y = 1;
+    else
+      x = 2;
+      y = 2;
+    fi
+  tel
+  ok = (x = y);
+  check "if_agree" ok;
+tel
+
+node when_block() returns (x, y: int);
+let
+  frame (x, y)
+    x = 0;
+    y = 0;
+  let
+    when nondet() then
+      x = 1; y = 1;
+    else
+      x = 2; y = 2;
+    end
+  tel
+  check "when_agree" x = y;
+tel
+
+-- The guard of a nested when block is also a single shared instance,
+-- activated on the enclosing guard.
+node nested_when(c1: bool) returns (x, y: int);
+let
+  frame (x, y)
+    x = 0;
+    y = 0;
+  let
+    when c1 then
+      when nondet() then
+        x = 1; y = 1;
+      else
+        x = 2; y = 2;
+      end
+    end
+  tel
+  check "nested_agree" x = y;
+tel

--- a/tests/regression/success/nested_when_guard_clock.lus
+++ b/tests/regression/success/nested_when_guard_clock.lus
@@ -1,0 +1,27 @@
+-- The guard of a when block nested inside another when block is evaluated
+-- lazily: its node calls are activated on the enclosing guard. Here toggle()
+-- must alternate per outer activation (not per timestep), so the inner branch
+-- is taken on every other activation and n2 = ceil(n1/2). If the abstracted
+-- inner guard were evaluated on the base clock instead, a c1 pattern like
+-- true, false, true would make toggle() true at both activations and falsify
+-- the property.
+node toggle() returns (b: bool);
+let
+  b = true -> not (pre b);
+tel
+
+node top(c1: bool) returns (n1, n2: int);
+let
+  frame (n1, n2)
+    n1 = 0;
+    n2 = 0;
+  let
+    when c1 then
+      n1 = last n1 + 1;
+      when toggle() then
+        n2 = last n2 + 1;
+      end
+    end
+  tel
+  check "inner_alternates" (2 * n2 = n1) or (2 * n2 = n1 + 1);
+tel


### PR DESCRIPTION
## Problem

Kind 2 can report counterexamples that are impossible under the source semantics when an if/when-block guard contains a call to a node whose outputs are not uniquely determined by its inputs (e.g. an imported node without a defining contract). Minimal reproducer:

```
node imported nondet() returns (r: bool);

node top() returns (ok: bool);
var x, y: int;
let
  frame (x, y)
    x = 0; y = 0;
  let
    if nondet() then
      x = 1; y = 1;
    else
      x = 2; y = 2;
    fi
  tel
  ok = (x = y);
  --%PROPERTY ok;
tel
```

The property `x = y` is falsified at k=0 with `x = 2, y = 1`: the two variables take *different branches* of the same if block. The same issue produced a spurious k=5 counterexample for a two-phase-commit model, where the coordinator sent a `DecisionMsg` (the `nw_send` frame variable took the decision branch) while its `decision` frame variable simultaneously took the stutter branch and stayed `None`.

## Cause

The desugaring of if/when blocks duplicates block guards: each variable defined by a block gets its own copy of the guards in its generated ITE (`lustreDesugarIfBlocks.ml`), and equations pulled out of when-block branches embed the guard again in their `ClockedOutput` sources (`lustreRemoveMultAssign.ml`). Node calls are instantiated per syntactic occurrence, so each copy of a nondeterministic call is an independent instance and the copies of a guard can evaluate differently within the same step.

## Fix

In `lustreRemoveMultAssign.ml`, before multiple-assignment removal, any block guard containing a node call is now bound to a fresh generated boolean local (suffix `_bguard`), and the guard is replaced by that identifier, so every downstream copy refers to the same call instance. Function calls are deterministic (a single UF application) and are still duplicated freely.

The guard of a when block nested inside another when block is evaluated lazily: its node calls are activated on the enclosing guards (nested `LazyIte` conditions are normalized under the call context of the outer ones). To preserve this, the binding equation of a nested guard is generated with a `ClockedOutput` source on the (polarity-adjusted) conjunction of the enclosing guards — built from the *abstracted* outer guards, so the clocks also reference the shared instances. Top-level guards are bound with an unclocked (`Local`) equation, matching the eager evaluation of if-block conditions.

## Tests

- `tests/regression/success/block_guard_nondet.lus` — a nondeterministic guard shared by two variables, for an if block, a when block, and a nested when block (all variables must take the same branch).
- `tests/regression/success/nested_when_guard_clock.lus` — a *stateful* call (`toggle()`) as a nested when guard; the property distinguishes activation on the enclosing guard (valid) from base-clock evaluation (falsified at 1 step), guarding the `ClockedOutput` clocking of nested guards.

Full regression suite passes (429 tests, including the two new ones).

## Documentation

`doc/usr/source/2_input/1_lustre.rst` now specifies the evaluation semantics of block guards: guards are evaluated at most once per timestep and their values (including nondeterministic choices) are shared by all variables assigned by the block; nested when-block guards are evaluated only when the enclosing branch is selected, with node calls activated on the enclosing guards. It also documents the single shared evaluation of frame block initializations referenced through `last` (the semantics fixed in 6d73ee8f, #1408), with a runnable example for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
