### PR TITLE
Do not generate refinement type obligations for 'last' locals

### DIFF
--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -1356,11 +1356,20 @@ and normalize_node info map
   (* Record constraints on locals *)
   let gids7, warnings7 = locals
     |> List.filter (function
-      | A.NodeVarDecl (_, (_, id, _, _)) 
-      | A.NodeConstDecl (_, TypedConst (_, id, _, _)) -> 
-        let ty = Ctx.lookup_ty info.context id |> get in 
+      | A.NodeVarDecl (_, (_, id, _, _))
+      | A.NodeConstDecl (_, TypedConst (_, id, _, _)) ->
+        let ty = Ctx.lookup_ty info.context id |> get in
         let ty = Ctx.expand_type_syn info.context ty in
-        Ctx.type_contains_ref ctx ty
+        (* Locals introduced to desugar the 'last' operator are Kind 2 generated
+           and keep the declared type of the variable they shadow (so that
+           'last x' types exactly like 'x'). Their refinement type constraint is
+           implied by the one already generated for that variable: a
+           last-variable is defined by [init_x -> pre x], the frame
+           initialization [init_x] is what [x] is assigned in the initial state,
+           and [pre x] is [x] at the previous instant. Emitting it anyway would
+           only add a redundant proof obligation reported under a generated name
+           the user never wrote. *)
+        not (var_is_last_local id) && Ctx.type_contains_ref ctx ty
       | A.NodeConstDecl (_, FreeConst _)
       | A.NodeConstDecl (_, UntypedConst _) -> false)
     |> List.fold_left (fun (acc_g, acc_w) l -> match l with

--- a/tests/regression/success/frame_last_refinement_type.lus
+++ b/tests/regression/success/frame_last_refinement_type.lus
@@ -1,0 +1,49 @@
+-- Locals introduced to desugar 'last' must not generate refinement type
+-- proof obligations of their own: they are Kind 2 generated, so the obligation
+-- would be reported under a name the user never wrote, and it is anyway implied
+-- by the obligation already generated for the variable they shadow.
+
+type Nat = subrange [0,*] of int;
+
+datatype Option<T> = Some (value: T) | None;
+
+-- 'last' on a refinement-typed frame variable, both directly and nested in a
+-- datatype.
+node counter (m: bool) returns (x: Nat; y: Option<Nat>);
+let
+  frame (x, y)
+    x = 0;
+    y = None@<Nat>;
+  let
+    if m then
+      x = last x + 1;
+      y = Some(x);
+    fi
+  tel
+  check "nonneg" x >= 0;
+tel
+
+node main (m: bool) returns (ok: bool);
+var x: Nat;
+var y: Option<Nat>;
+let
+  x, y = counter(m);
+  ok = x >= 0 and (Some?(y) => y.value >= 0);
+  check "ok" ok;
+tel
+
+-- 'last' on a refinement-typed frame variable that the frame does *not*
+-- initialize. The generated local is then defined by an unguarded 'pre z', so
+-- an obligation on it would be falsifiable at the initial state even though z
+-- itself always satisfies its refinement type. This node is deliberately left
+-- uncalled so that it is analyzed as a top node: p is unconstrained at the
+-- first timestep, so no caller could observe it without being falsifiable.
+node hold () returns (p: int);
+var z: Nat;
+let
+  frame (z, p)
+  let
+    z = 0;
+    p = last z;
+  tel
+tel


### PR DESCRIPTION
The locals introduced to desugar the `last` operator are Kind 2 generated, but they keep the declared type of the variable they shadow so that `last x` types exactly like `x`. As a result they are picked up by the pass that records refinement type constraints on node locals, and each one produces a proof obligation of its own — reported under a generated name the user never wrote:

```
Server[L113C37].SubType[L54C3]: valid (k=2)
  (Some?(0_glast_currentRequest) =>
  (Req?(0_glast_currentRequest.value) =>
    (0 <= 0_glast_currentRequest.value.reqId)))
```

These obligations are redundant. A last-variable is defined by `init_x -> pre x`; the frame initialization `init_x` is what `x` is assigned in the initial state, and `pre x` is `x` at the previous instant, so the constraint already generated for `x` implies them.

They are also not always provable. When the frame does **not** initialize `x`, the last-variable is defined by an unguarded `pre x`, so its value at the first timestep is arbitrary and the obligation is reported as invalid — with a counterexample whose only displayed variable satisfies the constraint it supposedly violates:

```
SubType[L44C3]: invalid after 0 steps
  (0 <= 2_glast_z)

Counterexample:
  Node hold ()
    == Locals ==
    z 0
```

Note this is a distinct path from the one closed by #1422: that rejected `last` on inputs, but an uninitialized frame variable reaches the same unguarded-`pre` branch of `gen_last_defs`.

## Fix

Skip these locals when recording refinement type constraints, using the existing `GeneratedIdentifiers.var_is_last_local` predicate.

Their declared type is deliberately left alone. Weakening it to the base type would make `currentRequest = last currentRequest` ill-typed (the base type is not a subtype of the refinement), and would not help anyway when the refinement sits inside a datatype declaration rather than in a type argument — e.g. `Option<Request>` where `Request` is `Req (clientId: ClientId, reqId: Nat)`, which is exactly the case in the model that surfaced this.

## Testing

New `tests/regression/success/frame_last_refinement_type.lus` covers `last` on a refinement-typed frame variable, on one nested in a datatype (`Option<Nat>`), and on a frame variable the frame does not initialize. It exits 40 against `main` and 0 with this change, so the exit-code-based harness catches a regression.

Full regression suite: 439 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)