### PR TITLE
Support functions with container-typed arguments in IC3IA

### DIFF
--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -134,7 +134,17 @@ let sys_def solver sys offset =
         Term.mk_not init_term_prev
       ]
    in
-   Term.mk_and (global_constraints sys @
+   (* Ground functional congruence instances over the two concrete offsets of
+      the transition query, enforcing determinism of (abstracted) functions
+      with container-typed arguments within the one-step window. Each is a
+      valid formula of the intended semantics, so conjoining them preserves
+      the over-approximation the frames rest on
+      (see [TransSys.fn_congruence_instances]). *)
+   let congruence =
+     TransSys.fn_congruence_instances sys Numeral.one
+     |> List.map (Term.bump_state (Numeral.pred offset))
+   in
+   Term.mk_and (global_constraints sys @ congruence @
      [Term.mk_or [init; trans]])
 
 let sys_def_unrolling solver sys offset =
@@ -404,27 +414,65 @@ let refine fwd solver sys predicates cubes =
 
   in
 
-  let interpolizers =
+  (* Ground functional congruence instances over the bounds of the concrete
+     unrolling; empty when no function of the system has container-typed
+     arguments. They are not asserted up front: a satisfiable answer stands
+     only if it satisfies all of them, so their conjunction is evaluated in
+     the model first, and exactly the instances the model violates are added
+     to the query before looking again
+     (see [TransSys.fn_congruence_instances]). *)
+  let congruence =
+    TransSys.fn_congruence_instances sys (Numeral.of_int (len - 2))
+  in
+
+  (* The interpolation partition must cover every assertion, so an instance
+     is conjoined into the interpolizer of the last bound it mentions rather
+     than asserted on its own. Sitting there, it lets an interpolant at an
+     earlier cut point mention the instance's earlier bound too; such
+     two-state atoms cannot serve as abstraction predicates and are filtered
+     out below. *)
+  let interpolizer_index inst =
+    match Term.var_offsets_of_term inst with
+    | _, Some mx -> Numeral.to_int mx
+    | _, None -> 0
+  in
+
+  let mk_interpolizers asserted =
+    let extras = Array.make len [] in
+    List.iter
+      (fun i ->
+        let g = interpolizer_index i in
+        extras.(g) <- i :: extras.(g))
+      asserted ;
     cubes
     |> List.mapi (fun i c ->
       let cube = Cube.to_term c |> Term.bump_state (Numeral.of_int (i - 1)) in
-      if i < (len - 1) then
-        Term.mk_and
-          [ cube; sys_def_unrolling intrpo sys (Numeral.of_int i) ]
-      else
-        cube
-      (* If prop is not in the set of initial predicates: *)
-      (*Term.mk_and
-        [ Cube.to_term c |> Term.bump_state (Numeral.of_int (i - 1));
-          if i < (len - 1) then
-            sys_def_unrolling intrpo sys (Numeral.of_int i)
-          else
-            Term.mk_not (prop |> Term.bump_state (Numeral.of_int (i - 1)))
-        ]*)
+      let base =
+        if i < (len - 1) then
+          Term.mk_and
+            [ cube; sys_def_unrolling intrpo sys (Numeral.of_int i) ]
+        else
+          cube
+        (* If prop is not in the set of initial predicates: *)
+        (*Term.mk_and
+          [ Cube.to_term c |> Term.bump_state (Numeral.of_int (i - 1));
+            if i < (len - 1) then
+              sys_def_unrolling intrpo sys (Numeral.of_int i)
+            else
+              Term.mk_not (prop |> Term.bump_state (Numeral.of_int (i - 1)))
+          ]*)
+      in
+      match extras.(i) with
+      | [] -> base
+      | l -> Term.mk_and (base :: l)
     )
   in
 
-  SMTSolver.push intrpo;  
+  let rec solve asserted =
+
+  let interpolizers = mk_interpolizers asserted in
+
+  SMTSolver.push intrpo;
 
   (* Compute the interpolants *)
   let names =
@@ -457,9 +505,28 @@ let refine fwd solver sys predicates cubes =
     | _ -> failwith ("Interpolating solver not found or unsupported")
   in
 
-  if SMTSolver.check_sat 
+  if SMTSolver.check_sat
       intrpo
   then (
+    (* A model of the unrolling represents a genuine counterexample only if
+       it satisfies determinism. The conjunction is asked first, one term
+       hence one query; only when it fails are the instances evaluated one
+       by one, to find exactly those the model violates. *)
+    let violated =
+      match congruence with
+      | [] -> []
+      | _ -> (
+        match SMTSolver.get_term_values intrpo [Term.mk_and congruence] with
+        | [(_, v)] when Term.equal v Term.t_false ->
+          SMTSolver.get_term_values intrpo congruence
+          |> List.filter_map (fun (i, v) ->
+               if Term.equal v Term.t_false then Some i else None)
+        | _ -> []
+      )
+    in
+
+    match violated with
+    | [] ->
     let cex_path =
       (* Use [get_var_values] rather than [get_model]: it retrieves the value
          of an array-typed variable by evaluating its elements one index at a
@@ -479,9 +546,17 @@ let refine fwd solver sys predicates cubes =
     in
 
     raise (Counterexample cex_path)
+
+    | _ ->
+      (* The path violates determinism of a function over containers: rule
+         it out and look again *)
+      SMTSolver.trace_comment intrpo
+        "Asserting the functional congruence instances the path violates." ;
+      SMTSolver.pop intrpo ;
+      solve (asserted @ violated)
   )
   else (
-    
+
     let interpolants =
       match Flags.Smt.itp_solver () with
       | `cvc5_QE
@@ -515,8 +590,40 @@ let refine fwd solver sys predicates cubes =
     |> Term.TermSet.elements
     |> List.iteri (fun i t -> Format.printf "ATOM%d: %a@." i Term.pp_print_term t);*)
 
-    add_predicates solver predicates atoms
+    (* A congruence instance spans two bounds, so once instances are in the
+       query an interpolant can too. The abstraction only supports
+       single-state predicates: keep the atoms over the cut point's own
+       bound (offset 0 after the bump above), and those over none. *)
+    let atoms =
+      if asserted = [] then atoms
+      else
+        TS.filter
+          (fun t ->
+            match Term.var_offsets_of_term t with
+            | Some lo, Some hi ->
+              Numeral.(equal lo zero) && Numeral.(equal hi zero)
+            | _ -> true)
+          atoms
+    in
+
+    let predicates' = add_predicates solver predicates atoms in
+
+    (* Every single-state atom of the interpolants is already a predicate:
+       the abstraction cannot make progress on this spurious path, which is
+       ruled out by determinism alone across bounds no single-state
+       predicate relates. Stop instead of looping on it forever. *)
+    if asserted <> [] && TS.cardinal predicates' = TS.cardinal predicates
+    then
+      raise (UnsupportedFeature
+        "IC3IA disabled: the functional congruence instances of a function \
+         with container-typed arguments leave no single-state predicate to \
+         refine the abstraction with.")
+    else
+      predicates'
   )
+
+  in
+  solve []
 
 
 let is_blocked solver frames s =
@@ -1073,24 +1180,11 @@ let main fwd slice_to_prop prop in_sys param sys =
     in
     raise (UnsupportedFeature msg) ) ;
 
-  (* Note: IC3IA does not assert the functional congruence instances that
-     enforce determinism of (abstracted) functions with container-typed
-     arguments (see [TransSys.fn_congruence_instances]); without them, the
-     counterexamples it finds for such systems may be spurious with respect
-     to the intended (deterministic) semantics. Today this is subsumed by
-     [has_fn_congruence_groups] check below. To support these systems, the
-     instances would have to be asserted in the solvers (bounds 0 and 1 for
-     the transition queries), and the implicit abstraction would have to
-     account for the difference witness functions the instances contain. *)
-  if TransSys.has_fn_congruence_groups sys then (
-    let msg =
-      Format.sprintf
-        "IC3IA disabled for property %s: system requires functional \
-         congruence instances for functions with container-typed arguments."
-        prop.Property.prop_name
-    in
-    raise (UnsupportedFeature msg)
-  ) ;
+  (* Note: the functional congruence instances that enforce determinism of
+     (abstracted) functions with container-typed arguments are part of the
+     transition queries ([sys_def]) and of the concrete unrolling that
+     validates counterexamples ([refine]), so these systems are supported
+     (see [TransSys.fn_congruence_instances]). *)
 
   let check_system_is_supported itp_solver =
     if TransSys.subsystem_includes_function_symbol sys then

--- a/src/ic3ia/IC3IA.ml
+++ b/src/ic3ia/IC3IA.ml
@@ -591,19 +591,25 @@ let refine fwd solver sys predicates cubes =
     |> List.iteri (fun i t -> Format.printf "ATOM%d: %a@." i Term.pp_print_term t);*)
 
     (* A congruence instance spans two bounds, so once instances are in the
-       query an interpolant can too. The abstraction only supports
-       single-state predicates: keep the atoms over the cut point's own
-       bound (offset 0 after the bump above), and those over none. *)
+       query an interpolant can too: sitting in the partition of its later
+       bound, an instance lets the interpolants of the cut points in between
+       mention its earlier bound as well. The abstraction only supports
+       single-state predicates, so an atom over two bounds is dropped; an
+       atom over one bound is a state predicate whichever bound that is,
+       and is kept once bumped to the cut point's own (offset 0 after the
+       bump above). Atoms over no bound are kept as they are. *)
     let atoms =
       if asserted = [] then atoms
       else
-        TS.filter
-          (fun t ->
+        TS.fold
+          (fun t acc ->
             match Term.var_offsets_of_term t with
-            | Some lo, Some hi ->
-              Numeral.(equal lo zero) && Numeral.(equal hi zero)
-            | _ -> true)
+            | Some lo, Some hi when Numeral.equal lo hi ->
+              TS.add (Term.bump_state (Numeral.neg lo) t) acc
+            | Some _, Some _ -> acc
+            | _ -> TS.add t acc)
           atoms
+          TS.empty
     in
 
     let predicates' = add_predicates solver predicates atoms in

--- a/tests/regression/success/ic3ia/declined/ic3ia_fn_congruence_recurrence.lus
+++ b/tests/regression/success/ic3ia/declined/ic3ia_fn_congruence_recurrence.lus
@@ -1,0 +1,19 @@
+-- A valid property that rests on determinism of a function over a container
+-- across two steps, with a different argument in between. The congruence
+-- instance that rules the spurious counterexample out relates two distant
+-- bounds, and no single-state predicate can stand in for it, so IC3IA's
+-- implicit abstraction cannot be refined for it: the engine turns the
+-- property down (and k-induction proves it at k=3). IC3IA must not claim it
+-- is falsifiable: reporting `unknown` is the expected outcome here.
+type Color = enum { Red, Green, Blue };
+
+function imported F(s: set<Color>) returns (out: int);
+
+node Top(b: bool) returns (r: int);
+var t: set<Color>; cnt: int;
+let
+  cnt = 0 -> pre cnt + 1;
+  t = if (cnt mod 2 = 0) then {Red, Green} else {Blue};
+  r = F(t);
+  check "fn of a recurring set" (cnt >= 2) => (r = pre (pre r));
+tel

--- a/tests/regression/success/ic3ia/declined/ic3ia_fn_congruence_recurrence.lus
+++ b/tests/regression/success/ic3ia/declined/ic3ia_fn_congruence_recurrence.lus
@@ -5,15 +5,18 @@
 -- implicit abstraction cannot be refined for it: the engine turns the
 -- property down (and k-induction proves it at k=3). IC3IA must not claim it
 -- is falsifiable: reporting `unknown` is the expected outcome here.
-type Color = enum { Red, Green, Blue };
-
-function imported F(s: set<Color>) returns (out: int);
+--
+-- The container is an array of integers on purpose: the harness pins
+-- MathSAT as the interpolating solver here, and MathSAT rejects the
+-- Bool-element arrays that sets and maps compile to before the refinement
+-- this test is about is ever reached.
+function imported F(a: int^2) returns (out: int);
 
 node Top(b: bool) returns (r: int);
-var t: set<Color>; cnt: int;
+var arr: int^2; cnt: int;
 let
   cnt = 0 -> pre cnt + 1;
-  t = if (cnt mod 2 = 0) then {Red, Green} else {Blue};
-  r = F(t);
-  check "fn of a recurring set" (cnt >= 2) => (r = pre (pre r));
+  arr[i] = if (cnt mod 2 = 0) then i else 5;
+  r = F(arr);
+  check "fn of a recurring array" (cnt >= 2) => (r = pre (pre r));
 tel

--- a/tests/regression/success/ic3ia/ic3ia_fn_container_determinism.lus
+++ b/tests/regression/success/ic3ia/ic3ia_fn_container_determinism.lus
@@ -1,0 +1,23 @@
+-- Determinism of an imported function with a container-typed argument.
+-- Containers compile to uninterpreted arrays constrained only at their
+-- canonical positions, so UF congruence alone cannot equate two containers
+-- holding the same elements; both properties hold only through the ground
+-- congruence instances, which IC3IA conjoins to its transition queries and
+-- to the concrete unrolling that validates counterexamples.
+function imported F(a: int^2) returns (out: int);
+
+node Top(b: bool) returns (r, q: int);
+var arr, brr: int^2;
+let
+  arr[i] = i;
+  brr[i] = if i >= 1 then 1 else 0;
+
+  r = F(arr);
+  q = F(brr);
+
+  check "imported fn is a function of a recurring array"
+    true -> (r = pre r);
+
+  check "imported fn agrees on structurally equal arrays"
+    r = q;
+tel


### PR DESCRIPTION
### Problem

Since #1424, functions with container-typed (set, map, or sized array) arguments are kept deterministic by ground congruence instances that the engines assert lazily. IC3IA did not assert them in its solvers, so its counterexamples for such systems could be spurious with respect to the intended semantics, and the engine turned these systems down wholesale:

```
IC3IA disabled for property P: system requires functional congruence
instances for functions with container-typed arguments.
```

The exclusion note left in `IC3IA.ml` laid out what support requires — the instances in the transition queries, the instances in the concrete unrolling, and an implicit abstraction that accounts for the difference witness functions they contain. This PR implements exactly that.

### Approach

**Transition queries: instances asserted eagerly.** `sys_def` conjoins the instances for the two concrete offsets of the query (`TransSys.fn_congruence_instances` at bounds 0–1, bumped), under the same activation literal as the system definition. Each instance is a valid formula of the intended semantics, so the over-approximation the frames rest on is preserved: every intended trace lifts to an abstract path satisfying them, UNSAT answers stay sound, and the invariants IC3IA reports remain sound for the engines that receive them (their solvers already declare the witness functions, which travel with the function symbols).

**Counterexample validation: the lazy refinement of the other engines.** In `refine`, a satisfiable unrolling stands only if the model satisfies determinism. The conjunction of the instances over the unrolling's bounds is evaluated first — one term, hence one `get-value` — and when it holds the counterexample is genuine and is reported with nothing asserted at all. When it fails, the instances are evaluated one by one and exactly the violated ones are added before looking again; the loop terminates because each round rules out the model that drove it and the instance set is finite.

A violated instance is conjoined into the interpolizer of the last bound it mentions rather than asserted on its own, so the interpolation partition keeps covering every assertion — which MathSAT's interpolation groups and SMTInterpol's named terms both need.

**Implicit abstraction: single-state predicates only.** An instance spans two bounds, so once instances are in the query an interpolant can span two bounds as well. Interpolant atoms are filtered to those over the cut point's own bound before becoming predicates. When that leaves nothing new — a spurious path ruled out by determinism alone, across bounds no single-state predicate relates — the engine declines with a warning instead of looping on the path forever:

```
IC3IA disabled: the functional congruence instances of a function with
container-typed arguments leave no single-state predicate to refine the
abstraction with.
```

That class is real: determinism at distance ≥ 2 with a different argument in between is beyond single-state predicate abstraction, and k-induction proves it (at k=3 in the new `declined` test, which pins that IC3IA must not call the property falsifiable). Solver traces confirm both the violated-instance rounds and the bail-out fire on that model.

### Results

- `two_phase_commit.lus` with `--enable IC3IA --smt_itp_solver SMTInterpol`: previously refused outright; now IC3IA alone proves SafetyAC1, SafetyAC4, and three of the checks within a 120s budget, the rest unknown, with no spurious answers.
- Determinism properties over containers that IC3IA can now settle: `imported fn deterministic over map` from `success/choose_container_determinism.lus` (valid, k=1), and both properties of the new `ic3ia_fn_container_determinism.lus` — a recurring `int^2` array and two structurally equal but differently built arrays — under MathSAT interpolation, matching the pinned configuration of the `ic3ia/` test directory.
- Genuine counterexamples still surface: the vacuity probe of `falsifiable/choose_container_determinism_sound.lus` is reported invalid, as is a fresh probe over a system with congruence groups whose model satisfies determinism.
- MathSAT still declines set/map models at refinement time — it does not support the Bool-element arrays they compile to; that is the existing arrays limitation (#1445), and the message already points at SMTInterpol.
- Regression suite: 485 passed (483 + the two tests added here); strict-profile build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
