### PR TITLE
Enforce determinism of functions with container-typed arguments

### DIFF
--- a/src/certif/certifChecker.ml
+++ b/src/certif/certifChecker.ml
@@ -465,11 +465,10 @@ let under_approx sys k invs prop =
     |> SMTSolver.assert_term solver;
   done;
 
-  (* Asserting functional congruence instances up to k *)
-  for i = 0 to k do
-    TransSys.fn_congruence_instances sys (Numeral.of_int i)
-    |> List.iter (SMTSolver.assert_term solver);
-  done;
+  (* Asserting functional congruence instances over the unrolling. A replay
+     needs every instance, so nothing is reported as already satisfied. *)
+  TransSys.fn_congruence_instances sys (Numeral.of_int k)
+  |> List.iter (SMTSolver.assert_term solver);
 
   (* create activation literals *)
   let acts = List.map (create_acts solver k) invs in
@@ -895,11 +894,7 @@ let rec find_bound sys solver k kmax invs prop =
     sys (Numeral.of_int k)
   |> SMTSolver.assert_term solver;
 
-  (* Asserting functional congruence instances (at bound zero as well when
-     asserting the first unrolling). *)
-  if k = 1 then
-    TransSys.fn_congruence_instances sys Numeral.zero
-    |> List.iter (SMTSolver.assert_term solver);
+  (* Asserting functional congruence instances over the unrolling *)
   TransSys.fn_congruence_instances sys (Numeral.of_int k)
   |> List.iter (SMTSolver.assert_term solver);
 
@@ -929,11 +924,7 @@ let unroll_trans_actlits sys solver kmax =
           (Some (SMTSolver.declare_fun solver))
           sys (Numeral.of_int k) in
       (* Functional congruence instances are valid formulas of the intended
-         semantics; they can be asserted unguarded (at bound zero as well
-         when asserting the first unrolling) *)
-      if k = 1 then
-        TransSys.fn_congruence_instances sys Numeral.zero
-        |> List.iter (SMTSolver.assert_term solver);
+         semantics, so they can be asserted unguarded *)
       TransSys.fn_congruence_instances sys (Numeral.of_int k)
       |> List.iter (SMTSolver.assert_term solver);
       let tuptok = match prev with Some p -> Term.mk_and [p; tk] | _ -> tk in

--- a/src/certif/certifChecker.ml
+++ b/src/certif/certifChecker.ml
@@ -465,6 +465,12 @@ let under_approx sys k invs prop =
     |> SMTSolver.assert_term solver;
   done;
 
+  (* Asserting functional congruence instances up to k *)
+  for i = 0 to k do
+    TransSys.fn_congruence_instances sys (Numeral.of_int i)
+    |> List.iter (SMTSolver.assert_term solver);
+  done;
+
   (* create activation literals *)
   let acts = List.map (create_acts solver k) invs in
 
@@ -889,6 +895,14 @@ let rec find_bound sys solver k kmax invs prop =
     sys (Numeral.of_int k)
   |> SMTSolver.assert_term solver;
 
+  (* Asserting functional congruence instances (at bound zero as well when
+     asserting the first unrolling). *)
+  if k = 1 then
+    TransSys.fn_congruence_instances sys Numeral.zero
+    |> List.iter (SMTSolver.assert_term solver);
+  TransSys.fn_congruence_instances sys (Numeral.of_int k)
+  |> List.iter (SMTSolver.assert_term solver);
+
   match try_at_bound sys solver k invs prop [] with
   | Not_inductive ->
     (* Not k-inductive *)
@@ -914,6 +928,14 @@ let unroll_trans_actlits sys solver kmax =
       let tk = TransSys.trans_of_bound
           (Some (SMTSolver.declare_fun solver))
           sys (Numeral.of_int k) in
+      (* Functional congruence instances are valid formulas of the intended
+         semantics; they can be asserted unguarded (at bound zero as well
+         when asserting the first unrolling) *)
+      if k = 1 then
+        TransSys.fn_congruence_instances sys Numeral.zero
+        |> List.iter (SMTSolver.assert_term solver);
+      TransSys.fn_congruence_instances sys (Numeral.of_int k)
+      |> List.iter (SMTSolver.assert_term solver);
       let tuptok = match prev with Some p -> Term.mk_and [p; tk] | _ -> tk in
       let a = actlitify ~imp:true solver tuptok in
       fill (IntM.add k a acc) (Some a) (k + 1)

--- a/src/ic3/IC3.ml
+++ b/src/ic3/IC3.ml
@@ -3275,6 +3275,24 @@ let main input_sys aparam trans_sys =
   )
   | _ -> () );
 
+  (* Note: IC3 does not assert the functional congruence instances that
+     enforce determinism of (abstracted) functions with container-typed
+     arguments (see [TransSys.fn_congruence_instances]); without them, the
+     counterexamples it finds for such systems may be spurious with respect
+     to the intended (deterministic) semantics. Today this is subsumed by
+     the abstract-function check below, since a system with congruence
+     groups always includes a function symbol; the explicit check makes the
+     dependency visible in case that limitation is ever lifted. To support
+     these systems, the instances for bounds 0 and 1 would have to be
+     asserted alongside the transition relation in the frame solvers, and
+     clause generalization would have to account for the difference witness
+     functions the instances contain. *)
+  if TransSys.has_fn_congruence_groups trans_sys then
+    raise (UnsupportedFeature
+      "Shutting down IC3: system requires functional congruence instances \
+       for functions with container-typed arguments.")
+  ;
+
   match Flags.IC3QE.abstr () with
   | `IA -> main_ic3 input_sys aparam trans_sys
   | `None -> (

--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -974,6 +974,27 @@ let main fwd slice_to_prop prop in_sys param sys =
     raise (UnsupportedFeature msg)
   | _ -> () ) ;
 
+  (* Note: IC3IA does not assert the functional congruence instances that
+     enforce determinism of (abstracted) functions with container-typed
+     arguments (see [TransSys.fn_congruence_instances]); without them, the
+     counterexamples it finds for such systems may be spurious with respect
+     to the intended (deterministic) semantics. Today this is subsumed by
+     the array check above, since container-typed arguments put arrays in
+     the system's logic; the explicit check makes the dependency visible in
+     case array support is ever added. To support these systems, the
+     instances would have to be asserted in the solvers (bounds 0 and 1 for
+     the transition queries), and the implicit abstraction would have to
+     account for the difference witness functions the instances contain. *)
+  if TransSys.has_fn_congruence_groups sys then (
+    let msg =
+      Format.sprintf
+        "IC3IA disabled for property %s: system requires functional \
+         congruence instances for functions with container-typed arguments."
+        prop.Property.prop_name
+    in
+    raise (UnsupportedFeature msg)
+  ) ;
+
   let check_system_is_supported itp_solver =
     if TransSys.subsystem_includes_function_symbol sys then
       let msg =

--- a/src/induction/base.ml
+++ b/src/induction/base.ml
@@ -40,18 +40,6 @@ let on_exit _ =
   (* Output statistics *)
   print_stats ()
 
-(* Whether the functional congruence instances have been asserted in the
-   solver. They are activated lazily: only when a candidate counterexample
-   is found, to check whether it is spurious with respect to the intended
-   (deterministic) semantics of functions with container-typed arguments
-   (see [TransSys.fn_congruence_instances]).
-
-   Domain-local: each engine runs in its own domain with its own solver, and
-   the flag records whether the instances were asserted in *that* solver. *)
-let fn_congruence_activated_key = Domain.DLS.new_key (fun () -> ref false)
-
-let fn_congruence_activated () = Domain.DLS.get fn_congruence_activated_key
-
 (* Returns true if the property is not falsified or valid. *)
 let shall_keep trans (s,_) =
   match TransSys.get_prop_status trans s with
@@ -59,18 +47,26 @@ let shall_keep trans (s,_) =
   | Property.PropFalse _ -> false
   | _ -> true
 
-(* Check-sat and splits properties.. *)
-let rec split trans solver k to_split actlit =
+(* Check-sat and splits properties..
+
+   The functional congruence instances are given to the solver as terms to
+   evaluate rather than asserted: those the model makes false are exactly
+   the ones that refute this counterexample, and they are the only ones
+   worth asserting. When none is false the model already satisfies
+   determinism, so the counterexample is genuine and nothing is asserted at
+   all (see [TransSys.fn_congruence_instances]). *)
+let rec split trans solver k to_split actlit congruence =
 
   (* Function to run if sat. *)
-  let if_sat _ =
+  let if_sat _ fn_congruence_values =
 
