### PR TITLE
Arm the last resort before the teardown, not after it

### DIFF
--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -406,38 +406,67 @@ let slaughter_kids ?(exiting = false) process sys =
   if not exiting then Signals.set_sigalrm_timeout_from_flag ()
 
 
+(* Last resort for the whole exit path: a deadlock, a join that never
+   returns or a solver that refuses to die would leave Kind 2 hanging
+   forever once the teardown has begun, since the wall clock timeout is
+   disabled while an analysis is torn down, and on Windows there is no
+   wall clock timeout at all outside the polling loop of the
+   supervisor. Leave the process a few seconds to exit in an orderly
+   way, and terminate it the hard way if it does not.
+
+   Armed before the first step of the teardown rather than after the
+   engines have been dealt with: most of the teardown happens in
+   [slaughter_kids], and a watchdog that only starts after it covers
+   only the tail of what can wedge.
+
+   The status the watchdog exits with is kept in a cell rather than
+   captured, so that arming early does not mean exiting with a status
+   from before the exception was looked at: [post_clean_exit] refines
+   it once [status_of_exn] has run. *)
+let watchdog_status = Atomic.make ExitCodes.error
+let watchdog_armed = Atomic.make false
+
+let arm_exit_watchdog status =
+  Atomic.set watchdog_status status ;
+  if not (Atomic.exchange watchdog_armed true) then
+    ( try
+        Thread.create
+          (fun () ->
+            Thread.delay 10.0 ;
+            prerr_endline "Kind 2 did not exit in time, terminating." ;
+            (* The solvers first: they are children of this process,
+               and killing it does not kill them. One left behind
+               holds the standard output of Kind 2 open on Windows,
+               where a child inherits every inheritable handle, so
+               whoever reads that output keeps waiting for an end that
+               never comes.
+
+               This is the path that must not hang, and it waits for a
+               lock to take it. Every critical section that lock
+               guards is a map operation with no I/O in it, held for
+               as long as an insertion or a swap takes, so waiting for
+               it cannot become the reason we never get to [_exit]. *)
+            ( try SMTSolver.destroy_all_of_process () with _ -> () ) ;
+            (* Flushing after the sweep, not before: the sweep is what
+               frees whoever reads the output of Kind 2, so nothing may
+               stand between the watchdog waking and it running --
+               [prerr_endline] has already flushed the one channel this
+               path writes to. The tail of standard output is worth a
+               try once the sweep is done, and no more than a try. *)
+            ( try Stdlib.flush_all () with _ -> () ) ;
+            Unix._exit (Atomic.get watchdog_status))
+          ()
+        |> ignore
+      with _ -> () )
+
 (** Called after everything has been cleaned up. *)
 let post_clean_exit process base_status exn =
   (* Exit status of process depends on exception. *)
   let status = status_of_exn process base_status exn in
