### PR TITLE
Fix structural equality of sets and maps with enum-typed index dimensions

### DIFF
--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1243,19 +1243,40 @@ and compile_ast_expr
         let e2' = List.fold_left (fun acc arr_i -> 
           E.mk_select_and_push acc arr_i
         ) e2 arr_is in
-        let guard = List.fold_left (fun acc (idx_var, bound) -> 
-          match bound with 
+        (* A dimension whose index type is an enumerated datatype (the
+           discriminant dimension of a set/map over an ADT, or a set/map over
+           an enum) is only *defined* at the values of that enum: the equations
+           defining such a variable are inlined over [l..u] (see
+           [LustreTransSys.constraints_of_arrays]). The index variables
+           introduced here range over the whole integer domain, so without this
+           constraint two structurally equal sets could be told apart at an
+           index outside the enum. *)
+        let enum_range_cond idx_var =
+          let ty = Var.type_of_var idx_var in
+          if not (Type.is_enum ty) then E.t_true
+          else
+            let l, u = Type.bounds_of_enum ty in
+            let ctors = Type.constructors_of_enum ty in
+            let ctor_of n = List.nth ctors (Numeral.(to_int (n - l))) in
+            let idx_var = E.mk_free_var idx_var in
+            E.mk_and
+              (E.mk_lte (E.mk_constr (ctor_of l) ty) idx_var)
+              (E.mk_lte idx_var (E.mk_constr (ctor_of u) ty))
+        in
+        let guard = List.fold_left (fun acc (idx_var, bound) ->
+          let acc = E.mk_and (enum_range_cond idx_var) acc in
+          match bound with
           (* For arrays we only consider indices that are in bounds *)
           | E.Bound n
-          | E.Fixed n -> 
+          | E.Fixed n ->
             let n = E.mk_of_expr n in
             let idx_var = E.mk_free_var idx_var in
-            let cond = E.mk_and 
-              (E.mk_lte (E.mk_int (Numeral.of_int 0)) idx_var) 
-              (E.mk_lt idx_var n) 
+            let cond = E.mk_and
+              (E.mk_lte (E.mk_int (Numeral.of_int 0)) idx_var)
+              (E.mk_lt idx_var n)
             in
-            E.mk_and cond acc 
-          | E.Unbound _ -> 
+            E.mk_and cond acc
+          | E.Unbound _ ->
             acc
         ) E.t_true (List.combine idx_vars bounds) in
         (* For map value equality we only consider m1[k] = m2[k] for k in the maps.

--- a/tests/regression/falsifiable/set_adt_key_equality_diff.lus
+++ b/tests/regression/falsifiable/set_adt_key_equality_diff.lus
@@ -1,0 +1,13 @@
+-- Same as set_enum_key_equality_diff, but the enum dimension comes from the
+-- discriminant of an algebraic datatype element type.
+
+datatype D = A (a: int) | B (b: bool);
+
+node main(i: int) returns (ok: bool);
+var u, v: set<D>;
+let
+  u = { A(i) };
+  v = { B(true) };
+  ok = u = v;
+  check ok;
+tel

--- a/tests/regression/falsifiable/set_enum_key_equality_diff.lus
+++ b/tests/regression/falsifiable/set_enum_key_equality_diff.lus
@@ -1,0 +1,13 @@
+-- Guarding the enum dimension of a set's index must not make structural
+-- equality vacuous: sets that really differ are still unequal.
+
+type Color = enum { Red, Green, Blue };
+
+node main() returns (ok: bool);
+var s, t: set<Color>;
+let
+  s = { Red };
+  t = { Red, Green };
+  ok = s = t;
+  check ok;
+tel

--- a/tests/regression/success/set_map_enum_key_equality.lus
+++ b/tests/regression/success/set_map_enum_key_equality.lus
@@ -1,0 +1,39 @@
+-- Structural equality of sets and maps whose element/key type contains an
+-- enumerated datatype: the discriminant dimension of the underlying array is
+-- only defined at the values of the enum, so the quantified index variable
+-- must be constrained to that range.
+
+type Color = enum { Red, Green, Blue };
+datatype D = A (a: int) | B (b: bool);
+
+node main(d: D) returns (ok: bool);
+var s, t: set<Color>;
+    u, e: set<D>;
+    m: map<D, int>;
+    ce: set<Color>;
+let
+  s  = { Red };
+  t  = { Red, Green };
+  ce = {}@<Color>;
+  u  = { d };
+  e  = {}@<D>;
+  m  = map[d := 7];
+
+  -- enum element type
+  check "empty enum set" ce = {}@<Color>;
+  check "enum set literal" s = { Red };
+  check "enum set order" t = { Green, Red };
+  check "enum set duplicates" t = { Red, Green, Red };
+  check "enum set union" (s + { Green }) = t;
+  check "enum set difference" (t - { Green }) = s;
+  check "enum set intersection" (t * s) = s;
+  check "enum sets differ" s <> t;
+
+  -- ADT element/key type (the discriminant is an enum)
+  check "empty adt set" e = {}@<D>;
+  check "adt set singleton" u = { d };
+  check "adt sets differ" u <> e;
+  check "adt keyed map" m = map[d := 7];
+
+  ok = true;
+tel


### PR DESCRIPTION
### Problem

Structural equality of a `set` or `map` whose element/key type contains an enum is falsifiable for values that are provably identical:

```lustre
datatype D1 = C1 (a: int);

node M() returns (e: set<D1>);
let
  e = {}@<D1>;
  check "EQ"  ({}@<D1>) = ({}@<D1>);          -- invalid after 0 steps
  check "MEM" forall (d: D1) not (d in e);    -- valid (k=1)
tel
```

The same happens for `set<Color>` where `Color` is a plain `enum`, for `map` types with such key types, and for any two set expressions with identical definitions (`x = x2` fails; only the syntactically identical `x = x` succeeds). Element types built from `int`, records, tuples, or subranges are unaffected.

### Cause

Sets and maps compile to nested arrays with one dimension per leaf of the element/key type's index trie. When the element/key type is an enum — or an ADT, whose trie carries an `AdtTagIndex` discriminant — one of those dimensions has an enum index type.

The two sides of the encoding disagree about that dimension's domain:

- `LustreTransSys.constraints_of_arrays` inlines an enum dimension over its values `[l..u]`, so the definition of an empty `set<D1>` is emitted as
  `(forall ((X1 Int)) (let ((X2 0)) (= (_select_1 s X1 X2) false)))` — the tag `X2` is pinned.
- `compile_equality` quantified every dimension unguarded, emitting
  `(forall ((X1 Int) (X2 Int)) (= (_select_1 s X1 X2) (_select_1 t X1 X2)))`.

At any `X2` outside the enum both arrays are unconstrained and free to differ, so the equality is falsifiable. Membership is unaffected because `mk_enum_reftype_constraints` already range-constrains user-quantified enum variables.

### Fix

`compile_equality` now guards each index variable whose type is an enum with `first_ctor <= v <= last_ctor`. The bounds are built with `E.mk_constr` so they type check as enum-to-enum comparisons rather than against integer literals, and constructors are picked by offset from the type's lower bound so this stays correct if an `Enum (l, u)` ever denotes a sub-range of a larger enum. The condition joins the existing `guard`, so it applies to disequality (`exists x. guard and a[x] <> b[x]`) as well.

Subranges were never affected — set/map element types go through `expand_type_syn_reftype_history`, which reduces them to `int`.

### Testing

The fix does not make equality vacuous; sets that genuinely differ are still unequal.

| | before | after |
|---|---|---|
| `{}@<D1> = {}@<D1>`, `x = x2` (identical definitions) | invalid | **valid** |
| `set<Color>`, `set<D>`, `map<D,int>` equality | invalid | **valid** |
| union / difference / intersection / order / duplicate identities over `set<Color>` | invalid | **valid** |
| `{Red} = {Red,Green}`, `{A(i)} = {B(true)}` | invalid | invalid (correct) |
| `s <> t` for differing sets | valid | valid |

`make test`: 435 passed (432 before, plus the 3 tests added here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)