-    (* A candidate counterexample without the functional congruence
-       instances may be spurious; activate them and check again. *)
-    if not !(fn_congruence_activated ())
-       && TransSys.has_fn_congruence_groups trans
-    then `Activate
-    else `Split (
+    match
+      List.filter_map (fun (i, v) ->
+        if Term.equal v Term.t_false then Some i else None
+      ) fn_congruence_values
+    with
+    | _ :: _ as spurious -> `Refine spurious
+    | [] -> `Split (
 
     (* Get the full model *)
     let model =
@@ -113,20 +109,27 @@ let rec split trans solver k to_split actlit =
   |> SMTSolver.trace_comment solver ;
 
   (* Check sat assuming with actlits. *)
-  match SMTSolver.check_sat_assuming solver if_sat if_unsat [actlit] with
+  match
+    SMTSolver.check_sat_assuming_and_get_term_values
+      solver if_sat if_unsat [actlit]
+      congruence
+  with
   | `Split res -> res
-  | `Activate ->
+  | `Refine spurious ->
+    (* The counterexample violates determinism of a function over
+       containers; rule it out and look again *)
     SMTSolver.trace_comment solver
-      "Activating functional congruence instances." ;
-    TransSys.fn_congruence_instances_up_to trans k
-    |> List.iter (SMTSolver.assert_term solver) ;
-    fn_congruence_activated () := true ;
-    split trans solver k to_split actlit
+      "Asserting the functional congruence instances the counterexample \
+       violates." ;
+    List.iter (SMTSolver.assert_term solver) spurious ;
+    split trans solver k to_split actlit congruence
 
 (* Splits its input list of properties between those that can be
    falsified and those that cannot after asserting the actlit
    implications. *)
 let split_closure trans solver k to_split =
+  (* Built once for the bound: the same instances serve every split *)
+  let congruence = TransSys.fn_congruence_instances trans k in
 
   let rec loop falsifiable list =
     (* Building negative term. *)
@@ -147,7 +150,7 @@ let split_closure trans solver k to_split =
     Term.mk_implies [ actlit ; term ]
     |> SMTSolver.assert_term solver ;
     (* Splitting. *)
-    match split trans solver k list actlit with
+    match split trans solver k list actlit congruence with
     | None ->
       deactivate () ;
       list, falsifiable
@@ -191,11 +194,6 @@ let skip_steps_next trans solver k unknowns =
     TransSys.trans_of_bound (Some (SMTSolver.declare_fun solver)) trans !step
     |> SMTSolver.assert_term solver ;
 
-    (* Asserting functional congruence instances for the new bound, if
-       they have been activated. *)
-    if !(fn_congruence_activated ()) then
-      TransSys.fn_congruence_instances trans !step
-      |> List.iter (SMTSolver.assert_term solver) ;
 
     (* Assert the value of the counter at each timestep *)
     match TransSys.get_ctr trans with
@@ -371,11 +369,6 @@ let rec next (input_sys, aparam, trans, solver, k, unknowns, skip) =
      TransSys.trans_of_bound (Some (SMTSolver.declare_fun solver)) trans k_p_1
     |> SMTSolver.assert_term solver ;
 
-    (* Asserting functional congruence instances for the new bound, if
-       they have been activated. *)
-    if !(fn_congruence_activated ()) then
-      TransSys.fn_congruence_instances trans k_p_1
-      |> List.iter (SMTSolver.assert_term solver) ;
 
     (* Assert the value of the counter at each timestep *)
     (match TransSys.get_ctr trans with
@@ -435,8 +428,6 @@ let init input_sys aparam trans skip =
     (Some (SMTSolver.declare_fun solver)) trans Numeral.zero
   |> SMTSolver.assert_term solver ;
 
-  (* Functional congruence instances start deactivated (see [split]). *)
-  fn_congruence_activated () := false ;
 
   SMTSolver.trace_comment solver "Initial state satisfiability check." ;
 

--- a/src/induction/base.ml
+++ b/src/induction/base.ml
@@ -49,24 +49,30 @@ let shall_keep trans (s,_) =
 
 (* Check-sat and splits properties..
 
-   The functional congruence instances are given to the solver as terms to
-   evaluate rather than asserted: those the model makes false are exactly
-   the ones that refute this counterexample, and they are the only ones
-   worth asserting. When none is false the model already satisfies
-   determinism, so the counterexample is genuine and nothing is asserted at
-   all (see [TransSys.fn_congruence_instances]). *)
-let rec split trans solver k to_split actlit congruence =
+   The functional congruence instances are evaluated in the model rather
+   than asserted. Their conjunction is one term, hence one query, and when
+   it holds the counterexample already satisfies determinism: it is genuine
+   and nothing is asserted at all. Only when it fails are the instances
+   evaluated one by one, to assert exactly those the counterexample
+   violates (see [TransSys.fn_congruence_instances]). *)
+let rec split trans solver k to_split actlit congruence congruence_holds =
 
   (* Function to run if sat. *)
-  let if_sat _ fn_congruence_values =
+  let if_sat s fn_congruence_values =
 
     match
-      List.filter_map (fun (i, v) ->
-        if Term.equal v Term.t_false then Some i else None
-      ) fn_congruence_values
+      List.exists (fun (_, v) -> Term.equal v Term.t_false)
+        fn_congruence_values
     with
-    | _ :: _ as spurious -> `Refine spurious
-    | [] -> `Split (
+    | true ->
+      (* Determinism is violated somewhere: ask which instances, so that
+         only those are asserted *)
+      `Refine (
+        SMTSolver.get_term_values s congruence
+        |> List.filter_map (fun (i, v) ->
+             if Term.equal v Term.t_false then Some i else None)
+      )
+    | false -> `Split (
 
     (* Get the full model *)
     let model =
@@ -112,7 +118,7 @@ let rec split trans solver k to_split actlit congruence =
   match
     SMTSolver.check_sat_assuming_and_get_term_values
       solver if_sat if_unsat [actlit]
-      congruence
+      congruence_holds
   with
   | `Split res -> res
   | `Refine spurious ->
@@ -122,7 +128,7 @@ let rec split trans solver k to_split actlit congruence =
       "Asserting the functional congruence instances the counterexample \
        violates." ;
     List.iter (SMTSolver.assert_term solver) spurious ;
-    split trans solver k to_split actlit congruence
+    split trans solver k to_split actlit congruence congruence_holds
 
 (* Splits its input list of properties between those that can be
    falsified and those that cannot after asserting the actlit
@@ -130,6 +136,11 @@ let rec split trans solver k to_split actlit congruence =
 let split_closure trans solver k to_split =
   (* Built once for the bound: the same instances serve every split *)
   let congruence = TransSys.fn_congruence_instances trans k in
+  (* Asked as a single question: the solver is queried for one term value at
+     a time, so evaluating them one by one would cost a round trip each *)
+  let congruence_holds =
+    if congruence = [] then [] else [Term.mk_and congruence]
+  in
 
   let rec loop falsifiable list =
     (* Building negative term. *)
@@ -150,7 +161,7 @@ let split_closure trans solver k to_split =
     Term.mk_implies [ actlit ; term ]
     |> SMTSolver.assert_term solver ;
     (* Splitting. *)
-    match split trans solver k list actlit congruence with
+    match split trans solver k list actlit congruence congruence_holds with
     | None ->
       deactivate () ;
       list, falsifiable

--- a/src/induction/base.ml
+++ b/src/induction/base.ml
@@ -40,6 +40,13 @@ let on_exit _ =
   (* Output statistics *)
   print_stats ()
 
+(* Whether the functional congruence instances have been asserted in the
+   solver. They are activated lazily: only when a candidate counterexample
+   is found, to check whether it is spurious with respect to the intended
+   (deterministic) semantics of functions with container-typed arguments
+   (see [TransSys.fn_congruence_instances]). *)
+let fn_congruence_activated = ref false
+
 (* Returns true if the property is not falsified or valid. *)
 let shall_keep trans (s,_) =
   match TransSys.get_prop_status trans s with
@@ -48,10 +55,17 @@ let shall_keep trans (s,_) =
   | _ -> true
 
 (* Check-sat and splits properties.. *)
-let split trans solver k to_split actlit =
+let rec split trans solver k to_split actlit =
 
   (* Function to run if sat. *)
   let if_sat _ =
+
+    (* A candidate counterexample without the functional congruence
+       instances may be spurious; activate them and check again. *)
+    if not !fn_congruence_activated
+       && TransSys.has_fn_congruence_groups trans
+    then `Activate
+    else `Split (
 
     (* Get the full model *)
     let model =
@@ -80,11 +94,12 @@ let split trans solver k to_split actlit =
     in
     (* Building result. *)
     Some (new_to_split, (new_falsifiable, cex))
+    )
   in
 
   (* Function to run if unsat. *)
   let if_unsat _ =
-    None
+    `Split None
   in
 
   Format.asprintf
@@ -93,7 +108,15 @@ let split trans solver k to_split actlit =
   |> SMTSolver.trace_comment solver ;
 
   (* Check sat assuming with actlits. *)
-  SMTSolver.check_sat_assuming solver if_sat if_unsat [actlit]
+  match SMTSolver.check_sat_assuming solver if_sat if_unsat [actlit] with
+  | `Split res -> res
+  | `Activate ->
+    SMTSolver.trace_comment solver
+      "Activating functional congruence instances." ;
+    TransSys.fn_congruence_instances_up_to trans k
+    |> List.iter (SMTSolver.assert_term solver) ;
+    fn_congruence_activated := true ;
+    split trans solver k to_split actlit
 
 (* Splits its input list of properties between those that can be
    falsified and those that cannot after asserting the actlit
@@ -162,6 +185,12 @@ let skip_steps_next trans solver k unknowns =
     (* Asserting transition relation for next iteration. *)
     TransSys.trans_of_bound (Some (SMTSolver.declare_fun solver)) trans !step
     |> SMTSolver.assert_term solver ;
+
+    (* Asserting functional congruence instances for the new bound, if
+       they have been activated. *)
+    if !fn_congruence_activated then
+      TransSys.fn_congruence_instances trans !step
+      |> List.iter (SMTSolver.assert_term solver) ;
 
     (* Assert the value of the counter at each timestep *)
     match TransSys.get_ctr trans with
@@ -337,6 +366,12 @@ let rec next (input_sys, aparam, trans, solver, k, unknowns, skip) =
      TransSys.trans_of_bound (Some (SMTSolver.declare_fun solver)) trans k_p_1
     |> SMTSolver.assert_term solver ;
 
+    (* Asserting functional congruence instances for the new bound, if
+       they have been activated. *)
+    if !fn_congruence_activated then
+      TransSys.fn_congruence_instances trans k_p_1
+      |> List.iter (SMTSolver.assert_term solver) ;
+
     (* Assert the value of the counter at each timestep *)
     (match TransSys.get_ctr trans with
     | Some ctr ->
@@ -394,6 +429,9 @@ let init input_sys aparam trans skip =
   TransSys.init_of_bound
     (Some (SMTSolver.declare_fun solver)) trans Numeral.zero
   |> SMTSolver.assert_term solver ;
+
+  (* Functional congruence instances start deactivated (see [split]). *)
+  fn_congruence_activated := false ;
 
   SMTSolver.trace_comment solver "Initial state satisfiability check." ;
 

--- a/src/induction/step.ml
+++ b/src/induction/step.ml
@@ -251,6 +251,13 @@ let eval_terms_assert_first_false trans solver eval k =
 
   result
 
+(* Whether the functional congruence instances have been asserted in the
+   solver. They are activated lazily: only when a counterexample to
+   induction is found, to check whether it is spurious with respect to the
+   intended (deterministic) semantics of functions with container-typed
+   arguments (see [TransSys.fn_congruence_instances]). *)
+let fn_congruence_activated = ref false
+
 (* Check-sat and splits properties.. *)
 let split (input_sys, analysis, trans) solver k to_split actlits =
   
@@ -302,7 +309,20 @@ let split (input_sys, analysis, trans) solver k to_split actlits =
     with
 
     | Some model ->
-        
+
+      (* A counterexample to induction without the functional congruence
+         instances may be spurious; activate them and check again. *)
+      if not !fn_congruence_activated
+         && TransSys.has_fn_congruence_groups trans
+      then (
+        SMTSolver.trace_comment solver
+          "Activating functional congruence instances." ;
+        TransSys.fn_congruence_instances_up_to trans k
+        |> List.iter (SMTSolver.assert_term solver) ;
+        fn_congruence_activated := true ;
+        loop ()
+      ) else (
+
       (* Evaluation function. *)
       let term_to_val =
         Eval.eval_term (TransSys.uf_defs trans) model
@@ -365,7 +385,7 @@ let split (input_sys, analysis, trans) solver k to_split actlits =
                 |> SMTSolver.assert_term solver ;
               (* Rechecking satisfiability. *)
               loop () )
-      )
+      ) )
 
     | None ->
       (* Returning the unsat result. *)
@@ -558,6 +578,12 @@ let rec next input_sys aparam trans solver k unfalsifiables unknowns =
      |> SMTSolver.assert_term solver
      |> ignore ;
 
+     (* Asserting functional congruence instances for the new bound, if
+        they have been activated. *)
+     if !fn_congruence_activated then
+       TransSys.fn_congruence_instances trans k_p_1
+       |> List.iter (SMTSolver.assert_term solver) ;
+
      (* Asserting invariants if we are not in lazy invariants mode. *)
      if not (Flags.BmcKind.lazy_invariants ()) then (
        (* Asserting new invariants from 0 to k. *)
@@ -698,6 +724,9 @@ let launch input_sys aparam trans =
     Compress.init (SMTSolver.declare_fun solver) trans ;
 
   TransSys.assert_global_constraints trans (SMTSolver.assert_term solver) ;
+
+  (* Functional congruence instances start deactivated (see [split]). *)
+  fn_congruence_activated := false ;
 
   (* Invariants of the system at 0. *)
   TransSys.invars_of_bound ~one_state_only:true trans Numeral.zero

--- a/src/induction/step.ml
+++ b/src/induction/step.ml
@@ -251,18 +251,6 @@ let eval_terms_assert_first_false trans solver eval k =
 
   result
 
-(* Whether the functional congruence instances have been asserted in the
-   solver. They are activated lazily: only when a counterexample to
-   induction is found, to check whether it is spurious with respect to the
-   intended (deterministic) semantics of functions with container-typed
-   arguments (see [TransSys.fn_congruence_instances]).
-
-   Domain-local: each engine runs in its own domain with its own solver, and
-   the flag records whether the instances were asserted in *that* solver. *)
-let fn_congruence_activated_key = Domain.DLS.new_key (fun () -> ref false)
-
-let fn_congruence_activated () = Domain.DLS.get fn_congruence_activated_key
-
 (* Check-sat and splits properties.. *)
 let split (input_sys, analysis, trans) solver k to_split actlits =
   
@@ -297,36 +285,53 @@ let split (input_sys, analysis, trans) solver k to_split actlits =
 
   in
 
+  (* The functional congruence instances are given to the solver as terms to
+     evaluate rather than asserted: those the model makes false are exactly
+     the ones that refute this counterexample to induction, and they are the
+     only ones worth asserting. When none is false the model already
+     satisfies determinism, so the counterexample is genuine and nothing is
+     asserted at all (see [TransSys.fn_congruence_instances]). *)
+  let if_sat s values =
+    match
+      List.filter_map (fun (i, v) ->
+        if Term.equal v Term.t_false then Some i else None
+      ) values
+    with
+    | _ :: _ as spurious -> `Refine spurious
+    | [] -> `Model (if_sat s)
+  in
+
   let print_cex = Flags.BmcKind.ind_print_cex () in
 
   (* Function to run if unsat. *)
-  let if_unsat _ = None in
+  let if_unsat _ = `Model None in
 
   (* Appending to the list of actlits. *)
   let all_actlits = path_comp_act_term :: actlits in
+
+  (* Built once: the same instances serve every iteration *)
+  let congruence = TransSys.fn_congruence_instances trans k in
 
   (* Loops as long as counterexamples can be compressed. *)
   let rec loop () = 
     match
       (* Check sat assuming with actlits. *)
-      SMTSolver.check_sat_assuming
+      SMTSolver.check_sat_assuming_and_get_term_values
         solver if_sat if_unsat all_actlits
+        congruence
     with
 
-    | Some model ->
+    | `Refine spurious ->
+      (* The counterexample violates determinism of a function over
+         containers; rule it out and look again *)
+      SMTSolver.trace_comment solver
+        "Asserting the functional congruence instances the counterexample \
+         violates." ;
+      List.iter (SMTSolver.assert_term solver) spurious ;
+      loop ()
 
-      (* A counterexample to induction without the functional congruence
-         instances may be spurious; activate them and check again. *)
-      if not !(fn_congruence_activated ())
-         && TransSys.has_fn_congruence_groups trans
-      then (
-        SMTSolver.trace_comment solver
-          "Activating functional congruence instances." ;
-        TransSys.fn_congruence_instances_up_to trans k
-        |> List.iter (SMTSolver.assert_term solver) ;
-        fn_congruence_activated () := true ;
-        loop ()
-      ) else (
+    | `Model (Some model) ->
+      (
 
       (* Evaluation function. *)
       let term_to_val =
@@ -392,7 +397,7 @@ let split (input_sys, analysis, trans) solver k to_split actlits =
               loop () )
       ) )
 
-    | None ->
+    | `Model None ->
       (* Returning the unsat result. *)
       None
   in
@@ -583,11 +588,6 @@ let rec next input_sys aparam trans solver k unfalsifiables unknowns =
      |> SMTSolver.assert_term solver
      |> ignore ;
 
-     (* Asserting functional congruence instances for the new bound, if
-        they have been activated. *)
-     if !(fn_congruence_activated ()) then
-       TransSys.fn_congruence_instances trans k_p_1
-       |> List.iter (SMTSolver.assert_term solver) ;
 
      (* Asserting invariants if we are not in lazy invariants mode. *)
      if not (Flags.BmcKind.lazy_invariants ()) then (
@@ -730,8 +730,6 @@ let launch input_sys aparam trans =
 
   TransSys.assert_global_constraints trans (SMTSolver.assert_term solver) ;
 
-  (* Functional congruence instances start deactivated (see [split]). *)
-  fn_congruence_activated () := false ;
 
   (* Invariants of the system at 0. *)
   TransSys.invars_of_bound ~one_state_only:true trans Numeral.zero

--- a/src/induction/step.ml
+++ b/src/induction/step.ml
@@ -285,20 +285,28 @@ let split (input_sys, analysis, trans) solver k to_split actlits =
 
   in
 
-  (* The functional congruence instances are given to the solver as terms to
-     evaluate rather than asserted: those the model makes false are exactly
-     the ones that refute this counterexample to induction, and they are the
-     only ones worth asserting. When none is false the model already
-     satisfies determinism, so the counterexample is genuine and nothing is
-     asserted at all (see [TransSys.fn_congruence_instances]). *)
+  (* Built once: the same instances serve every iteration *)
+  let congruence = TransSys.fn_congruence_instances trans k in
+  let congruence_holds =
+    if congruence = [] then [] else [Term.mk_and congruence]
+  in
+
+  (* The functional congruence instances are evaluated in the model rather
+     than asserted. Their conjunction is one term, hence one query, and when
+     it holds the counterexample to induction already satisfies determinism:
+     it is genuine and nothing is asserted at all. Only when it fails are
+     the instances evaluated one by one, to assert exactly those the
+     counterexample violates (see [TransSys.fn_congruence_instances]). *)
   let if_sat s values =
-    match
-      List.filter_map (fun (i, v) ->
-        if Term.equal v Term.t_false then Some i else None
-      ) values
-    with
-    | _ :: _ as spurious -> `Refine spurious
-    | [] -> `Model (if_sat s)
+    if List.exists (fun (_, v) -> Term.equal v Term.t_false) values then
+      (* Determinism is violated somewhere: ask which instances, so that
+         only those are asserted *)
+      `Refine (
+        SMTSolver.get_term_values s congruence
+        |> List.filter_map (fun (i, v) ->
+             if Term.equal v Term.t_false then Some i else None)
+      )
+    else `Model (if_sat s)
   in
 
   let print_cex = Flags.BmcKind.ind_print_cex () in
@@ -309,16 +317,13 @@ let split (input_sys, analysis, trans) solver k to_split actlits =
   (* Appending to the list of actlits. *)
   let all_actlits = path_comp_act_term :: actlits in
 
-  (* Built once: the same instances serve every iteration *)
-  let congruence = TransSys.fn_congruence_instances trans k in
-
   (* Loops as long as counterexamples can be compressed. *)
   let rec loop () = 
     match
       (* Check sat assuming with actlits. *)
       SMTSolver.check_sat_assuming_and_get_term_values
         solver if_sat if_unsat all_actlits
-        congruence
+        congruence_holds
     with
 
     | `Refine spurious ->

--- a/src/induction/step2.ml
+++ b/src/induction/step2.ml
@@ -247,14 +247,19 @@ let split { solver ; sys ; map ; _ } =
       (* Deactivation function. *)
       let deactivate () = Term.mk_not nactlit |> Smt.assert_term solver in
 
-      (* The functional congruence instances ride along as terms to evaluate
-         rather than being asserted: those the model makes false are exactly
-         the ones that refute this counterexample to 2-induction, and they
-         are the only ones worth asserting. When none is false the model
-         already satisfies determinism, so the counterexample is genuine and
-         nothing is asserted at all
+      (* The functional congruence instances are evaluated in the model
+         rather than asserted: when their conjunction holds, the
+         counterexample to 2-induction already satisfies determinism, so it
+         is genuine and nothing is asserted at all. Only when it fails are
+         the instances asserted, and then only once, since they hold in
+         every model that follows. Asked as a single question: the solver is
+         queried for one term value at a time, so evaluating them one by one
+         would cost a round trip each
          (see [TransSys.fn_congruence_instances]). *)
       let congruence = Sys.fn_congruence_instances sys Num.(succ one) in
+      let congruence_holds =
+        if congruence = [] then [] else [Term.mk_and congruence]
+      in
 
       (* Check-sat. *)
       match
@@ -270,15 +275,23 @@ let split { solver ; sys ; map ; _ } =
                   else
                     match List.assq_opt term map_back with
                     | Some prop -> (sp, prop :: fa)
-                    | None -> (term :: sp, fa)
-              ) ([], [])
+                    | None -> (true, fa)
+              ) (false, [])
             in
-            if spurious <> [] then `Refine spurious else `Sat falsifiable
+            if spurious then
+              (* Ask which instances are violated, so that only those are
+                 asserted *)
+              `Refine (
+                Smt.get_term_values solver congruence
+                |> List.filter_map (fun (i, v) ->
+                     if Term.equal v Term.t_false then Some i else None)
+              )
+            else `Sat falsifiable
           )
           (fun _ -> (* If unsat. *)
             `Unsat
           )
-          (nactlit :: actlits) (unknowns @ congruence)
+          (nactlit :: actlits) (unknowns @ congruence_holds)
       with
       | `Unsat -> (* Unsat, remaining properties are unfalsifiable. *)
         deactivate () ;

--- a/src/induction/step2.ml
+++ b/src/induction/step2.ml
@@ -24,18 +24,6 @@ module Sys = TransSys
 module Prop = Property
 module Num = Numeral
 
-(* Whether the functional congruence instances have been asserted in the
-   solver. They are activated lazily: only when a counterexample to
-   2-induction is found, to check whether it is spurious with respect to the
-   intended (deterministic) semantics of functions with container-typed
-   arguments (see [TransSys.fn_congruence_instances]).
-
-   Domain-local: each engine runs in its own domain with its own solver, and
-   the flag records whether the instances were asserted in *that* solver. *)
-let fn_congruence_activated_key = Domain.DLS.new_key (fun () -> ref false)
-
-let fn_congruence_activated () = Domain.DLS.get fn_congruence_activated_key
-
 let zero = Num.zero
 let one = Num.one
 let two = Num.(succ one)
@@ -134,8 +122,6 @@ let mk_ctx in_sys param sys =
   Sys.trans_of_bound (Some (Smt.declare_fun solver)) sys Numeral.(succ one)
   |> Smt.assert_term solver ;
 
-  (* Functional congruence instances start deactivated (see [split]). *)
-  fn_congruence_activated () := false ;
 
   {
     solver ; in_sys ; param ; sys ;
@@ -261,43 +247,54 @@ let split { solver ; sys ; map ; _ } =
       (* Deactivation function. *)
       let deactivate () = Term.mk_not nactlit |> Smt.assert_term solver in
 
+      (* The functional congruence instances ride along as terms to evaluate
+         rather than being asserted: those the model makes false are exactly
+         the ones that refute this counterexample to 2-induction, and they
+         are the only ones worth asserting. When none is false the model
+         already satisfies determinism, so the counterexample is genuine and
+         nothing is asserted at all
+         (see [TransSys.fn_congruence_instances]). *)
+      let congruence = Sys.fn_congruence_instances sys Num.(succ one) in
+
       (* Check-sat. *)
       match
         Smt.check_sat_assuming_and_get_term_values
           solver
           (fun _ term_values -> (* If sat. *)
-            (* Retrieve values. *)
-            term_values |> List.fold_left (
-              fun l (term, value) ->
-                if value == Term.t_false then
-                  (List.assq term map_back) :: l
-                else l
-            ) []
-            |> fun l -> Some l
+            (* Retrieve values: a term of [map_back] is a property, any
+               other one is a congruence instance. *)
+            let spurious, falsifiable =
+              term_values |> List.fold_left (
+                fun (sp, fa) (term, value) ->
+                  if not (Term.equal value Term.t_false) then (sp, fa)
+                  else
+                    match List.assq_opt term map_back with
+                    | Some prop -> (sp, prop :: fa)
+                    | None -> (term :: sp, fa)
+              ) ([], [])
+            in
+            if spurious <> [] then `Refine spurious else `Sat falsifiable
           )
           (fun _ -> (* If unsat. *)
-            None
+            `Unsat
           )
-          (nactlit :: actlits) unknowns
+          (nactlit :: actlits) (unknowns @ congruence)
       with
-      | None -> (* Unsat, remaining properties are unfalsifiable. *)
+      | `Unsat -> (* Unsat, remaining properties are unfalsifiable. *)
         deactivate () ;
         unknowns |> List.map (fun t -> List.assq t map_back)
-      | Some _
-        when not !(fn_congruence_activated ())
-             && Sys.has_fn_congruence_groups sys ->
-        (* A counterexample to 2-induction without the functional congruence
-           instances may be spurious; activate them and check again. *)
+      | `Refine spurious ->
+        (* The counterexample violates determinism of a function over
+           containers; rule it out and look again *)
         deactivate () ;
         Smt.trace_comment solver
-          "Activating functional congruence instances." ;
-        Sys.fn_congruence_instances_up_to sys Num.(succ one)
-        |> List.iter (Smt.assert_term solver) ;
-        fn_congruence_activated () := true ;
+          "Asserting the functional congruence instances the counterexample \
+           violates." ;
+        List.iter (Smt.assert_term solver) spurious ;
         loop falsifiable
-      | Some [] ->
+      | `Sat [] ->
         failwith "got empty list of falsifiable properties"
-      | Some nu_falsifiable ->
+      | `Sat nu_falsifiable ->
         deactivate () ;
         (* Sat, we need to check the remaining properties. *)
         List.rev_append nu_falsifiable falsifiable |> loop

--- a/src/induction/step2.ml
+++ b/src/induction/step2.ml
@@ -24,6 +24,13 @@ module Sys = TransSys
 module Prop = Property
 module Num = Numeral
 
+(* Whether the functional congruence instances have been asserted in the
+   solver. They are activated lazily: only when a counterexample to
+   2-induction is found, to check whether it is spurious with respect to the
+   intended (deterministic) semantics of functions with container-typed
+   arguments (see [TransSys.fn_congruence_instances]). *)
+let fn_congruence_activated = ref false
+
 let zero = Num.zero
 let one = Num.one
 let two = Num.(succ one)
@@ -122,6 +129,9 @@ let mk_ctx in_sys param sys =
   Sys.trans_of_bound (Some (Smt.declare_fun solver)) sys Numeral.(succ one)
   |> Smt.assert_term solver ;
 
+  (* Functional congruence instances start deactivated (see [split]). *)
+  fn_congruence_activated := false ;
+
   {
     solver ; in_sys ; param ; sys ;
     (* Creating map from properties to positive actlit/term pairs. *)
@@ -208,7 +218,7 @@ let rec check_new_things new_stuff ({ solver ; sys ; map } as ctx) =
       )
 
 (* Returns the properties that cannot be falsified. *)
-let split { solver ; map } =
+let split { solver ; sys ; map ; _ } =
 
   let rec loop falsifiable =
     if (List.length falsifiable) = (List.length map) then
@@ -268,6 +278,18 @@ let split { solver ; map } =
       | None -> (* Unsat, remaining properties are unfalsifiable. *)
         deactivate () ;
         unknowns |> List.map (fun t -> List.assq t map_back)
+      | Some _
+        when not !fn_congruence_activated
+             && Sys.has_fn_congruence_groups sys ->
+        (* A counterexample to 2-induction without the functional congruence
+           instances may be spurious; activate them and check again. *)
+        deactivate () ;
+        Smt.trace_comment solver
+          "Activating functional congruence instances." ;
+        Sys.fn_congruence_instances_up_to sys Num.(succ one)
+        |> List.iter (Smt.assert_term solver) ;
+        fn_congruence_activated := true ;
+        loop falsifiable
       | Some [] ->
         failwith "got empty list of falsifiable properties"
       | Some nu_falsifiable ->

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2263,6 +2263,210 @@ let constraints_of_equations node init stateful_vars terms equations definition_
      |> Term.convert_select], definition_set
 
 
+(* Functional congruence template for the UF symbols of a function with
+   container-typed (array-compiled) inputs.
+
+   Functional determinism of an (imported or abstracted) function normally
+   follows from congruence of its UF symbols. Under the default array
+   encoding, a container is an uninterpreted array constrained only at its
+   canonical positions (in-range enum dimensions, keys present in a map), so
+   two containers holding the same elements are in general distinct terms and
+   congruence never fires. The template states congruence modulo structural
+   equality of the containers over one pair of free variables per argument:
+
+     (\/_scalar-args a_i <> b_i)
+     \/ (\/_container-args inRange(w(a,b)) /\ select(a,w) <> select(b,w))
+     \/ /\_outputs f_out(as) = f_out(bs)
+
+   where each [w] is a fresh difference witness function (an explicit Skolem
+   function: witnesses shared between instances over the same argument pair
+   are sound precisely because they are functions of the pair). Substituting
+   the argument tuples of two applications for the a/b variables yields a
+   ground, quantifier-free congruence instance; the engines assert these for
+   the application pairs of their unrolling
+   (see [TransSys.fn_congruence_instances]). A quantified version of the
+   template was measured to be intractable: satisfiable queries (e.g.
+   counterexamples to induction) require the solver to build a model of a
+   quantified formula over uninterpreted array sorts, which neither
+   skolemization nor instantiation patterns can help.
+
+   Mirroring structural equality of containers, index dimensions of enum or
+   bounded integer type are compared only within their range (with a fixed
+   array bound taken from the bounds table when the index type is
+   unbounded), and the value arrays of a map are compared only at keys
+   present in the map (guarded by its domain array). *)
+let function_congruence_group state_var_bounds inputs uf_symbols
+    constrained_outputs =
+  let bindings = D.bindings inputs in
+  if constrained_outputs = [] ||
+     not (
+       List.exists
+         (fun (_, sv) -> StateVar.type_of_state_var sv |> Type.is_array)
+         bindings
+     )
+  then None
+  else (
+    (* One pair of free variables per argument *)
+    let arg_vars =
+      List.map (fun (idx, sv) ->
+        let ty = StateVar.type_of_state_var sv in
+        idx, sv, ty, Var.mk_fresh_var ty, Var.mk_fresh_var ty
+      ) bindings
+    in
+    (* [Term.convert_select] cannot rewrite a select whose array is a free
+       variable, so apply the select function of the argument's array type
+       directly (it performs all projections in a single application) *)
+    let mk_sel sv v iterms =
+      if Flags.Arrays.smt () then
+        List.fold_left Term.mk_select (Term.mk_var v) iterms
+      else
+        Term.mk_uf (StateVar.encode_select sv) (Term.mk_var v :: iterms)
+    in
+    let args_a = List.map (fun (_, _, _, a, _) -> Term.mk_var a) arg_vars in
+    let args_b = List.map (fun (_, _, _, _, b) -> Term.mk_var b) arg_vars in
+    (* The domain prefixes of a leaf index: for every MapValue-tagged entry,
+       the index up to that position with the MapDomain tag instead (cf.
+       [LustreNodeGen.compile_equality]) *)
+    let domain_prefixes_of_leaf idx =
+      let rec scan prefix_rev = function
+        | [] -> []
+        | D.TupleIndex (_, Some D.MapValue) :: rest ->
+          let dpfx =
+            List.rev_append prefix_rev [D.TupleIndex (0, Some D.MapDomain)]
+          in
+          dpfx :: scan (D.TupleIndex (1, Some D.MapValue) :: prefix_rev) rest
+        | hd :: rest -> scan (hd :: prefix_rev) rest
+      in
+      scan [] idx
+    in
+    (* The domain array of a map value leaf: the container argument whose
+       index extends the domain prefix with (only) its own key dimensions *)
+    let find_domain_container dpfx =
+      let n = List.length dpfx in
+      List.find_opt (fun (idx, sv, _, _, _) ->
+        Type.is_array (StateVar.type_of_state_var sv) &&
+        List.length idx > n &&
+        (let pfx, rest = Lib.list_split n idx in
+         D.equal_index pfx dpfx &&
+         List.for_all (function D.SetMapIndex _ -> true | _ -> false) rest)
+      ) arg_vars
+    in
+    (* Difference witness for each container argument: "the two sides are
+       pointwise equal at all canonical positions" is used negatively, so its
+       universal index quantifier is an existential of the instances.
+       Skolemize it explicitly with a fresh witness function per dimension,
+       applied to the two sides. *)
+    let witness_ufs = ref [] in
+    let container_diffs =
+      arg_vars |> List.filter_map (fun (idx, sv, ty, a, b) ->
+        if not (Type.is_array ty) then None
+        else begin
+          let idx_tys = Type.all_index_types_of_array ty in
+          let iterms =
+            idx_tys |> List.map (fun ity ->
+              let wuf = UfSymbol.mk_fresh_uf_symbol [ty; ty] ity in
+              witness_ufs := wuf :: !witness_ufs ;
+              Term.mk_uf wuf [Term.mk_var a; Term.mk_var b]
+            )
+          in
+          let sel v = mk_sel sv v iterms in
+          (* Bounds of the dimensions from the bounds table (a fixed-size
+             array's index type is a plain integer; its size is only recorded
+             there). Only an instant-independent bound can be used in a
+             global constraint. *)
+          let dim_bounds =
+            match StateVar.StateVarHashtbl.find state_var_bounds sv with
+            | bounds when List.length bounds = List.length idx_tys ->
+              bounds |> List.map (function
+                | E.Bound e | E.Fixed e ->
+                  let t = E.unsafe_term_of_expr e in
+                  if Term.var_offsets_of_term t = (None, None) then Some t
+                  else None
+                | E.Unbound _ -> None)
+            | _ | exception Not_found ->
+              List.map (fun _ -> None) idx_tys
+          in
+          (* The guard of a dimension must cover at least every canonical
+             position: a too-narrow guard would equate containers that
+             actually differ and could make the system inconsistent. An
+             array dimension is recognized by its entry in the bounds table
+             and guarded by [0, n) (its index type uses the exclusive-upper
+             convention); a set/map dimension has no bound entry and is
+             guarded by its type: the inclusive range of an enum (e.g. the
+             discriminant of an ADT element type) or of a subrange. *)
+          let range_guards =
+            List.map2 (fun (it, bnd) ity ->
+              match bnd with
+              | Some n ->
+                Term.mk_and [
+                  Term.mk_leq [Term.mk_num Numeral.zero; it];
+                  Term.mk_lt [it; n]
+                ]
+              | None -> (
+                match Type.node_of_type ity with
+                | Type.IntRange (Some l, Some u) | Type.Enum (l, u) ->
+                  Term.mk_leq [Term.mk_num l; it; Term.mk_num u]
+                | Type.IntRange (Some l, None) ->
+                  Term.mk_leq [Term.mk_num l; it]
+                | Type.IntRange (None, Some u) ->
+                  Term.mk_leq [it; Term.mk_num u]
+                | _ -> Term.t_true
+              )
+            ) (List.combine iterms dim_bounds) idx_tys
+            |> List.filter (fun t -> not (Term.equal t Term.t_true))
+          in
+          (* Compare map values only at keys present in the map *)
+          let domain_guards =
+            domain_prefixes_of_leaf idx |> List.filter_map (fun dpfx ->
+              match find_domain_container dpfx with
+              | Some (_, dsv, dty, da, _) ->
+                let arity =
+                  List.length (Type.all_index_types_of_array dty)
+                in
+                let dom_iterms, _ = Lib.list_split arity iterms in
+                Some (mk_sel dsv da dom_iterms)
+              | None -> None
+            )
+          in
+          (* The two sides differ at an in-range (and, for a map value,
+             present) witness position *)
+          let neq = Term.mk_not (Term.mk_eq [sel a; sel b]) in
+          Some (Term.mk_and (range_guards @ domain_guards @ [neq]))
+        end
+      )
+    in
+    let scalar_diffs =
+      arg_vars |> List.filter_map (fun (_, _, ty, a, b) ->
+        if Type.is_array ty then None
+        else Some (Term.mk_not (Term.mk_eq [Term.mk_var a; Term.mk_var b]))
+      )
+    in
+    let outputs_eq =
+      constrained_outputs |> List.map (fun output ->
+        let uf = SVM.find output uf_symbols in
+        Term.mk_eq [Term.mk_uf uf args_a; Term.mk_uf uf args_b]
+      ) |> Term.mk_and
+    in
+    let template =
+      Term.mk_or (scalar_diffs @ container_diffs @ [outputs_eq])
+    in
+    Some (
+      { TransSys.fcg_template = template;
+        TransSys.fcg_a_vars = List.map (fun (_, _, _, a, _) -> a) arg_vars;
+        TransSys.fcg_b_vars = List.map (fun (_, _, _, _, b) -> b) arg_vars;
+        TransSys.fcg_apps = [List.map snd bindings] },
+      List.rev !witness_ufs
+    )
+  )
+
+(* Functional congruence groups of the subtree of an already created
+   transition system, keyed by its scope. Reset at each [trans_sys_of_nodes]
+   entry; used to lift the application tuples of the functions of a subtree
+   into each ancestor system. *)
+let fn_congruence_groups_tbl
+    : (Scope.t, TransSys.fn_congruence_group list) Hashtbl.t =
+  Hashtbl.create 7
+
 let rec trans_sys_of_node' options globals top_name analysis_param
   trans_sys_defs output_input_dep nodes definition_set = function
 
@@ -2487,7 +2691,7 @@ let rec trans_sys_of_node' options globals top_name analysis_param
           (* If node is a function, for each undefined output,
           create the term `(= (f <inputs>) output)` to add it to `init` and
           `trans`. *)
-          let function_ufs, function_constraints_at_0 =
+          let function_ufs, function_constraints_at_0, fn_congruence_group =
             match comp_type with
             | Function { uf_symbols; rec_info } when options.add_functional_constraints -> (
               (* For a recursive function we tie the outputs of *every*
@@ -2529,9 +2733,21 @@ let rec trans_sys_of_node' options globals top_name analysis_param
                   ]
                 )
               in
-              function_ufs, constraints
+              let congruence_group, witness_ufs =
+                match
+                  function_congruence_group
+                    globals.G.state_var_bounds inputs uf_symbols
+                    constrained_outputs
+                with
+                | Some (group, wufs) -> Some group, wufs
+                | None -> None, []
+              in
+              (* The difference witness functions occur only in the
+                 congruence instances; declare them wherever the function
+                 symbols are declared *)
+              function_ufs @ witness_ufs, constraints, congruence_group
             )
