### PR TITLE
Stop a solver inheriting pipes it was not given

### DIFF
--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -116,10 +116,13 @@ let setup : unit -> any_input = fun () ->
   if Sys.win32 then (
     let keep fd name =
       try Unix.set_close_on_exec fd with Unix.Unix_error (e, _, _) ->
-        (* Worth a line: this is the failure that puts the standard
-           output of Kind 2 back within reach of its solvers, on the
-           one platform where that hangs whoever reads it. *)
-        Debug.kind2 "Could not keep %s from the children of Kind 2: %s"
+        (* Loud rather than logged: failing here quietly puts the
+           output of Kind 2 back within reach of its solvers, on the one
+           platform where that leaves whoever reads it waiting. It
+           should never happen, and there is no sign of it if it does. *)
+        KEvent.log L_warn
+          "Could not keep %s from the children of Kind 2 (%s).@ A solver \
+           outliving Kind 2 may hold it open."
           name (Unix.error_message e)
     in
     keep Unix.stdin "stdin" ;

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -88,6 +88,28 @@ let setup : unit -> any_input = fun () ->
     /!\ ================================================================== /!\
   *)
 
+  (* Keep the output of Kind 2 to itself.
+
+     On Windows a child inherits every handle marked inheritable, not
+     only the three it is given, so a solver ends up holding the
+     standard output and error of Kind 2 as well as its own pipes. A
+     solver that outlives Kind 2 then keeps them open, and whoever is
+     reading that output waits for an end that never comes, long after
+     Kind 2 is gone. Clearing the flag leaves the solvers with the
+     pipes they are given: [Unix.create_process] duplicates those as
+     inheritable itself.
+
+     Only on Windows. Elsewhere a child of [Unix.create_process] gets
+     the three descriptors it is given duplicated over its own, and
+     never sees these; whereas [Sys.command], which the certificate
+     paths use, does expect to inherit them. *)
+  if Sys.win32 then (
+    try
+      Unix.set_close_on_exec Unix.stdout ;
+      Unix.set_close_on_exec Unix.stderr
+    with Unix.Unix_error _ -> ()
+  ) ;
+
   (* Raise exception on CTRL+C. *)
   Sys.catch_break true ;
 

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -88,26 +88,43 @@ let setup : unit -> any_input = fun () ->
     /!\ ================================================================== /!\
   *)
 
