### PR TITLE
Fix the Docker build: release base image, and no static PIE

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:alpine-3.22-ocaml-5.5-flambda AS builder
+FROM ocaml/opam:alpine-3.23-ocaml-5.5-flambda AS builder
 
 USER root
 

--- a/scripts/gen-linking-flags.sh
+++ b/scripts/gen-linking-flags.sh
@@ -13,7 +13,7 @@ case "$LINKING_MODE" in
     static)
         case "$OS" in
             linux) # Assuming Alpine here
-                CCLIB="-static";;
+                CCLIB="-static -no-pie";;
             macosx)
                 FLAGS="-noautolink"
                 NAT=$(echo $OCAML_VERSION | awk -F. '{print ($1 <= 4 || ($1 == 5 && $2 == 0)) ? "" : "nat"}')


### PR DESCRIPTION
The Docker workflow has failed since #1425 was merged ([run](https://github.com/kind2-mc/kind2/actions/runs/31262678562/job/93115816621)). There were two problems, one behind the other.

## The build could not start

`ocaml/opam:alpine-3.22-ocaml-5.5-flambda` is a *development* switch:

```
switch 5.5: ocaml-variants.5.5.0+trunk
ocaml-beta        enabled
ocaml-compiler    5.5      "Latest 5.5 development"
```

The Dockerfile points opam at the live repository and updates before installing dependencies. There `ocaml-compiler` is 5.5.1, which requires `ocaml = 5.5.1` and cannot stand beside the pinned trunk base, so opam exits 20 with `base of this switch (use --unlock-base to force)`.

`alpine-3.23-ocaml-5.5-flambda` carries the release instead — `ocaml-variants.5.5.0+options`, `ocaml-compiler 5.5.0` "Official release of OCaml 5.5.0", no beta repository — and resolves. This is the same kind of switch the 5.4 image had (`5.4.0+options`), which is why the Dockerfile worked before the compiler was raised.

## The binary it produced did not run

With that fixed the image builds, and the binary segmentation faults on any argument, `--version` included. `-static` alone links a static PIE (ELF type `ET_DYN`), which the OCaml 5 runtime does not survive under musl. Built dynamically from the same source in the same image, it runs; asking for `-no-pie` as well links an ordinary static executable (`ET_EXEC`), and it runs.

| build | ELF | `--version` |
|---|---|---|
| `-static` | `ET_DYN` (static PIE) | SIGSEGV |
| `-static -no-pie` | `ET_EXEC` | ok |

Only the `linux` branch of the script changes; macOS static linking is untouched.

## Checked

Built from this commit and run: reports its version, proves a property (`valid (k=1)`), and falsifies another (`invalid by bounded model checking for k=4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)