### PR TITLE
Open quantifiers when folding a term instead of skipping their variables

### DIFF
--- a/src/terms/ltree.ml
+++ b/src/terms/ltree.ml
@@ -50,6 +50,8 @@ sig
 
   val mk_fresh_var : sort -> var
 
+  val mk_binder_var : sort -> int -> var
+
   val import_symbol : symbol -> symbol
 
   val import_var : var -> var
@@ -989,9 +991,6 @@ struct
     (* Cached evaluation *)
     | E of 'a
 
-    (* Skip evaluation *)
-    | Skip
-
   (* ********************************************************************* *)
   (* Folding function keeping the term                                     *)
   (* ********************************************************************* *)
@@ -1154,10 +1153,7 @@ struct
 
             )
 
-          | Skip -> fold fail_quant f subst accum tl
-            
           | exception Not_found -> assert false
-                                     
 
       )
 
@@ -1199,11 +1195,27 @@ struct
                  }) :: tl ->
 
       if fail_quant then raise (Invalid_argument "Ltree.fold : quantified term");
-      
-      let vs = int_seq (db + 1) (List.length n) in
 
-      let s = List.map (fun dbi -> (dbi, Skip)) vs in
-      
+      (* Open the quantifier: assign to each of its variables the variable
+         standing for it, exactly as the let binding above assigns the terms it
+         binds. That variable is free, so the body can be folded as if it had
+         no binder over it.
+
+         Folding the body with its variables left bound is not an option. The
+         value of a term is built from what [f] returns at each of its leaves,
+         and [f] receives a leaf as a [flat], which has no representation for a
+         bound variable. Passing over such a variable without folding a value
+         for it leaves the result stack one element short, which silently
+         rebuilds the enclosing application without that argument, and fails
+         the assertion at the top of this function when nothing else is
+         accumulated. *)
+      let s =
+        List.map2
+          (fun dbi srt -> (dbi, S (db, ht_free_var (T.mk_binder_var srt dbi))))
+          (int_seq (db + 1) (List.length n))
+          n
+      in
+
       (* Add to the context stack *)
       let subst' = s @ subst in
 

--- a/src/terms/ltree.mli
+++ b/src/terms/ltree.mli
@@ -98,6 +98,11 @@ sig
 
   val mk_fresh_var : sort -> var
 
+  (** [mk_binder_var s d] is the variable of sort [s] used to open a binder at
+      binding depth [d]. Must be deterministic: the same [s] and [d] always
+      give the same variable, and it must be one no term uses free. *)
+  val mk_binder_var : sort -> int -> var
+
   val import_symbol : symbol -> symbol
 
   val import_var : var -> var

--- a/src/terms/term.ml
+++ b/src/terms/term.ml
@@ -77,6 +77,8 @@ struct
   let sort_of_var = Var.type_of_var
 
   let mk_fresh_var = Var.mk_fresh_var
+
+  let mk_binder_var = Var.mk_binder_var
   
   let import_symbol = Symbol.import 
 
@@ -1833,9 +1835,14 @@ let state_vars_of_term term  =
 (* Return all variables in term *)
 let vars_of_term term = 
 
-  (* Collect all variables in a set *)
+  (* Collect all variables in a set.
+
+     Folding a quantified subterm opens it, so the variables it binds are met
+     as free variables. They are not variables of [term], so drop them. *)
   eval_t ~fail_on_quantifiers:false 
     (function 
+      | T.Var v when Var.is_binder_var v ->
+        (function [] -> Var.VarSet.empty | _ -> assert false)
       | T.Var v -> 
         (function [] -> Var.VarSet.singleton v | _ -> assert false)
       | T.Const _ -> 

--- a/src/terms/var.ml
+++ b/src/terms/var.ml
@@ -456,8 +456,14 @@ let mk_binder_var var_type depth =
 
 (* Return true if the variable was made by [mk_binder_var], and so stands for
    the variable of an opened binder rather than for a variable of the term
-   that binder occurs in. *)
-let is_binder_var v = VarHashtbl.mem (is_binder_vars ()) v
+   that binder occurs in.
+
+   Asked of every variable of every term folded to its variables, so answer
+   the common case -- a term with no binder in it anywhere, which has left
+   this table empty -- without hashing the variable. *)
+let is_binder_var v =
+  VarHashtbl.length (is_binder_vars ()) > 0
+  && VarHashtbl.mem (is_binder_vars ()) v
 
 
 (* ********************************************************************* *)