-            | _ -> [], []
+            | _ -> [], [], None
           in
 
 
@@ -3163,10 +3379,76 @@ let rec trans_sys_of_node' options globals top_name analysis_param
           (* Create transition system                               *)
           (* ****************************************************** *)
 
+          (* Functional congruence groups of this system's subtree: this
+             node's own group (if it is a function with container-typed
+             inputs) with its formal inputs as the single application, plus
+             the groups of its subsystems with their application tuples
+             lifted to this system's state variables through each call
+             instance. Groups originating from the same function (same
+             template) are merged so that applications reached through
+             different call paths are paired with each other. *)
+          let fn_congruence_groups =
+            let lift_svar map_up sv =
+              match SVM.find_opt sv map_up with
+              | Some sv' -> Some sv'
+              | None ->
+                (* Global constants are not in the instance maps *)
+                if StateVar.is_const sv then Some sv else None
+            in
+            let lifted =
+              List.concat_map (fun (t, instances) ->
+                match
+                  Hashtbl.find_opt fn_congruence_groups_tbl
+                    (TransSys.scope_of_trans_sys t)
+                with
+                | None -> []
+                | Some groups ->
+                  groups |> List.map (fun g ->
+                    let apps =
+                      List.concat_map (fun { TransSys.map_up; _ } ->
+                        g.TransSys.fcg_apps |> List.filter_map (fun app ->
+                          let app' =
+                            List.filter_map (lift_svar map_up) app
+                          in
+                          if List.length app' = List.length app then
+                            Some app'
+                          else None
+                        )
+                      ) instances
+                    in
+                    { g with TransSys.fcg_apps = apps }
+                  )
+              ) subsystems
+            in
+            let all =
+              (match fn_congruence_group with Some g -> [g] | None -> [])
+              @ lifted
+            in
+            List.fold_left (fun acc g ->
+              match
+                List.partition
+                  (fun g' ->
+                     g'.TransSys.fcg_template == g.TransSys.fcg_template)
+                  acc
+              with
+              | [g'], rest ->
+                { g' with
+                  TransSys.fcg_apps =
+                    (* Applications may be duplicated when the same call is
+                       reachable through several paths; deduplicate *)
+                    List.sort_uniq compare
+                      (g.TransSys.fcg_apps @ g'.TransSys.fcg_apps) }
+                :: rest
+              | _ -> g :: acc
+            ) [] all
+          in
+          Hashtbl.replace fn_congruence_groups_tbl scope fn_congruence_groups ;
+
           (* Create transition system *)
           let trans_sys, _ =
             TransSys.mk_trans_sys
               ~datatype_types:globals.G.recursive_datatypes
+              ~fn_congruence_groups
               scope
               None (* instance_state_var *)
               init_flag
@@ -3226,7 +3508,11 @@ let trans_sys_of_nodes
   (* Prevent the garbage collector from running too often during the frontend
      operations *)
   Lib.set_liberal_gc ();
-  
+
+  (* The same scope can recur across analyses with a different abstraction,
+     changing which outputs are undefined and thus which axioms exist *)
+  Hashtbl.reset fn_congruence_groups_tbl ;
+
   let { A.top } =
     A.info_of_param analysis_param
   in

--- a/src/smt/SMTSolver.mli
+++ b/src/smt/SMTSolver.mli
@@ -195,6 +195,11 @@ val check_sat_and_get_term_values : t ->
   'a
 
 
+(** Get the values of the given terms in the current context. The context
+    must be satisfiable, as after a [check_sat] that returned true. *)
+val get_term_values : t -> Term.t list -> (Term.t * Term.t) list
+
+
 (** Check satisfiability under assumptions as with {!check_sat_assuming},
     but if the solver returns satisfiable, the values of the terms in the
     current context are given to the continuation [t] as its second argument *)

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -38,7 +38,28 @@ type pred_def = UfSymbol.t * (Var.t list * Term.t)
 
 
 (* Instance of a subsystem *)
-type instance = 
+(* Functional congruence group of an (abstracted) function with
+   container-typed arguments.
+
+   The template is a quantifier-free formula over the free variables
+   [fcg_a_vars] and [fcg_b_vars] (one pair per function argument, in
+   argument order) stating: some pair of corresponding arguments differs
+   (containers are compared pointwise at canonical positions, via difference
+   witness functions), or the function results at the two argument tuples
+   coincide. [fcg_apps] are the argument state variable tuples of the
+   applications of the function in this system's subtree, lifted to this
+   system's state variables. Substituting two applications (at two bounds)
+   into the template yields a ground congruence instance, a valid formula of
+   the intended (deterministic) semantics. *)
+type fn_congruence_group =
+  {
+    fcg_template : Term.t;
+    fcg_a_vars : Var.t list;
+    fcg_b_vars : Var.t list;
+    fcg_apps : StateVar.t list list;
+  }
+
+type instance =
   {
     (* Unique identifier of the instance *)
     uid : int;
@@ -100,8 +121,14 @@ type t =
 
     global_consts : Var.t list;
     (** List of global free constants *)
-    
+
     global_constraints : Term.t list;
+
+    fn_congruence_groups : fn_congruence_group list;
+    (** Functional congruence groups of the (abstracted) functions with
+        container-typed arguments in this system's subtree; used to generate
+        ground congruence instances per unrolling bound
+        (see {!fn_congruence_instances}) *)
 
     state_vars : StateVar.t list;
     (** State variables in the scope of this transition system 
@@ -491,6 +518,62 @@ let collect_instances ({ scope } as trans_sys) =
 (* ********************************************************************** *)
 
 let global_constraints { global_constraints } = global_constraints
+
+let fn_congruence_groups { fn_congruence_groups } = fn_congruence_groups
+
+(* Ground congruence instances pairing every function application at bound
+   [k] with every application at bounds [0..k]. Asserting the result for
+   each bound of a monotone unrolling yields the instances for all pairs of
+   applications in the unrolling. Every instance is a valid formula of the
+   intended semantics regardless of which bounds are actually asserted, so
+   over-approximating the unrolled window is sound. *)
+let has_fn_congruence_groups { fn_congruence_groups } =
+  fn_congruence_groups <> []
+
+let fn_congruence_instances { fn_congruence_groups } k =
+  let inst { fcg_template; fcg_a_vars; fcg_b_vars } app1 o1 app2 o2 =
+    let bind vars app o =
+      List.map2 (fun v sv ->
+        v, Term.mk_var (Var.mk_state_var_instance sv o)
+      ) vars app
+    in
+    Term.apply_subst
+      (bind fcg_a_vars app1 o1 @ bind fcg_b_vars app2 o2)
+      fcg_template
+  in
+  List.concat_map (fun ({ fcg_apps } as g) ->
+    (* pairs of distinct applications at bound [k] *)
+    let rec same_bound = function
+      | [] -> []
+      | app1 :: tl ->
+        List.map (fun app2 -> inst g app1 k app2 k) tl @ same_bound tl
+    in
+    (* pairs of an application at bound [k] with one at a smaller bound *)
+    let cross_bound =
+      let rec loop j acc =
+        if Numeral.(j >= k) then acc
+        else
+          loop Numeral.(succ j) (
+            List.fold_left (fun acc app1 ->
+              List.fold_left (fun acc app2 ->
+                inst g app1 k app2 j :: acc
+              ) acc fcg_apps
+            ) acc fcg_apps
+          )
+      in
+      loop Numeral.zero []
+    in
+    same_bound fcg_apps @ cross_bound
+  ) fn_congruence_groups
+
+(* Ground congruence instances for all pairs of applications at bounds
+   [0..k] *)
+let fn_congruence_instances_up_to sys k =
+  let rec loop j acc =
+    if Numeral.(j > k) then acc
+    else loop Numeral.(succ j) (List.rev_append (fn_congruence_instances sys j) acc)
+  in
+  loop Numeral.zero []
 
 (* Close term by binding variables to terms with a let binding *)
 let close_term bindings term = 
@@ -1734,9 +1817,10 @@ let copy t =
   ) Scope.Map.empty t in
   Scope.Map.find (scope_of_trans_sys t) copies
 
-let mk_trans_sys 
+let mk_trans_sys
   ?(instance_var_id_start = 0)
   ?(datatype_types = [])
+  ?(fn_congruence_groups = [])
   scope
   instance_state_var
   init_flag_state_var
@@ -1935,6 +2019,7 @@ let mk_trans_sys
       subsystems;
       global_consts;
       global_constraints;
+      fn_congruence_groups;
       ufs;
       init_uf_symbol;
       init_formals;

--- a/src/transSys.ml
+++ b/src/transSys.ml
@@ -521,17 +521,20 @@ let global_constraints { global_constraints } = global_constraints
 
 let fn_congruence_groups { fn_congruence_groups } = fn_congruence_groups
 
-(* Ground congruence instances pairing every function application at bound
-   [k] with every application at bounds [0..k]. Asserting the result for
-   each bound of a monotone unrolling yields the instances for all pairs of
-   applications in the unrolling. Every instance is a valid formula of the
-   intended semantics regardless of which bounds are actually asserted, so
-   over-approximating the unrolled window is sound. *)
 let has_fn_congruence_groups { fn_congruence_groups } =
   fn_congruence_groups <> []
 
+(* Ground congruence instances for every pair of function applications over
+   bounds [0..k].
+
+   Each is a valid formula of the intended semantics, so asserting any
+   subset of them is sound, and an engine can leave them all out until a
+   query comes back satisfiable. The engines pass them to the solver as
+   terms to evaluate: those the model makes false are exactly the instances
+   that refute it, and when there are none the model satisfies determinism,
+   so the counterexample it represents is genuine. *)
 let fn_congruence_instances { fn_congruence_groups } k =
-  let inst { fcg_template; fcg_a_vars; fcg_b_vars } app1 o1 app2 o2 =
+  let inst { fcg_template; fcg_a_vars; fcg_b_vars; _ } app1 o1 app2 o2 =
     let bind vars app o =
       List.map2 (fun v sv ->
         v, Term.mk_var (Var.mk_state_var_instance sv o)
@@ -541,39 +544,33 @@ let fn_congruence_instances { fn_congruence_groups } k =
       (bind fcg_a_vars app1 o1 @ bind fcg_b_vars app2 o2)
       fcg_template
   in
-  List.concat_map (fun ({ fcg_apps } as g) ->
-    (* pairs of distinct applications at bound [k] *)
-    let rec same_bound = function
-      | [] -> []
-      | app1 :: tl ->
-        List.map (fun app2 -> inst g app1 k app2 k) tl @ same_bound tl
+  List.fold_left (fun acc ({ fcg_apps; _ } as g) ->
+    let rec bounds j acc =
+      if Numeral.(j > k) then acc
+      else
+        (* every application at [j], against every application at a bound
+           at most [j] (itself included, at a strictly smaller bound) *)
+        let rec over_apps acc = function
+          | [] -> acc
+          | app1 :: tl ->
+            let acc =
+              List.fold_left (fun acc app2 -> inst g app1 j app2 j :: acc)
+                acc tl
+            in
+            let rec earlier i acc =
+              if Numeral.(i >= j) then acc
+              else
+                earlier Numeral.(succ i) (
+                  List.fold_left (fun acc app2 -> inst g app1 j app2 i :: acc)
+                    acc fcg_apps
+                )
+            in
+            over_apps (earlier Numeral.zero acc) tl
+        in
+        bounds Numeral.(succ j) (over_apps acc fcg_apps)
     in
-    (* pairs of an application at bound [k] with one at a smaller bound *)
-    let cross_bound =
-      let rec loop j acc =
-        if Numeral.(j >= k) then acc
-        else
-          loop Numeral.(succ j) (
-            List.fold_left (fun acc app1 ->
-              List.fold_left (fun acc app2 ->
-                inst g app1 k app2 j :: acc
-              ) acc fcg_apps
-            ) acc fcg_apps
-          )
-      in
-      loop Numeral.zero []
-    in
-    same_bound fcg_apps @ cross_bound
-  ) fn_congruence_groups
-
-(* Ground congruence instances for all pairs of applications at bounds
-   [0..k] *)
-let fn_congruence_instances_up_to sys k =
-  let rec loop j acc =
-    if Numeral.(j > k) then acc
-    else loop Numeral.(succ j) (List.rev_append (fn_congruence_instances sys j) acc)
-  in
-  loop Numeral.zero []
+    bounds Numeral.zero acc
+  ) [] fn_congruence_groups
 
 (* Close term by binding variables to terms with a let binding *)
 let close_term bindings term = 

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -153,22 +153,21 @@ val global_constraints : t -> Term.t list
 val fn_congruence_groups : t -> fn_congruence_group list
 
 (** [fn_congruence_instances t k] returns the ground functional congruence
-    instances pairing every function application at bound [k] with every
-    application at bounds [0..k]. Asserting the result for each bound of a
-    monotone unrolling covers all pairs of applications in the unrolling.
-    Every instance is a valid formula of the intended semantics, so
-    over-approximating the unrolled window is sound. The result is empty
-    when the system's subtree has no function with container-typed
-    arguments. *)
+    instances for every pair of function applications over bounds [0..k].
+    Empty when the system's subtree has no function with container-typed
+    arguments.
+
+    Each is a valid formula of the intended semantics, so asserting any
+    subset of them is sound, and an engine can leave them all out until a
+    query comes back satisfiable. Given to the solver as terms to evaluate,
+    those the model makes false are exactly the instances that refute it;
+    when there are none the model satisfies determinism, so the
+    counterexample it represents is genuine. *)
 val fn_congruence_instances : t -> Numeral.t -> Term.t list
 
 (** Return true if the system's subtree has at least one functional
     congruence group *)
 val has_fn_congruence_groups : t -> bool
-
-(** [fn_congruence_instances_up_to t k] returns the ground functional
-    congruence instances for all pairs of applications at bounds [0..k] *)
-val fn_congruence_instances_up_to : t -> Numeral.t -> Term.t list
 
 (** Close the initial state constraint by binding all instance
     identifiers, and bump the state variable offsets to be at the given

--- a/src/transSys.mli
+++ b/src/transSys.mli
@@ -71,8 +71,22 @@ module Hashtbl : Hashtbl.S with type key = t
     list. *)
 type pred_def = UfSymbol.t * (Var.t list * Term.t)
 
+(** Functional congruence group of an (abstracted) function with
+    container-typed arguments: a quantifier-free template over one pair of
+    free variables per function argument, together with the argument state
+    variable tuples of the function's applications in the system's subtree.
+    Substituting two applications (at two bounds) into the template yields a
+    ground congruence instance (see {!fn_congruence_instances}). *)
+type fn_congruence_group =
+  {
+    fcg_template : Term.t;
+    fcg_a_vars : Var.t list;
+    fcg_b_vars : Var.t list;
+    fcg_apps : StateVar.t list list;
+  }
+
 (** Instance of a subsystem *)
-type instance = 
+type instance =
   {
     uid : int;
     (** Unique identifier of the instance *)
@@ -134,6 +148,27 @@ val pp_print_trans_sys_name : Format.formatter -> t -> unit
 
 (** Return global constraints on free constants *)
 val global_constraints : t -> Term.t list
+
+(** Return the functional congruence groups of the system's subtree *)
+val fn_congruence_groups : t -> fn_congruence_group list
+
+(** [fn_congruence_instances t k] returns the ground functional congruence
+    instances pairing every function application at bound [k] with every
+    application at bounds [0..k]. Asserting the result for each bound of a
+    monotone unrolling covers all pairs of applications in the unrolling.
+    Every instance is a valid formula of the intended semantics, so
+    over-approximating the unrolled window is sound. The result is empty
+    when the system's subtree has no function with container-typed
+    arguments. *)
+val fn_congruence_instances : t -> Numeral.t -> Term.t list
+
+(** Return true if the system's subtree has at least one functional
+    congruence group *)
+val has_fn_congruence_groups : t -> bool
+
+(** [fn_congruence_instances_up_to t k] returns the ground functional
+    congruence instances for all pairs of applications at bounds [0..k] *)
+val fn_congruence_instances_up_to : t -> Numeral.t -> Term.t list
 
 (** Close the initial state constraint by binding all instance
     identifiers, and bump the state variable offsets to be at the given
@@ -243,6 +278,9 @@ val mk_trans_sys :
 
   (* Recursive ADTs used anywhere in this system, in dependency order *)
   ?datatype_types:Type.t list ->
+
+  (* Functional congruence groups of the system's subtree *)
+  ?fn_congruence_groups:fn_congruence_group list ->
 
   (* Name of the transition system *)
   Scope.t ->

--- a/tests/regression/falsifiable/choose_container_determinism_reach.lus
+++ b/tests/regression/falsifiable/choose_container_determinism_reach.lus
@@ -1,0 +1,20 @@
+-- Reachability form of container-function determinism. Without the ground
+-- congruence instances the two applications below can take different values,
+-- and the reachability check succeeds with a witness that does not exist in
+-- the intended (deterministic) semantics. With them the check is proved
+-- unreachable, which is the expected outcome of this test (an unreachable
+-- 'check reachable' is reported as falsified).
+--
+-- 'm1' and 'm2' are structurally equal, but built so that the value slot of
+-- the key removed from 'm2' is a cell the encoding never addresses.
+
+function imported K(m: map<int, int>) returns (out: int);
+
+node main(v: int) returns (ok: bool);
+var m1, m2: map<int, int>;
+let
+  m1 = map[0 := 7];
+  m2 = (map[0 := 7; 1 := v]) - {1};
+  ok = true;
+  check reachable "fn disagrees on structurally equal maps" (K(m1) <> K(m2));
+tel

--- a/tests/regression/falsifiable/choose_container_determinism_sound.lus
+++ b/tests/regression/falsifiable/choose_container_determinism_sound.lus
@@ -1,0 +1,23 @@
+-- The congruence instances for functions over containers must not over-merge:
+-- results at containers that actually differ remain unconstrained, and the
+-- system stays consistent.
+
+datatype D = A (a: int) | B (b: bool);
+
+function imported F(s: set<D>) returns (out: int);
+
+node main(b: bool) returns (r: int);
+var t: set<int>; u: set<D>; cnt: int;
+let
+  cnt = 0 -> pre cnt + 1;
+  t = if b then {1, 2} else {3};
+  u = if b then {A(1)} else {B(true)};
+  r = choose { x: int | x in t };
+
+  -- all three must be falsifiable
+  check "choose forced equal across different sets"
+    (cnt >= 1 and not (t = pre t)) => (r = pre r);
+  check "imported fn forced equal across different adt sets"
+    (cnt >= 1 and not (u = pre u)) => (F(u) = pre (F(u)));
+  check "system is vacuous" false;
+tel

--- a/tests/regression/success/choose_container_determinism.lus
+++ b/tests/regression/success/choose_container_determinism.lus
@@ -1,0 +1,45 @@
+-- Determinism of 'choose' and imported functions over container arguments
+-- (sets, maps, arrays). Containers compile to uninterpreted arrays, so UF
+-- congruence alone cannot equate two containers holding the same elements;
+-- ground congruence instances modulo structural equality, activated lazily
+-- by the engines when a candidate counterexample is found, restore
+-- determinism.
+
+type Color = enum { Red, Green, Blue };
+datatype D = A (a: int) | B (b: bool);
+
+function imported F(s: set<D>) returns (out: int);
+function imported G(m: map<Color, int>) returns (out: int);
+function imported H(a: int^2) returns (out: int);
+
+node main(b: bool; c: int) returns (r, q: int);
+var t: set<int>; u: set<D>; m: map<Color, int>; arr: int^2; cnt: int;
+let
+  cnt = 0 -> pre cnt + 1;
+  t = if b then {1, 2} else {3};
+  u = if b then {A(1)} else {B(true)};
+  m = if b then map[Red := 1] else map[Green := 2];
+  arr[i] = if b then 0 else 1;
+  r = choose { x: int | x in t };
+  q = choose { x: int | x > c };
+
+  check "choose satisfies its predicate" r in t;
+
+  check "scalar choose is a function of its argument"
+    true -> ((c = pre c) => (q = pre q));
+
+  -- full determinism: the result is a function of the container value,
+  -- even when the value recurs after an intermediate change
+  check "choose is a function of a recurring set"
+    (cnt >= 2 and t = pre (pre t) and not (t = pre t)) => (r = pre (pre r));
+
+  -- congruence at structurally equal consecutive arguments
+  check "imported fn deterministic over adt set"
+    true -> ((u = pre u) => (F(u) = pre (F(u))));
+
+  check "imported fn deterministic over map"
+    true -> ((m = pre m) => (G(m) = pre (G(m))));
+
+  check "imported fn deterministic over array"
+    true -> ((arr = pre arr) => (H(arr) = pre (H(arr))));
+tel

--- a/tests/regression/success/choose_container_determinism.lus
+++ b/tests/regression/success/choose_container_determinism.lus
@@ -43,3 +43,17 @@ let
   check "imported fn deterministic over array"
     true -> ((arr = pre arr) => (H(arr) = pre (H(arr))));
 tel
+
+-- Congruence at two containers that are structurally equal but built
+-- differently, so that the cells the encoding never addresses (here the
+-- value slot of a key removed from the map) may hold different values.
+function imported K(m: map<int, int>) returns (out: int);
+
+node built_differently(v: int) returns (ok: bool);
+var m1, m2: map<int, int>;
+let
+  m1 = map[0 := 7];
+  m2 = (map[0 := 7; 1 := v]) - {1};
+  ok = (K(m1) = K(m2));
+  check "imported fn agrees on structurally equal maps" ok;
+tel

--- a/tests/regression/success/choose_scalar_determinism.lus
+++ b/tests/regression/success/choose_scalar_determinism.lus
@@ -1,0 +1,17 @@
+-- 'choose' over scalar arguments is deterministic: the generated function's
+-- SMT symbol is congruent over equal arguments.
+
+node main(c: int; b: bool) returns (r, s: int);
+let
+  r = choose { x: int | x > c };
+  s = choose { x: int | x > 0 };
+
+  check "choose is a function of its scalar argument"
+    true -> ((c = pre c) => (r = pre r));
+
+  check "choose with no argument is constant"
+    true -> (s = pre s);
+
+  check "choose satisfies its predicate"
+    r > c and s > 0;
+tel

--- a/tests/regression/success/two_phase_commit.lus
+++ b/tests/regression/success/two_phase_commit.lus
@@ -52,8 +52,12 @@ function imported AllVotesCollected(votes: map<HostId,Vote>) returns (r: bool);
 
 function imported GetDecision(votes: map<HostId,Vote>) returns (d: Decision);
 (*@contract
-  guarantee (forall (i: HostId) votes[i]=Yes) = (d = Commit);
-  guarantee (not (forall (i: HostId) votes[i]=Yes)) = (d = Abort);
+  (* 'votes[i]' is unconstrained where 'i' is not a key of 'votes', so the
+     reads are guarded by membership: 'i in votes and votes[i]=Yes' is false
+     at an absent key whatever the map holds there. The second guarantee is
+     the negation of the first, so that a decision exists for every map. *)
+  guarantee (forall (i: HostId) i in votes and votes[i]=Yes) = (d = Commit);
+  guarantee (not (forall (i: HostId) i in votes and votes[i]=Yes)) = (d = Abort);
 *)
 
 node Coordinator(my_turn: bool; nw_recv: Option<Message>)


### PR DESCRIPTION
### Problem

An imported function — or the function generated for a `choose` operator — with a container-typed (set, map, or array) argument is not deterministic. Containers compile to uninterpreted arrays constrained only at their canonical positions, so two containers holding the same elements are in general distinct terms and UF congruence never fires:

```lustre
node M1() returns (r: int);
var s: set<int>;
let
  s = {1, 2};                        -- the same set at every step
  r = choose { x: int | x in s };
  check true -> (r = pre r);         -- invalid (!), though 'choose' is documented as functional
tel
```

The same holds for user-written imported functions over sets, maps, and sized arrays. In particular, a `choose` over a container behaves exactly like an `any`.

The gap surfaces in both user-facing directions. With `m1` and `m2` structurally equal but built differently, so that a cell the encoding never addresses may hold different values:

```lustre
m1 = map[0 := 7];
m2 = (map[0 := 7; 1 := v]) - {1};

check           K(m1) =  K(m2)   -- invalid: a counterexample that cannot occur
check reachable K(m1) <> K(m2)   -- reachable: a witness that cannot occur
```

Only container *identity* is affected. Structural equality, membership, indexing, set/map operations, `pre`, `ite` and node calls are all compiled with guards matching the canonical positions, and are correct today — checked against `main` with a battery of probes over maps, enum sets and ADT sets built to differ in their unaddressed cells.

### Approach

**Ground congruence instances modulo structural equality, asserted only when a counterexample calls for them.**

For each (abstracted) function with container-typed inputs, `LustreTransSys` builds a quantifier-free congruence *template* over one pair of free variables per argument:

> some scalar argument pair differs, **or** some container pair differs at an in-range (and, for map values, present) difference-witness position, **or** all outputs coincide.

Difference witnesses are explicit Skolem *functions* of the two sides, declared with the function symbols, which is what lets instances be shared and bumped. Dimension guards mirror structural equality of containers: bounds-table entries for array dimensions (exclusive upper), enum/subrange ranges for set and map dimensions (inclusive), map values guarded by the domain array. A guard that is too narrow would equate containers that differ, so the bounds table takes priority over the index type wherever it has an entry. The applications of the function are collected per call site and lifted to every ancestor system through the call-instance maps (`TransSys.fn_congruence_group`); substituting two of them, at two bounds, into the template yields a ground instance — a valid formula of the intended semantics (`TransSys.fn_congruence_instances`).

**Nothing is asserted until a counterexample needs ruling out.** Leaving the instances out is sound for proofs: the encoding without them over-approximates the deterministic semantics, so missing instances can only cause spurious SAT answers, never wrong UNSAT ones. A spurious SAT is a false alarm for an invariant property and a false positive for a reachability property; a safety property can never be wrongly proved valid.

So the engines never assert the instances up front. Instead their **conjunction** rides along as a term to evaluate on the very query that looks for the counterexample (`check_sat_assuming_and_get_term_values`), which costs one term and no extra query:

- when it **holds**, the counterexample already satisfies determinism: it is genuine, and is reported with **nothing asserted at all**;
- when it **fails**, the instances are evaluated one by one, and exactly those the counterexample violates are asserted before looking again.

Only the queries that actually refine pay for the second step. `SMTSolver.get_term_values` sends one `get-value` per term — deliberately, since cvc5 can answer a batched query with syntactically different terms — so evaluating every instance on every satisfiable answer would cost a round trip each.

The loop terminates because each round asserts an instance the current model violates, which the next model cannot reproduce, and the instance set is finite. Deciding what to assert from the query itself, rather than remembering it across queries, also means the engines keep no state for this.

Scope notes:

- certifChecker asserts the instances unconditionally, so a proof that used them replays (checked with `--print_invs`).
- Invariant generation runs without them — sound, since an invariant of the relaxed encoding is an invariant of the refined one.
- IC3 and IC3IA already skip these systems for independent reasons (function symbols, arrays in the logic). A separate commit makes that exclusion explicit, with notes on what support would require, and closes the `--ic3qe_abstr ia` path, which skips the abstract-function check.
- Engines run as OCaml 5 domains since #1425, so a subsystem's congruence groups are read from the subsystem's own transition system: nothing is shared between two transition-system constructions, which can run concurrently.

### Alternatives evaluated and rejected

**A quantified congruence axiom** (asserted as a global constraint) is intractable: satisfiable queries — counterexamples to induction — require the solver to build a model of a quantified formula over uninterpreted array sorts, which diverges on `two_phase_commit.lus` (>600s with nothing proved, on both Z3 and cvc5). Neither skolemizing the inner quantifier nor `:pattern` annotations recover it; patterns measurably made it worse, by forcing eager pairwise instantiation inside otherwise-unsatisfiable queries.

**Array extensionality**, which would fix the root cause rather than each function, does not reach far enough. Because containers are constrained only at canonical positions, extensionality never fires for the types that matter, and it works only where a container has no finite dimension. Totalizing those dimensions makes it work for sets and arrays but not for maps, whose value array is unconstrained at absent keys: the guard needed there refers to the companion domain array, which an axiom quantified over an array sort cannot name. Totalizing sized array dimensions also changes documented semantics — an out-of-bounds read is unconstrained today, and would become the default — and, tried on a branch, cost the suite 314s against 68s with 7 models no longer converging.

### Results

Measured against `main` at 430c4b70, i.e. after #1425 moved the engines to OCaml 5 domains and sped `main` up considerably.

| | `main` | this PR |
|---|---|---|
| `two_phase_commit.lus`, as amended here | 31.5s, 37 valid | **25.0s**, 37 valid |
| `two_phase_commit.lus`, with its original contract | 33.9s | 41.5s |
| `choose`/imported fn determinism over sets, maps, arrays — including recurrence after an intermediate change, and structurally equal but differently built maps | invalid | **valid (k≤3)** |
| same, reachability form | spuriously `reachable` | **`unreachable`** |
| soundness probes (results at *different* containers stay free; system not vacuous) | falsifiable | falsifiable, unchanged |
| regression suite | 460 passed | **464 passed** |

`two_phase_commit` was the one test that regressed, by 21%, and chasing it turned up a flaw in the model rather than in the encoding. `GetDecision`'s guarantees read `votes[i]` for every host, including hosts absent from the map, where the read is unconstrained: the contract defined the decision as a function of the *array*, not of the map's bindings, which is exactly what the congruence instances contradict. The protocol never depends on this, since `GetDecision` runs only once `AllVotesCollected` holds, but the contract does not say so. A commit here guards those reads by membership, keeping the second guarantee the negation of the first so that a decision exists for every map — dropping that, for instance by asking instead for a host that voted No, leaves a partial map with no No vote satisfying neither guarantee, so the contract becomes unrealizable and every property holds vacuously. The amended model verifies without vacuity (a `false` check stays falsifiable), still exercises the instances (9 refinement rounds), and is faster on both sides.

Where the cost sat, while the original contract was still in place: entirely in the inductive step, which is where the satisfiable queries are. BMC reached the same depth on both sides (6 steps in 60s) and asserted nothing, `INVGENOS` was unaffected, and the two next-slowest tests, `test-issue-123` (10.8s) and `bv_compression` (1.7s), were unchanged to the millisecond. It was the solver reasoning with the asserted instances rather than overhead: detecting a spurious counterexample with one `get-value` instead of one per instance (2815 → 27 on that model) halves the trace and leaves the running time unchanged. Suite wall time is not a usable comparison here — `main` alone measured 44.4s and 65.7s on identical code, so the runner's scheduling dominates it; on matched runs it is 65.7s against 68.4s.

Four regression tests are added, each failing on `main` and passing here: determinism over sets, maps and arrays, including recurrence and structurally equal but differently built maps (`success/choose_container_determinism.lus`); scalar `choose` congruence (`success/choose_scalar_determinism.lus`); no-over-merging soundness (`falsifiable/choose_container_determinism_sound.lus`); and the reachability form (`falsifiable/choose_container_determinism_reach.lus`), which also exercises the reachability path of the refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