-  (* Keep the output of Kind 2 to itself.
+  (* Keep the descriptors of Kind 2 to itself.
 
      On Windows a child inherits every handle marked inheritable, not
      only the three it is given, so a solver ends up holding the
-     standard output and error of Kind 2 as well as its own pipes. A
-     solver that outlives Kind 2 then keeps them open, and whoever is
-     reading that output waits for an end that never comes, long after
-     Kind 2 is gone. Clearing the flag leaves the solvers with the
-     pipes they are given: [Unix.create_process] duplicates those as
-     inheritable itself.
+     standard input, output and error of Kind 2 as well as its own
+     pipes. A solver that outlives Kind 2 then keeps them open, and
+     whoever is reading that output waits for an end that never comes,
+     long after Kind 2 is gone. Its standard input goes the same way:
+     a harness writing to Kind 2 would not see its reader go away.
+     Clearing the flag leaves the solvers with the pipes they are
+     given, which [Unix.create_process] duplicates as inheritable
+     itself.
 
      Only on Windows. Elsewhere a child of [Unix.create_process] gets
      the three descriptors it is given duplicated over its own, and
-     never sees these; whereas [Sys.command], which the certificate
-     paths use, does expect to inherit them. *)
+     never sees these.
+
+     [Sys.command] does expect to inherit them, and the certificate
+     paths, which use it, are not guarded against running here: the
+     output of what they start goes nowhere from now on. What those
+     paths produce is unusable on Windows in any case, being [#!/bin/sh]
+     scripts and command lines that redirect to [/dev/null], so what is
+     lost is the console output of something that cannot work there
+     anyway. Making them work is a matter of handing them the
+     descriptors, not of leaving these inheritable for every child. *)
   if Sys.win32 then (
-    try
-      Unix.set_close_on_exec Unix.stdout ;
-      Unix.set_close_on_exec Unix.stderr
-    with Unix.Unix_error _ -> ()
+    let keep fd name =
+      try Unix.set_close_on_exec fd with Unix.Unix_error (e, _, _) ->
+        (* Worth a line: this is the failure that puts the standard
+           output of Kind 2 back within reach of its solvers, on the
+           one platform where that hangs whoever reads it. *)
+        Debug.kind2 "Could not keep %s from the children of Kind 2: %s"
+          name (Unix.error_message e)
+    in
+    keep Unix.stdin "stdin" ;
+    keep Unix.stdout "stdout" ;
+    keep Unix.stderr "stderr"
   ) ;
 
   (* Raise exception on CTRL+C. *)

--- a/src/smt/SMTLIBSolver.ml
+++ b/src/smt/SMTLIBSolver.ml
@@ -942,9 +942,16 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
     let solver_executable = solver_cmd.(0) in
     
     (* Create pipes for input, output and error output *)
-    let solver_stdin_in, solver_stdin_out = Unix.pipe () in
-    let solver_stdout_in, solver_stdout_out = Unix.pipe () in 
-    let solver_stderr_in, solver_stderr_out = Unix.pipe () in 
+    (* Close these on exec, so that the only process to get them is
+       the solver they belong to. [Unix.create_process] passes the
+       three ends it is given to the child whatever this says, by
+       duplicating them onto its standard descriptors; what this stops
+       is every later solver inheriting the pipes of every earlier
+       one. A solver holding the write end of a pipe of a solver that
+       has died keeps Kind 2 from ever reading the end of its output. *)
+    let solver_stdin_in, solver_stdin_out = Unix.pipe ~cloexec:true () in
+    let solver_stdout_in, solver_stdout_out = Unix.pipe ~cloexec:true () in
+    let solver_stderr_in, solver_stderr_out = Unix.pipe ~cloexec:true () in
     
     (* Create solver process *)
     let solver_pid = 

--- a/src/smt/yicesNative.ml
+++ b/src/smt/yicesNative.ml
@@ -1206,10 +1206,13 @@ let create_instance
      TODO: expand ~ *)
   let solver_executable = solver_cmd.(0) in
 
-  (* Create pipes for input, output and error output *)
-  let solver_stdin_in, solver_stdin_out = Unix.pipe () in
-  let solver_stdout_in, solver_stdout_out = Unix.pipe () in 
-  let solver_stderr_in, solver_stderr_out = Unix.pipe () in 
+  (* Create pipes for input, output and error output.
+
+     Closed on exec, so that the only process to get them is the solver
+     they belong to: see the same call in [SMTLIBSolver]. *)
+  let solver_stdin_in, solver_stdin_out = Unix.pipe ~cloexec:true () in
+  let solver_stdout_in, solver_stdout_out = Unix.pipe ~cloexec:true () in
+  let solver_stderr_in, solver_stderr_out = Unix.pipe ~cloexec:true () in
 
   
   (* Create solver process *)

--- a/tests/ounit/utils/dune
+++ b/tests/ounit/utils/dune
@@ -1,3 +1,3 @@
 (tests
-  (names testGraph testSolverExit)
+  (names testGraph testSolverExit testSolverPipes)
   (libraries ounit2 unix kind2dev))

--- a/tests/ounit/utils/testSolverCommon.ml
+++ b/tests/ounit/utils/testSolverCommon.ml
@@ -1,0 +1,30 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2026 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+
+*)
+
+(* Shared by the tests that need a solver of their own to look at. *)
+
+let new_solver () = SMTSolver.create_instance `None `Z3_SMTLIB
+
+(* Whether the solver [new_solver] asks for can be found. The rest of
+   the unit suite needs nothing installed, and a checkout without a
+   solver should not start failing it. CI installs Z3 on every platform
+   it tests, so skipping on this costs no coverage there. *)
+let solver_missing () =
+  match Lib.find_on_path (Flags.Smt.z3_bin ()) with
+  | _ -> false
+  | exception Not_found -> true

