### PR TITLE
Accept the run the Windows stalls take past the budget

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,27 @@ def pytest_collection_modifyitems(session, items):
 unfinished_runs = []
 
 
+# Runs the Windows stalls of #1449 take past the harness budget.
+#
+# On Windows the whole Kind 2 process stops running for seconds at a time,
+# repeatedly, so a run overruns the `--timeout` it was given by minutes and
+# this one, the longest of the suite, sometimes crosses `run_timeout` and is
+# killed. Accepting that here is a workaround for the CI noise and not a
+# mitigation: Kind 2 still does not honour its timeout on Windows, which is
+# what #1449 is about.
+#
+# Narrow on purpose -- this test, that platform, that one outcome -- so that
+# any other test crossing the budget, or this one failing any other way,
+# still fails. Reported at the end rather than passed over in silence, so
+# that the day it stops happening is visible.
+stalled_on_windows = {
+    "regression/falsifiable/test-issue-127.lus::test-issue-127 [slice_on]",
+}
+
+# The runs of `stalled_on_windows` that had to be killed this session.
+stalled_runs = []
+
+
 class LustreException(Exception): ...
 
 
@@ -306,7 +327,13 @@ class LustreItem(pytest.Item):
         if self._is_ic3ia() and shutil.which(ic3ia_solver) is None:
             pytest.skip(f"{ic3ia_solver} is not installed")
 
-        self.res = run_kind2(self._command())
+        try:
+            self.res = run_kind2(self._command())
+        except LustreTimeout:
+            if os.name == "nt" and self.nodeid in stalled_on_windows:
+                stalled_runs.append(self.nodeid)
+                return
+            raise
 
         if self._ic3ia_declines():
             # Answering is allowed, answering `falsifiable` is not
@@ -364,18 +391,27 @@ class LustreItem(pytest.Item):
         return super().repr_failure(excinfo, style)
 
 
-# Report the runs that gave up, which pass and would otherwise leave no trace
+# Report the runs that gave up, and the ones we had to kill and accepted,
+# which pass and would otherwise leave no trace
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    if not unfinished_runs:
-        return
+    if unfinished_runs:
+        terminalreporter.section("Kind 2 ran out of time")
+        terminalreporter.write_line(
+            f"{len(unfinished_runs)} test(s) exited 30 after the "
+            f"{common_args['--timeout']}s budget (not counted as failures):"
+        )
+        for nodeid in unfinished_runs:
+            terminalreporter.write_line(f"  {nodeid}")
 
-    terminalreporter.section("Kind 2 ran out of time")
-    terminalreporter.write_line(
-        f"{len(unfinished_runs)} test(s) exited 30 after the "
-        f"{common_args['--timeout']}s budget (not counted as failures):"
-    )
-    for nodeid in unfinished_runs:
-        terminalreporter.write_line(f"  {nodeid}")
+    if stalled_runs:
+        terminalreporter.section("Killed and accepted (see #1449)")
+        terminalreporter.write_line(
+            f"{len(stalled_runs)} test(s) did not stop within {run_timeout:.0f}s "
+            f"and were accepted rather than failed, which only happens on "
+            f"Windows and only for these:"
+        )
+        for nodeid in stalled_runs:
+            terminalreporter.write_line(f"  {nodeid}")
 
 
 # Log test failures


### PR DESCRIPTION
The Windows job fails intermittently on one test, and has since #1445: `test-issue-127.lus [slice_on]` does not stop within the 204s the harness allows, so it is killed and reported as a failure. It is the longest test of the suite and the only one close enough to the budget to cross it. Three of the four Windows jobs that ran to completion in one stretch failed this way.

What is behind it is **not a hang**, and it is not this harness's to fix. On Windows the Kind 2 process stops running for seconds at a time, repeatedly — a `Thread.create` ticker in the main domain and a `Domain.spawn` ticker of its own both stop together, by the same amounts at the same moments, and it is not the collector (5.6s stalls with zero collections of any kind). So a run overruns the `--timeout` it was given by minutes. That is #1449; it is not diagnosed yet.

## What this does

Accepts the kill for that one run, so the job is usable while the cause is found.

Narrow on three axes at once — **this test, on Windows, killed after the budget**:

- any other test that crosses the budget still fails;
- this test failing any other way still fails;
- on any other platform it still fails.

Reported at the end beside the runs that gave up, so a job carrying the workaround says so out loud, and so the day it stops happening is visible rather than silent:

```
--- Killed and accepted (see #1449) ---
1 test(s) did not stop within 204s and were accepted rather than failed,
which only happens on Windows and only for these:
  regression/falsifiable/test-issue-127.lus::test-issue-127 [slice_on]
```

## What it is not

**This is a workaround for the CI noise, not a mitigation.** Kind 2 on Windows still does not honour the timeout it is given, and someone running it there still waits minutes past `--timeout`. #1449 should be weighed on that, not on how quiet CI is.

## Considered and not taken

- **Raising `run_timeout`** (now `--timeout + 120`). Keeps every failure signal, which is its virtue, but the tail is long and not bounded by the Kind 2 timeout: at `--timeout 20` runs of 204s, 243s and 271s were sampled. Covering that means roughly `+300`, which makes every stuck run cost 384s instead of 204s on an already twelve-minute job, and loosens the budget for all 482 tests to accommodate one.
- **Lowering `--timeout` for the suite.** Looks attractive and does not work: the overrun is not proportional to it. Runs at `--timeout 20` reached 271s while runs at `--timeout 84` topped out near 200s.
- **Treating any Windows kill as non-fatal.** Masks exactly the class of bug CI is there to catch.

## Validation

- The acceptance was driven directly on all four combinations of platform and test: accepted and recorded only for this test on Windows, propagated in the other three.
- The summary section renders for either kind of report, and stays silent when there is nothing to say.
- The 482 regression tests pass in 35.4s.

To revert when #1449 closes: delete `stalled_on_windows`, `stalled_runs`, the `try`/`except` in `runtest`, and the second section in `pytest_terminal_summary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
