### PR TITLE
Support arrays in IC3IA

### DIFF
--- a/.github/workflows/kind2-ci.yml
+++ b/.github/workflows/kind2-ci.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  Z3_VERSION: "4.15.3"
+  MATHSAT_VERSION: "5.6.17"
+
 jobs:
   kind2-build:
     strategy:
@@ -60,36 +64,84 @@ jobs:
       with:
         ocaml-version: ${{ matrix.ocaml-version }}
 
-    - name: Install Z3 (Ubuntu)
-      if: runner.os == 'Linux'
-      run: |
-        Z3_VERSION=4.15.3
-        ARCH=$(uname -m)
-        if [[ "$ARCH" == "x86_64" ]]; then
-          Z3_OS_VERSION=x64-glibc-2.39
-        else
-          Z3_OS_VERSION=arm64-glibc-2.34
-        fi
-        Z3_ZIP_NAME=z3-$Z3_VERSION-$Z3_OS_VERSION
-        wget -q https://github.com/Z3Prover/z3/releases/download/z3-$Z3_VERSION/$Z3_ZIP_NAME.zip
-        unzip -q $Z3_ZIP_NAME.zip
-        sudo cp $Z3_ZIP_NAME/bin/z3 /usr/bin/
+    # Z3 is the SMT solver the tests run with; MathSAT is the interpolating
+    # solver, which IC3IA needs to reach the systems the `ic3ia` regression
+    # tests cover (they skip themselves when it is missing). Both are pinned
+    # and cached the way the benchmark workflows do it, so only the first run
+    # for a given pair of versions pays for the download.
+    #
+    # The cache lives in the workspace rather than the home directory so that
+    # the same path can go on PATH on Windows, where it has to be a native
+    # path. `actions/checkout` runs before the restore, so its clean does not
+    # take the restored directory with it.
+    - name: Cache SMT solvers
+      id: cache-solvers
+      uses: actions/cache@v6
+      with:
+        path: solver-bin
+        key: smt-solvers-${{ matrix.name }}-z3-${{ env.Z3_VERSION }}-mathsat-${{ env.MATHSAT_VERSION }}
 
-    - name: Install Z3 (macOS)
-      if: runner.os == 'macOS'
-      run: brew install z3
-
-    - name: Install Z3 (Windows)
-      if: runner.os == 'Windows'
+    - name: Download SMT solvers (on cache miss)
+      if: steps.cache-solvers.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        Z3_VERSION=4.15.3
-        Z3_ZIP_NAME=z3-$Z3_VERSION-x64-win
-        curl -sL -o z3.zip https://github.com/Z3Prover/z3/releases/download/z3-$Z3_VERSION/$Z3_ZIP_NAME.zip
+        set -euo pipefail
+        mkdir -p solver-bin
+        case "${{ matrix.name }}" in
+          linux-x86_64)   Z3_DIR=z3-${Z3_VERSION}-x64-glibc-2.39   ; MS_DIR=mathsat-${MATHSAT_VERSION}-linux-x86_64  ;;
+          linux-arm64)    Z3_DIR=z3-${Z3_VERSION}-arm64-glibc-2.34 ; MS_DIR=mathsat-${MATHSAT_VERSION}-linux-aarch64 ;;
+          macos-x86_64)   Z3_DIR=z3-${Z3_VERSION}-x64-osx-13.7.6   ; MS_DIR=mathsat-${MATHSAT_VERSION}-macos         ;;
+          macos-arm64)    Z3_DIR=z3-${Z3_VERSION}-arm64-osx-13.7.6 ; MS_DIR=mathsat-${MATHSAT_VERSION}-macos         ;;
+          windows-x86_64) Z3_DIR=z3-${Z3_VERSION}-x64-win          ; MS_DIR=mathsat-${MATHSAT_VERSION}-win64         ;;
+        esac
+        curl -sSL -o z3.zip "https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/${Z3_DIR}.zip"
         unzip -q z3.zip