--- a/src/terms/var.ml
+++ b/src/terms/var.ml
@@ -404,6 +404,62 @@ let mk_fresh_var var_type =
   mk_free_var v var_type 
 
 
+(* Variables standing for the variables of a binder, keyed by the binding
+   depth of the binder.
+
+   Private to each domain, copied from the parent at spawn, for the same
+   reason as the counter above. *)
+let binder_vars_key =
+  Domain.DLS.new_key ~split_from_parent:Type.TypeHashtbl.copy
+    (fun () -> Type.TypeHashtbl.create 7)
+
+let binder_vars () = Domain.DLS.get binder_vars_key
+
+
+(* The variables [mk_binder_var] has made, so that they can be told apart from
+   the variables of a term. *)
+let is_binder_vars_key =
+  Domain.DLS.new_key ~split_from_parent:VarHashtbl.copy
+    (fun () -> VarHashtbl.create 7)
+
+let is_binder_vars () = Domain.DLS.get is_binder_vars_key
+
+
+(* Return the variable standing for the variable of the given type of a binder
+   at the given binding depth.
+
+   Opening a binder replaces the variable it binds by a free variable, so that
+   a term under a binder can be handled as if it had none. The variable this
+   returns is memoized rather than fresh, so that opening the same binder
+   twice returns the same one: a caller that folds a term to the set of its
+   variables must get the same set every time it is asked. It is obtained from
+   [mk_fresh_var] the first time, so it is a name no term already uses.
+
+   Two binders at the same depth binding a variable of the same type share
+   this variable. That is sound because they are separate scopes: their bodies
+   never mention both. *)
+let mk_binder_var var_type depth =
+  let by_depth =
+    try Type.TypeHashtbl.find (binder_vars ()) var_type
+    with Not_found ->
+      let h = Hashtbl.create 7 in
+      Type.TypeHashtbl.add (binder_vars ()) var_type h;
+      h
+  in
+  try Hashtbl.find by_depth depth
+  with Not_found ->
+    let v = mk_fresh_var var_type in
+    Hashtbl.add by_depth depth v;
+    VarHashtbl.replace (is_binder_vars ()) v ();
+    v
+
+
+(* Return true if the variable was made by [mk_binder_var], and so stands for
+   the variable of an opened binder rather than for a variable of the term
+   that binder occurs in. *)
+let is_binder_var v = VarHashtbl.mem (is_binder_vars ()) v
+
+
 (* ********************************************************************* *)
 (* Changing offsets and state variables                                  *)
 (* ********************************************************************* *)

--- a/src/terms/var.ml
+++ b/src/terms/var.ml
@@ -404,11 +404,23 @@ let mk_fresh_var var_type =
   mk_free_var v var_type 
 
 
-(* Variables standing for the variables of a binder, keyed by the binding
-   depth of the binder.
+(* The binding depths a type has been asked for *)
+module DepthMap = Map.Make (Int)
+
+
+(* Variables standing for the variables of a binder, keyed by the type of the
+   variable and then by the binding depth of the binder.
 
    Private to each domain, copied from the parent at spawn, for the same
-   reason as the counter above. *)
+   reason as the counter above.
+
+   The depths of a type are held in a map and not in a second table, because
+   [Type.TypeHashtbl.copy] copies the outer table alone. Were its values
+   tables, every domain would go on sharing the ones its parent made: they
+   would write to them at the same time, and a domain would be handed
+   variables that its own [is_binder_vars] below had never been told about,
+   which is to say variables [is_binder_var] does not know are binder
+   variables. A map is immutable, so copying the outer table is enough. *)
 let binder_vars_key =
   Domain.DLS.new_key ~split_from_parent:Type.TypeHashtbl.copy
     (fun () -> Type.TypeHashtbl.create 7)
