### PR TITLE
Fix vacuously valid termination checks for non-terminating recursive functions and lemmas

### DIFF
--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -983,6 +983,34 @@ let call_terms_of_node_call mk_fresh_state_var globals caller_comp_type
 
   let node_props = node_assume_props @ func_termination_props @ node_props in
 
+  (* Guard the constraints of a recursive call with its termination checks.
+
+     At the recursion cutoff the callee is sliced to its contract abstraction,
+     so calling it *assumes* its guarantees: that is the inductive hypothesis
+     of the recursion, and it is only justified if the recursion is well
+     founded. Asserting it unconditionally lets a non-decreasing function or
+     lemma assume its own guarantees at the very same argument. With an
+     unsatisfiable guarantee the whole transition system becomes inconsistent
+     and every property is vacuously valid -- including the termination checks
+     meant to detect the problem, which are then of no help either.
+
+     Guarding leaves the caller's own variables untouched, so the termination
+     checks themselves (stated over the actual arguments) are unaffected and
+     stay falsifiable. *)
+  let guard_rec_call offset term =
+    match func_termination_props with
+    | [] -> term
+    | props ->
+      let guard =
+        props
+        |> List.map (fun { P.prop_term } -> prop_term)
+        |> Term.mk_and
+        (* The checks are stated at [TransSys.prop_base]. *)
+        |> Term.bump_state Numeral.(offset - TransSys.prop_base)
+      in
+      Term.mk_implies [guard; term]
+  in
+
   let node_assumes =
     if node_assume_props = [] then None
     else (
@@ -1049,15 +1077,17 @@ let call_terms_of_node_call mk_fresh_state_var globals caller_comp_type
       (E.base_term_of_state_var TransSys.init_base)
 
     |> Term.mk_uf init_uf_symbol
+    |> guard_rec_call TransSys.init_base
 
   in
 
   (* Term for initial state constraint at current state *)
-  let init_call_term_trans = 
+  let init_call_term_trans =
     init_params_of_bound
       (E.cur_term_of_state_var TransSys.trans_base)
 
     |> Term.mk_uf init_uf_symbol
+    |> guard_rec_call TransSys.trans_base
 
   in
 
@@ -1067,6 +1097,7 @@ let call_terms_of_node_call mk_fresh_state_var globals caller_comp_type
       (E.cur_term_of_state_var TransSys.trans_base)
       (E.pre_term_of_state_var TransSys.trans_base)
     |> Term.mk_uf trans_uf_symbol
+    |> guard_rec_call TransSys.trans_base
   in
 
   (* apply subsitutions on bounds also *)

--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -2607,30 +2607,20 @@ let rec trans_sys_of_node' options globals top_name analysis_param
               (E.base_term_of_t TransSys.init_base)
               contract_asserts
 
-            (* Add functional constraints on ouputs if any. *)
-            |> List.rev_append function_constraints_at_0
-
           in
 
           (* Transition relation *)
-          let trans_terms = 
+          let trans_terms =
 
             (* Init flag becomes and stays false at the second
                tick *)
             (E.cur_term_of_state_var TransSys.trans_base init_flag
-             |> Term.negate) :: 
+             |> Term.negate) ::
 
             (* Add invariants from contracts as assertions *)
             List.map
               (E.cur_term_of_t TransSys.trans_base)
               contract_asserts
-
-            (* Add functional constraints on ouputs if any. *)
-            |> List.rev_append (
-              (* Bump to `1`. *)
-              function_constraints_at_0
-              |> List.map (Term.bump_state Numeral.one)
-            )
 
           in
 
@@ -2754,6 +2744,50 @@ let rec trans_sys_of_node' options globals top_name analysis_param
               init_terms
               trans_terms
               calls
