### PR TITLE
Fix misc bugs from previous PRs

### DIFF
--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -277,6 +277,21 @@ let rec pat_bound_vars = function
   | VarPat (_, id) -> SI.singleton id
   | Pat (_, _, sub_pats) -> SI.flatten (List.map pat_bound_vars sub_pats)
 
+(* Renames a variable bound by a pattern. Reached only after type checking, so
+   a VarPat is always a genuine binder and never a 0-arg constructor. *)
+let rec rename_pat_var id id' = function
+  | VarPat (pos, i) -> if i = id then VarPat (pos, id') else VarPat (pos, i)
+  | Pat (pos, ctor, sub_pats) ->
+    Pat (pos, ctor, List.map (rename_pat_var id id') sub_pats)
+
+let alpha_rename_counter = ref 0
+
+(* A fresh identifier, guaranteed not to clash with any source-level Lustre
+   identifier (which can never start with '.'). *)
+let fresh_alpha_ident () =
+  incr alpha_rename_counter;
+  HString.mk_hstring (Format.sprintf ".alpha_%d" !alpha_rename_counter)
+
 (* Substitute t for var. AnyOp/ChooseOp is not supported due to introduction of bound variables. *)
 let rec substitute_naive (var:HString.t) t = function
   | Ident (_, i) as e -> if i = var then t else e
@@ -301,11 +316,24 @@ let rec substitute_naive (var:HString.t) t = function
   (* Not supported due to introduction of bound variables *)
   | AnyOp _ -> assert false 
   | ChooseOp _ -> assert false 
+  (* Match arms introduce bound variables, so substituting into an arm body
+     must avoid capture *)
   | Match (pos, e, arms, ty) ->
     let e = substitute_naive var t e in
     let arms = List.map (fun (pat, arm_e) ->
-      let arm_e = if SI.mem var (pat_bound_vars pat) then arm_e else substitute_naive var t arm_e in
-      (pat, arm_e)
+      let bound = pat_bound_vars pat in
+      if SI.mem var bound then (pat, arm_e)
+      else
+        let pat, arm_e =
+          SI.fold (fun i (pat, arm_e) ->
+            if expr_contains_id i t then
+              let fresh = fresh_alpha_ident () in
+              (rename_pat_var i fresh pat,
+               substitute_naive i (Ident (pos, fresh)) arm_e)
+            else (pat, arm_e)
+          ) bound (pat, arm_e)
+        in
+        (pat, substitute_naive var t arm_e)
     ) arms in
     Match (pos, e, arms, ty)
   | ADTTerm (pos, ty_args, ctor, args) ->

--- a/src/lustre/lustreAstNormalizer.ml
+++ b/src/lustre/lustreAstNormalizer.ml
@@ -2515,7 +2515,7 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
       (normalize_expr ?guard info node_id map)
       expr_list in
     GroupExpr (pos, kind, nexpr_list), gids, warnings
-  | StructUpdate (pos, expr1, i, expr2) ->
+  | StructUpdate (pos, expr1, i, expr2) as expr ->
     let i = 
       List.map (Chk.desugar_generic_index info.context node_id expr1) i 
       |> List.map unwrap 
@@ -2524,14 +2524,58 @@ and normalize_expr ?guard info (node_id : NI.t option) map =
       (* The MapIndex and SetIndex cases are handled specially *)
       then normalize_expr ?guard info node_id map (StructUpdate (pos, expr1, i, expr2)) 
     else 
-      let nexpr1, gids1, warnings1 = normalize_expr ?guard info node_id map expr1 in
-      let nexpr2, gids2, warnings2 = match expr2 with 
-      | Some expr2 -> 
-        let nexpr2, gids2, warnings2 = normalize_expr ?guard info node_id map expr2 in 
-        Some nexpr2, gids2, warnings2
-      | None -> None, empty (), [] 
+      (* An index expression is a subexpression like any other: it may hold a
+         node call or a read that later passes require to have been abstracted *)
+      let normalize_idx ?guard idx = match idx with
+        | A.Index (p, e, k) ->
+          let ne, gids, warnings = normalize_expr ?guard info node_id map e in
+          A.Index (p, ne, k), gids, warnings
+        | A.Label _ as idx -> idx, empty (), []
+        (* Map and set updates take their own branches above, and generic
+           indices are resolved by desugar_generic_index *)
+        | (A.MapIndex _ | A.SetIndex _ | A.GenericIndex _) as idx ->
+          idx, empty (), []
       in
-      StructUpdate (pos, nexpr1, i, nexpr2), union gids1 gids2, warnings1 @ warnings2
+      (match i with
+      (* Bind an array-element update to a local:
+         x = (arr[i := v])[i]  becomes  l = arr[i := v]; x = l[i] *)
+      | [A.Index (_, _, A.ArrayElem)] ->
+        (* No guard: binding can leave a pre unguarded, so it needs an oracle *)
+        let nexpr1, gids1, _ = normalize_expr info node_id map expr1 in
+        let nexpr2, gids2 = match expr2 with
+          | Some expr2 ->
+            let nexpr2, gids2, _ = normalize_expr info node_id map expr2 in
+            Some nexpr2, gids2
+          | None -> None, empty ()
+        in
+        let ni, gids3, _ = normalize_list normalize_idx i in
+        let _, _, warnings1 = normalize_expr ?guard info node_id map expr1 in
+        let warnings2 = match expr2 with
+          | Some expr2 ->
+            let _, _, warnings2 = normalize_expr ?guard info node_id map expr2 in
+            warnings2
+          | None -> []
+        in
+        let _, _, warnings3 = normalize_list (normalize_idx ?guard) i in
+        let nexpr = A.StructUpdate (pos, nexpr1, ni, nexpr2) in
+        let ty = get_expr_ty info map node_id expr in
+        let iexpr, gids4 =
+          mk_fresh_local false info pos info.inductive_variables ty nexpr
+        in
+        iexpr, List.fold_left union (empty ()) [gids1; gids2; gids3; gids4],
+        warnings1 @ warnings2 @ warnings3
+      | _ ->
+        let nexpr1, gids1, warnings1 = normalize_expr ?guard info node_id map expr1 in
+        let nexpr2, gids2, warnings2 = match expr2 with 
+        | Some expr2 -> 
+          let nexpr2, gids2, warnings2 = normalize_expr ?guard info node_id map expr2 in 
+          Some nexpr2, gids2, warnings2
+        | None -> None, empty (), [] 
+        in
+        let ni, gids3, warnings3 = normalize_list (normalize_idx ?guard) i in
+        A.StructUpdate (pos, nexpr1, ni, nexpr2),
+        List.fold_left union (empty ()) [gids1; gids2; gids3],
+        warnings1 @ warnings2 @ warnings3)
   | IndexAccess (pos, expr1, expr2, _) ->
     let expr1_ty = get_expr_ty info map node_id expr1 in 
     let nexpr1, gids1, warnings1 = normalize_expr ?guard info node_id map expr1 in

--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1303,20 +1303,8 @@ and compile_ast_expr
       (* For LustreNode array types (LustreAst arrays, maps, and sets) we need quantification 
          for structural equality *)
       | ty when Type.is_array ty ->
-        let sv = state_var_of_expr e1 in
         let idx_tys = Type.all_index_types_of_array ty in
-        (* [bounds] are recorded for the whole state variable [sv], so they cover
-           all of its array/map/set dimensions. When [e1] is a sub-selection of
-           [sv] (e.g. a map value [m\[k\]] whose type is itself a set or array),
-           the outer, already-indexed dimensions are not part of [e1]'s type.
-           Those dimensions come first (dimensions are ordered outer-to-inner), so
-           drop the leading ones and keep the [List.length idx_tys] bounds that
-           correspond to [e1]'s own remaining dimensions. *)
-        let bounds =
-          let all_bounds = SVT.find !map.bounds sv in
-          let drop = List.length all_bounds - List.length idx_tys in
-          if drop > 0 then snd (list_split drop all_bounds) else all_bounds
-        in
+        let bounds = bounds_of_index i in
         assert (List.length bounds = List.length idx_tys);
         let idx_vars = List.map (Var.mk_fresh_var) idx_tys in
         let arr_is = List.map E.mk_free_var idx_vars in

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1333,23 +1333,9 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
           let i, b = is_expr_int_type ctx nname i in
           if b then
             let* e_ty, e, warnings2 = infer_type_expr ctx nname (Option.get e) in
-            (*** TODO: Address the bug that makes this necessary ***)
-            let nested_array_update_pos = function
-              | LA.StructUpdate (p, _, [LA.Index (_, _, LA.ArrayElem)], Some _) -> Some p
-              | _ -> None
-            in
-            (match nested_array_update_pos ue, nested_array_update_pos e with
-            | Some p, _ | None, Some p ->
-              type_error p
-                (Unsupported "An array-element update whose updated array \
-                              or new value is itself an array-element \
-                              update is not supported; assign the inner \
-                              update to a local variable first")
-            | None, None ->
-              R.ifM (eq_lustre_type ctx b_ty e_ty)
-                (R.ok (ue_ty', LA.StructUpdate (pos, ue, [LA.Index (pos, i, LA.ArrayElem)], Some e), warnings1 @ warnings2))
-                (type_error pos (ExpectedType (e_ty, b_ty))))
-            (*** (end) ***)
+            R.ifM (eq_lustre_type ctx b_ty e_ty)
+              (R.ok (ue_ty', LA.StructUpdate (pos, ue, [LA.Index (pos, i, LA.ArrayElem)], Some e), warnings1 @ warnings2))
+              (type_error pos (ExpectedType (e_ty, b_ty)))
           else
             type_error pos (ExpectedIntegerTypeForArrayIndex index_type)
         )

--- a/tests/regression/falsifiable/struct_update_call_in_index_not_whole_array.lus
+++ b/tests/regression/falsifiable/struct_update_call_in_index_not_whole_array.lus
@@ -1,0 +1,9 @@
+node Id(n: int) returns (o: int);
+let o = n; tel
+
+node Top(base: int^3; i: int; j: int; v: int) returns ();
+var arr: int^3;
+let
+  arr = base[Id(i) := v];
+  check (i>=0 and i<3 and j>=0 and j<3) => (arr[j] = v);
+tel

--- a/tests/regression/falsifiable/struct_update_not_whole_array.lus
+++ b/tests/regression/falsifiable/struct_update_not_whole_array.lus
@@ -1,0 +1,6 @@
+node Top(base: int^3; i: int; j: int; v: int) returns ();
+var arr: int^3;
+let
+  arr = base[i := v];
+  check (i >= 0 and i < 3 and j >= 0 and j < 3) => (arr[j] = v);
+tel

--- a/tests/regression/success/adt_match_nested_binder_capture.lus
+++ b/tests/regression/success/adt_match_nested_binder_capture.lus
@@ -1,0 +1,16 @@
+datatype Box = B (v: int);
+datatype BoxBox = BB (inner: Box);
+
+node N (b: Box; c: BoxBox) returns (y: int)
+let
+  y = match b with
+      | B (v) : (match c with
+                 | BB (b) : v
+                 end)
+      end;
+tel
+
+node main (b: Box; c: BoxBox) returns ()
+let
+  check N(b, c) = b.v;
+tel

--- a/tests/regression/success/adt_match_nested_binder_capture_deep.lus
+++ b/tests/regression/success/adt_match_nested_binder_capture_deep.lus
@@ -1,0 +1,18 @@
+datatype Box = B (v: int);
+datatype Pair = P (x: Box, y: Box);
+
+node N (b: Box; p: Pair) returns (y: int)
+let
+  y = match b with
+      | B (v) : (match p with
+                 | P (b, v2) : (match b with
+                                | B (v) : v2.v - v
+                                end)
+                 end)
+      end;
+tel
+
+node main (b: Box; p: Pair) returns ()
+let
+  check N(b, p) = p.y.v - p.x.v;
+tel

--- a/tests/regression/success/map_ite_equality.lus
+++ b/tests/regression/success/map_ite_equality.lus
@@ -1,0 +1,5 @@
+node Top(c: bool; m1: map<int,int>; m2: map<int,int>) returns (ok: bool);
+let
+  ok = ((if c then m1 else m2) = (if c then m1 else m2));
+  check ok;
+tel

--- a/tests/regression/success/map_nested_select_equality.lus
+++ b/tests/regression/success/map_nested_select_equality.lus
@@ -1,0 +1,5 @@
+node Top(x: int; st: map<int, map<int, int>>) returns (ok: bool);
+let
+  ok = (st[x] = st[x]);
+  check ok;
+tel

--- a/tests/regression/success/map_nested_select_equality_set_value.lus
+++ b/tests/regression/success/map_nested_select_equality_set_value.lus
@@ -1,0 +1,5 @@
+node Top(x: int; y: int; st: map<int, map<int, set<int>>>) returns (ok: bool);
+let
+  ok = (st[x][y] = st[x][y]);
+  check ok;
+tel

--- a/tests/regression/success/map_select_equality_agrees_at_key.lus
+++ b/tests/regression/success/map_select_equality_agrees_at_key.lus
@@ -1,0 +1,5 @@
+node Top(x: int; s1: map<int, map<int,int>>; s2: map<int, map<int,int>>) returns ();
+let
+  check not ((x in s1) and (x in s2) and s1[x] = s2[x]
+             and (100 in s1[x]) and not (100 in s2[x]));
+tel

--- a/tests/regression/success/struct_update_2d_cell.lus
+++ b/tests/regression/success/struct_update_2d_cell.lus
@@ -1,0 +1,7 @@
+node Top(base: int^2^2; i: int; j: int; v: int) returns (x: int);
+var arr: int^2^2;
+let
+  arr = base[i := base[i][j := v]];
+  x = arr[i][j];
+  check (i >= 0 and i < 2 and j >= 0 and j < 2) => (x = v);
+tel

--- a/tests/regression/success/struct_update_3d_nested.lus
+++ b/tests/regression/success/struct_update_3d_nested.lus
@@ -1,0 +1,7 @@
+node Top(base: int^2^2^2; i: int; j: int; k: int; v: int) returns ();
+var arr: int^2^2^2;
+let
+  arr = base[i := base[i][j := base[i][j][k := v]]];
+  check (i>=0 and i<2 and j>=0 and j<2 and k>=0 and k<2) => (arr[i][j][k] = v);
+  check (i>=0 and i<2 and j>=0 and j<2 and k>=0 and k<2) => (arr[i][j][1-k] = base[i][j][1-k]);
+tel

--- a/tests/regression/success/struct_update_call_in_index.lus
+++ b/tests/regression/success/struct_update_call_in_index.lus
@@ -1,0 +1,10 @@
+node Id(n: int) returns (o: int);
+let o = n; tel
+
+node Top(base: int^3; i: int; j: int; v: int) returns ();
+var arr: int^3;
+let
+  arr = base[Id(i) := v];
+  check (i>=0 and i<3) => (arr[i] = v);
+  check (i>=0 and i<3 and j>=0 and j<3 and i<>j) => (arr[j] = base[j]);
+tel

--- a/tests/regression/success/struct_update_chained_bracket.lus
+++ b/tests/regression/success/struct_update_chained_bracket.lus
@@ -1,0 +1,6 @@
+node Top(v1: int; v2: int) returns ();
+var arr: int^3;
+let
+  arr = (0^3)[0 := v1; 1 := v2];
+  check arr[0] = v1 and arr[1] = v2 and arr[2] = 0;
+tel

--- a/tests/regression/success/struct_update_equality.lus
+++ b/tests/regression/success/struct_update_equality.lus
@@ -1,0 +1,9 @@
+node Top(i: int; v: int) returns (ok: bool);
+var arr1: int^3;
+    arr2: int^3;
+let
+  arr1 = 1^3;
+  arr2 = arr1[i := v];
+  ok = (arr1[i := v] = arr2);
+  check ok;
+tel

--- a/tests/regression/success/struct_update_frame_condition.lus
+++ b/tests/regression/success/struct_update_frame_condition.lus
@@ -1,0 +1,7 @@
+node Top(base: int^3; i: int; j: int; v: int) returns ();
+var arr: int^3;
+let
+  arr = base[i := v];
+  check (i >= 0 and i < 3 and j >= 0 and j < 3 and i <> j) => (arr[j] = base[j]);
+  check (i >= 0 and i < 3) => (arr[i] = v);
+tel

--- a/tests/regression/success/struct_update_in_ite_indexed.lus
+++ b/tests/regression/success/struct_update_in_ite_indexed.lus
@@ -1,0 +1,4 @@
+node Top(c: bool; a: int^3; b: int^3; i: int; v: int) returns ();
+let
+  check (i>=0 and i<3 and c) => ((if c then a[i := v] else b)[i] = v);
+tel

--- a/tests/regression/success/struct_update_nested_array_value.lus
+++ b/tests/regression/success/struct_update_nested_array_value.lus
@@ -1,0 +1,7 @@
+node Top(i: int; j: int; v: int) returns (x: int);
+var arr: int^2^2;
+let
+  arr = (0^2^2)[i := (0^2)[j := v]];
+  x = arr[i][j];
+  check (i >= 0 and i < 2 and j >= 0 and j < 2) => (x = v);
+tel

--- a/tests/regression/success/struct_update_read_in_index.lus
+++ b/tests/regression/success/struct_update_read_in_index.lus
@@ -1,0 +1,7 @@
+node Top(base: int^3; idx: int^3; i: int; v: int) returns ();
+var arr: int^3;
+let
+  arr = base[(idx[i := 2])[i] := v];
+  check (i>=0 and i<3) => (arr[2] = v);
+  check (i>=0 and i<3) => (arr[0] = base[0] and arr[1] = base[1]);
+tel

--- a/tests/regression/success/struct_update_reindex.lus
+++ b/tests/regression/success/struct_update_reindex.lus
@@ -1,0 +1,7 @@
+node Top(i: int; v: int) returns (x: int);
+var arr: int^3;
+let
+  arr = 1^3;
+  x = (arr[i := v])[i];
+  check (i >= 0 and i < 3) => (x = v);
+tel

--- a/tests/regression/success/struct_update_under_pre.lus
+++ b/tests/regression/success/struct_update_under_pre.lus
@@ -1,0 +1,6 @@
+node Top(i: int; v: int) returns ();
+var arr: int^3;
+let
+  arr = (0^3) -> (pre arr)[i := v];
+  check (i>=0 and i<3) => (true -> arr[i] = v);
+tel


### PR DESCRIPTION
This PR addresses a handful of bugs encountered from previous PRs.

1. It addresses the future work referenced in a previous PR (#1412) relating to `StructUpdate` compilation bugs. See `src/lustre/lustreAstNormalizer.ml:2540`, `src/lustre/lustreTypeChecker.ml:1335` 

2. It fixes bounds lookup for map and set equality, a follow-up to #1404. See `src/lustre/lustreNodeGen.ml:1307`. (In other words, this is to ensure that the map-of-map equality fix in #1404 generalizes to other combinations of nested container types.)

3. It fixes variable capture in `substitute_naive`'s `Match` case, reported in review of #1426. See `src/lustre/lustreAstHelpers.ml:319`

4. It fixes a pre-existing crash found while stress-testing (1): `normalize_expr`'s `StructUpdate` branch never normalized its index list. See`src/lustre/lustreAstNormalizer.ml:2527` 

This PR will not be merged; items 1-4 (and their corresponding test cases) will go in separate PRs. 