### PR TITLE
Let no solver outlive Kind 2

### DIFF
--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -426,7 +426,13 @@ let post_clean_exit process base_status exn =
              killing it does not kill them. One left behind holds the
              standard output of Kind 2 open on Windows, where a child
              inherits every inheritable handle, so whoever reads that
-             output keeps waiting for an end that never comes. *)
+             output keeps waiting for an end that never comes.
+
+             This is the path that must not hang, and it now waits for
+             a lock to take it. Every critical section that lock
+             guards is a map operation with no I/O in it, held for as
+             long as an insertion or a swap takes, so waiting for it
+             cannot become the reason we never get to [_exit]. *)
           ( try SMTSolver.destroy_all_of_process () with _ -> () ) ;
           Unix._exit status)
         ()
@@ -434,6 +440,12 @@ let post_clean_exit process base_status exn =
     with _ -> () ) ;
   (* Close tags in JSON/XML output. *)
   KEvent.terminate_log () ;
+  (* The engines that are still running are on their way out with the
+     process, whatever they are in the middle of. Saying so before the
+     sweep is what keeps an engine that was given up on from being
+     reported as having crashed when the solver it asks for is refused,
+     the way one is not reported for the solvers killed under it. *)
+  EngineDomains.set_terminating true ;
   (* Kill all live solvers of the whole process. *)
   SMTSolver.destroy_all_of_process () ;
   (* Exit with status. *)

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -422,6 +422,12 @@ let post_clean_exit process base_status exn =
           Thread.delay 10.0 ;
           prerr_endline "Kind 2 did not exit in time, terminating." ;
           Stdlib.flush_all () ;
+          (* The solvers first: they are children of this process, and
+             killing it does not kill them. One left behind holds the
+             standard output of Kind 2 open on Windows, where a child
+             inherits every inheritable handle, so whoever reads that
+             output keeps waiting for an end that never comes. *)
+          ( try SMTSolver.destroy_all_of_process () with _ -> () ) ;
           Unix._exit status)
         ()
       |> ignore

--- a/src/smt/SMTSolver.ml
+++ b/src/smt/SMTSolver.ml
@@ -21,6 +21,7 @@ open Lib
 
 exception Unknown
 exception Timeout
+exception Exiting
 
 
 module IntMap = Map.Make(
@@ -76,10 +77,30 @@ See [destroy_all]. *)
 let all_solvers = ref IntMap.empty
 let all_solvers_lock = Mutex.create ()
 
-(** Registers a solver, owned by the calling domain. *)
+(* Latched by [destroy_all_of_process]: no solver may be created from
+   then on.
+
+   The sweep before the process exits is only final if nothing can
+   start a solver behind it. Something can: an engine the supervisor
+   gave up on keeps running in the background, and it dies with the
+   process rather than at a point we choose. A solver it starts after
+   the sweep is left running, with nobody to kill it.
+
+   Such a solver outlives Kind 2, and on Windows it holds the standard
+   output of Kind 2 open, since a child there inherits every
+   inheritable handle rather than only the ones it was given. Whoever
+   reads that output, the regression harness for one, then waits for an
+   end that never comes, long after Kind 2 itself is gone. *)
+let no_new_solvers = Atomic.make false
+
+(** Registers a solver, owned by the calling domain. Raises [Exiting]
+    if the process is on its way out, in which case the caller must
+    dispose of the instance it just created: past that point nothing
+    else will. *)
 let add_solver ( { id } as solver ) =
   let owner = (Domain.self () :> int) in
   Mutex.protect all_solvers_lock (fun () ->
+    if Atomic.get no_new_solvers then raise Exiting ;
     all_solvers := IntMap.add id (owner, solver) !all_solvers)
 
 (** Forgets a solver. *)
@@ -201,7 +222,14 @@ let create_instance
       last_assumptions = [| |]; }
   in
 
-  add_solver solver ;
+  (* The solver process is already running: it is started by the
+     functor application above, before there is anything to register.
+     If the sweep has been and gone, kill it here, since it would
+     otherwise be the one solver that outlives Kind 2. *)
+  ( try add_solver solver with Exiting ->
+      let module S = (val fomodule) in
+      S.kill_instance () ;
+      raise Exiting ) ;
 
   solver
 
