### PR TITLE
Revert non-linear atom filter in IC3IA (Z3 bug fixed upstream)

### DIFF
--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -448,21 +448,6 @@ let refine fwd solver sys predicates cubes =
     |> Term.TermSet.elements
     |> List.iteri (fun i t -> Format.printf "ATOM%d: %a@." i Term.pp_print_term t);*)
 
-    (* Z3's quantifier elimination can return non-linear atoms (e.g. a product
-       of two integer variables) even when its input is linear; cvc5 does not.
-       For a linear transition system such atoms are spurious, and adding them
-       as predicates would make the SMT solver reject later queries with
-       "logic does not support non-linear arithmetic". Drop them here. *)
-    let atoms =
-      match TransSys.get_logic sys with
-      | `Inferred l when not (TermLib.FeatureSet.mem TermLib.NA l) ->
-        Term.TermSet.filter
-          (fun a ->
-            not (TermLib.FeatureSet.mem TermLib.NA (TermLib.logic_of_term [] a)))
-          atoms
-      | _ -> atoms
-    in
-
     add_predicates solver predicates atoms
   )
 


### PR DESCRIPTION
Reverts #1406.

That PR worked around IC3IA receiving atoms with a product of two variables from Z3's quantifier elimination (`(apply (then qe-light qe2))`) even when the input formula was linear. Those atoms became abstraction predicates and were asserted into a `QF_LIA` solver, which then rejected the query with `logic does not support nonlinear arithmetic`.

The root cause was a Z3 bug, [Z3Prover/z3#10170](https://github.com/Z3Prover/z3/issues/10170), which has since been fixed upstream. With that fix, Z3's QE no longer returns non-linear atoms for linear input, so the filter in `refine` is dead weight and is removed here.

- Single file touched: `src/ic3ia/IC3IA.ml`, restoring `atoms` to flow directly into `add_predicates`.
- `dune build src/ic3ia/` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)