-  (* Last resort: engines abandoned in the background hold no lock the
-     exit path needs, but a deadlock or a solver that refuses to die
-     would otherwise leave Kind 2 hanging forever, since the wall clock
-     timeout is disabled while an analysis is torn down. Leave the
-     process a few seconds to exit in an orderly way, and terminate it
-     the hard way if it does not. *)
-  ( try
-      Thread.create
-        (fun () ->
-          Thread.delay 10.0 ;
-          prerr_endline "Kind 2 did not exit in time, terminating." ;
-          Stdlib.flush_all () ;
-          (* The solvers first: they are children of this process, and
-             killing it does not kill them. One left behind holds the
-             standard output of Kind 2 open on Windows, where a child
-             inherits every inheritable handle, so whoever reads that
-             output keeps waiting for an end that never comes.
-
-             This is the path that must not hang, and it now waits for
-             a lock to take it. Every critical section that lock
-             guards is a map operation with no I/O in it, held for as
-             long as an insertion or a swap takes, so waiting for it
-             cannot become the reason we never get to [_exit]. *)
-          ( try SMTSolver.destroy_all_of_process () with _ -> () ) ;
-          Unix._exit status)
-        ()
-      |> ignore
-    with _ -> () ) ;
+  (* Arms on the paths that come here directly; on the path through
+     [on_exit] the watchdog is already running and this refines the
+     status it will use. *)
+  arm_exit_watchdog status ;
   (* Close tags in JSON/XML output. *)
   KEvent.terminate_log () ;
   (* The engines that are still running are on their way out with the
@@ -453,6 +482,9 @@ let post_clean_exit process base_status exn =
 
 (** Clean up before exit *)
 let on_exit sys process status exn =
+  (* From here to [exit] nothing bounds the teardown but the watchdog,
+     so it starts now, with the status as understood so far. *)
+  arm_exit_watchdog status ;
   try
     slaughter_kids ~exiting:true process sys;
     post_clean_exit process status exn

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -420,26 +420,48 @@ let slaughter_kids ?(exiting = false) process sys =
    only the tail of what can wedge.
 
    The status the watchdog exits with is kept in a cell rather than
-   captured, so that arming early does not mean exiting with a status
-   from before the exception was looked at: [post_clean_exit] refines
-   it once [status_of_exn] has run. *)
+   captured, and it is not lowered before [status_of_exn] has run: until
+   the exception has been accounted for, the only honest thing to report
+   is that Kind 2 had to be terminated. [post_clean_exit] sets the
+   verdict of the run once it knows it.
+
+   It never reports success. A run the watchdog had to kill did not
+   finish, whatever it had proved by then, and the output saying so is
+   the output that was cut short. A hang fails loudly wherever Kind 2
+   runs; a zero passes silently. *)
 let watchdog_status = Atomic.make ExitCodes.error
 let watchdog_armed = Atomic.make false
 
-let arm_exit_watchdog status =
-  Atomic.set watchdog_status status ;
+(* Run [f] on a thread of its own and wait at most [seconds] for it.
+
+   For the steps of the last resort that write to a descriptor: the
+   standard output of Kind 2 may be a pipe whose reader has stalled,
+   and a write to it blocks rather than failing. Catching exceptions
+   does not bound a blocking call, so the call goes somewhere it can
+   block without taking [_exit] with it. *)
+let within seconds f =
+  let over = Atomic.make false in
+  match Thread.create (fun () -> ( try f () with _ -> () ) ; Atomic.set over true) () with
+  | exception _ -> ()
+  | _ ->
+    let deadline = Unix.gettimeofday () +. seconds in
+    while not (Atomic.get over) && Unix.gettimeofday () < deadline do
+      Thread.delay 0.02
+    done
+
+let arm_exit_watchdog () =
   if not (Atomic.exchange watchdog_armed true) then
     ( try
         Thread.create
           (fun () ->
             Thread.delay 10.0 ;
-            prerr_endline "Kind 2 did not exit in time, terminating." ;
-            (* The solvers first: they are children of this process,
-               and killing it does not kill them. One left behind
-               holds the standard output of Kind 2 open on Windows,
-               where a child inherits every inheritable handle, so
-               whoever reads that output keeps waiting for an end that
-               never comes.
+            (* The solvers first, before anything that writes: they are
+               children of this process, and killing it does not kill
+               them. One left behind holds the standard output of Kind 2
+               open on Windows, where a child inherits every inheritable
+               handle, so whoever reads that output keeps waiting for an
+               end that never comes. Freeing that reader first is also
+               what gives the lines below their best chance of landing.
 
                This is the path that must not hang, and it waits for a
                lock to take it. Every critical section that lock
@@ -447,26 +469,32 @@ let arm_exit_watchdog status =
                as long as an insertion or a swap takes, so waiting for
                it cannot become the reason we never get to [_exit]. *)
             ( try SMTSolver.destroy_all_of_process () with _ -> () ) ;
-            (* Flushing after the sweep, not before: the sweep is what
-               frees whoever reads the output of Kind 2, so nothing may
-               stand between the watchdog waking and it running --
-               [prerr_endline] has already flushed the one channel this
-               path writes to. The tail of standard output is worth a
-               try once the sweep is done, and no more than a try. *)
-            ( try Stdlib.flush_all () with _ -> () ) ;
+            (* Saying so, and the tail of the output, are worth a
+               moment and no more. Both write to descriptors that may
+               be pipes nobody is draining, and neither may become the
+               reason we do not exit. *)
+            within 1.0 (fun () ->
+              prerr_endline "Kind 2 did not exit in time, terminating." ;
+              Stdlib.flush_all ()) ;
             Unix._exit (Atomic.get watchdog_status))
           ()
         |> ignore
       with _ -> () )
+
+(* The verdict of the run, for the watchdog to exit with if it has to.
+   Never success: see [watchdog_status]. *)
+let watchdog_reports status =
+  if status <> ExitCodes.success then Atomic.set watchdog_status status
 
 (** Called after everything has been cleaned up. *)
 let post_clean_exit process base_status exn =
   (* Exit status of process depends on exception. *)
   let status = status_of_exn process base_status exn in
   (* Arms on the paths that come here directly; on the path through
-     [on_exit] the watchdog is already running and this refines the
-     status it will use. *)
-  arm_exit_watchdog status ;
+     [on_exit] the watchdog is already running, and either way this is
+     where it learns the verdict of the run. *)
+  arm_exit_watchdog () ;
+  watchdog_reports status ;
   (* Close tags in JSON/XML output. *)
   KEvent.terminate_log () ;
   (* The engines that are still running are on their way out with the
@@ -483,8 +511,11 @@ let post_clean_exit process base_status exn =
 (** Clean up before exit *)
 let on_exit sys process status exn =
   (* From here to [exit] nothing bounds the teardown but the watchdog,
-     so it starts now, with the status as understood so far. *)
-  arm_exit_watchdog status ;
+     so it starts now. Without a status: [status] here has not been
+     through [status_of_exn], and on the paths that pass a results
+     verdict it can be success, which is not something a killed run may
+     report. *)
+  arm_exit_watchdog () ;
   try
     slaughter_kids ~exiting:true process sys;
     post_clean_exit process status exn