@@ -228,16 +256,30 @@ let destroy_all () =
   in
   IntMap.iter (fun _ (_, s) -> destroy s) mine
 
-(* Destroys every live solver of the whole process. Only for final
-   cleanup before the process exits. *)
+(* Destroys every live solver of the whole process and bars any
+   further one. Only for final cleanup before the process exits.
+
+   Solvers are killed rather than asked to exit: nothing is left to
+   compute, and an engine that was given up on may still be inside a
+   call to one of them.
+
+   Latching [no_new_solvers] under the lock that guards the map is what
+   makes the sweep final. A solver registering at that moment either
+   makes it into the map, and is killed here, or finds the latch set
+   and kills itself; there is no in between. *)
 let destroy_all_of_process () =
   let entries =
     Mutex.protect all_solvers_lock (fun () ->
+      Atomic.set no_new_solvers true ;
       let entries = !all_solvers in
       all_solvers := IntMap.empty ;
       entries)
   in
-  IntMap.iter (fun _ (_, s) -> destroy s) entries
+  IntMap.iter
+    (fun _ (_, s) ->
+      let module S = (val s.solver_inst) in
+      S.kill_instance ())
+    entries
 
 (* Kills the solver processes owned by the given domain without
    interacting with them. Used by the supervisor to unblock an engine

--- a/src/smt/SMTSolver.ml
+++ b/src/smt/SMTSolver.ml
@@ -90,8 +90,12 @@ let all_solvers_lock = Mutex.create ()
    output of Kind 2 open, since a child there inherits every
    inheritable handle rather than only the ones it was given. Whoever
    reads that output, the regression harness for one, then waits for an
-   end that never comes, long after Kind 2 itself is gone. *)
-let no_new_solvers = Atomic.make false
+   end that never comes, long after Kind 2 itself is gone.
+
+   Guarded by [all_solvers_lock], like the map: it has to be read and
+   the registration decided in one go, or the two could interleave and
+   let exactly the solver this bars through. *)
+let no_new_solvers = ref false
 
 (** Registers a solver, owned by the calling domain. Raises [Exiting]
     if the process is on its way out, in which case the caller must
@@ -100,7 +104,7 @@ let no_new_solvers = Atomic.make false
 let add_solver ( { id } as solver ) =
   let owner = (Domain.self () :> int) in
   Mutex.protect all_solvers_lock (fun () ->
-    if Atomic.get no_new_solvers then raise Exiting ;
+    if !no_new_solvers then raise Exiting ;
     all_solvers := IntMap.add id (owner, solver) !all_solvers)
 
 (** Forgets a solver. *)
@@ -227,6 +231,9 @@ let create_instance
      If the sweep has been and gone, kill it here, since it would
      otherwise be the one solver that outlives Kind 2. *)
   ( try add_solver solver with Exiting ->
+      (* Only the process is disposed of. The pipes to it go with the
+         process image moments later, and there is no instance left to
+         close them through. *)
       let module S = (val fomodule) in
       S.kill_instance () ;
       raise Exiting ) ;
@@ -256,6 +263,15 @@ let destroy_all () =
   in
   IntMap.iter (fun _ (_, s) -> destroy s) mine
 