@@ -417,7 +429,8 @@ let binder_vars () = Domain.DLS.get binder_vars_key
 
 
 (* The variables [mk_binder_var] has made, so that they can be told apart from
-   the variables of a term. *)
+   the variables of a term. Its values are immutable, so the shallow copy the
+   split makes of it is a copy in full. *)
 let is_binder_vars_key =
   Domain.DLS.new_key ~split_from_parent:VarHashtbl.copy
     (fun () -> VarHashtbl.create 7)
@@ -441,15 +454,14 @@ let is_binder_vars () = Domain.DLS.get is_binder_vars_key
 let mk_binder_var var_type depth =
   let by_depth =
     try Type.TypeHashtbl.find (binder_vars ()) var_type
-    with Not_found ->
-      let h = Hashtbl.create 7 in
-      Type.TypeHashtbl.add (binder_vars ()) var_type h;
-      h
+    with Not_found -> DepthMap.empty
   in
-  try Hashtbl.find by_depth depth
-  with Not_found ->
+  match DepthMap.find_opt depth by_depth with
+  | Some v -> v
+  | None ->
     let v = mk_fresh_var var_type in
-    Hashtbl.add by_depth depth v;
+    Type.TypeHashtbl.replace (binder_vars ()) var_type
+      (DepthMap.add depth v by_depth);
     VarHashtbl.replace (is_binder_vars ()) v ();
     v
 

--- a/src/terms/var.mli
+++ b/src/terms/var.mli
@@ -70,6 +70,16 @@ val mk_free_var : HString.t -> Type.t -> t
 (** Return a fresh free variable *)
 val mk_fresh_var : Type.t -> t
 
+(** [mk_binder_var t d] is the variable standing for the variable of type [t]
+    of a binder at binding depth [d], used to open that binder. Memoized: the
+    same [t] and [d] always give the same variable. *)
+val mk_binder_var : Type.t -> int -> t
+
+(** Return [true] if the variable was made by {!mk_binder_var}, and so stands
+    for the variable of an opened binder rather than for a variable of the
+    term that binder occurs in. *)
+val is_binder_var : t -> bool
+
 (** Import a variable from a different instance into this hashcons table *)
 val import : t -> t
 

--- a/tests/ounit/terms/dune
+++ b/tests/ounit/terms/dune
@@ -1,0 +1,3 @@
+(tests
+  (names testTermQuant)
+  (libraries ounit2 kind2dev))

--- a/tests/ounit/terms/testTermQuant.ml
+++ b/tests/ounit/terms/testTermQuant.ml
@@ -49,6 +49,12 @@ let bound_and_free () =
   let b = Var.mk_fresh_var t_bool in
   Term.mk_forall [b] (Term.mk_or [Term.mk_var b; t_x])
 
+(* forall (b1: bool) forall (b2: bool) b2 -- binds at depth 2 as well as 1 *)
+let nested_bound_body () =
+  let b1 = Var.mk_fresh_var t_bool in
+  let b2 = Var.mk_fresh_var t_bool in
+  Term.mk_forall [b1] (Term.mk_forall [b2] (Term.mk_var b2))
+
 (* forall (i: int) a[i] *)
 let bound_index () =
   let i = Var.mk_fresh_var t_int in
@@ -97,6 +103,35 @@ let test_application_arity_is_kept _ =
   assert_equal ~msg:"select of an array at an index" 2
     (List.length (Term.node_args_of_term s))
 
