### PR TITLE
Compare benchmarks against main on every platform, Windows included

### DIFF
--- a/.github/workflows/kind2-benchmarks-all-platforms.yml
+++ b/.github/workflows/kind2-benchmarks-all-platforms.yml
@@ -1,0 +1,456 @@
+name: Kind 2 Benchmarks (all platforms)
+
+# The same head-vs-base comparison as kind2-pr-benchmarks.yml, run on every
+# platform Kind 2 supports rather than on linux-x86_64 alone, and reported once
+# per platform. Five platforms multiply the job count, so the benchmark set is
+# split into fewer shards than the pull request workflow uses: each job runs
+# more of the set and takes longer, and there are fewer of them at once.
+# Windows is the exception with more shards, since its runners are the
+# slowest; its jobs are separate anyway because nearly every step needs some
+# Windows adjustment.
+#
+# Not attached to pull requests: five platforms cost too much to pay on every
+# push to a pull request, and the linux-x86_64 comparison already runs there.
+# Start it by hand from the Actions tab (once this file is on the default
+# branch), or push a branch named bench-* (which works from anywhere).
+#
+# The head of the comparison is the commit the run was started on; the base
+# defaults to main and can be overridden when dispatching by hand.
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Base ref to compare against"
+        required: false
+        default: main
+  push:
+    branches:
+      - 'bench-*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # The two sides of the comparison.
+  HEAD_REF: ${{ github.sha }}
+  BASE_REF: ${{ inputs.base_ref || 'main' }}
+  BENCHMARKS_REPO: kind2-mc/kind2-benchmarks
+  BENCHMARKS_REF: main
+  BENCHMARKS_SUBDIRS: "FMCAD08/Bool FMCAD08/Int FMCAD08/Real_Int"
+  # Per-benchmark wall-clock timeout (seconds).
+  BENCH_TIMEOUT: "120"
+  OCAML_VERSION: 5.5.0
+  Z3_VERSION: "4.15.3"
+  MATHSAT_VERSION: "5.6.17"
+
+jobs:
+  build:
+    name: build (${{ matrix.platform }} ${{ matrix.side }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux-x86_64, linux-arm64, macos-x86_64, macos-arm64]
+        side: [head, base]
+        include:
+          - platform: linux-x86_64
+            os: ubuntu-latest
+          - platform: linux-arm64
+            os: ubuntu-24.04-arm
+          - platform: macos-x86_64
+            os: macos-15-intel
+          - platform: macos-arm64
+            os: macos-latest
+    steps:
+      - name: Checkout Kind 2 (${{ matrix.side }})
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.side == 'head' && env.HEAD_REF || env.BASE_REF }}
+
+      - name: Update package information (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -y
+
+      - name: Update package information (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          # Untap aws to silence Homebrew trust warnings
+          # See https://github.com/actions/runner-images/issues/14232
+          brew untap aws/tap || true
+          brew update
+
+      - name: Set up OCaml ${{ env.OCAML_VERSION }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ env.OCAML_VERSION }}
+          cache-prefix: bench-all-${{ matrix.platform }}-${{ matrix.side }}
+
+      - name: Build Kind 2 (${{ matrix.side }})
+        run: |
+          opam install -y . --deps-only
+          opam exec make build
+
+      - name: Upload Kind 2 binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: kind2-${{ matrix.platform }}-${{ matrix.side }}
+          path: bin/kind2
+
+  build-windows:
+    name: build (windows-x86_64 ${{ matrix.side }})
+    runs-on: windows-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        side: [head, base]
+    steps:
+      - name: Checkout Kind 2 (${{ matrix.side }})
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.side == 'head' && env.HEAD_REF || env.BASE_REF }}
+
+      - name: Set up OCaml ${{ env.OCAML_VERSION }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ env.OCAML_VERSION }}
+          cache-prefix: bench-all-windows-x86_64-${{ matrix.side }}
+
+      - name: Install OCaml dependencies
+        shell: bash
+        run: opam install -y . --deps-only
+
+      - name: Build Kind 2 (${{ matrix.side }})
+        shell: bash
+        run: |
+          opam exec -- dune build -p kind2 @install
+          opam exec -- dune install -p kind2 --sections=bin --prefix .
+
+      - name: Upload Kind 2 binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: kind2-windows-x86_64-${{ matrix.side }}
+          path: bin/kind2.exe
+
+  benchmark:
+    name: benchmark (${{ matrix.platform }} ${{ matrix.side }} ${{ matrix.shard }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+    # Fewer shards means each job runs more of the set, and the macOS runners
+    # are slow.
+    timeout-minutes: 360
+    env:
+      # This MUST match the length of the `shard` matrix list below.
+      SHARD_COUNT: "2"
+    strategy:
+      # Run every (platform, side, shard) independently; a failure on one still
+      # lets the others finish, which aids diagnosis.
+      fail-fast: false
+      matrix:
+        platform: [linux-x86_64, linux-arm64, macos-x86_64, macos-arm64]
+        side: [head, base]
+        # This list length MUST equal SHARD_COUNT above.
+        shard: [0, 1]
+        include:
+          - platform: linux-x86_64
+            os: ubuntu-latest
+          - platform: linux-arm64
+            os: ubuntu-24.04-arm
+          - platform: macos-x86_64
+            os: macos-15-intel
+          - platform: macos-arm64
+            os: macos-latest
+
+    steps:
+      # Drive the run with the head's copy of the harness, so it works even
+      # when the base commit predates these scripts.
+      - name: Checkout benchmark harness (head)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.HEAD_REF }}
+          sparse-checkout: scripts/benchmarks
+          sparse-checkout-cone-mode: false
+
+      # run-benchmarks.sh uses mapfile, GNU timeout and date +%s.%N, none of
+      # which the bash 3.2 and BSD userland of macOS provide. The GNU ones go
+      # first in the PATH so that the harness is the same on every platform.
+      - name: Install GNU userland (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install coreutils bash
+          echo "$(brew --prefix coreutils)/libexec/gnubin" >> "$GITHUB_PATH"
+          echo "$(brew --prefix bash)/bin" >> "$GITHUB_PATH"
+
+      - name: Check the harness has what it needs
+        run: |
+          bash --version | head -1
+          timeout --version | head -1
+          date +%s.%N
+
+      - name: Download Kind 2 (${{ matrix.side }})
+        uses: actions/download-artifact@v7
+        with:
+          name: kind2-${{ matrix.platform }}-${{ matrix.side }}
+          path: kind2-bin
+
+      - name: Make Kind 2 executable
+        run: chmod +x kind2-bin/kind2
+
+      # A binary that cannot start looks exactly like a benchmark set that
+      # times out everywhere: the harness classifies every run by its output,
+      # and a run that produced none is a Timeout. Ask it for its version
+      # before trusting several hours of that.
+      - name: Check Kind 2 runs
+        run: |
+          ./kind2-bin/kind2 --version
+
+      - name: Cache SMT solvers
+        id: cache
+        uses: actions/cache@v6
+        with:
+          path: ~/solver-bin
+          key: smt-solvers-${{ matrix.platform }}-z3-${{ env.Z3_VERSION }}-mathsat-${{ env.MATHSAT_VERSION }}
+
+      - name: Download SMT solvers (on cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/solver-bin
+          case "${{ matrix.platform }}" in
+            linux-x86_64) Z3_DIR=z3-${Z3_VERSION}-x64-glibc-2.39   ; MS_DIR=mathsat-${MATHSAT_VERSION}-linux-x86_64  ;;
+            linux-arm64)  Z3_DIR=z3-${Z3_VERSION}-arm64-glibc-2.34 ; MS_DIR=mathsat-${MATHSAT_VERSION}-linux-aarch64 ;;
+            macos-x86_64) Z3_DIR=z3-${Z3_VERSION}-x64-osx-13.7.6   ; MS_DIR=mathsat-${MATHSAT_VERSION}-macos         ;;
+            macos-arm64)  Z3_DIR=z3-${Z3_VERSION}-arm64-osx-13.7.6 ; MS_DIR=mathsat-${MATHSAT_VERSION}-macos         ;;
+          esac
+          curl -sSL -o z3.zip "https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/${Z3_DIR}.zip"
+          unzip -q z3.zip
+          cp "$Z3_DIR/bin/z3" ~/solver-bin/
+          curl -sSL -o mathsat.tar.gz "https://mathsat.fbk.eu/release/${MS_DIR}.tar.gz"
+          tar xzf mathsat.tar.gz
+          cp "$MS_DIR/bin/mathsat" ~/solver-bin/
+
+      - name: Check both solvers are in the cache
+        run: |
+          set -euo pipefail
+          ls -l ~/solver-bin/z3 ~/solver-bin/mathsat
+
+      # The macOS build of MathSAT is universal (x86_64 and arm64), so it runs
+      # on both of the macOS runners, but it loads GMP from the MacPorts path
+      # it was linked against and the runners carry Homebrew. Put the library
+      # where it looks for it.
+      - name: Give MathSAT the GMP it links against (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          brew install gmp
+          sudo mkdir -p /opt/local/lib
+          sudo ln -sf "$(brew --prefix gmp)/lib/libgmp.10.dylib" /opt/local/lib/libgmp.10.dylib
+
+      # Both solvers must work: Kind 2 interpolates with MathSAT, and falling
+      # back to Z3 for it would compare a different search from the other
+      # platforms'. Fail here rather than run for hours and report that.
+      - name: Install SMT solvers
+        run: |
+          set -euo pipefail
+          chmod +x ~/solver-bin/*
+          sudo cp ~/solver-bin/z3 ~/solver-bin/mathsat /usr/local/bin/
+          z3 --version
+          mathsat -version | head -1
+
+      - name: Checkout benchmarks
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.BENCHMARKS_REPO }}
+          ref: ${{ env.BENCHMARKS_REF }}
+          path: benchmarks
+
+      - name: Run benchmarks (${{ matrix.platform }}, ${{ matrix.side }}, shard ${{ matrix.shard }})
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}
+        run: |
+          bash scripts/benchmarks/run-benchmarks.sh \
+            "$PWD/kind2-bin/kind2" \
+            "${BENCH_TIMEOUT}" \
+            "$RUNNER_TEMP/${{ matrix.side }}-${{ matrix.shard }}.stat" \
+            benchmarks ${BENCHMARKS_SUBDIRS}
+
+      - name: Upload stat shard
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-stat-${{ matrix.platform }}-${{ matrix.side }}-${{ matrix.shard }}
+          path: ${{ runner.temp }}/${{ matrix.side }}-${{ matrix.shard }}.stat
+
+  benchmark-windows:
+    name: benchmark (windows-x86_64 ${{ matrix.side }} ${{ matrix.shard }})
+    needs: build-windows
+    runs-on: windows-latest
+    timeout-minutes: 360
+    env:
+      # This MUST match the length of the `shard` matrix list below. The
+      # Windows runners are the slowest of the five platforms, so its
+      # benchmark set is cut finer than the others'.
+      SHARD_COUNT: "4"
+    strategy:
+      fail-fast: false
+      matrix:
+        side: [head, base]
+        # This list length MUST equal SHARD_COUNT above.
+        shard: [0, 1, 2, 3]
+
+    steps:
+      - name: Checkout benchmark harness (head)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.HEAD_REF }}
+          sparse-checkout: scripts/benchmarks
+          sparse-checkout-cone-mode: false
+
+      - name: Download Kind 2 (${{ matrix.side }})
+        uses: actions/download-artifact@v7
+        with:
+          name: kind2-windows-x86_64-${{ matrix.side }}
+          path: kind2-bin
+
+      # A Kind 2 that cannot start looks exactly like a benchmark set that
+      # times out everywhere, since the harness classifies each run by output
+      # a run that never started cannot produce. Ask it for its version first.
+      - name: Check Kind 2 runs
+        shell: bash
+        run: ./kind2-bin/kind2.exe --version
+
+      - name: Cache SMT solvers
+        id: cache
+        uses: actions/cache@v6
+        with:
+          path: ~/solver-bin
+          key: smt-solvers-windows-v2-z3-${{ env.Z3_VERSION }}-mathsat-${{ env.MATHSAT_VERSION }}
+
+      - name: Download SMT solvers (on cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ~/solver-bin
+          curl -sSL -o z3.zip "https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/z3-${Z3_VERSION}-x64-win.zip"
+          unzip -q z3.zip
+          curl -sSL -o mathsat.zip "https://mathsat.fbk.eu/release/mathsat-${MATHSAT_VERSION}-win64.zip"
+          unzip -q mathsat.zip
+          # The executables are not the solvers here: mathsat.exe is a 9kB
+          # launcher for mathsat.dll, which in turn wants gmp.dll. Take every
+          # executable and library of both, and let the loader find them beside
+          # the caller.
+          cp "z3-${Z3_VERSION}-x64-win/bin/"*.exe "z3-${Z3_VERSION}-x64-win/bin/"*.dll ~/solver-bin/ 2>/dev/null || true
+          cp "mathsat-${MATHSAT_VERSION}-win64/bin/"*.exe "mathsat-${MATHSAT_VERSION}-win64/bin/"*.dll ~/solver-bin/
+          ls -l ~/solver-bin/
+
+      - name: Install SMT solvers
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -l ~/solver-bin/z3.exe ~/solver-bin/mathsat.exe
+          cygpath -w "$HOME/solver-bin" >> "$GITHUB_PATH"
+          "$HOME/solver-bin/z3.exe" --version
+          "$HOME/solver-bin/mathsat.exe" -version | head -1
+
+      # The harness is a bash script that wants GNU tools. Windows ships a
+      # timeout.exe and a find.exe of its own that do something else entirely,
+      # and picking those up would spoil a run of several hours quietly, so
+      # check what the names resolve to before starting.
+      - name: Check the harness has the tools it needs
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash --version | head -1
+          timeout --version | head -1 | grep -qi coreutils \
+            || { echo "::error::'timeout' is not GNU coreutils: $(command -v timeout)"; exit 1; }
+          find --version | head -1 | grep -qi findutils \
+            || { echo "::error::'find' is not GNU findutils: $(command -v find)"; exit 1; }
+          case "$(date +%s.%N)" in
+            *N) echo "::error::'date' does not support %N: $(command -v date)"; exit 1;;
+          esac
+          echo "bash, timeout, find and date are the GNU ones"
+
+      - name: Checkout benchmarks
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.BENCHMARKS_REPO }}
+          ref: ${{ env.BENCHMARKS_REF }}
+          path: benchmarks
+
+      - name: Run benchmarks (windows-x86_64, ${{ matrix.side }}, shard ${{ matrix.shard }})
+        shell: bash
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}
+        run: |
+          bash scripts/benchmarks/run-benchmarks.sh \
+            "$PWD/kind2-bin/kind2.exe" \
+            "${BENCH_TIMEOUT}" \
+            "$RUNNER_TEMP/${{ matrix.side }}-${{ matrix.shard }}.stat" \
+            benchmarks ${BENCHMARKS_SUBDIRS}
+
+      - name: Upload stat shard
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-stat-windows-x86_64-${{ matrix.side }}-${{ matrix.shard }}
+          path: ${{ runner.temp }}/${{ matrix.side }}-${{ matrix.shard }}.stat
+
+  compare:
+    name: compare (${{ matrix.platform }})
+    needs: [benchmark, benchmark-windows]
+    # Every platform is compared here: the comparison only reads the stat files
+    # the runs produced, so it needs nothing of the platform they came from.
+    runs-on: ubuntu-latest
+    if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          [linux-x86_64, linux-arm64, macos-x86_64, macos-arm64, windows-x86_64]
+    steps:
+      - name: Checkout benchmark harness (head)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.HEAD_REF }}
+          sparse-checkout: scripts/benchmarks
+          sparse-checkout-cone-mode: false
+
+      - name: Download stat shards of ${{ matrix.platform }}
+        uses: actions/download-artifact@v7
+        with:
+          pattern: benchmark-stat-${{ matrix.platform }}-*
+          merge-multiple: true
+          path: stats
+
+      # A platform whose runs all failed still reports, saying so, rather than
+      # taking the comparison of the other four down with it.
+      - name: Assemble per-side stat files
+        id: assemble
+        run: |
+          cat stats/head-*.stat > head.stat 2>/dev/null || : > head.stat
+          cat stats/base-*.stat > base.stat 2>/dev/null || : > base.stat
+          h=$(wc -l < head.stat); b=$(wc -l < base.stat)
+          echo "head: $h rows, base: $b rows"
+          if [ "$h" -eq 0 ] || [ "$b" -eq 0 ]; then
+            echo "have_results=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_results=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compare results
+        run: |
+          echo "## ${{ matrix.platform }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.assemble.outputs.have_results }}" != "true" ]; then
+            echo "No results: the benchmark jobs of this platform did not finish." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          bash scripts/benchmarks/compare-benchmarks.sh \
+            head.stat \
+            base.stat \
+            "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Brings the ad-hoc benchmark workflow of the `bench-all-platforms` branch into the repository, extended to Windows now that main builds there natively.

The workflow runs the same head-vs-base comparison as `kind2-pr-benchmarks.yml`, on every platform Kind 2 supports — linux-x86_64, linux-arm64, macos-x86_64, macos-arm64 and windows-x86_64 — and reports one comparison per platform in the run summary. It is not attached to pull requests: five platforms cost too much to pay on every push, and the linux-x86_64 comparison already runs there.

**How to start it**
- By hand from the Actions tab (`workflow_dispatch`), with an optional base ref that defaults to `main`; the head is the commit the run is started on.
- By pushing a branch named `bench-*`, which also works from a fork before this file reaches the default branch.

**Changes from the ad-hoc versions**
- The Windows run of the `windows-benchmarks` branch reported one side only, because at the time no earlier commit built on Windows at all; main does now, so Windows joins the same head-vs-base comparison as the other four platforms and the separate report job is gone.
- The ZeroMQ installation steps are gone for the same reason: they served the base side of the comparison, and no commit from main on needs the library.
- Windows keeps separate build/benchmark jobs (`.exe`, cygpath, GNU-tool checks, DLL handling differ too much to share steps) and runs 4 shards where the others run 2, since its runners are the slowest.

**Validation**
A full run of this workflow on a fork: https://github.com/daniel-larraz/kind2/actions/runs/31320575971 — all five platforms built both sides, ran the 859-benchmark set per side, and reported per-platform comparisons with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)