### PR TITLE
Reject decreases measures that are not functions of the inputs

### DIFF
--- a/src/lustre/lustreSyntaxChecks.ml
+++ b/src/lustre/lustreSyntaxChecks.ml
@@ -80,6 +80,7 @@ type error_kind = Unknown of string
   | InductiveVarsWithArrayConstr of LustreAst.expr
   | DuplicatePatternVariable of HString.t
   | MissingDecreasesClause of HString.t
+  | IllegalDecreasesMeasure of HString.t
   | MisplacedAuto
   | LemmaCallOutsideCallStatement of HString.t
   | CallStatementCallsNonLemma of HString.t
@@ -158,6 +159,10 @@ let error_message kind = match kind with
   | MissingDecreasesClause id -> "Recursive function '"
     ^ HString.string_of_hstring id
     ^ "' must include a decreases clause in its contract"
+  | IllegalDecreasesMeasure id -> "Identifier '"
+    ^ HString.string_of_hstring id
+    ^ "' cannot occur in a decreases clause; a decreases measure may only "
+    ^ "mention the input parameters of the function and constants"
   | MisplacedAuto -> "The 'auto' keyword is only allowed in the body of a lemma"
   | LemmaCallOutsideCallStatement id -> "Lemma '"
     ^ HString.string_of_hstring id ^ "' can only be invoked in a call statement"
@@ -948,6 +953,50 @@ and no_reachability_modifiers item = match item with
     syntax_error pos (IllegalTemporalOperator ("pre", "reachability query modifier")) 
   | _ -> Ok ()
 
+(* A decreases measure is compared across a recursive call by substituting the
+   callee's formal parameters with the actual arguments, so it must be a
+   function of the input parameters (and of constants) alone.
+
+   An output is not a legal measure: its value is what the recursion is
+   supposed to define, so using it to justify termination is circular, and the
+   resulting obligation compares the callee's output with the caller's own
+   while being rendered as if both were the same variable. Ghost variables and
+   ghost constants are not legal either: the measure is compiled before the
+   contract is, so they are not in scope yet and reaching one raises an
+   assertion failure in LustreNodeGen. *)
+and check_decreases_measures inputs outputs contract =
+  let contract_items = match contract with
+    | Some (_, items) -> items
+    | None -> []
+  in
+  let illegal_ids =
+    let add_id set id = LA.SI.add id set in
+    let over_contract_item acc = function
+      | LA.GhostConst (FreeConst (_, id, _))
+      | LA.GhostConst (UntypedConst (_, id, _))
+      | LA.GhostConst (TypedConst (_, id, _, _)) -> add_id acc id
+      | LA.GhostVars (_, GhostVarDec (_, tis), _) ->
+        List.fold_left (fun acc (_, id, _) -> add_id acc id) acc tis
+      | _ -> acc
+    in
+    let ids =
+      List.fold_left over_contract_item LA.SI.empty contract_items
+      |> fun acc -> List.fold_left (fun acc (_, id, _, _) -> add_id acc id) acc outputs
+    in
+    (* An identifier shadowed by an input is legal: it denotes the input. *)
+    List.fold_left (fun acc (_, id, _, _, _) -> LA.SI.remove id acc) ids inputs
+  in
+  let check_measure (pos, e) =
+    let used = LAH.vars_without_node_call_ids e in
+    match LA.SI.elements (LA.SI.inter used illegal_ids) with
+    | [] -> Ok ()
+    | id :: _ -> syntax_error pos (IllegalDecreasesMeasure id)
+  in
+  contract_items
+  |> List.filter_map (function LA.Decreases d -> Some d | _ -> None)
+  |> List.map check_measure
+  |> Res.seq_
+
 and check_input_items (pos, _id, _ty, clock, _const) =
   no_clock_inputs_or_outputs pos clock
 