+          in
+
+          (* Add functional constraints on outputs if any.
+
+             For an expanded instance of a recursive function, tying the
+             output to the functional UF asserts the function's defining
+             equation at the instance's argument. That is only justified once
+             the recursion is known to be well founded: for a non-terminating
+             definition such as [f(n) = 1 + f(n)] the equation is
+             unsatisfiable, and an inconsistent transition system makes every
+             property vacuously valid -- including the very termination
+             checks meant to detect the non-termination.
+
+             We therefore guard the constraint with the termination checks of
+             the instance's recursive calls. The guarded axiom is satisfiable
+             for any recursive definition (define the function by
+             well-founded recursion on the measure wherever the guard holds,
+             and arbitrarily elsewhere), and it is as strong as the unguarded
+             one on functions whose measure does decrease. *)
+          let init_terms, trans_terms =
+            match function_constraints_at_0 with
+            | [] -> init_terms, trans_terms
+            | _ -> (
+              let termination_guards =
+                lifted_props |> List.filter_map (fun { P.prop_source; P.prop_term } ->
+                  match prop_source with
+                  | P.TerminationCheck _ -> Some prop_term
+                  | _ -> None
+                )
+              in
+              let function_constraints_at_0 =
+                match termination_guards with
+                | [] -> function_constraints_at_0
+                | _ ->
+                  let guard = Term.mk_and termination_guards in
+                  function_constraints_at_0
+                  |> List.map (fun c -> Term.mk_implies [guard; c])
+              in
+              List.rev_append function_constraints_at_0 init_terms,
+              List.rev_append
+                (* Bump to `1`. *)
+                (List.map (Term.bump_state Numeral.one) function_constraints_at_0)
+                trans_terms
+            )
           in
 
           let history_svars =

--- a/tests/regression/falsifiable/decreases_self_call.lus
+++ b/tests/regression/falsifiable/decreases_self_call.lus
@@ -1,0 +1,18 @@
+-- A recursive function that calls itself on its own arguments: the measure
+-- stays equal instead of decreasing, so the decrease_check must be falsified.
+-- The defining equation "out = 1 + Loop(n)" has no solution, so tying every
+-- instance of Loop to its functional UF must not be assumed unconditionally:
+-- an inconsistent transition system would make every property (including the
+-- termination checks themselves) vacuously valid.
+function rec Loop(n: int) returns (out: int);
+(*@contract
+  decreases n;
+*)
+let
+  out = 1 + Loop(n);
+tel
+
+node main() returns ();
+let
+  check "should_be_falsifiable" Loop(0) < 0;
+tel

--- a/tests/regression/falsifiable/decreases_self_call_guarantee.lus
+++ b/tests/regression/falsifiable/decreases_self_call_guarantee.lus
@@ -1,0 +1,21 @@
+-- Same as decreases_self_call_lemma.lus, but for a plain recursive function
+-- with a contract. At the recursion cutoff the callee is sliced to its
+-- contract abstraction, so the call assumes the unsatisfiable guarantee; that
+-- assumption is only justified if the recursion is well founded.
+--
+-- "vacuity" detects an inconsistent transition system: it must be falsified,
+-- as must the decrease check.
+function rec h(n: int) returns (r: int);
+con
+  guarantee "bogus" 1 = 0;
+  decreases n;
+noc
+let
+  r = h(n);
+tel
+
+node main(k: int) returns ();
+let
+  check "vacuity" false;
+  check "sanity" h(k) = 0;
+tel

--- a/tests/regression/falsifiable/decreases_self_call_lemma.lus
+++ b/tests/regression/falsifiable/decreases_self_call_lemma.lus
@@ -1,0 +1,17 @@
+-- A recursive lemma whose measure does not decrease: it invokes itself on its
+-- own argument, so its inductive hypothesis is the goal itself. The decrease
+-- check must be falsified, and the guarantee must not be provable from that
+-- hypothesis.
+--
+-- The guarantee is unsatisfiable on purpose: assuming it unconditionally at
+-- the recursion cutoff makes the whole transition system inconsistent, which
+-- would report every property -- including the termination checks themselves
+-- -- as vacuously valid.
+lemma Bad(a: int)
+con
+  guarantee "bogus" 1 = 0;
+  decreases a;
+noc
+let
+  Bad(a);
+tel


### PR DESCRIPTION
Two soundness holes let a **non-terminating** recursive function or lemma be reported as terminating and correct. Both have the same shape: information whose validity depends on the recursion being well founded is asserted *unconditionally*, in the very system where the termination checks are verified. When that information is unsatisfiable the transition system becomes inconsistent and **every** property is vacuously valid — including the termination checks meant to detect the problem.

Both are fixed by the same principle: **guard the assumption with the termination checks of the recursive call that introduces it.**

## 1. The functional-UF tie

```
function rec Loop (n: int) returns (out: int)
con decreases n; noc
let
  out = 1 + Loop(n);
tel

node main () returns ()
let
  check "should_be_false" Loop(0) < 0;
tel
```

```
should_be_false:                     valid (k=1)   (Loop(0) < 0)
Loop[L11C27].decrease_check[L5C13]:  valid (k=1)   (n < n)
Loop[L11C27].bounded_check[L5C13]:   valid (k=1)   (0 <= n)
```

`n < n` is proven valid.

