### PR TITLE
Block on the mailbox instead of polling in engine wait loops

### DIFF
--- a/src/ic3/IC3.ml
+++ b/src/ic3/IC3.ml
@@ -1264,7 +1264,7 @@ let rec block solver input_sys aparam trans_sys prop_set term_tbl predicates =
                        aparam 
                        trans_sys
                        (C.props_of_prop_set prop_set);
-                     minisleep 0.01;
+                     KEvent.wait_for_message ();
                      wait ()
                    in
                    ignore (wait ()); 
@@ -2410,8 +2410,8 @@ let rec ic3 solver input_sys aparam trans_sys prop_set frames predicates =
 
             (
 
-              (* Delay *)
-              minisleep 0.1;
+              (* Wait for the next message *)
+              KEvent.wait_for_message ();
 
               (* Wait *)
               wait_for_bmc ()

--- a/src/induction/step.ml
+++ b/src/induction/step.ml
@@ -519,7 +519,7 @@ let rec next input_sys aparam trans solver k unfalsifiables unknowns =
      stop ()
   | [], _ ->
      (* Need to wait for base confirmation. *)
-     minisleep 0.001 ;
+     KEvent.wait_for_message () ;
      next input_sys aparam trans solver k unfalsifiables unknowns'
   | _ when Flags.BmcKind.max () > 0 && k_int + 1 > Flags.BmcKind.max () ->
      KEvent.log

--- a/src/induction/step2.ml
+++ b/src/induction/step2.ml
@@ -168,8 +168,8 @@ let rec check_new_things new_stuff ({ solver ; sys ; map } as ctx) =
   match props with
     (* Nothing new property-wise, keep going if no new invariant. *)
     | [] -> if not new_stuff then (
-      (* No new invariants, sleeping and looping. *)
-      minisleep 0.07 ;
+      (* No new invariants, waiting for the next message and looping. *)
+      KEvent.wait_for_message () ;
       check_new_things false ctx
     )
     (* Some properties changed status. *)
@@ -203,7 +203,7 @@ let rec check_new_things new_stuff ({ solver ; sys ; map } as ctx) =
       ctx.map <- map ;
       (* We got new stuff we don't loop. *)
       if not new_stuff then (
-        minisleep 0.07 ;
+        KEvent.wait_for_message () ;
         check_new_things false ctx
       )
 

--- a/src/invgen/invGen.ml
+++ b/src/invgen/invGen.ml
@@ -650,8 +650,6 @@ module Make (Graph : GraphSig) : Out = struct
       "./dot" "graph" suff Graph.fmt_graph_dot graph ;
     InvGenGraph.write_dot_to
       "./dot" "classes" suff Graph.fmt_graph_classes_dot graph ; *)
-    (* minisleep 2.0 ;
-    exit () ; *)
 
     let memory, res = (sys, graph, non_trivial, trivial) :: memory, res
     in

--- a/src/kEvent.ml
+++ b/src/kEvent.ml
@@ -2215,8 +2215,18 @@ let recv () =
          []
          (EventMessaging.recv ()))
 
-  (* Don't fail if not initialized *) 
+  (* Don't fail if not initialized *)
   with Messaging.NotInitialized -> []
+
+
+(* Block until a message is queued for the calling domain. Termination
+   requests arrive as messages too, so a waiting engine is woken up on
+   shutdown and raises {!Terminate} in its next call to {!recv}. *)
+let wait_for_message () =
+  try EventMessaging.wait_for_message ()
+  (* Don't fail if not initialized. No message can ever arrive then:
+     sleep so that callers waiting in a loop do not spin. *)
+  with Messaging.NotInitialized -> minisleep 0.01
 
 let purge_im : messaging_setup -> unit =
   fun ctx ->

--- a/src/kEvent.mli
+++ b/src/kEvent.mli
@@ -192,6 +192,12 @@ val terminate : unit -> unit
 (** Receive all queued events *)
 val recv : unit -> (Lib.kind_module * event) list
 
+(** Block until an event is queued for the calling domain. Returns
+    immediately if there are queued events. Termination requests
+    arrive as messages too, so a waiting engine is woken up on
+    shutdown and raises {!Terminate} in its next call to {!recv}. *)
+val wait_for_message : unit -> unit
+
 (** Terminates if a termination message was received. Does NOT modify
     received messages. *)
 val check_termination: unit -> unit

--- a/src/messaging.ml
+++ b/src/messaging.ml
@@ -39,7 +39,9 @@
    There are no background threads and no acknowledgement or resend
    protocol: delivery is a mutex-protected queue operation and is
    reliable by construction. [recv] drains the mailbox of the calling
-   domain. *)
+   domain without blocking; [wait_for_message] blocks the calling
+   domain until its mailbox is not empty, so that a domain with
+   nothing to do until the next message does not have to poll. *)
 
 exception NotInitialized
 
@@ -102,6 +104,8 @@ sig
   val send_term_message_to : int -> unit
 
   val recv : unit -> (Lib.kind_module * message) list
+
+  val wait_for_message : unit -> unit
 
   val purge_im_mailbox : ctx -> unit
 
