### PR TITLE
Keep ADT constructors out of the arguments of generated nodes

### DIFF
--- a/src/lustre/lustreGenNodes.ml
+++ b/src/lustre/lustreGenNodes.ml
@@ -35,6 +35,18 @@ fun pos node_name node_type ->
   let name = HString.concat2 name pos |> HString.concat2 (NI.get_name node_name)  in
   NI.mk_node_id ~node_type ~user_name:name name
 
+(* Not every identifier occurring in an expression or a type denotes a variable
+   that a generated node must take as an argument. Global constants are in
+   scope everywhere, and nullary ADT constructors are parsed as identifiers
+   even though they denote values. *)
+let node_arguments: Ctx.tc_context -> HString.t list -> HString.t list =
+fun ctx ids ->
+  List.filter (fun i ->
+    match Ctx.lookup_const ctx i with
+    | Some (_, _, Ctx.Global) -> false
+    | _ -> Ctx.lookup_constructor ctx i |> Option.is_none
+  ) ids
+
 (* When a branch of a when-then-else expression is temporal (it uses '->' or
    'pre'), abstract it into a call to a fresh internal node whose single output
    equals the original expression and whose arguments are the variables used in
@@ -48,13 +60,7 @@ fun ctx node_name e ->
     let span = { A.start_pos = pos; A.end_pos = pos } in
     let node_id = mk_fresh_fn_name pos node_name ClockedExpr in
     (* The variables used in the expression become the node's arguments *)
-    let inputs = AH.vars_without_node_call_ids e |> Ctx.SI.elements in
-    (* Global constants don't need to be passed as arguments to generated nodes *)
-    let inputs = List.filter (fun i ->
-      match Ctx.lookup_const ctx i with
-        | Some (_, _, Ctx.Global) -> false
-        | _ -> true
-    ) inputs in
+    let inputs = AH.vars_without_node_call_ids e |> Ctx.SI.elements |> node_arguments ctx in
     let inputs_call = List.map (fun str -> A.Ident (pos, str)) inputs in
     let input_tys = List.map (fun input -> Ctx.lookup_ty ctx input) inputs in
     (* If the type of any free variable cannot be determined here (e.g. a
@@ -162,13 +168,7 @@ fun ctx node_name fun_ids expr ->
     in 
     let ty_args = List.map (fun id -> A.UserType (pos, [], id)) ty_params in
     let ty = Ctx.expand_type_syn ctx ty in
-    let inputs = AH.vars_of_type ty |> Ctx.SI.elements in
-    (* Global constants don't need to be passed as arguments to generated nodes *)
-    let inputs = List.filter (fun i -> 
-      match Ctx.lookup_const ctx i with 
-        | Some (_, _, Ctx.Global) -> false 
-        | _ -> true
-    ) inputs in 
+    let inputs = AH.vars_of_type ty |> Ctx.SI.elements |> node_arguments ctx in
     let inputs_call = List.map (fun str -> A.Ident (pos, str)) inputs in
     let inputs = List.map (fun input -> (pos, input, Ctx.lookup_ty ctx input, A.ClockTrue)) inputs in
     let inputs = List.map (fun (p, inp, opt, cl) -> match opt with 
@@ -194,14 +194,9 @@ fun ctx node_name fun_ids expr ->
       let vars_of_exprs =
         Ctx.SI.diff vars_of_expr1 (Ctx.SI.singleton id)
       in 
-      Ctx.SI.union vars_of_exprs (AH.vars_of_type ty) |> Ctx.SI.elements
+      Ctx.SI.union vars_of_exprs (AH.vars_of_type ty)
+      |> Ctx.SI.elements |> node_arguments ctx
     in
-    (* Global constants don't need to be passed as arguments to generated nodes *)
-    let inputs = List.filter (fun i -> 
-      match Ctx.lookup_const ctx i with 
-        | Some (_, _, Ctx.Global) -> false 
-        | _ -> true
-    ) inputs in 
     let inputs_call = List.map (fun str -> A.Ident (pos, str)) inputs in
     let ctx = Ctx.add_ty ctx id ty in
     let inputs = List.map (fun input -> (pos, input, Ctx.lookup_ty ctx input, A.ClockTrue)) inputs in

--- a/tests/regression/success/adt_nullary_ctor_gen_nodes.lus
+++ b/tests/regression/success/adt_nullary_ctor_gen_nodes.lus
@@ -1,0 +1,26 @@
+-- A nullary ADT constructor is parsed as an identifier, but it denotes a
+-- value, not a variable, so it must not be turned into an argument of the
+-- nodes generated for 'any'/'choose' expressions and abstracted temporal
+-- branches.
+
+datatype T = A (v: int) | B;
+
+node main(i: int; c: bool) returns (ok1, ok2, ok3: bool);
+var x, y, z: T;
+var seen_c: bool;
+let
+  x = any { t: T | t <> B };
+  ok1 = x <> B;
+  check ok1;
+
+  y = choose { t: T | t <> B };
+  ok2 = y <> B;
+  check ok2;
+
+  -- The '->' of the branch is clocked by the guard, so the branch only steps
+  -- while 'c' holds and 'z' can only be an 'A' after 'c' has already held.
+  z = when c then (B -> A(i)) else B;
+  seen_c = false -> (pre c or pre seen_c);
+  ok3 = A?(z) => seen_c;
+  check ok3;
+tel


### PR DESCRIPTION
Kind 2 abstracts several constructs into freshly generated nodes: `any` and `choose` expressions, type ascriptions, and the temporal branches of a when-then-else. The free variables of the abstracted expression become the generated node's arguments.

A nullary ADT constructor is parsed as a plain identifier, so it was collected as a free variable and made an argument like any other. It has no type in the typing context, being a value rather than a variable, and the two argument lists built from a type lookup asserted instead:

```lustre
datatype Token_Holder = CoordinatorHost | ParticipantHost (id: HostId) | NoHost;
...
tk_holder = any { tk : Token_Holder | tk = NoHost -> tk <> NoHost };
```

failed with `File "src/lustre/lustreGenNodes.ml", line 212: Assertion failed` rather than being analyzed.

The third site, `abstract_temporal_branch`, does not assert: it silently leaves the branch unabstracted when a free variable has no type. That is a wrong answer rather than a crash, since the branch's `->` then steps on the global clock instead of the guard. In

```lustre
z = when c then (B -> A(i)) else B;
```

`z` became `A(i)` on the first instant `c` holds, instead of on the second.

## The fix

Identifiers that name a constructor are filtered out of the arguments, next to the global constants that were already being filtered out for the same reason: both are in scope inside the generated node without being passed in. This matches how the type checker resolves a bare identifier, which looks for a constructor before a variable.

## Testing

`tests/regression/success/adt_nullary_ctor_gen_nodes.lus` covers `any`, `choose`, and the temporal-branch abstraction with a nullary constructor. On the unpatched build the first two hit the assertion and the third is falsified; all three pass now.

The model this came from — a two-phase-commit protocol using `any` over a datatype with a nullary constructor — now analyzes cleanly: three contract guarantees and nine `check`s valid by 2-induction, seven reachability properties reachable.

Full regression suite passes (483), strict build clean.

## Not fixed here

Found while writing the test: a type ascription whose refinement type mentions any ADT term — `(A(i) : subtype { t: T | t <> C(1) })` — fails downstream with `Invalid_argument("Trie.map2")` from `LustreNodeGen.compile_equality`. It reproduces without any nullary constructor, so it is a separate pre-existing bug and out of scope here. That is why the type-ascription site is not covered by the new test.

That bug is fixed in #1453, which is stacked on this PR. It turned out to be a gap in the type checker rather than anything about type ascriptions: the checked types of a node's inputs and outputs are discarded, so a constructor in the predicate of a refinement type written on an input is never rewritten into an ADT term. A type ascription reaches it because it is desugared into a generated node carrying the ascribed type on its input. Once that is in, the type-ascription site here is covered by that PR's tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