### PR DESCRIPTION
Hardens the exit path against the class of hang tracked in #1449, and validated by fault injection on both sides.

## The gap

The watchdog that terminates Kind 2 the hard way when its exit does not finish was started in `post_clean_exit` — *after* `slaughter_kids` had already run. Most of the teardown happens in `slaughter_kids`, so the last resort covered only the tail of what can wedge: a teardown stuck terminating the engines hung Kind 2 forever, with nothing to notice. The wall clock timeout does not reach there — it is ignored while an analysis is torn down, and on Windows it never existed outside the polling loop of the supervisor in the first place.

## The change

Arm the watchdog on entry to `on_exit`, before the first step of the teardown; the paths that reach `post_clean_exit` directly arm it there, as before. The exit status lives in a cell the watchdog reads when it fires, so arming early does not mean exiting with a stale status: `post_clean_exit` refines it once `status_of_exn` has run.

In the watchdog itself, the solvers are swept **before** the channels are flushed rather than after. The sweep is what frees whoever reads the output of Kind 2, so nothing may stand between the watchdog waking and it running; the tail of standard output is worth a try once the sweep is done, and no more than a try.

## Validation

By wedging `slaughter_kids` with an injected sleep and running `test-issue-127.lus` pinned to two cores, so that the wall clock timeout fires with every engine live:

| | outcome |
|---|---|
| `main`, wedged | still running 25s later, **silent** — the watchdog was never armed |
| this change, wedged | `Kind 2 did not exit in time, terminating.` and gone at ten seconds, solvers swept — single-engine and full-fleet scenarios alike, three runs of each |

The ounit suite and the 482 regression tests pass, in 35.9s.

## What it does not cover

The injection also exposed a gap this change leaves open, now recorded in #1449: the **between-analyses** `slaughter_kids`, where the wall clock timeout is equally suppressed and no exit is in sight, hangs Kind 2 forever with no output at all when wedged — and on Windows, so does the whole stretch from spawning the engines to the first iteration of the polling loop, since the polled timeout check only lives inside the loop. That is the window the CI hang's signature falls into, and it needs a design of its own rather than a bigger watchdog.

This is not the fix for the Windows CI failure of #1449: sampling that test on this branch still gives runs of 169s and 183s against a `--timeout` of 84s, where a teardown wedge would have been capped near 94s. That failure overruns its own timeout before the exit path is entered, and is a slow run rather than a hang. What this change fixes is the gap the injection above demonstrates, which is real either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

