### PR TITLE
Release a Windows binary, and let opam install it there

### DIFF
--- a/.github/workflows/kind2-release.yml
+++ b/.github/workflows/kind2-release.yml
@@ -68,7 +68,7 @@ jobs:
     needs: [get-nightly-ready, create-new-release]
     strategy:
       matrix:
-        name: [ linux-x86_64, linux-arm64, macos-x86_64, macos-arm64 ]
+        name: [ linux-x86_64, linux-arm64, macos-x86_64, macos-arm64, windows-x86_64 ]
         ocaml-version: [ 5.5.0 ]
         macos-target: [ 12 ]
         include:
@@ -80,6 +80,8 @@ jobs:
             os: macos-15-intel
           - name: macos-arm64
             os: macos-latest
+          - name: windows-x86_64
+            os: windows-latest
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -129,14 +131,31 @@ jobs:
         flambda: true
         build-target: static
     
+    # Not built statically: the linking flags have no Windows case, and it
+    # needs none. Every library the binary imports ships with Windows —
+    # kernel32, msvcrt, advapi32, ws2_32, shell32, shlwapi, ole32, version
+    # and the synch API set — and it loads nothing else at run time.
+    - name: Build Kind 2 Windows binary
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/build-kind2
+      with:
+        ocaml-version: ${{ matrix.ocaml-version }}
+        cache-prefix: windows
+
     - name: Test Kind 2 binary
-      run: ./bin/kind2 --version
+      shell: bash
+      run: |
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          ./bin/kind2.exe --version
+        else
+          ./bin/kind2 --version
+        fi
 
     - name: Create asset
       id: create_asset
+      shell: bash
       run: |
         cd bin
-        chmod u+x kind2
         if [[ "$GITHUB_REF" =~ ^refs/tags/v.* ]]; then
           vtag=$GITHUB_REF_NAME
           echo "release=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
@@ -144,16 +163,26 @@ jobs:
           vtag=$(date "+%Y-%m-%d")
           echo "release=nightly" >> $GITHUB_OUTPUT
         fi
-        if [[ "$RUNNER_OS" == "Linux" ]]; then
-          ptag="${{ matrix.name }}"
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          # A zip is what a Windows user expects, and Compress-Archive is
+          # always there, where zip and 7z are not guaranteed.
+          asset=kind2-$vtag-windows-x86_64.zip
+          powershell -NoProfile -Command \
+            "Compress-Archive -Path kind2.exe -DestinationPath $asset"
         else
-          ptag="macos-${{ matrix.macos-target }}-$(uname -m)"
+          chmod u+x kind2
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            ptag="${{ matrix.name }}"
+          else
+            ptag="macos-${{ matrix.macos-target }}-$(uname -m)"
+          fi
+          asset=kind2-$vtag-$ptag.tar.gz
+          tar -czf $asset kind2
         fi
-        tarball=kind2-$vtag-$ptag.tar.gz
-        tar -czf $tarball kind2
-        echo "filepath=./bin/$tarball" >> $GITHUB_OUTPUT
+        echo "filepath=./bin/$asset" >> $GITHUB_OUTPUT
 
     - name: Upload release asset
+      shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/kind2.opam
+++ b/kind2.opam
@@ -39,4 +39,3 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/kind2-mc/kind2.git"
-available: os != "win32"

--- a/kind2.opam.template
+++ b/kind2.opam.template
@@ -1,1 +1,0 @@
-available: os != "win32"


### PR DESCRIPTION
Follows #1430, which builds and tests Kind 2 on Windows but does not release it. This adds `windows-x86_64` to the release matrix.

## Not built statically, and does not need to be

`gen-linking-flags.sh` has no Windows case, so the Windows binary is built the way the CI job builds it. Read off the binary the CI produces, it needs nothing but Windows:

- every library it imports ships with the system — `kernel32`, `msvcrt`, `advapi32`, `ws2_32`, `shell32`, `shlwapi`, `ole32`, `version`, and the `api-ms-win-core-synch-l1-2-0` API set
- the delay-import table is empty
- no other DLL name appears anywhere in it, so nothing is loaded at run time either

There is no MinGW or MSYS2 runtime to ship beside it. The API set — how the OCaml 5 runtime reaches `WaitOnAddress` — puts the floor at Windows 8.1 / Server 2012 R2.

## The asset

A zip rather than a tarball, which is what a Windows user expects, made with `Compress-Archive` because it is always present where `zip` and `7z` are not.

## A latent problem this uncovered

Three steps of the release job are bash scripts that never said so: testing the binary, creating the asset, and uploading it. The four existing platforms default to bash and let that pass; Windows defaults to PowerShell, where neither `\` line continuations nor `$GITHUB_REPOSITORY` mean anything. The upload step would have failed *after* a successful build. All three declare `shell: bash` now, and the first two know the binary is called `kind2.exe`.

## opam

`kind2.opam.template` held one line, `available: os != "win32"`, which kept opam from offering the package on Windows. That is no longer true, so the line and the template with it are gone, and the generated `kind2.opam` follows — opam files are generated from `dune-project` and the template, so that hunk is the regeneration rather than an edit.

## Note

As on every platform, the asset does not carry an SMT solver, and Kind 2 needs one on the `PATH`. Worth knowing for Windows specifically: MathSAT there is a 9kB `mathsat.exe` that loads `mathsat.dll` and `gmp.dll`, so all three have to travel together.

## Untested

The release job runs on a tag or on the nightly schedule, so CI on this PR does not exercise it. The build and asset steps mirror what the Windows CI job already does, but `Compress-Archive` and the upload run for real only at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