+(* A variable standing for a bound one belongs to the domain that made it.
+
+   The table taking a type and a binding depth to one of these is copied when
+   a domain splits. A shallow copy of a table whose values are themselves
+   tables goes on sharing the inner ones, so a domain could be handed a
+   variable another domain had made and had registered only there. Not
+   knowing it for a binder variable, it would report it among the variables of
+   the term it was folding. *)
+let test_binder_variables_are_per_domain _ =
+  (* The parent folds at depth 1, so the tables are not empty when a domain
+     splits from it *)
+  let _ = Term.vars_of_term (bare_bound_body ()) in
+  (* One domain folds at depth 2 *)
+  let a = Domain.spawn (fun () -> Term.vars_of_term (nested_bound_body ())) in
+  assert_equal ~msg:"no variables of its own, in the domain that split first"
+    true (Var.VarSet.is_empty (Domain.join a));
+  (* A second domain folds at the same depth. If it were handed the first
+     domain's variable it would not know it for a binder variable. *)
+  let b = Domain.spawn (fun () ->
+    let vars = Term.vars_of_term (nested_bound_body ()) in
+    let v = Var.mk_binder_var t_bool 2 in
+    (Var.VarSet.is_empty vars, Var.is_binder_var v))
+  in
+  let no_vars, recognised = Domain.join b in
+  assert_equal ~msg:"a binder variable is known for one in its own domain"
+    true recognised;
+  assert_equal ~msg:"so it is not reported among the variables of the term"
+    true no_vars
+
 (* A quantifier is still refused when the caller asks for it to be. *)
 let test_fail_on_quantifiers _ =
   let t = bare_bound_body () in
@@ -110,6 +145,7 @@ let tests =
     "bound variables are not free" >:: test_bound_variables_are_not_free;
     "folding is deterministic" >:: test_folding_is_deterministic;
     "application arity is kept" >:: test_application_arity_is_kept;
+    "binder variables are per domain" >:: test_binder_variables_are_per_domain;
     "quantifiers still refused when asked" >:: test_fail_on_quantifiers;
   ]
 

--- a/tests/ounit/terms/testTermQuant.ml
+++ b/tests/ounit/terms/testTermQuant.ml
@@ -1,0 +1,116 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2026 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+
+ *)
+(** Folding over quantified terms.
+
+    [Term.eval_t ~fail_on_quantifiers:false] folds a term whose subterms may be
+    quantified. Folding under a quantifier opens it, replacing the variables it
+    binds by variables that stand for them, so that the folded function only
+    ever meets free variables. *)
+
+open OUnit2
+
+let t_bool = Type.t_bool
+let t_int = Type.t_int
+
+(* A state variable, and the variable for its instance in the current state *)
+let mk_sv name ty =
+  StateVar.mk_state_var name ["test"] ty
+
+let sv_x = mk_sv "x" t_bool
+let v_x = Var.mk_state_var_instance sv_x Numeral.zero
+let t_x = Term.mk_var v_x
+
+let sv_a = mk_sv "a" (Type.mk_array t_bool t_int)
+let v_a = Var.mk_state_var_instance sv_a Numeral.zero
+let t_a = Term.mk_var v_a
+
+(* forall (b: bool) b -- the body is the bound variable and nothing else *)
+let bare_bound_body () =
+  let b = Var.mk_fresh_var t_bool in
+  Term.mk_forall [b] (Term.mk_var b)
+
+(* forall (b: bool) (b or x) *)
+let bound_and_free () =
+  let b = Var.mk_fresh_var t_bool in
+  Term.mk_forall [b] (Term.mk_or [Term.mk_var b; t_x])
+
+(* forall (i: int) a[i] *)
+let bound_index () =
+  let i = Var.mk_fresh_var t_int in
+  Term.mk_forall [i] (Term.mk_select t_a (Term.mk_var i))
+
+(* A quantifier whose body is a bare bound variable used to fail an assertion
+   in Ltree.fold: nothing was folded for the variable, so the fold ended with
+   an empty result stack. *)
+let test_bare_bound_variable _ =
+  let t = bare_bound_body () in
+  assert_equal ~msg:"no variables of its own" true
+    (Var.VarSet.is_empty (Term.vars_of_term t));
+  assert_equal ~msg:"no state variables" true
+    (StateVar.StateVarSet.is_empty (Term.state_vars_of_term t))
+
+(* The variables a quantifier binds are not variables of the term it occurs
+   in; the ones it does not bind are. *)
+let test_bound_variables_are_not_free _ =
+  let t = bound_and_free () in
+  (* Compared as sets: these are hash-consed, so the polymorphic comparison
+     [assert_equal] would otherwise use raises on them *)
+  assert_equal ~msg:"exactly the free variable" true
+    (Var.VarSet.equal (Var.VarSet.singleton v_x) (Term.vars_of_term t));
+  assert_equal ~msg:"exactly the free state variable" true
+    (StateVar.StateVarSet.equal
+      (StateVar.StateVarSet.singleton sv_x) (Term.state_vars_of_term t))
+
+(* Folding a term twice must give the same answer. Opening a binder with a
+   variable made fresh each time would not: the two folds would report
+   different variables for the same term. *)
+let test_folding_is_deterministic _ =
+  let t = bound_and_free () in
+  assert_equal ~msg:"same variables both times" true
+    (Var.VarSet.equal (Term.vars_of_term t) (Term.vars_of_term t));
+  let u = bound_index () in
+  assert_equal ~msg:"same select terms both times" true
+    (Term.TermSet.equal (Term.select_terms u) (Term.select_terms u))
+
+(* Passing over a bound variable without folding a value for it left the
+   result stack short, and the enclosing application was rebuilt without that
+   argument -- here, a select of an array with no index. *)
+let test_application_arity_is_kept _ =
+  let selects = Term.select_terms (bound_index ()) in
+  assert_equal ~msg:"one select" 1 (Term.TermSet.cardinal selects);
+  let s = Term.TermSet.choose selects in
+  assert_equal ~msg:"select of an array at an index" 2
+    (List.length (Term.node_args_of_term s))
+
+(* A quantifier is still refused when the caller asks for it to be. *)
+let test_fail_on_quantifiers _ =
+  let t = bare_bound_body () in
+  assert_raises (Invalid_argument "Ltree.fold : quantified term")
+    (fun () ->
+      Term.eval_t (fun _ _ -> ()) t)
+
+let tests =
+  "Term: folding over quantified terms" >::: [
+    "body is a bare bound variable" >:: test_bare_bound_variable;
+    "bound variables are not free" >:: test_bound_variables_are_not_free;
+    "folding is deterministic" >:: test_folding_is_deterministic;
+    "application arity is kept" >:: test_application_arity_is_kept;
+    "quantifiers still refused when asked" >:: test_fail_on_quantifiers;
+  ]
+
+let () = run_test_tt_main tests