+(* Kills the solver processes of the given registry entries, without
+   interacting with them. *)
+let kill_entries entries =
+  IntMap.iter
+    (fun _ (_, s) ->
+      let module S = (val s.solver_inst) in
+      S.kill_instance ())
+    entries
+
 (* Destroys every live solver of the whole process and bars any
    further one. Only for final cleanup before the process exits.
 
@@ -270,16 +286,12 @@ let destroy_all () =
 let destroy_all_of_process () =
   let entries =
     Mutex.protect all_solvers_lock (fun () ->
-      Atomic.set no_new_solvers true ;
+      no_new_solvers := true ;
       let entries = !all_solvers in
       all_solvers := IntMap.empty ;
       entries)
   in
-  IntMap.iter
-    (fun _ (_, s) ->
-      let module S = (val s.solver_inst) in
-      S.kill_instance ())
-    entries
+  kill_entries entries
 
 (* Kills the solver processes owned by the given domain without
    interacting with them. Used by the supervisor to unblock an engine
@@ -294,11 +306,7 @@ let kill_solvers_of_domain owner =
       all_solvers := others ;
       mine)
   in
-  IntMap.iter
-    (fun _ (_, s) ->
-      let module S = (val s.solver_inst) in
-      S.kill_instance ())
-    entries
+  kill_entries entries
 
 (* Return the unique identifier of the solver instance *)
 let id_of_instance { id } = id

--- a/src/smt/SMTSolver.mli
+++ b/src/smt/SMTSolver.mli
@@ -28,6 +28,11 @@ type t
 exception Unknown
 exception Timeout
 
+(** Exception raised by {!create_instance} when the process is exiting.
+    No solver can be created from then on: the ones that exist have
+    been killed, and a new one would be left running. *)
+exception Exiting
+
 (** {1 Creating and finalizing a solver instance} *)
 
 (** Create a new instance of an SMT solver of the given kind and with
@@ -55,8 +60,10 @@ val delete_instance : t -> unit
 (** Destroys all live solver instances owned by the calling domain. *)
 val destroy_all : unit -> unit
 
-(** Destroys every live solver instance of the whole process. Only for
-    final cleanup before the process exits. *)
+(** Destroys every live solver instance of the whole process and bars
+    any further one, so that no solver outlives Kind 2. Only for final
+    cleanup before the process exits: {!create_instance} raises
+    {!Exiting} once this has been called. *)
 val destroy_all_of_process : unit -> unit
 
 (** Kills the solver processes owned by the given domain (as returned by

--- a/src/smt/SMTSolver.mli
+++ b/src/smt/SMTSolver.mli
@@ -36,7 +36,10 @@ exception Exiting
 (** {1 Creating and finalizing a solver instance} *)
 
 (** Create a new instance of an SMT solver of the given kind and with
-    the given flags *)
+    the given flags.
+
+    @raise Exiting if the process is exiting, in which case no solver
+    is left running. *)
 val create_instance :
   ?timeout: int ->
   ?produce_models:bool ->

--- a/tests/ounit/utils/dune
+++ b/tests/ounit/utils/dune
@@ -1,3 +1,3 @@
 (tests
-  (names testGraph)
-  (libraries ounit2 kind2dev))
+  (names testGraph testSolverExit)
+  (libraries ounit2 unix kind2dev))

--- a/tests/ounit/utils/testSolverExit.ml
+++ b/tests/ounit/utils/testSolverExit.ml
@@ -1,0 +1,64 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2026 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+
+*)
+
+open OUnit2
+
+(* No solver may outlive Kind 2.
+
+   The sweep before the process exits is only final if nothing can start
+   a solver behind it, and something can: an engine the supervisor gave
+   up on keeps running in the background. A solver it starts after the
+   sweep has nobody left to kill it, and on Windows it holds the
+   standard output of Kind 2 open, so whoever reads that output waits
+   for an end that never comes. *)
+
+let new_solver () = SMTSolver.create_instance `None `Z3_SMTLIB
+
+(* Reap whatever has exited and report whether a child process is still
+   running. The only children here are the solvers created above. *)
+let rec no_child_left deadline =
+  match Unix.waitpid [ Unix.WNOHANG ] (-1) with
+  | exception Unix.Unix_error (Unix.ECHILD, _, _) -> true
+  | 0, _ ->
+    (* Children are left, and none of them has exited. They may still be
+       on their way out, so wait a little before calling it a leak. *)
+    if Unix.gettimeofday () > deadline then false
+    else ( Unix.sleepf 0.05 ; no_child_left deadline )
+  | _ -> no_child_left deadline
+
+let test_no_solver_outlives_the_sweep _ =
+  ignore (new_solver ()) ;
+
+  SMTSolver.destroy_all_of_process () ;
+
+  (* Creating one now would leave it running, so it must not be possible *)
+  assert_raises SMTSolver.Exiting (fun () -> ignore (new_solver ())) ;
+
+  (* The solver started before the sweep is gone, and so is the one the
+     call above got as far as starting. [waitpid] on any child is not
+     supported on Windows, where the two assertions above still hold. *)
+  if not Sys.win32 then
+    assert_bool
+      "a solver process was left running"
+      (no_child_left (Unix.gettimeofday () +. 5.))
+
+let tests = "SolverExit" >::: [
+  "no solver outlives the sweep" >:: test_no_solver_outlives_the_sweep ;
+]
+
+let () = run_test_tt_main tests

--- a/tests/ounit/utils/testSolverExit.ml
+++ b/tests/ounit/utils/testSolverExit.ml
@@ -29,6 +29,15 @@ open OUnit2
 
 let new_solver () = SMTSolver.create_instance `None `Z3_SMTLIB
 
+(* Whether the solver [new_solver] asks for can be found. The rest of
+   the unit suite needs nothing installed, and a checkout without a
+   solver should not start failing it. CI installs Z3 on every platform
+   it tests, so this skips nowhere that matters. *)
+let solver_missing () =
+  match Lib.find_on_path (Flags.Smt.z3_bin ()) with
+  | _ -> false
+  | exception Not_found -> true
+
 (* Reap whatever has exited and report whether a child process is still
    running. The only children here are the solvers created above. *)
 let rec no_child_left deadline =
@@ -42,6 +51,8 @@ let rec no_child_left deadline =
   | _ -> no_child_left deadline
 
 let test_no_solver_outlives_the_sweep _ =
+  skip_if (solver_missing ()) "no Z3 on PATH" ;
+
   ignore (new_solver ()) ;
 
   SMTSolver.destroy_all_of_process () ;


### PR DESCRIPTION
A Windows CI run [failed](https://github.com/kind2-mc/kind2/actions/runs/32657498757/job/97238457246) with Kind 2 gone and the harness still waiting on its output:

```
Killed after 204s: the run did not stop on its own, although it was given 84s
Kind 2 had already exited (status 30), but its output pipes were still open: something it spawned outlived it
```

A solver of that run was still alive. On Windows it held the standard output of Kind 2 open, because a child there inherits every inheritable handle and not only the ones it is given, so the harness reading that output never saw the end of it and waited until it was killed. The same leak is what the job that [hung for 94 minutes](https://github.com/daniel-larraz/kind2/actions/runs/31332087766) ran into, before there was a harness to stop it.

Kind 2 honoured its own `--timeout` in both cases, and exited 30 on schedule. It is the cleanup that was incomplete.

## The leak

The sweep before the process exits was not final. Engines the supervisor gave up on keep running in the background and die with the process, at a point they do not choose; one that starts a solver after the sweep leaves it behind, with nobody left to kill it. The window is wider than it looks, since a solver process is running before it is registered: it is started by the functor application, and the registration only follows.

Latch the registry closed in `destroy_all_of_process`, under the lock that guards it, so that the sweep and a registration cannot interleave: a solver either makes it into the map, and is killed by the sweep, or finds the latch closed, in which case `create_instance` kills the process it has just started and raises `Exiting`. Kill rather than ask to exit, since nothing is left to compute and an engine that was given up on may still be inside a call.

Kill the solvers in the last-resort exit path too. It exists for when the orderly one does not finish, and went straight to `Unix._exit`, which leaves the children of the process running: exactly the case this is about.

## Validation

A new ounit test creates a solver, sweeps, and checks that creating another raises and that no child process is left running. It was checked both ways:

- with the latch check removed, it fails on the first count;
- with the raise removed as well, it fails on the second, reporting `a solver process was left running`.

So the leak reproduces deterministically, and on Linux: the bug is not Windows-specific, only its consequence is. On Linux an orphaned solver is harmless to whoever reads the output of Kind 2, which is why it never showed up there.

The ounit suite and the 475 regression tests pass, the latter in 36.7s, and the strict profile builds clean.

## Not in scope

This stops a solver outliving Kind 2. It does not stop a solver inheriting the standard output of Kind 2 in the first place, which is worth doing as defence in depth: `Unix.pipe ~cloexec:true` for the solver pipes would also stop each solver inheriting the pipes of the previous one, a file descriptor leak on every platform. Left for a separate change, since clearing inheritance on the standard output of Kind 2 itself interacts with the `Sys.command` calls in the certificate paths, which rely on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
