### PR TITLE
Allow structure updates on values with a refinement type

### DIFF
--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1266,25 +1266,27 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
     if List.length i_or_ls != 1
     then type_error pos (Unsupported ("List of labels or indices for structure update is not supported"))
     else
-      let* i_or_ls = R.seq (List.map (desugar_generic_index ctx nname ue) i_or_ls) in 
+      let* i_or_ls = R.seq (List.map (desugar_generic_index ctx nname ue) i_or_ls) in
       (match List.hd i_or_ls with
       | LA.GenericIndex _ -> assert false (* handled by desugar_generic_index *)
-      | LA.Label (pos, l) ->  
-          infer_type_expr ctx nname ue
-          >>= (function 
-              | RecordType (_, _, flds) as r_ty, ue, warnings1 ->
+      | LA.Label (pos, l) ->
+          let* ue_ty, ue, warnings1 = infer_type_expr ctx nname ue in
+          let* ue_ty' = expand_type_syn_reftype_history ctx ue_ty in
+          (match ue_ty' with
+              | RecordType (_, _, flds) ->
                   (let typed_fields = List.map (fun (_, i, ty) -> (i, ty)) flds in
                   (match (List.assoc_opt l typed_fields) with
                     | Some f_ty ->
                       let* e_ty, e, warnings2 = infer_type_expr ctx nname (Option.get e) in
                       R.ifM (eq_lustre_type ctx f_ty e_ty)
-                        (R.ok (r_ty, LA.StructUpdate (pos, ue, i_or_ls, Some e), warnings1 @ warnings2))
+                        (R.ok (ue_ty', LA.StructUpdate (pos, ue, i_or_ls, Some e), warnings1 @ warnings2))
                         (type_error pos (TypeMismatchOfRecordLabel (l, f_ty, e_ty)))
                     | None -> type_error pos (NotAFieldOfRecord l)))
-              | r_ty, _, _ -> type_error pos (IlltypedUpdateWithLabel r_ty))
+              | _ -> type_error pos (IlltypedUpdateWithLabel ue_ty))
       | LA.Index (pos, i) ->
         let* ue_ty, ue, warnings1 = infer_type_expr ctx nname ue in
-        (match ue_ty with
+        let* ue_ty' = expand_type_syn_reftype_history ctx ue_ty in
+        (match ue_ty' with
         | TupleType _ -> (
           let* idx =
             match LH.get_const_num_value i with
@@ -1293,7 +1295,7 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
           in
           let* e_ty, e, warnings2 = infer_type_expr ctx nname (Option.get e) in
           let* ue, warnings3 = check_type_tuple_proj pos ctx nname ue idx e_ty in
-          R.ok (ue_ty, LA.StructUpdate (pos, ue, i_or_ls, Some e), warnings1 @ warnings2 @ warnings3)
+          R.ok (ue_ty', LA.StructUpdate (pos, ue, i_or_ls, Some e), warnings1 @ warnings2 @ warnings3)
         )
         | ArrayType (_, (b_ty, _)) -> (
           let* index_type, i, warnings1 = infer_type_expr ctx nname i in
@@ -1302,35 +1304,37 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
           if b then
             let* e_ty, e, warnings2 = infer_type_expr ctx nname (Option.get e) in
             R.ifM (eq_lustre_type ctx b_ty e_ty)
-              (R.ok (ue_ty, LA.StructUpdate (pos, ue, LA.Index (pos, i) :: List.tl i_or_ls, Some e), warnings1 @ warnings2))
+              (R.ok (ue_ty', LA.StructUpdate (pos, ue, LA.Index (pos, i) :: List.tl i_or_ls, Some e), warnings1 @ warnings2))
               (type_error pos (ExpectedType (e_ty, b_ty)))
           else
             type_error pos (ExpectedIntegerTypeForArrayIndex index_type)
         )
         | _ -> type_error pos (IlltypedUpdateWithIndex ue_ty)
         )
-      | LA.MapIndex (p, idx_e) -> 
+      | LA.MapIndex (p, idx_e) ->
         let* ue_ty, ue, warnings1 = infer_type_expr ctx nname ue in
-         (match ue_ty with 
+        let* ue_ty' = expand_type_syn_reftype_history ctx ue_ty in
+         (match ue_ty' with
          | Map (_, kt, vt) -> (
             let* index_type, idx_e, warnings2 = infer_type_expr ctx nname idx_e in
             let* index_type = expand_type_syn_reftype_history ctx index_type in
             R.ifM (eq_lustre_type ctx index_type kt)
               (let* e_ty, e, warnings3 = infer_type_expr ctx nname (Option.get e) in
                 R.ifM (eq_lustre_type ctx e_ty vt)
-                  (R.ok (ue_ty, LA.StructUpdate (pos, ue, [LA.MapIndex (p, idx_e)], Some e), warnings1 @ warnings2 @ warnings3))
+                  (R.ok (ue_ty', LA.StructUpdate (pos, ue, [LA.MapIndex (p, idx_e)], Some e), warnings1 @ warnings2 @ warnings3))
                   (type_error pos (ExpectedType (e_ty, vt))))
               (type_error pos (ExpectedType (index_type, kt)))
           )
          | _ -> type_error pos (IlltypedUpdateWithIndex ue_ty))
-      | LA.SetIndex (p, idx_e) -> 
+      | LA.SetIndex (p, idx_e) ->
         let* ue_ty, ue, warnings1 = infer_type_expr ctx nname ue in
-         (match ue_ty with 
+        let* ue_ty' = expand_type_syn_reftype_history ctx ue_ty in
+         (match ue_ty' with
          | Set (_, kt) -> (
             let* index_type, idx_e, warnings2 = infer_type_expr ctx nname idx_e in
             let* index_type = expand_type_syn_reftype_history ctx index_type in
             R.ifM (eq_lustre_type ctx index_type kt)
-              (R.ok (ue_ty, LA.StructUpdate (pos, ue, [LA.SetIndex (p, idx_e)], None), warnings1 @ warnings2))
+              (R.ok (ue_ty', LA.StructUpdate (pos, ue, [LA.SetIndex (p, idx_e)], None), warnings1 @ warnings2))
               (type_error pos (ExpectedType (index_type, kt)))
           )
          | _ -> type_error pos (IlltypedUpdateWithIndex ue_ty))
@@ -2030,17 +2034,18 @@ and check_type_record_proj: Lib.position -> tc_context -> NI.t option -> LA.expr
 
 and check_type_tuple_proj : Lib.position -> tc_context -> NI.t option -> LA.expr -> int -> tc_type -> (LA.expr * [> warning] list, [> error]) result =
   fun pos ctx nname expr idx exp_ty ->
-  infer_type_expr ctx nname expr
-  >>= function
-  | TupleType (_, tys) as ty, expr, warnings ->
+  let* ty, expr', warnings = infer_type_expr ctx nname expr in
+  let* ty' = expand_type_syn_reftype_history ctx ty in
+  match ty' with
+  | TupleType (_, tys) ->
     if List.length tys <= idx
-    then type_error pos (TupleIndexOutOfBounds (idx, ty))
+    then type_error pos (TupleIndexOutOfBounds (idx, ty'))
     else R.ok (List.nth tys idx)
     >>= fun ity ->
     R.ifM (eq_lustre_type ctx ity exp_ty)
-      (R.ok (expr, warnings))
+      (R.ok (expr', warnings))
       (type_error pos (UnificationFailed (exp_ty, ity)))
-  | ty, _, _ -> type_error (LH.pos_of_expr expr) (IlltypedTupleProjection ty)
+  | _ -> type_error (LH.pos_of_expr expr) (IlltypedTupleProjection ty)
 
 and check_type_const_decl: tc_context -> NI.t option -> LA.const_decl -> tc_type -> (LA.const_decl * [> warning] list, [> error]) result =
   fun ctx nname const_decl exp_ty ->

--- a/tests/regression/error/struct_update_non_updatable_ref_type.lus
+++ b/tests/regression/error/struct_update_non_updatable_ref_type.lus
@@ -1,0 +1,8 @@
+-- A refinement type over a non-updatable base type must still be rejected:
+-- expanding the type before dispatching on its shape must not make every
+-- update type check.
+
+node N(x: subtype { xx: int | xx > 0 }; k, v: int) returns (o: int);
+let
+  o = x[k := v];
+tel

--- a/tests/regression/success/struct_update_ref_types.lus
+++ b/tests/regression/success/struct_update_ref_types.lus
@@ -1,0 +1,35 @@
+-- Structure updates (`e[i := v]`) applied to a value whose type is a
+-- refinement type, either written inline or behind a type synonym.
+-- The updated expression's type must be expanded before dispatching on its
+-- shape, otherwise the refinement type hides the record/tuple/array/map.
+
+type Nat = subtype { x: int | x >= 0 };
+
+type R = struct { f: Nat; g: bool };
+type Pair = [Nat, bool];
+
+type TotalMap = subtype { m: map<int, Nat> | forall (k: int) k in m };
+
+node N(r: subtype { rr: R | rr.f > 0 };
+       p: subtype { pp: Pair | pp[0] > 0 };
+       a: subtype { aa: Nat^3 | aa[0] > 0 };
+       m: TotalMap;
+       m2: map<int, Nat>;
+       k: int)
+returns (r2: R; p2: Pair; a2: Nat^3; m3: map<int, Nat>; n: Nat);
+let
+  r2 = r[f := 7];
+  p2 = p[0 := 7];
+  a2 = a[0 := 7];
+  m3 = m[k := 7];
+
+  -- The refinement type must be usable as an assumption: a lookup in a total
+  -- map yields a Nat even for a key not known to be present.
+  n = m[k];
+
+  check r2.f = 7;
+  check p2[0] = 7;
+  check a2[0] = 7;
+  check m3[k] = 7;
+  check k in m2 => m2[k] >= 0;
+tel


### PR DESCRIPTION
## Problem

The `StructUpdate` branches in `infer_type_expr` match the inferred type of the updated expression without expanding it first, so a record, tuple, array, or map hidden behind a refinement type — or behind a type synonym for one — never reaches the corresponding case and is rejected.

Plain index access `e[i]` already calls `expand_type_syn_reftype_history` on the inferred type, which is why the lookup and the update behave differently on the same variable:

```lustre
node M(m: subtype { mm: map<int,int> | true }; k, v: int) returns (o: int; p: map<int,int>);
let
  o = m[k];        -- OK
  p = m[k := v];   -- Error
tel
```

```
<Error> Parser error at 4:7: Expected a tuple, array, map, or set type
        but found subtype { mm: map<int; int> | true }
```

This is not map-specific: arrays (`a[0 := 1]`), tuples, and records fail the same way, the record case via `IlltypedUpdateWithLabel`.

It came up writing a total-map invariant directly on a node input, where the refinement is what makes the surrounding proof go through:

```lustre
last_responses: subtype { m: map<ClientId,set<Nat>> | forall (c: ClientId) c in m }
```

Without it, `last_responses[id]` for an absent key is an unconstrained set and the generated `set<Nat>` obligations are invalid — but the node body updates the map, so the constraint could not be written at all.

## Fix

Expand the type before dispatching on its shape, in each of the label, index, map-index, and set-index branches, and in `check_type_tuple_proj` (which re-infers the type internally and so needed the same treatment). Errors keep reporting the unexpanded type, which is the one the user wrote.

A structure update may break the refinement predicate of the type it is applied to, so the update is now typed with the expanded type rather than the refinement type. That is also what the normalizer expects: the map and set update cases in `lustreAstNormalizer.ml` select base types out of the inferred type and `assert false` on anything that is not a `Map` or a `Set`, so returning the refinement type turned the type error into an assertion failure.

## Testing

- `tests/regression/success/struct_update_ref_types.lus` — record, tuple, array, and map updates on refinement types, inline and behind a type synonym, plus the total-map lookup that motivated this.
- `tests/regression/error/struct_update_non_updatable_ref_type.lus` — a refinement over `int` must still be rejected, so that expanding does not make every update type check.
- Also checked by hand that ill-typed updates still fail with unchanged messages: non-updatable base type, wrong value type, wrong key type, unknown record field, and tuple type mismatch.
- Full suite: 434 passed (432 before this change), plus `dune build @runtest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)