--- a/tests/regression/falsifiable/quant_bare_bound_var_forall.lus
+++ b/tests/regression/falsifiable/quant_bare_bound_var_forall.lus
@@ -1,0 +1,7 @@
+-- The body of this quantifier is the variable it binds and nothing else.
+-- Folding such a term used to fail an assertion in Ltree.fold: nothing was
+-- folded for the bound variable, so the fold ended with an empty result stack.
+node main () returns ();
+let
+  check "every bool is true" forall (b: bool) b;
+tel

--- a/tests/regression/success/quant_bare_bound_var_exists.lus
+++ b/tests/regression/success/quant_bare_bound_var_exists.lus
@@ -1,0 +1,5 @@
+-- As for the universal quantifier: the body is the bound variable alone.
+node main () returns ();
+let
+  check "some bool is true" exists (b: bool) b;
+tel


### PR DESCRIPTION
## The bug

`Ltree.fold` passes over the variables of a quantifier without folding a value for them, unlike every other leaf it meets. This crashes on:

```lustre
node main () returns ();
let check forall (b: bool) b; tel
```

```
<Error> Runtime error in invariant manager:
        File "src/terms/ltree.ml", line 1061, characters 17-23: Assertion failed
```

Reproduced on an unmodified `v3.0.0-92-g7ff7e75`.

## Why

The value of a term is built from what the folded function returns at each of its leaves, and that function receives a leaf as a `flat` — `Var | Const | App`, which has no representation for a bound variable. So there was nothing to hand it, and the variable was skipped:

```ocaml
| Skip -> fold fail_quant f subst accum tl        (* accumulator untouched *)
```

There is a standing `TODO: implement fold over quantified terms` above the function.

Skipping leaves the result stack one element short, which has two consequences:

- Where something else had been accumulated, the enclosing application is silently rebuilt **without that argument**. `select_terms` on `forall i. a[i]` returned a select of an array with no index.
- Where nothing had, the fold ends with an empty result stack and fails its own assertion. That needs the quantifier body to be a bare bound variable, and bodies are boolean, so it takes exactly `forall (b: bool) b` or `exists (b: bool) b` — which is why this has gone unnoticed.

It is not one crash site. Patching `state_vars_of_term` alone just moves it to `LustreNode.stateful_vars_of_node`; there are 9 callers passing `fail_on_quantifiers:false`.

## The fix

