### PR TITLE
Report the regression runs that did not finish

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,13 +137,27 @@ def pytest_collection_modifyitems(session, items):
     items[:] = extra_items + items
 
 
+# Tests whose run gave up before finishing, that is, exited 30 because it
+# reached the `--timeout` it was given.
+#
+# No test expects that outcome: the regression tree only holds `success`,
+# `falsifiable` and `error` cases. It is accepted anyway, since a large model
+# on a slow machine may legitimately run out of time, but accepting it
+# silently means a run that stops making progress passes without a trace.
+# Collect them so that the session reports them at the end.
+unfinished_runs = []
+
+
 class LustreException(Exception): ...
 
 
 class LustreTimeout(Exception):
-    def __init__(self, stdout: bytes):
+    def __init__(self, stdout: bytes, status):
         super().__init__()
         self.stdout = stdout
+        # Exit status of Kind 2 when we gave up on it, or None if it was
+        # still running then
+        self.status = status
 
 
 def kill_tree(proc: Popen):
@@ -163,11 +177,14 @@ def kill_tree(proc: Popen):
         except (OSError, TimeoutExpired):
             pass
     else:
-        # The run has a process group of its own (see `run_kind2`), which its
-        # solvers belong to as well
+        # The run leads a process group of its own (see `run_kind2`), which
+        # its solvers belong to as well. Address the group by the pid of its
+        # leader rather than by asking for it: a group outlives its leader,
+        # but `os.getpgid` does not, so looking it up would fail exactly when
+        # Kind 2 has already exited and only the solvers are left to kill.
         try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except (OSError, ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        except OSError:
             pass
 
     proc.kill()
@@ -187,6 +204,14 @@ def run_kind2(command) -> CompletedProcess:
     try:
         stdout, _ = proc.communicate(timeout=run_timeout)
     except TimeoutExpired:
+        # Whether Kind 2 is still running says where the run is stuck, and
+        # the two cases have nothing in common. Still running: it did not
+        # honour its own `--timeout`. Already gone: the pipes are held open
+        # by something it spawned and outlived it, and no timeout of its own
+        # could ever have helped. Ask before killing it, which would answer
+        # the question with our own signal.
+        status = proc.poll()
+
         kill_tree(proc)
         try:
             stdout, _ = proc.communicate(timeout=kill_timeout)
@@ -195,7 +220,7 @@ def run_kind2(command) -> CompletedProcess:
             # what we have rather than wait for the rest forever: the reader
             # threads are daemons, and they do not keep the session alive.
             stdout = b""
-        raise LustreTimeout(stdout)
+        raise LustreTimeout(stdout, status)
 
     return CompletedProcess(command, proc.returncode, stdout, None)
 
@@ -221,10 +246,11 @@ class LustreItem(pytest.Item):
     def runtest(self):
         self.res = run_kind2(self._command())
 
-        # Timeout is OK 
+        # Timeout is OK
         result = code_to_expected.get(self.res.returncode)
-        if result == "timeout": 
-          return   
+        if result == "timeout":
+          unfinished_runs.append(self.nodeid)
+          return
 
         if self.res.returncode != expected_to_code[self.expected]:
             raise LustreException
@@ -234,10 +260,20 @@ class LustreItem(pytest.Item):
 
     def repr_failure(self, excinfo, style=None):
         if isinstance(excinfo.value, LustreTimeout):
+            status = excinfo.value.status
+            if status is None:
+                stuck = "Kind 2 was still running when it was killed"
+            else:
+                stuck = (
+                    f"Kind 2 had already exited (status {status}), but its "
+                    "output pipes were still open: something it spawned "
+                    "outlived it"
+                )
             return "\n".join(
                 [
                     f"Killed after {run_timeout:.0f}s: the run did not stop "
                     f"on its own, although it was given {common_args['--timeout']}s",
+                    stuck,
                     " ".join(map(str, self._command())),
                     excinfo.value.stdout.decode("utf-8"),
                 ]
@@ -258,6 +294,20 @@ class LustreItem(pytest.Item):
             )
 
         return super().repr_failure(excinfo, style)
+
+
+# Report the runs that gave up, which pass and would otherwise leave no trace
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if not unfinished_runs:
+        return
+
+    terminalreporter.section("Kind 2 ran out of time")
+    terminalreporter.write_line(
+        f"{len(unfinished_runs)} test(s) exited 30 after the "
+        f"{common_args['--timeout']}s budget (not counted as failures):"
+    )
+    for nodeid in unfinished_runs:
+        terminalreporter.write_line(f"  {nodeid}")
 
 
 # Log test failures


### PR DESCRIPTION
Two things the harness knows and keeps to itself.

**A run that gives up passes silently.** A run that reaches its `--timeout` exits 30, and the harness accepts that outcome for any test. No test asks for it: the regression tree holds `success`, `falsifiable` and `error` cases and nothing else. It is worth accepting anyway, since a large model on a slow machine may legitimately run out of time, but accepting it silently means a run that has stopped making progress passes without leaving a trace. `falsifiable/test-issue-123.lus` had been running at around 50s of its 84s budget on Windows for several runs before it hung in [run 31332087766](https://github.com/daniel-larraz/kind2/actions/runs/31332087766), and none of that was visible.

Collect those runs and report them in a section of their own at the end of the session, so that they show on a green run and can be counted across runs from the job log:

```
============================ Kind 2 ran out of time ============================
1 test(s) exited 30 after the 84s budget (not counted as failures):
  regression/falsifiable/test-issue-123.lus::test-issue-123 [slice_on]
```

**A kill does not say what was stuck.** When the harness has to kill a run, whether Kind 2 is still running at that point says where the run is stuck, and the two cases have nothing in common. Still running means it did not honour its own `--timeout`. Already gone means the output pipes are held open by something it spawned that outlived it, which no timeout of its own could ever have helped. Record which it was and say so in the failure:

```
Kind 2 was still running when it was killed
Kind 2 had already exited (status 30), but its output pipes were still open: something it spawned outlived it
```

Asking costs a `poll`, which reaps the process, and `os.getpgid` then fails on the pid, so killing the process group was addressing it through a lookup that breaks exactly when Kind 2 has already exited and the solvers are all that is left to kill. Address the group by the pid of its leader instead, which the run is by construction under `start_new_session=True` and which outlives it.

**Validation**

- Both verdicts are exercised against a stub that holds its pipes open from a child: still running reports `status is None`, exited reports the status it exited with, and the captured output survives the kill in both cases. Before addressing the group by leader pid, the second case lost the output and left the child running.
- The section shows on a green run, with the budget lowered so that a run gives up: `1 test(s) exited 30 after the 2s budget`.
- The 460 regression tests pass, in 66.7s.

**Limits**

On Windows, `taskkill /T` walks parent-child links, so if Kind 2 has already exited its orphaned solvers cannot be killed by pid. The verdict reports that it happened; the harness cannot clean up after it.

The count measures runs that hit the budget, which is a superset of the bug: a genuinely slow model on a slow runner shows up too. The signal is the trend, not the first entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