@@ -178,17 +182,28 @@ struct
   (* ******************************************************************** *)
 
   (* A queue with O(1) enqueue: [front] is in order, [back] is
-     reversed *)
+     reversed. [nonempty] is signalled whenever a message is added, so
+     that the owner of the mailbox can block until a message arrives
+     instead of polling. *)
   type 'a mailbox = {
     lock : Mutex.t ;
+    nonempty : Condition.t ;
     mutable front : 'a list ;
     mutable back : 'a list ;
   }
 
-  let mk_mailbox () = { lock = Mutex.create () ; front = [] ; back = [] }
+  let mk_mailbox () = {
+    lock = Mutex.create () ;
+    nonempty = Condition.create () ;
+    front = [] ;
+    back = [] ;
+  }
 
   let enqueue entry mb =
-    Mutex.protect mb.lock (fun () -> mb.back <- entry :: mb.back)
+    Mutex.protect mb.lock (fun () ->
+      mb.back <- entry :: mb.back ;
+      (* Only the domain owning the mailbox waits on it *)
+      Condition.signal mb.nonempty)
 
   (* Return all messages in order and empty the mailbox *)
   let drain mb =
@@ -197,6 +212,14 @@ struct
       mb.front <- [] ;
       mb.back <- [] ;
       msgs)
+
+  (* Block until the mailbox contains a message. Returns immediately
+     if the mailbox is not empty. *)
+  let wait_nonempty mb =
+    Mutex.protect mb.lock (fun () ->
+      while mb.front = [] && mb.back = [] do
+        Condition.wait mb.nonempty mb.lock
+      done)
 
   (* Check if some message satisfies [f] without consuming anything *)
   let mailbox_exists f mb =
@@ -312,6 +335,15 @@ struct
     | Uninitialized -> raise NotInitialized
     | Supervisor -> drain im_inbox
     | Worker ep -> drain ep.ep_inbox
+
+  (* Block until a message is queued for the calling domain. Any event
+     a domain may wait for arrives as a message, including termination
+     requests, so waiting without a timeout cannot delay shutdown. *)
+  let wait_for_message () =
+    match get_role () with
+    | Uninitialized -> raise NotInitialized
+    | Supervisor -> wait_nonempty im_inbox
+    | Worker ep -> wait_nonempty ep.ep_inbox
 
   (* Return true if a termination message is queued for the calling
      domain, without consuming any message *)

--- a/src/messaging.mli
+++ b/src/messaging.mli
@@ -23,7 +23,10 @@
     value dropped into the in-memory mailbox of the receiver, without
     any serialization. There are no background threads: sending is a
     mutex-protected queue operation and {!S.recv} drains the mailbox of
-    the calling domain.
+    the calling domain without blocking. {!S.wait_for_message} blocks
+    until the mailbox of the calling domain is not empty, so that a
+    domain with nothing to do until the next message does not have to
+    poll.
 
     @author Jason Oxley, Christoph Sticksel *)
 
@@ -104,6 +107,13 @@ sig
 
   (** Receive the messages queued in the mailbox of the calling domain *)
   val recv : unit -> (Lib.kind_module * message) list
+
+  (** Block until a message is queued in the mailbox of the calling
+      domain. Returns immediately if the mailbox is not empty. Any
+      event a domain may wait for arrives as a message, including
+      termination requests, so waiting without a timeout cannot delay
+      shutdown. *)
+  val wait_for_message : unit -> unit
 
   (** Purge the invariant manager mailbox. Should be called between two
       analyses, after all engines of the previous analysis have


### PR DESCRIPTION
Engines that had nothing to do until another engine sent them something polled their mailbox with tuned sleeps: 1ms in IND while waiting for base confirmation, 70ms in IND2 while waiting for invariants, and 10ms and 100ms in IC3 while waiting for BMC. That style is a leftover from when messages went through ZeroMQ sockets and blocking on one from OCaml was not an option; since engines moved into domains of a single process, the mailbox is an in-memory queue we control.

Give each mailbox a condition variable, signalled on every enqueue, and a `wait_for_message` primitive that blocks the calling domain until its mailbox is not empty. The emptiness check runs under the mailbox mutex in a `while` loop, so there are no lost or spurious wakeups.

Waiting needs no timeout. Every event an engine may wait for arrives as a message, and that includes termination: `send_term_message`, `send_term_message_to` and `disconnect` all enqueue into the target's mailbox, so a blocked engine is always woken up on shutdown and raises `Terminate` at its next `recv`.

The `minisleep` calls that remain are the ones a condition variable cannot replace: the supervisor's polling loop and the teardown wait multiplex mailbox traffic with wall-clock deadlines, and `SMTLIBSolver` polls `waitpid WNOHANG` on an external process before escalating to `SIGKILL`. Those are left as they are. The commented-out `minisleep` in `invGen.ml` is dead code and is removed.

Engines now react to invariants and property statuses immediately instead of after up to 70-100ms, the tuned sleep constants are gone, and an idle engine consumes no CPU while waiting.

**Validation**

- 460 regression tests and the ounit suite pass.
- A full run of the all-platforms benchmark workflow against `main`: https://github.com/daniel-larraz/kind2/actions/runs/31320575971 — 859 benchmarks per side on linux-x86_64, linux-arm64, macos-x86_64, macos-arm64 and windows-x86_64. No soundness bugs, no regressions and no errors on any platform, and total wall time is lower than the base everywhere (from -1.3% on macos-x86_64 to -4.5% on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)