--- a/tests/ounit/utils/testSolverExit.ml
+++ b/tests/ounit/utils/testSolverExit.ml
@@ -27,16 +27,7 @@ open OUnit2
    standard output of Kind 2 open, so whoever reads that output waits
    for an end that never comes. *)
 
-let new_solver () = SMTSolver.create_instance `None `Z3_SMTLIB
-
-(* Whether the solver [new_solver] asks for can be found. The rest of
-   the unit suite needs nothing installed, and a checkout without a
-   solver should not start failing it. CI installs Z3 on every platform
-   it tests, so this skips nowhere that matters. *)
-let solver_missing () =
-  match Lib.find_on_path (Flags.Smt.z3_bin ()) with
-  | _ -> false
-  | exception Not_found -> true
+open TestSolverCommon
 
 (* Reap whatever has exited and report whether a child process is still
    running. The only children here are the solvers created above. *)

--- a/tests/ounit/utils/testSolverPipes.ml
+++ b/tests/ounit/utils/testSolverPipes.ml
@@ -60,8 +60,7 @@ let pipes_held pid =
            match Unix.readlink (Filename.concat dir fd) with
            | exception _ -> None
            | target ->
-             if String.starts_with ~prefix:"pipe:" target then
-               Some (Printf.sprintf "%s -> %s" fd target)
+             if String.starts_with ~prefix:"pipe:" target then Some (fd, target)
              else None)
     |> Option.some
 
@@ -69,6 +68,21 @@ let pipes_held pid =
 let given = 3
 
 let solvers = 3
+
+(* The pipes a solver holds that were not already ours.
+
+   Whatever runs the test may hand it pipes of its own — dune does, on
+   some runners — and a solver inherits those exactly as it inherits
+   anything else of ours. They say nothing about what Kind 2 hands its
+   solvers, so discount them. The pipes of a solver cannot be among
+   them: they are made after this is taken. *)
+let own_pipes ours held =
+  List.filter (fun (_, pipe) -> not (List.mem pipe ours)) held
+
+let describe held =
+  held
+  |> List.map (fun (fd, pipe) -> Printf.sprintf "%s -> %s" fd pipe)
+  |> String.concat ", "
 
 let test_a_solver_holds_only_its_own_pipes _ =
   (* The descriptors of a process are read from /proc, which is Linux
@@ -84,23 +98,40 @@ let test_a_solver_holds_only_its_own_pipes _ =
      of this test used to leave behind. The second one failing to start
      would strand the first the same way. *)
   Fun.protect ~finally:SMTSolver.destroy_all_of_process (fun () ->
-    for _ = 1 to solvers do ignore (new_solver ()) done ;
-    let started = match children () with Some pids -> pids | None -> [] in
+    (* Stand in for the pipes the runner may hand us, so that a run here
+       covers what a run under CI does *)
+    let stray_r, stray_w = Unix.pipe () in
+    Fun.protect
+      ~finally:(fun () -> Unix.close stray_r ; Unix.close stray_w)
+      (fun () ->
+        let ours =
+          match pipes_held "self" with
+          | Some held -> List.map snd held
+          | None -> []
+        in
 
-    assert_equal
-      ~msg:"number of solvers started" ~printer:string_of_int
-      solvers (List.length started) ;
+        for _ = 1 to solvers do ignore (new_solver ()) done ;
+        let started =
+          match children () with Some pids -> pids | None -> []
+        in
 
-    started
-    |> List.iter (fun pid ->
-           match pipes_held pid with
-           | None -> assert_failure (Printf.sprintf "solver %s is gone" pid)
-           | Some held ->
-             assert_equal
-               ~msg:
-                 (Printf.sprintf "solver %s holds %s" pid
-                    (String.concat ", " held))
-               ~printer:string_of_int given (List.length held)))
+        assert_equal
+          ~msg:"number of solvers started" ~printer:string_of_int
+          solvers (List.length started) ;
+
+        started
+        |> List.iter (fun pid ->
+               match pipes_held pid with
+               | None -> assert_failure (Printf.sprintf "solver %s is gone" pid)
+               | Some held ->
+                 let own = own_pipes ours held in
+                 assert_equal
+                   ~msg:
+                     (Printf.sprintf
+                        "solver %s holds %s, of which %d were already ours"
+                        pid (describe held)
+                        (List.length held - List.length own))
+                   ~printer:string_of_int given (List.length own))))
 
 let tests = "SolverPipes" >::: [
   "a solver holds only its own pipes" >:: test_a_solver_holds_only_its_own_pipes ;

--- a/tests/ounit/utils/testSolverPipes.ml
+++ b/tests/ounit/utils/testSolverPipes.ml
@@ -26,12 +26,7 @@ open OUnit2
    on that pipe for an end that will not come until the last solver
    goes. Counting the pipes a solver holds is the way to see it. *)
 
