### PR TITLE
Report what a run says on standard error

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import shutil
 import signal
 import subprocess
 from pathlib import Path
-from subprocess import PIPE, CompletedProcess, Popen, TimeoutExpired
+from subprocess import PIPE, STDOUT, CompletedProcess, Popen, TimeoutExpired
 
 import pytest
 
@@ -185,9 +185,9 @@ class LustreException(Exception): ...
 
 
 class LustreTimeout(Exception):
-    def __init__(self, stdout: bytes, status):
+    def __init__(self, output: bytes, status):
         super().__init__()
-        self.stdout = stdout
+        self.output = output
         # Exit status of Kind 2 when we gave up on it, or None if it was
         # still running then
         self.status = status
@@ -232,10 +232,18 @@ def run_kind2(command) -> CompletedProcess:
         # spawns can be killed along with it
         popen_args["start_new_session"] = True
 
-    proc = Popen(command, stdout=PIPE, stderr=PIPE, **popen_args)
+    # Standard error goes into the same stream as standard output rather
+    # than into a pipe of its own that nothing read: what Kind 2 says when
+    # its exit goes wrong goes to standard error and nowhere else -- the
+    # last-resort "did not exit in time" line, an uncaught exception, a
+    # warning that clearing handle inheritance failed. A run that hangs
+    # without them in its report cannot be told apart from a run that never
+    # got that far. The verdict of a test reads the exit code alone, so the
+    # merge changes what a failure shows, not what passes.
+    proc = Popen(command, stdout=PIPE, stderr=STDOUT, **popen_args)
 
     try:
-        stdout, _ = proc.communicate(timeout=run_timeout)
+        output, _ = proc.communicate(timeout=run_timeout)
     except TimeoutExpired:
         # Whether Kind 2 is still running says where the run is stuck, and
         # the two cases have nothing in common. Still running: it did not
@@ -247,15 +255,15 @@ def run_kind2(command) -> CompletedProcess:
 
         kill_tree(proc)
         try:
-            stdout, _ = proc.communicate(timeout=kill_timeout)
+            output, _ = proc.communicate(timeout=kill_timeout)
         except TimeoutExpired:
             # Some process we could not kill still holds the pipes. Report
             # what we have rather than wait for the rest forever: the reader
             # threads are daemons, and they do not keep the session alive.
-            stdout = b""
-        raise LustreTimeout(stdout, status)
+            output = b""
+        raise LustreTimeout(output, status)
 
-    return CompletedProcess(command, proc.returncode, stdout, None)
+    return CompletedProcess(command, proc.returncode, output, None)
 
 
 class LustreItem(pytest.Item):
@@ -335,7 +343,7 @@ class LustreItem(pytest.Item):
                     f"on its own, although it was given {common_args['--timeout']}s",
                     stuck,
                     " ".join(map(str, self._command())),
-                    excinfo.value.stdout.decode("utf-8"),
+                    excinfo.value.output.decode("utf-8", errors="replace"),
                 ]
             )
 
@@ -349,7 +357,7 @@ class LustreItem(pytest.Item):
                 [
                     f"Expected: {self.expected}, got {actual}",
                     " ".join(map(str, self._command())),
-                    self.res.stdout.decode("utf-8"),
+                    self.res.stdout.decode("utf-8", errors="replace"),
                 ]
             )
 


### PR DESCRIPTION
The harness read the standard error of a run into a pipe of its own and threw it away: `communicate` returned both streams, and the report kept only the first. What Kind 2 says when its exit goes wrong goes to standard error and nowhere else — the last-resort `Kind 2 did not exit in time, terminating.` line, the backtrace of an uncaught exception, the warning (since #1447) that clearing handle inheritance failed on Windows.

The Windows CI hang of `test-issue-127 [slice_on]` is undiagnosable without them. Its report shows Kind 2 alive two minutes past its own `--timeout` and silent since the analysis header, and that silence is ambiguous three ways:

- the supervisor loop that enforces the timeout on Windows stopped turning, or
- the timeout fired and the teardown wedged before its first visible line, or
- the teardown ran all the way to its last resort, and the last resort failed.

The first words of the exit path that are visible at the default log level go to standard error, so the report cannot currently tell these apart. With the streams merged, the next occurrence will. (The hang itself predates #1446/#1447 — the same failure is on `main` at the #1445 and #1446 merges — and is tracked separately.)

Merge standard error into the output rather than reading it separately: one stream to read while a run is being given up on, and the lines arrive in the report where they fell in the output. The verdict of a test reads the exit code alone, so what passes does not change; only what a failure shows does. Reports are decoded with replacement rather than strictly, so that a stray byte from a solver on the merged stream cannot turn a report into a decoding error.

## Validation

- A run writing to both streams shows both in its result, and a run that has to be killed shows both in the report of `LustreTimeout`, on both reading paths.
- The 482 regression tests pass, in 35.0s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
