### PR TITLE
Update cvc5 to 1.3.4

### DIFF
--- a/proofs/get-ethos-checker
+++ b/proofs/get-ethos-checker
@@ -33,7 +33,7 @@ EO_DIR="$BASE_DIR/tmp/ethos-checker"
 mkdir -p $EO_DIR
 
 # download and unpack ethos
-ETHOS_VERSION="59e9ea6a077e1fd73dfc3107966b9f5603896c86"
+ETHOS_VERSION="221641668d75eaffd308e0511d63962cea937110"
 download "https://github.com/cvc5/ethos/archive/$ETHOS_VERSION.tar.gz" $BASE_DIR/tmp/ethos.tgz
 tar --strip 1 -xzf $BASE_DIR/tmp/ethos.tgz -C $EO_DIR
 
@@ -48,7 +48,7 @@ popd
 ##### signatures
 
 # The CPC signatures live in the main cvc5 repository
-version="cvc5-1.3.2"
+version="cvc5-1.3.4"
 
 # download the CPC signatures
 pushd $BASE_DIR/tmp


### PR DESCRIPTION
Update version retrieved by `get-ethos-checker` from `1.3.2` to `1.3.4`. Also update Ethos to the version compatible with cvc5 `1.3.4`.