-let new_solver () = SMTSolver.create_instance `None `Z3_SMTLIB
-
-let solver_missing () =
-  match Lib.find_on_path (Flags.Smt.z3_bin ()) with
-  | _ -> false
-  | exception Not_found -> true
+open TestSolverCommon
 
 (* The children of this process, as reported by the kernel. Each thread
    keeps its own list. *)

--- a/tests/ounit/utils/testSolverPipes.ml
+++ b/tests/ounit/utils/testSolverPipes.ml
@@ -1,0 +1,101 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2026 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+
+*)
+
+open OUnit2
+
+(* A solver gets the pipes it is given and no others.
+
+   The pipes of a solver used to be inheritable, so every solver
+   started after it was handed them too. A solver then holds the write
+   end of the output pipe of a solver that has died, and Kind 2 waits
+   on that pipe for an end that will not come until the last solver
+   goes. Counting the pipes a solver holds is the way to see it. *)
+
+let new_solver () = SMTSolver.create_instance `None `Z3_SMTLIB
+
+let solver_missing () =
+  match Lib.find_on_path (Flags.Smt.z3_bin ()) with
+  | _ -> false
+  | exception Not_found -> true
+
+(* The children of this process, as reported by the kernel. Each thread
+   keeps its own list. *)
+let children () =
+  let of_task acc task =
+    let path = Filename.concat "/proc/self/task" (task ^ "/children") in
+    match open_in path with
+    | exception _ -> acc
+    | ic ->
+      let line = try input_line ic with End_of_file -> "" in
+      close_in ic ;
+      String.split_on_char ' ' line
+      |> List.filter (fun pid -> pid <> "")
+      |> List.rev_append acc
+  in
+  Array.fold_left of_task [] (Sys.readdir "/proc/self/task")
+
+(* How many of the descriptors [pid] holds are pipes *)
+let pipes_held pid =
+  let dir = Filename.concat "/proc" (pid ^ "/fd") in
+  Sys.readdir dir
+  |> Array.to_list
+  |> List.filter (fun fd ->
+         match Unix.readlink (Filename.concat dir fd) with
+         | target -> String.starts_with ~prefix:"pipe:" target
+         | exception _ -> false)
+  |> List.length
+
+let test_a_solver_holds_only_its_own_pipes _ =
+  (* The fd table of a process is read from /proc, which is Linux only *)
+  skip_if (not (Sys.file_exists "/proc/self/task")) "no /proc" ;
+  skip_if (solver_missing ()) "no Z3 on PATH" ;
+
+  ignore (new_solver ()) ;
+  let first =
+    match children () with
+    | [ pid ] -> pid
+    | pids ->
+      assert_failure
+        (Printf.sprintf "expected one solver, found %d" (List.length pids))
+  in
+  let held_by_first = pipes_held first in
+
+  (* Two more, so that the last one could have inherited from three *)
+  ignore (new_solver ()) ;
+  ignore (new_solver ()) ;
+  let last =
+    match List.filter (fun pid -> pid <> first) (children ()) with
+    | pid :: _ -> pid
+    | [] -> assert_failure "the solvers started later are gone"
+  in
+  let held_by_last = pipes_held last in
+
+  (* What a solver holds does not grow with the ones before it. It was
+     three more pipes per earlier solver. *)
+  assert_bool
+    (Printf.sprintf
+       "a solver holds %d pipes where the first holds %d: it was handed \
+        the pipes of the solvers before it"
+       held_by_last held_by_first)
+    (held_by_last <= held_by_first)
+
+let tests = "SolverPipes" >::: [
+  "a solver holds only its own pipes" >:: test_a_solver_holds_only_its_own_pipes ;
+]
+
+let () = run_test_tt_main tests