-        # Use the Windows-style workspace path: the PATH entry must be
-        # usable by the native kind2 executable, not only by bash
-        echo "$GITHUB_WORKSPACE/$Z3_ZIP_NAME/bin" >> $GITHUB_PATH
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          # The Windows builds load their libraries from beside the
+          # executable, so the DLLs have to travel with it
+          curl -sSL -o mathsat.zip "https://mathsat.fbk.eu/release/${MS_DIR}.zip"
+          unzip -q mathsat.zip
+          cp "$Z3_DIR"/bin/z3.exe "$Z3_DIR"/bin/*.dll solver-bin/
+          cp "$MS_DIR"/bin/mathsat.exe "$MS_DIR"/bin/*.dll solver-bin/
+        else
+          curl -sSL -o mathsat.tar.gz "https://mathsat.fbk.eu/release/${MS_DIR}.tar.gz"
+          tar xzf mathsat.tar.gz
+          cp "$Z3_DIR/bin/z3" solver-bin/
+          cp "$MS_DIR/bin/mathsat" solver-bin/
+        fi
+
+    # The macOS build of MathSAT is universal, so it runs on both macOS
+    # runners, but it loads GMP from the MacPorts path it was linked against
+    # and the runners carry Homebrew. Put the library where it looks for it.
+    - name: Give MathSAT the GMP it links against (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        set -euo pipefail
+        brew install gmp
+        sudo mkdir -p /opt/local/lib
+        sudo ln -sf "$(brew --prefix gmp)/lib/libgmp.10.dylib" /opt/local/lib/libgmp.10.dylib
+
+    - name: Install SMT solvers
+      shell: bash
+      run: |
+        set -euo pipefail
+        chmod +x solver-bin/*
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          # Use the Windows-style workspace path: the PATH entry must be
+          # usable by the native kind2 executable, not only by bash
+          echo "${GITHUB_WORKSPACE}\\solver-bin" >> $GITHUB_PATH
+        else
+          sudo cp solver-bin/z3 solver-bin/mathsat /usr/local/bin/
+        fi
+
+    # A solver Kind 2 cannot start is not distinguishable from one it decided
+    # not to use: the tests would quietly fall back or skip. Check here.
+    - name: Check the solvers run
+      shell: bash
+      run: |
+        set -euo pipefail
+        z3 --version
+        mathsat -version | head -1
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7

--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -100,6 +100,13 @@ let handle_events in_sys param sys prop_name =
   | Property.PropInvariant _ -> raise Terminate
   | _ -> ()
 
+(* [TransSys.assert_global_constraints] converts the selects of the global
+   constraints before asserting them; these are asserted directly, so do the
+   same here. Without it, printing a select over a free variable of array type
+   hits an assertion in the SMT-LIB driver. *)
+let global_constraints sys =
+  TransSys.global_constraints sys |> List.map Term.convert_select
+
 let sys_def solver sys offset =
   let init_term_curr =
     get_init offset
@@ -127,7 +134,7 @@ let sys_def solver sys offset =
         Term.mk_not init_term_prev
       ]
    in
-   Term.mk_and (TransSys.global_constraints sys @
+   Term.mk_and (global_constraints sys @
      [Term.mk_or [init; trans]])
 
 let sys_def_unrolling solver sys offset =
@@ -136,7 +143,7 @@ let sys_def_unrolling solver sys offset =
   in
   if Numeral.(equal offset zero) then
     Term.mk_and
-      (TransSys.global_constraints sys @
+      (global_constraints sys @
       [TransSys.init_of_bound
         (Some (SMTSolver.declare_fun solver))
         sys
@@ -331,21 +338,55 @@ let refine fwd solver sys predicates cubes =
           )
         in
 
-        let solver = 
-          SMTSolver.create_instance
-            ~produce_models:true
-            ~produce_interpolants
-            logic
-            (Flags.Smt.get_itp_solver ())
+        (* An interpolating solver that cannot represent the array encoding
+           rejects it either when the instance is created (OpenSMT and
+           Bitwuzla refuse arrays outright, and their drivers fail on the
+           logic) or when the select function is declared (MathSAT refuses
+           arrays whose elements are Bool, as sets and maps have). Report
+           either as an unsupported feature, the way the checks in [main] do,
+           rather than letting the engine die with a runtime failure. Note
+           that this is reached only once interpolation is actually needed:
+           a property IC3IA settles without refining is still proved. *)
+        let unsupported_array_encoding msg =
+          let mentions sub =
+            (* The solver echoes its error quoted, so match on a substring. *)
+            let n = String.length sub and m = String.length msg in
+            let rec at i = i + n <= m && (String.sub msg i n = sub || at (i + 1)) in
+            at 0
+          in
+          mentions "Arrays with Bool as argument are not supported" ||
+          mentions "Higher-order compound types not supported" ||
+          mentions "does not support arrays" ||
+          mentions "only supports BV logics"
         in
 
-        TransSys.define_and_declare_of_bounds
-          sys
-          (SMTSolver.define_fun solver)
-          (SMTSolver.declare_fun solver)
-          (SMTSolver.declare_sort solver)
-          (Numeral.(pred zero))
-          (Numeral.of_int len);
+        let solver =
+          try
+            SMTSolver.create_instance
+              ~produce_models:true
+              ~produce_interpolants
+              logic
+              (Flags.Smt.get_itp_solver ())
+          with Failure msg when unsupported_array_encoding msg ->
+            raise (UnsupportedFeature
+              "IC3IA disabled: the interpolating solver does not support the \
+               arrays this system uses. Use MathSAT or SMTInterpol instead.")
+        in
+
+        (try
+          TransSys.define_and_declare_of_bounds
+            sys
+            (SMTSolver.define_fun solver)
+            (SMTSolver.declare_fun solver)
+            (SMTSolver.declare_sort solver)
+            (Numeral.(pred zero))
+            (Numeral.of_int len)
+        with Failure msg when unsupported_array_encoding msg -> (
+          SMTSolver.delete_instance solver ;
+          raise (UnsupportedFeature
+            "IC3IA disabled: the interpolating solver does not support the \
+             arrays this system uses. Use SMTInterpol instead.")
+        )) ;
 
         declare_init_var
           (SMTSolver.declare_fun solver)
@@ -415,9 +456,20 @@ let refine fwd solver sys predicates cubes =
       intrpo
   then (
     let cex_path =
+      (* Use [get_var_values] rather than [get_model]: it retrieves the value
+         of an array-typed variable by evaluating its elements one index at a
+         time, whereas the models solvers print for such variables are not
+         parsable back (they range over the uninterpreted sort that encodes
+         arrays). This is what BMC does too, see {!Base.solve}. *)
+      let model =
+        SMTSolver.get_var_values
+          intrpo
+          (TransSys.get_state_var_bounds sys)
+          (TransSys.vars_of_bounds sys Numeral.zero (Numeral.of_int (len - 2)))
+      in
       Model.path_from_model
         (TransSys.state_vars sys)
-        (SMTSolver.get_model intrpo)
+        model
         (Numeral.of_int (len - 2))
     in
 
@@ -970,9 +1022,14 @@ let main fwd slice_to_prop prop in_sys param sys =
   let open TermLib in
   let open TermLib.FeatureSet in
   (match TransSys.get_logic sys with
-  | `Inferred l when mem A l ->
+  | `Inferred l when mem A l && mem Q l ->
+    (* The array encoding turns selects into applications of an uninterpreted
+       function over an uninterpreted sort. Quantifying over those is beyond
+       what the interpolating solvers handle reliably: MathSAT answers such
+       queries unsoundly, which makes IC3IA report spurious counterexamples. *)
     let msg =
-      Format.sprintf "IC3IA disabled for property %s: arrays are not supported."
+      Format.sprintf
+        "IC3IA disabled for property %s: quantified formulas over arrays are not supported."
         prop.Property.prop_name
     in
     raise (UnsupportedFeature msg)
@@ -989,9 +1046,7 @@ let main fwd slice_to_prop prop in_sys param sys =
      arguments (see [TransSys.fn_congruence_instances]); without them, the
      counterexamples it finds for such systems may be spurious with respect
      to the intended (deterministic) semantics. Today this is subsumed by
-     the array check above, since container-typed arguments put arrays in
-     the system's logic; the explicit check makes the dependency visible in
-     case array support is ever added. To support these systems, the
+     [has_fn_congruence_groups] check below. To support these systems, the
      instances would have to be asserted in the solvers (bounds 0 and 1 for
      the transition queries), and the implicit abstraction would have to
      account for the difference witness functions the instances contain. *)
@@ -1015,9 +1070,26 @@ let main fwd slice_to_prop prop in_sys param sys =
       raise (UnsupportedFeature msg)
   in
 
+  (* Arrays are encoded with an uninterpreted sort and an uninterpreted select
+     function, which the quantifier elimination tactics behind these
+     interpolating solvers reject. Unlike the solvers that refuse the encoding
+     when the interpolating instance is created (handled in [refine]), these
+     fail in the middle of computing an interpolant, so rule them out here. *)
+  let check_arrays_are_supported itp_solver =
+    match TransSys.get_logic sys with
+    | `Inferred l when mem A l ->
+      let msg =
+        Format.sprintf "IC3IA (%s) disabled for property %s: arrays are not supported. \
+          Use MathSAT or SMTInterpol instead."
+          itp_solver prop.Property.prop_name
+      in
+      raise (UnsupportedFeature msg)
+    | _ -> ()
+  in
+
   (match Flags.Smt.itp_solver () with
-  | `cvc5_QE -> check_system_is_supported "cvc5qe"
-  | `Z3_QE -> check_system_is_supported "Z3qe"
+  | `cvc5_QE -> check_system_is_supported "cvc5qe" ; check_arrays_are_supported "cvc5qe"
+  | `Z3_QE -> check_system_is_supported "Z3qe" ; check_arrays_are_supported "Z3qe"
   | `MathSAT_SMTLIB -> (let open TermLib in
     let open TermLib.FeatureSet in
     match TransSys.get_logic sys with

--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -339,14 +339,20 @@ let refine fwd solver sys predicates cubes =
         in
 
         (* An interpolating solver that cannot represent the array encoding
-           rejects it either when the instance is created (OpenSMT and
-           Bitwuzla refuse arrays outright, and their drivers fail on the
-           logic) or when the select function is declared (MathSAT refuses
-           arrays whose elements are Bool, as sets and maps have). Report
-           either as an unsupported feature, the way the checks in [main] do,
-           rather than letting the engine die with a runtime failure. Note
-           that this is reached only once interpolation is actually needed:
-           a property IC3IA settles without refining is still proved. *)
+           rejects it either when the instance is created (OpenSMT refuses
+           arrays outright, and its driver fails on the logic) or when the
+           select function is declared (MathSAT refuses arrays whose elements
+           are Bool, as sets and maps have). Report either as an unsupported
+           feature, the way the checks in [main] do, rather than letting the
+           engine die with a runtime failure. Note that this is reached only
+           once interpolation is actually needed: a property IC3IA settles
+           without refining is still proved.
+
+           Match only on what the solvers say about arrays. Bitwuzla reports
+           an unsupported logic for anything that is not bit vectors, and it
+           does so from `header_logic`, after the process is already up: that
+           failure is not this one, and swallowing it would both misreport it
+           and strand the process outside [SMTSolver]'s registry. *)
         let unsupported_array_encoding msg =
           let mentions sub =
             (* The solver echoes its error quoted, so match on a substring. *)
@@ -356,8 +362,7 @@ let refine fwd solver sys predicates cubes =
           in
           mentions "Arrays with Bool as argument are not supported" ||
           mentions "Higher-order compound types not supported" ||
-          mentions "does not support arrays" ||
-          mentions "only supports BV logics"
+          mentions "does not support arrays"
         in
 
         let solver =
@@ -997,6 +1002,33 @@ let main_ic3ia fwd prop in_sys param sys =
 
    SMTSolver.delete_instance solver
 
+(* [TransSys.get_logic] reports the logic that gets declared to the solver,
+   which is whatever `--smt_logic` says whenever it is not `detect`: it says
+   nothing about the terms then, and `ALL` in particular lists no features at
+   all. Anything the soundness of an answer rests on has to be decided on the
+   terms, so recompute the features the way the `detect` branch of
+   [TransSys.mk_trans_sys] does when the logic on record is not an inferred
+   one. The subsystems are covered too, since their definitions sit behind
+   uninterpreted symbols in the top system's init and trans terms. *)
+let features_of_terms sys =
+  let open TermLib.FeatureSet in
+  TransSys.fold_subsystems ~include_top:true
+    (fun acc t ->
+      TransSys.init_of_bound None t Numeral.zero ::
+      TransSys.trans_of_bound None t Numeral.one ::
+      TransSys.global_constraints t @
+      List.map Property.get_prop_term (TransSys.get_properties t)
+      |> List.fold_left
+           (fun acc term -> union acc (TermLib.logic_of_term [] term))
+           acc)
+    empty
+    sys
+
+let features sys =
+  match TransSys.get_logic sys with
+  | `Inferred l -> l
+  | `SMTLogic _ | `None -> features_of_terms sys
+
 let main fwd slice_to_prop prop in_sys param sys =
 
   let param = Analysis.param_clone param in
@@ -1021,8 +1053,9 @@ let main fwd slice_to_prop prop in_sys param sys =
 
   let open TermLib in
   let open TermLib.FeatureSet in
-  (match TransSys.get_logic sys with
-  | `Inferred l when mem A l && mem Q l ->
+  let l = features sys in
+
+  (if mem A l && mem Q l then
     (* The array encoding turns selects into applications of an uninterpreted
        function over an uninterpreted sort. Quantifying over those is beyond
        what the interpolating solvers handle reliably: MathSAT answers such
@@ -1033,13 +1066,12 @@ let main fwd slice_to_prop prop in_sys param sys =
         prop.Property.prop_name
     in
     raise (UnsupportedFeature msg)
-  | `Inferred l when mem DT l ->
+  else if mem DT l then
     let msg =
       Format.sprintf "IC3IA disabled for property %s: algebraic datatypes are not supported."
         prop.Property.prop_name
     in
-    raise (UnsupportedFeature msg)
-  | _ -> () ) ;
+    raise (UnsupportedFeature msg) ) ;
 
   (* Note: IC3IA does not assert the functional congruence instances that
      enforce determinism of (abstracted) functions with container-typed
@@ -1076,15 +1108,13 @@ let main fwd slice_to_prop prop in_sys param sys =
      when the interpolating instance is created (handled in [refine]), these
      fail in the middle of computing an interpolant, so rule them out here. *)
   let check_arrays_are_supported itp_solver =
-    match TransSys.get_logic sys with
-    | `Inferred l when mem A l ->
+    if mem A l then
       let msg =
         Format.sprintf "IC3IA (%s) disabled for property %s: arrays are not supported. \
           Use MathSAT or SMTInterpol instead."
           itp_solver prop.Property.prop_name
       in
       raise (UnsupportedFeature msg)
-    | _ -> ()
   in
 
   (match Flags.Smt.itp_solver () with

--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -1120,10 +1120,8 @@ let main fwd slice_to_prop prop in_sys param sys =
   (match Flags.Smt.itp_solver () with
   | `cvc5_QE -> check_system_is_supported "cvc5qe" ; check_arrays_are_supported "cvc5qe"
   | `Z3_QE -> check_system_is_supported "Z3qe" ; check_arrays_are_supported "Z3qe"
-  | `MathSAT_SMTLIB -> (let open TermLib in
-    let open TermLib.FeatureSet in
-    match TransSys.get_logic sys with
-    | `Inferred l when mem BV l && (mem IA l || mem RA l) -> (
+  | `MathSAT_SMTLIB -> (
+    if mem BV l && (mem IA l || mem RA l) then
       let msg =
         Format.sprintf
           "IC3IA disabled for property %s: MathSAT does not support programs with \
@@ -1131,8 +1129,6 @@ let main fwd slice_to_prop prop in_sys param sys =
            prop.Property.prop_name
       in
       raise (UnsupportedFeature msg)
-    )
-    | _ -> ()
   )
   | _ -> () ) ;
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import shutil
 import signal
 import subprocess
 from pathlib import Path
@@ -74,6 +75,31 @@ regression_dir = Path("regression").absolute()
 extra_files = [
     (Path("../examples/syntax-test.lus").resolve(), "falsifiable"),
 ]
+
+# Tests under a directory with this name pin the engine to IC3IA, so that they
+# exercise IC3IA itself instead of whichever engine happens to answer first.
+#
+# They also pin the interpolating solver. IC3IA reaches arrays only through an
+# interpolating solver that can represent them: the ones driven by quantifier
+# elimination turn the engine off for such systems, so leaving the choice to
+# auto-detection would make these tests vacuous wherever MathSAT is missing.
+# They are skipped instead, which says so rather than reporting a run that
+# never finished.
+#
+# These models are tiny and settle in milliseconds, so the allowance that lets
+# any other test exit 30 does not apply to them: with one engine and one solver
+# pinned, a 30 means IC3IA turned the system down, not that it ran out of time.
+# It is therefore a failure here, which is what makes these tests notice the
+# engine losing the ability to answer for such a system.
+#
+# The exception is the tests under `ic3ia_declined_dir_name`, which pin down
+# what IC3IA must *not* say about systems it cannot reason about soundly. All
+# they require is that the property is not reported falsifiable; declining to
+# answer is the outcome expected today.
+ic3ia_dir_name = "ic3ia"
+ic3ia_declined_dir_name = "declined"
+ic3ia_args = {"--enable": "IC3IA", "--smt_itp_solver": "MathSAT"}
+ic3ia_solver = "mathsat"
 
 # Where to write log files
 log_dir = Path("logs")
@@ -240,15 +266,33 @@ class LustreItem(pytest.Item):
         if self.expected == "error":
             args |= {"--lus_strict": "true"}
 
+        if self._is_ic3ia():
+            args |= ic3ia_args
+
         arg_list = list(itertools.chain.from_iterable(args.items()))
         return [kind2_bin, *arg_list, self.path]
 
+    def _is_ic3ia(self):
+        return ic3ia_dir_name in self.path.parts
+
+    def _ic3ia_declines(self):
+        return self._is_ic3ia() and ic3ia_declined_dir_name in self.path.parts
+
     def runtest(self):
+        if self._is_ic3ia() and shutil.which(ic3ia_solver) is None:
+            pytest.skip(f"{ic3ia_solver} is not installed")
+
         self.res = run_kind2(self._command())
 
-        # Timeout is OK
+        if self._ic3ia_declines():
+            # Answering is allowed, answering `falsifiable` is not
+            if self.res.returncode == expected_to_code["falsifiable"]:
+                raise LustreException
+            return
+
+        # Timeout is OK, except for the IC3IA tests: see `ic3ia_dir_name`
         result = code_to_expected.get(self.res.returncode)
-        if result == "timeout":
+        if result == "timeout" and not self._is_ic3ia():
           unfinished_runs.append(self.nodeid)
           return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,13 @@ return_codes = (
 expected_to_code = {expected: code for expected, code in return_codes}
 code_to_expected = {code: expected for expected, code in return_codes}
 
+# What a declined run is allowed to exit with: 30 is Kind 2's
+# `incomplete_analysis`, which is what turning the system down looks like, and
+# 0 covers IC3IA one day being able to answer. Every other code -- a crash, a
+# usage error, a solver it could not start -- is a failure rather than a
+# decline, and naming them keeps the test honest about what it pins down.
+ic3ia_declined_codes = (expected_to_code["success"], expected_to_code["timeout"])
+
 def pytest_collect_file(parent, file_path: Path):
     try:
         # We only want to collect lustre files which live under the regression dir
@@ -272,11 +279,20 @@ class LustreItem(pytest.Item):
         arg_list = list(itertools.chain.from_iterable(args.items()))
         return [kind2_bin, *arg_list, self.path]
 
+    def _regression_parts(self):
+        # Relative to the regression tree: an absolute path would also match a
+        # checkout that happens to sit under a directory of the same name, and
+        # pin the whole suite to IC3IA. `extra_files` live outside the tree.
+        try:
+            return self.path.relative_to(regression_dir).parts
+        except ValueError:
+            return ()
+
     def _is_ic3ia(self):
-        return ic3ia_dir_name in self.path.parts
+        return ic3ia_dir_name in self._regression_parts()
 
     def _ic3ia_declines(self):
-        return self._is_ic3ia() and ic3ia_declined_dir_name in self.path.parts
+        return self._is_ic3ia() and ic3ia_declined_dir_name in self._regression_parts()
 
     def runtest(self):
         if self._is_ic3ia() and shutil.which(ic3ia_solver) is None:
@@ -286,7 +302,7 @@ class LustreItem(pytest.Item):
 
         if self._ic3ia_declines():
             # Answering is allowed, answering `falsifiable` is not
-            if self.res.returncode == expected_to_code["falsifiable"]:
+            if self.res.returncode not in ic3ia_declined_codes:
                 raise LustreException
             return
 

--- a/tests/regression/falsifiable/ic3ia/ic3ia_array_counterexample.lus
+++ b/tests/regression/falsifiable/ic3ia/ic3ia_array_counterexample.lus
@@ -1,0 +1,8 @@
+-- IC3IA has to report a counterexample whose state includes an array-typed
+-- variable. Solvers do not print models for those in a form Kind 2 can read
+-- back, so the values have to be recovered one index at a time.
+node Top() returns (c: int^3);
+let
+  c[k] = 0 -> pre c[k] + 1;
+  check c[1] < 3;
+tel

--- a/tests/regression/success/ic3ia/declined/ic3ia_quantified_array_sound.lus
+++ b/tests/regression/success/ic3ia/declined/ic3ia_quantified_array_sound.lus
@@ -1,0 +1,11 @@
+-- A valid property that quantifies over the indices of an array. The array
+-- encoding turns the selects into an uninterpreted function over an
+-- uninterpreted sort, and quantifying over those is answered unsoundly by the
+-- interpolating solvers, which made IC3IA report a counterexample for this
+-- property. IC3IA must not claim it is falsifiable: reporting `unknown` (and
+-- leaving it to the other engines) is the expected outcome here.
+node Top() returns (c: int^10);
+let
+  c[k] = 0 -> pre c[k] + 1;
+  check forall (j: subrange [0, 9] of int) c[j] >= 0;
+tel

--- a/tests/regression/success/ic3ia/ic3ia_array_constant_index.lus
+++ b/tests/regression/success/ic3ia/ic3ia_array_constant_index.lus
@@ -1,0 +1,7 @@
+-- IC3IA over an array whose elements are read at constant indices.
+node Top(x: int) returns (a: int^3);
+let
+  a = [x, x + 1, x + 2];
+  check a[1] = a[0] + 1;
+  check a[2] = a[0] + 2;
+tel

--- a/tests/regression/success/ic3ia/ic3ia_array_interpolation.lus
+++ b/tests/regression/success/ic3ia/ic3ia_array_interpolation.lus
@@ -1,0 +1,9 @@
+-- The property does not hold inductively at k = 1, so IC3IA has to refine its
+-- predicate abstraction: this exercises the interpolating solver on terms that
+-- contain the array encoding, not just the initial abstraction.
+node Top() returns (c: int^3);
+let
+  c[k] = 0 -> (if pre c[k] < 5 then pre c[k] + 1 else pre c[k]);
+  check c[1] <= 5;
+  check c[1] >= 0;
+tel

--- a/tests/regression/success/ic3ia/ic3ia_array_symbolic_index.lus
+++ b/tests/regression/success/ic3ia/ic3ia_array_symbolic_index.lus
@@ -1,0 +1,6 @@
+-- IC3IA over an array read at an index that is not a literal.
+node Top(i: subrange [0,9] of int) returns (c: int^10);
+let
+  c[k] = 0 -> pre c[k] + 1;
+  check c[i] >= 0;
+tel

--- a/tests/regression/success/ic3ia/ic3ia_global_const_map.lus
+++ b/tests/regression/success/ic3ia/ic3ia_global_const_map.lus
@@ -1,0 +1,13 @@
+-- A global constant of map type contributes a global constraint that holds a
+-- select over a free variable. IC3IA asserts the global constraints directly,
+-- so it has to convert those selects the way TransSys.assert_global_constraints
+-- does; without the conversion, printing the term hits an assertion in the
+-- SMT-LIB driver.
+type H = enum { H0, H1 };
+const P : subtype { m : map<H,bool> | forall (h:H) h in m };
+
+node Top (h: H) returns (seen: bool);
+let
+  seen = (h in P) -> (pre seen and h in P);
+  check seen;
+tel

--- a/tests/regression/success/ic3ia/ic3ia_map_enum_key_membership.lus
+++ b/tests/regression/success/ic3ia/ic3ia_map_enum_key_membership.lus
@@ -1,0 +1,13 @@
+-- IC3IA over a map with enum keys. The map is encoded as an array, but every
+-- access is a select on a literal index, which IC3IA handles: it used to be
+-- turned away by a check that disabled the engine for any system whose logic
+-- mentioned arrays at all.
+type ABC = enum {A, B, C};
+
+node Top() returns (m: map<ABC,int>);
+let
+  m = map[A := 1; B := 2; C := 3];
+  check A in m;
+  check B in m;
+  check C in m;
+tel


### PR DESCRIPTION
IC3IA turned down any system whose logic mentioned arrays:

```
<Warning> IC3IA disabled for property InvProp[L8C3]: arrays are not supported.
```

The check keyed off the array *sort*, so it also caught systems IC3IA reasons
about perfectly well. A map with enum keys is one of them: it is encoded as an
array, but every access is a select on a literal index, and the property below
is proved at k=1 once the engine is allowed to try.

```
type ABC = enum {A, B, C};

node Top() returns (m: map<ABC,int>);
let
  m = map[A := 1; B := 2; C := 3];
  check A in m;
tel
```

Opening the check up exposes three problems it was hiding.

**Counterexample extraction.** IC3IA used `get_model`, and solvers do not print
models for array-typed variables in a form Kind 2 can read back: they range
over the uninterpreted sort that encodes arrays. The values have to be
recovered one index at a time with `get_var_values`, which is what BMC already
does. Until now IC3IA could not report a counterexample over an array at all.

**Global constraints.** IC3IA asserts them directly, without the
`Term.convert_select` that `TransSys.assert_global_constraints` applies. An
unconverted select over a free variable of array type hits an assertion in the
SMT-LIB driver.

**A latent unsoundness.** With a quantifier over array selects -- an
uninterpreted function over an uninterpreted sort -- MathSAT answers
unsoundly, and IC3IA went on to report a *valid* property as falsifiable. This
was pre-existing: the engine already took the counterexample branch, and the
crash in `get_model` masked it. Quantified formulas over arrays are still
turned down for that reason; quantifiers on their own are unaffected.

What remains is decided per interpolating solver rather than for all of them.
Z3qe and cvc5qe are ruled out up front, since their quantifier elimination
tactics reject the encoding partway through computing an interpolant. The
solvers that reject it when the instance is created -- OpenSMT and Bitwuzla
refuse arrays outright, MathSAT refuses arrays over bool, as sets and maps
have -- now report an unsupported feature instead of dying with a runtime
failure. That path is reached only once interpolation is needed, so a property
IC3IA settles without refining is still proved.

## Tests

A plain regression test does not hold IC3IA to anything here: every engine
runs, so 2-induction answers the quantified-array model before IC3IA reports
its spurious counterexample, and a test that regresses from proved back to
"engine disabled" exits 30, which the harness accepts for any test.

Tests under an `ic3ia` directory therefore pin the engine and the interpolating
solver, and exit 30 is a failure for them: these models settle in milliseconds,
so it means IC3IA turned the system down rather than that it ran out of time.
Tests under `ic3ia/declined` invert that, requiring only that the property is
not reported falsifiable. They skip when MathSAT is absent rather than
reporting a run that never finished.

Each test was checked to fail without the fix it covers: reverting only the
select conversion fails `ic3ia_global_const_map`, reverting only the
counterexample extraction fails `ic3ia_array_counterexample`, and dropping the
guard on quantified arrays fails `ic3ia_quantified_array_sound`.

Over the 113 array/map/set/ADT tests in `regression/success`, IC3IA on its own
now proves 63, up from 49, with no unsound answers and no runtime failures.

## CI

The new tests reach arrays only through an interpolating solver that can
represent them, so with Z3 alone they would skip. MathSAT is installed too,
pinned and cached by version the way the benchmark workflows do it.

Two points worth a look:

- This replaces the three per-platform Z3 steps with one setup covering all
  five, which also pins Z3 on macOS, where it came from Homebrew and was
  whatever version that had.
- The cache lives in the workspace rather than the home directory, so the same
  path can go on PATH on Windows, where it has to be a native path.

Adding MathSAT makes it the interpolating solver Kind 2 detects for *every*
test in CI, in place of Z3qe. The suite was run under that configuration
(z3 + mathsat only, 482 passed) and with Z3 alone (475 passed, 7 skipped), so
a failed MathSAT download degrades rather than breaking the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