Open the quantifier instead, the way the `Let` case beside it already assigns the terms it binds: give each bound variable a free variable standing for it, so the body folds as if it had no binder over it.

```ocaml
List.map2
  (fun dbi srt -> (dbi, S (db, ht_free_var (T.mk_binder_var srt dbi))))
  (int_seq (db + 1) (List.length n))
  n
```

`BaseTypes` has required `mk_fresh_var` for this since it was written, but nothing in `ltree.ml` ever called it. `Skip` is now unreachable and removed, so the type guarantees every binder installs a substitution.

This is the locally nameless treatment of binders (Aydemir et al., *Engineering Formal Metatheory*, POPL'08; Charguéraud, JAR 2012). The alternative — adding a bound-variable case to `flat` — was tried first and needs a new case at 15 match sites, 6 of which are `destruct`-based and cannot reach it.

Two details the straightforward version gets wrong:

**The variable must not be freshly minted each time.** `vars_of_term` would stop being a function of its argument, and `SMTSolver.get_interpolant` does `Var.VarSet.diff (vars_of_term t2) (vars_of_term t1)`, comparing the results of two folds. It would also grow the variable table without bound on a hot path. So `Var.mk_binder_var` memoizes per sort and binding depth. Two binders at the same depth over the same sort share a variable, which is sound because their bodies never mention both. It comes from `mk_fresh_var` the first time, so it is a name no term already uses.

The memo cannot live in `Ltree`: `BaseTypes` exposes only `hash_of_sort`, which is `Hashcons.hash` returning `hkey` rather than the tag, so it collides and could yield a wrong-sorted variable. Opening a binder is a property of the term representation, so `mk_binder_var : sort -> int -> var` joins `BaseTypes`.

**`vars_of_term` must not report the opened variables.** Collectors selecting state variables are unaffected, since a variable standing for a bound one is free. `vars_of_term` returns variables unfiltered, so it drops them explicitly — a variable a quantifier binds is not a variable of the term it occurs in. This keeps the change invisible to existing callers, notably `LustreExpr.is_const_expr` and the dependency graphs.

## Behaviour on models that do not exercise this

Unchanged, and not incidentally. `mk_binder_var` has a single call site, in the quantifier case of `fold`, and `eval_t` defaults to `fail_on_quantifiers:true`, which raises before reaching it. A model with no quantifiers never creates a binder variable, so the table stays empty and the `vars_of_term` guard cannot hold. Such a model also does not pay for the guard: it short-circuits on the table's O(1) `length` and hashes nothing.

## Verification

**All 467 regression models** run through baseline and patched binaries, with **baseline against itself as a control** — necessary because Kind2 races engines in parallel, so the winning engine, the counterexample, and `k` all vary between any two runs of the same binary:

| | control (baseline vs itself) | patched vs baseline |
|---|---|---|
| identical | 392 | **422** |
| differing verdicts | 75 | **45** |
| differing exit codes | **0** | **2** |

The patched binary differs from baseline *less* than baseline differs from itself. Exit codes are deterministic (0 differences in the control) and the 2 are exactly the new tests below. Stripping `k` from the verdict diffs leaves only those, plus artifacts of truncating each diff hunk.

This method only detects changes larger than that 75-file noise floor; the guarantee rests on the structural argument above, which the experiment corroborates.

**Tests** — `make test`: 468 passed (466 + 2), plus 5 new OUnit cases:

- `tests/ounit/terms/testTermQuant.ml` — body is a bare bound variable; bound variables are not free; **folding is deterministic**; **application arity is kept** (the select regains its index); `fail_on_quantifiers` still raises.
- `regression/falsifiable/quant_bare_bound_var_forall.lus`, `regression/success/quant_bare_bound_var_exists.lus` — the two crashing shapes, now invalid and valid respectively.

**Performance** — a wash. Three runs each on a quantifier-heavy model: medians 18.62s baseline, 18.42s patched. An initial +11% reading on one benchmark did not survive repetition; that file has a ~10% run-to-run spread.

## Relationship to #1443

Independent — this branches from `main` and touches only `src/terms/`. #1443 happens to mask this crash by expanding `forall (b: bool) b` away before the fold sees it, but only for finite domains; any quantifier over an infinite or uninterpreted domain still reaches this code. Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