@@ -1023,7 +1072,7 @@ and check_func_decl ctx span (node_id, ext, opac, params, inputs, outputs, local
         syntax_error span.start_pos
           (MissingDecreasesClause (NI.get_user_name node_id))
       else
-        Ok ()
+        check_decreases_measures inputs outputs contract
     else
       Ok ()
   in

--- a/src/lustre/lustreSyntaxChecks.mli
+++ b/src/lustre/lustreSyntaxChecks.mli
@@ -61,6 +61,7 @@ type error_kind = Unknown of string
   | InductiveVarsWithArrayConstr of LustreAst.expr
   | DuplicatePatternVariable of HString.t
   | MissingDecreasesClause of HString.t
+  | IllegalDecreasesMeasure of HString.t
   | MisplacedAuto
   | LemmaCallOutsideCallStatement of HString.t
   | CallStatementCallsNonLemma of HString.t

--- a/tests/regression/error/decreases_ghost_const.lus
+++ b/tests/regression/error/decreases_ghost_const.lus
@@ -1,0 +1,14 @@
+-- Same as decreases_ghost_var.lus, but for a ghost constant.
+function rec f(n: int) returns (r: int);
+(*@contract
+  const c: int = 0;
+  decreases n - c;
+*)
+let
+  r = when n <= 0 then 0 else 1 + f(n - 1);
+tel
+
+node main() returns ();
+let
+  check "ok" f(3) >= 0;
+tel

--- a/tests/regression/error/decreases_ghost_var.lus
+++ b/tests/regression/error/decreases_ghost_var.lus
@@ -1,0 +1,16 @@
+-- A decreases measure that mentions a ghost variable. The measure is compiled
+-- before the contract is, so the ghost variable is not in scope yet; this used
+-- to raise an assertion failure in LustreNodeGen instead of being reported.
+function rec f(n: int) returns (r: int);
+(*@contract
+  var d: int = n;
+  decreases d;
+*)
+let
+  r = when n <= 0 then 0 else 1 + f(n - 1);
+tel
+
+node main() returns ();
+let
+  check "ok" f(3) >= 0;
+tel

--- a/tests/regression/error/decreases_output.lus
+++ b/tests/regression/error/decreases_output.lus
@@ -1,0 +1,16 @@
+-- A decreases measure that mentions an output. The value of an output is what
+-- the recursion is supposed to define, so using it to justify termination is
+-- circular. It was silently accepted, and produced an obligation comparing the
+-- callee's output against the caller's own while being rendered as "r < r".
+function rec f(m, n: int) returns (r: int);
+(*@contract
+  decreases m, r;
+*)
+let
+  r = when m <= 0 then 0 else 1 + f(m - 1, n);
+tel
+
+node main() returns ();
+let
+  check "ok" f(3, 1) >= 0;
+tel


### PR DESCRIPTION
A `decreases` measure is compared across a recursive call by substituting the callee's formal parameters with the actual arguments (`mk_rec_decrease_expr`), so it must be a function of the input parameters (and of constants) alone. Two kinds of measure violate that and neither was reported.

## 1. Ghost variables and ghost constants crash

```
function rec f(n: int) returns (r: int);
(*@contract
  var d: int = n;
  decreases d;
*)
let
  r = when n <= 0 then 0 else 1 + f(n - 1);
tel
```

```
<Error> Error opening input file '...':
        File "src/lustre/lustreNodeGen.ml", line 1204, characters 6-12: Assertion failed
```

The measure is compiled in `compile_node_decl` while building the node's `comp_type`, against the identifier map that at that point holds only the node's inputs and outputs. The contract — and with it the ghost identifiers — is compiled later, so the lookup falls through every case and hits `assert false`. A ghost *constant* (`const c: int = 0; decreases n - c;`) fails the same way.

## 2. Outputs are silently accepted and produce a meaningless obligation

```
function rec f(n: int) returns (r: int);
(*@contract
  decreases r;
*)
let
  r = when n <= 0 then 0 else 1 + f(n - 1);
tel
```

```
f[L5C15].decrease_check[L3C37]: valid (k=1)
  (r < r)
```

Substituting the formals does not touch an output, so the obligation actually compares the *callee's* output with the *caller's* own — it is not the `r < r` it is printed as, and it is trivially valid here. Beyond the misleading rendering, an output is not a legitimate measure at all: its value is what the recursion is supposed to define, so using it to justify termination is circular.

## Fix

Reject both at syntax-check time (`check_decreases_measures`), next to the existing `MissingDecreasesClause` check:

```
<Error> Parser error at ...:4:3:
        Identifier 'd' cannot occur in a decreases clause; a decreases measure
        may only mention the input parameters of the function and constants
```

Node locals were already rejected (`Unknown identifier`), since they are not visible in contracts. Global constants remain allowed, and an input that shadows an outer name still denotes the input.

## Testing

Three new error tests, all of which crash or are wrongly accepted before this change:

- `decreases_ghost_var.lus`
- `decreases_ghost_const.lus`
- `decreases_output.lus` — output as one component of a lexicographic measure

Full regression suite: **457 passed**; dune unit tests OK. Every existing `decreases` test uses an input-only measure and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