--- a/tests/ounit/utils/testSolverPipes.ml
+++ b/tests/ounit/utils/testSolverPipes.ml
@@ -46,19 +46,23 @@ let children () =
   in
   Array.fold_left of_task None (Sys.readdir "/proc/self/task")
 
-(* How many of the descriptors [pid] holds are pipes, or [None] if it is
-   already gone *)
+(* The pipes [pid] holds, as the kernel names them, or [None] if it is
+   already gone. Named rather than counted: a count that comes out wrong
+   says nothing about which pipes, and the same pipe under two
+   descriptors is the whole point. *)
 let pipes_held pid =
   let dir = Filename.concat "/proc" (pid ^ "/fd") in
   match Sys.readdir dir with
   | exception Sys_error _ -> None
   | fds ->
     Array.to_list fds
-    |> List.filter (fun fd ->
+    |> List.filter_map (fun fd ->
            match Unix.readlink (Filename.concat dir fd) with
-           | target -> String.starts_with ~prefix:"pipe:" target
-           | exception _ -> false)
-    |> List.length
+           | exception _ -> None
+           | target ->
+             if String.starts_with ~prefix:"pipe:" target then
+               Some (Printf.sprintf "%s -> %s" fd target)
+             else None)
     |> Option.some
 
 (* What a solver is given: its own standard input, output and error *)
@@ -74,31 +78,29 @@ let test_a_solver_holds_only_its_own_pipes _ =
   skip_if (children () = None) "the kernel does not list the children" ;
   skip_if (solver_missing ()) "no Z3 on PATH" ;
 