**Cause.** Since #1381 a recursive function ties the outputs of *every* instance to the global functional UF, not just the abstracted leaves. On the expanded instance of `Loop` that gives `out = uf(n)` (the tie), `out = 1 + out_child` (the body) and `out_child = uf(n)` (the leaf, at the *same* argument) — i.e. `uf(n) = 1 + uf(n)`, unsatisfiable. Tying an expanded instance to the UF is exactly asserting the function's *defining equation*, which is only justified once the recursion is known to be well founded.

(#1381 itself remains necessary: without the tie the recurrence is lost at the uninterpreted leaf and inductive lemmas such as `even_odd_sum_props` no longer close.)

**Fix.** Guard the functional constraint with the termination checks of the instance's recursive calls:

```
(bounded_check and decrease_check) => (out = uf(inputs))
```

The guarded axiom is satisfiable for *any* recursive definition — define the function by well-founded recursion on the measure wherever the guard holds, and arbitrarily elsewhere — so the system can no longer be made inconsistent. Where the measure does decrease the guard is valid, so the constraint is exactly as strong as before. The constraint moves after `constraints_of_node_calls`, which is where the lifted `TerminationCheck` properties become available.

## 2. The inductive hypothesis

```
lemma Bad(a: int)
con
  guarantee "bogus" 1 = 0;
  decreases a;
noc
let
  Bad(a);
tel
```

```
bogus:                  valid (k=1)   (1 = 0)
bounded_check[L9C3]:    valid (k=1)   (0 <= a)
decrease_check[L9C3]:   valid (k=1)   (a < a)
```

The same with a plain recursive function additionally trips `<Error> Runtime failure in invariant manager: Property 'vacuity' proven invariant was falsified too!`.

**Cause.** At the recursion cutoff the callee is sliced to its contract abstraction, so calling it *assumes* its guarantees — that is the inductive hypothesis of the recursion. It was asserted unconditionally, letting a non-decreasing function or lemma assume its own guarantees at the very same argument.

A milder variant needs no inconsistency at all to be unsound:

```
lemma Bad2(a: int)
con guarantee "a is non-negative" a >= 0; decreases a; noc
let Bad2(a); tel
```

`a >= 0` was reported `valid (k=1)`, proven from an inductive hypothesis taken at the same argument.

**Fix.** Guard the constraints of a recursive call with that call's own termination checks (`guard_rec_call`). The checks are stated over the *caller's* actual arguments, so they are untouched by the guard and stay falsifiable.

## Result

| Property | Before | After |
|---|---|---|
| `should_be_false` (`Loop(0) < 0`) | `valid (k=1)` | **`invalid after 0 steps`** |
| `decrease_check` (`n < n`) | `valid (k=1)` | **`invalid after 0 steps`** |
| `bogus` (`1 = 0`, lemma) | `valid (k=1)` | **`invalid after 0 steps`** |
| `decrease_check` (`a < a`, lemma) | `valid (k=1)` | **`invalid after 0 steps`** |
| `a is non-negative` (`a >= 0`, lemma) | `valid (k=1)` | **`invalid after 0 steps`** |
| `bounded_check` (`0 <= n`) | `valid (k=1)` | `valid (k=1)` |

Both guards are kept. The second indirectly neutralises the first, because the UF tie can only become inconsistent through an abstracted leaf — but that holds only as long as there is exactly one expanded instance per recursive function, which is an artefact of the unrolling limit rather than a design invariant. Each guard is independently justified where it stands.

## Testing

New falsifiable regression tests, each of which returns `success` before this change:

- `decreases_self_call.lus` — self-call with unchanged arguments (case 1).
- `decreases_self_call_lemma.lus` — recursive lemma with a non-decreasing measure (case 2).
- `decreases_self_call_guarantee.lus` — same for a recursive function, with a `check false` vacuity probe.

Full regression suite: **1371 passed** (457 tests × 3 slicing modes); dune unit tests OK.

The motivating cases for the UF tie still prove valid at `k=1`: `even_odd_sum_props`, `even_odd`, `ackermann`, `factorial`, `fibonacci`, `sum_double`. `decreases_tuple_increasing` still falsifies its decrease check.

Additionally probed, all behaving correctly (no vacuity, checks falsified at the right call site): mutual recursion with unchanged arguments; mutual-recursion cycles of length 3; non-termination confined to one branch; a decreasing but unbounded measure over plain `int`; lexicographic measures with a same-argument cycle; a measure whose decrease obligation mentions the function itself; a contradictory `assume`; modes; and calls appearing only in a contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