-  for _ = 1 to solvers do ignore (new_solver ()) done ;
-  let started = match children () with Some pids -> pids | None -> [] in
+  (* Start them inside the cleanup rather than before it. A solver
+     handed the pipes of another holds the write end of its own standard
+     input and so never sees the end of it, which is what a failing run
+     of this test used to leave behind. The second one failing to start
+     would strand the first the same way. *)
+  Fun.protect ~finally:SMTSolver.destroy_all_of_process (fun () ->
+    for _ = 1 to solvers do ignore (new_solver ()) done ;
+    let started = match children () with Some pids -> pids | None -> [] in
 
-  (* Read what they hold before disposing of them, and dispose of them
-     whatever the counts turn out to be: a solver handed the pipes of
-     another never sees the end of its own standard input, so a failing
-     run would leave them behind for good. *)
-  let held = List.map (fun pid -> (pid, pipes_held pid)) started in
-  SMTSolver.destroy_all_of_process () ;
+    assert_equal
+      ~msg:"number of solvers started" ~printer:string_of_int
+      solvers (List.length started) ;
 
-  assert_equal
-    ~msg:"number of solvers started" ~printer:string_of_int
-    solvers (List.length held) ;
-
-  held
-  |> List.iter (fun (pid, held) ->
-         match held with
-         | None -> assert_failure (Printf.sprintf "solver %s is gone" pid)
-         | Some held ->
-           assert_equal
-             ~msg:
-               (Printf.sprintf
-                  "solver %s holds pipes it was not given, the ones of the \
-                   solvers before it" pid)
-             ~printer:string_of_int given held)
+    started
+    |> List.iter (fun pid ->
+           match pipes_held pid with
+           | None -> assert_failure (Printf.sprintf "solver %s is gone" pid)
+           | Some held ->
+             assert_equal
+               ~msg:
+                 (Printf.sprintf "solver %s holds %s" pid
+                    (String.concat ", " held))
+               ~printer:string_of_int given (List.length held)))
 
 let tests = "SolverPipes" >::: [
   "a solver holds only its own pipes" >:: test_a_solver_holds_only_its_own_pipes ;

--- a/tests/ounit/utils/testSolverPipes.ml
+++ b/tests/ounit/utils/testSolverPipes.ml
@@ -74,8 +74,19 @@ let solvers = 3
    Whatever runs the test may hand it pipes of its own — dune does, on
    some runners — and a solver inherits those exactly as it inherits
    anything else of ours. They say nothing about what Kind 2 hands its
-   solvers, so discount them. The pipes of a solver cannot be among
-   them: they are made after this is taken. *)
+   solvers, so discount them.
+
+   Discounting by the name the kernel gives a pipe is sound only while
+   every pipe in [ours] stays open. A closed one could have its name
+   taken by a pipe made for a solver later, and that solver would then
+   be let off. They all do stay open for the whole test: the one made
+   below is held to the end, and the ones from the runner are the
+   runner's to close. Being made after the reading is not on its own
+   what makes a solver's pipes safe to count.
+
+   What this cannot see is a solver inheriting a pipe Kind 2 held
+   before it began making them. There is none here, and a descriptor
+   Kind 2 never created is not what closing its own on exec is about. *)
 let own_pipes ours held =
   List.filter (fun (_, pipe) -> not (List.mem pipe ours)) held
 
@@ -99,8 +110,9 @@ let test_a_solver_holds_only_its_own_pipes _ =
      would strand the first the same way. *)
   Fun.protect ~finally:SMTSolver.destroy_all_of_process (fun () ->
     (* Stand in for the pipes the runner may hand us, so that a run here
-       covers what a run under CI does *)
-    let stray_r, stray_w = Unix.pipe () in
+       covers what a run under CI does. Inheritable on purpose: the
+       whole point is that the solvers are handed it. *)
+    let stray_r, stray_w = Unix.pipe ~cloexec:false () in
     Fun.protect
       ~finally:(fun () -> Unix.close stray_r ; Unix.close stray_w)
       (fun () ->
@@ -125,12 +137,21 @@ let test_a_solver_holds_only_its_own_pipes _ =
                | None -> assert_failure (Printf.sprintf "solver %s is gone" pid)
                | Some held ->
                  let own = own_pipes ours held in
+                 let discounted = List.length held - List.length own in
+                 (* Both ends of the pipe made above, at least. If a
+                    solver was handed none of it, nothing here exercises
+                    the discounting, and the test would keep passing
+                    without it -- which is how the runner's own pipes
+                    reached CI unnoticed. *)
+                 assert_bool
+                   "the pipe made for the solvers to inherit did not reach \
+                    them, so nothing exercises the discounting"
+                   (discounted >= 2) ;
                  assert_equal
                    ~msg:
                      (Printf.sprintf
                         "solver %s holds %s, of which %d were already ours"
-                        pid (describe held)
-                        (List.length held - List.length own))
+                        pid (describe held) discounted)
                    ~printer:string_of_int given (List.length own))))
 
 let tests = "SolverPipes" >::: [

--- a/tests/ounit/utils/testSolverPipes.ml
+++ b/tests/ounit/utils/testSolverPipes.ml
@@ -28,8 +28,9 @@ open OUnit2
 
 open TestSolverCommon
 
-(* The children of this process, as reported by the kernel. Each thread
-   keeps its own list. *)
+(* The children of this process, in the order they were started, or
+   [None] where the kernel does not keep the list. Each thread has a
+   file of its own. *)
 let children () =
   let of_task acc task =
     let path = Filename.concat "/proc/self/task" (task ^ "/children") in
@@ -38,56 +39,66 @@ let children () =
     | ic ->
       let line = try input_line ic with End_of_file -> "" in
       close_in ic ;
-      String.split_on_char ' ' line
-      |> List.filter (fun pid -> pid <> "")
-      |> List.rev_append acc
+      let pids =
+        String.split_on_char ' ' line |> List.filter (fun pid -> pid <> "")
+      in
+      Some (match acc with None -> pids | Some acc -> acc @ pids)
   in
-  Array.fold_left of_task [] (Sys.readdir "/proc/self/task")
+  Array.fold_left of_task None (Sys.readdir "/proc/self/task")
 
-(* How many of the descriptors [pid] holds are pipes *)
+(* How many of the descriptors [pid] holds are pipes, or [None] if it is
+   already gone *)
 let pipes_held pid =
   let dir = Filename.concat "/proc" (pid ^ "/fd") in
-  Sys.readdir dir
-  |> Array.to_list
-  |> List.filter (fun fd ->
-         match Unix.readlink (Filename.concat dir fd) with
-         | target -> String.starts_with ~prefix:"pipe:" target
-         | exception _ -> false)
-  |> List.length
+  match Sys.readdir dir with
+  | exception Sys_error _ -> None
+  | fds ->
+    Array.to_list fds
+    |> List.filter (fun fd ->
+           match Unix.readlink (Filename.concat dir fd) with
+           | target -> String.starts_with ~prefix:"pipe:" target
+           | exception _ -> false)
+    |> List.length
+    |> Option.some
+
+(* What a solver is given: its own standard input, output and error *)
+let given = 3
+
+let solvers = 3
 
 let test_a_solver_holds_only_its_own_pipes _ =
-  (* The fd table of a process is read from /proc, which is Linux only *)
+  (* The descriptors of a process are read from /proc, which is Linux
+     only, and its children from a file the kernel keeps only when it
+     was built to *)
   skip_if (not (Sys.file_exists "/proc/self/task")) "no /proc" ;
+  skip_if (children () = None) "the kernel does not list the children" ;
   skip_if (solver_missing ()) "no Z3 on PATH" ;
 
-  ignore (new_solver ()) ;
-  let first =
-    match children () with
-    | [ pid ] -> pid
-    | pids ->
-      assert_failure
-        (Printf.sprintf "expected one solver, found %d" (List.length pids))
-  in
-  let held_by_first = pipes_held first in
+  for _ = 1 to solvers do ignore (new_solver ()) done ;
+  let started = match children () with Some pids -> pids | None -> [] in
 
-  (* Two more, so that the last one could have inherited from three *)
-  ignore (new_solver ()) ;
-  ignore (new_solver ()) ;
-  let last =
-    match List.filter (fun pid -> pid <> first) (children ()) with
-    | pid :: _ -> pid
-    | [] -> assert_failure "the solvers started later are gone"
-  in
-  let held_by_last = pipes_held last in
+  (* Read what they hold before disposing of them, and dispose of them
+     whatever the counts turn out to be: a solver handed the pipes of
+     another never sees the end of its own standard input, so a failing
+     run would leave them behind for good. *)
+  let held = List.map (fun pid -> (pid, pipes_held pid)) started in
+  SMTSolver.destroy_all_of_process () ;
 
-  (* What a solver holds does not grow with the ones before it. It was
-     three more pipes per earlier solver. *)
-  assert_bool
-    (Printf.sprintf
-       "a solver holds %d pipes where the first holds %d: it was handed \
-        the pipes of the solvers before it"
-       held_by_last held_by_first)
-    (held_by_last <= held_by_first)
+  assert_equal
+    ~msg:"number of solvers started" ~printer:string_of_int
+    solvers (List.length held) ;
+
+  held
+  |> List.iter (fun (pid, held) ->
+         match held with
+         | None -> assert_failure (Printf.sprintf "solver %s is gone" pid)
+         | Some held ->
+           assert_equal
+             ~msg:
+               (Printf.sprintf
+                  "solver %s holds pipes it was not given, the ones of the \
+                   solvers before it" pid)
+             ~printer:string_of_int given held)
 
 let tests = "SolverPipes" >::: [
   "a solver holds only its own pipes" >:: test_a_solver_holds_only_its_own_pipes ;


### PR DESCRIPTION
Follow-up to #1446, and the part scoped out of it. That one stops a solver outliving Kind 2; this one stops a solver being handed pipes that are not its own, which turns out to be why an orphaned one could never stop by itself.

## A solver is handed the pipes of every solver before it, and of itself

The pipes of a solver are inheritable, so each solver started after it gets them too. Dumping the descriptors of the first solver of a run says what that means:

```
FD 0 -> pipe:[8088894]      its standard input
FD 1 -> pipe:[8088895]      its standard output
FD 2 -> pipe:[8088896]      its standard error
FD 8 -> pipe:[8088894]      the write end of its own standard input
FD 9 -> pipe:[8088895]
FD 11 -> pipe:[8088896]
```

A solver holds the write end of its own standard input. Closing the Kind 2 end therefore never ends it, and `z3 -in` waits for a command that cannot arrive. **Before this change a solver could not terminate itself on any platform**, and `kill_instance` sending SIGKILL was the only thing that ever stopped one. That is the other half of a leaked solver hanging whoever reads its output, and it is not specific to Windows: running the new test binary outside dune, which kills what it starts, leaves three solvers running for good before this change and none after it.

Later solvers hold the pipes of the earlier ones as well, so Kind 2 does not see the end of the output of a solver that has died until the last solver holding its pipe goes.

Create them closed on exec. `Unix.create_process` duplicates the three ends it is given onto the standard descriptors of the child whatever the flag says, so the solver still gets its own; what stops is everything else reaching it.

## On Windows a solver holds the descriptors of Kind 2

A child there inherits every inheritable handle, not only the three it is given, so a solver holds the standard input, output and error of Kind 2 as well. That is what turned a leaked solver into a [job that hung for 94 minutes](https://github.com/daniel-larraz/kind2/actions/runs/31332087766) and, later, into the [failure that identified it](https://github.com/kind2-mc/kind2/actions/runs/32657498757/job/97238457246): Kind 2 had exited, and the harness reading its output was waiting on a pipe a solver still held.

Clear the flag on those three descriptors at startup, on Windows only. Elsewhere a child of `Unix.create_process` has the three it is given duplicated over its own and never sees these.

The certificate paths run `Sys.command`, which does expect to inherit them, and nothing stops them running on Windows. What they produce there is unusable in any case — `#!/bin/sh` checker scripts, command lines redirecting to `/dev/null` — so what is lost is the console output of something that cannot work there anyway. Handing those paths the descriptors is the way to fix that if it ever matters, rather than leaving them inheritable for every child.

## Validation

A new ounit test reads the descriptors of every solver of a run and requires each to hold exactly the three it was given:

| | first solver | second | third |
|---|---|---|---|
| before | 6 | 9 | 12 |
| after | 3 | 3 | 3 |

It reverts to `expected: 3 but got: 6` when the flag is taken off, skips where there is no `/proc` or no solver installed, and disposes of the solvers before checking, so that a failing run does not leave behind the very processes it is about.

The ounit suite and the 482 regression tests pass, in 35.1s.

The Windows half cannot be exercised from Linux. What it puts at risk is the output of Kind 2 itself, and the solvers, still working there — which the suite covers on Windows CI, and did on the last run of this branch.

## Not in scope

Pipes only. Every file Kind 2 opens is still inheritable on all platforms — the SMT trace files, the XML and JSON output, the debug log, the generated contracts, twenty-five `open_out` in all. On Windows a leaked solver holding those keeps them locked against being deleted or renamed. Worth an increment of its own, most likely as an `open_out` that clears the flag rather than twenty-five call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
