### PR TITLE
Check the explicit type arguments of an ADT term

### DIFF
--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1663,6 +1663,13 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
     | _ -> type_error pos (MatchScrutineeNotADT scrut_ty)
     )
   | LA.ADTTerm (pos, ty_args, ctor, args) ->
+    (* Explicit type arguments are user-written, so they must be validated
+       before they are used to instantiate the constructor's field types *)
+    let* ty_args, warnings0 =
+      R.seq (List.map (check_type_well_formed ctx Local nname false) ty_args)
+      |> R.map List.split
+    in
+    let warnings0 = List.flatten warnings0 in
     (match lookup_constructor ctx ctor with
     | None -> type_error pos (UnboundConstructor ctor)
     | Some (ty_name, field_tys) ->
@@ -1705,7 +1712,7 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
           check_type_expr ctx nname arg ft
         ) args field_tys) in
         let checked_args, warnings = List.split pairs in
-        R.ok (LA.UserType (pos, ty_args, ty_name), LA.ADTTerm (pos, ty_args, ctor, checked_args), List.flatten warnings)
+        R.ok (LA.UserType (pos, ty_args, ty_name), LA.ADTTerm (pos, ty_args, ctor, checked_args), warnings0 @ List.flatten warnings)
     )
   | LA.AbstractSymConst (_, ty) -> R.ok (ty, e, [])
 (** Infer the type of a [LA.expr] with the types of free variables given in [tc_context] *)

--- a/tests/ounit/lustre/lustreTypeChecker/adt_undeclared_type_arg.lus
+++ b/tests/ounit/lustre/lustreTypeChecker/adt_undeclared_type_arg.lus
@@ -1,0 +1,8 @@
+datatype Option<T> = Some (value: T) | None;
+
+node N() returns (r: bool);
+var o: Option<int>;
+let
+  o = None@<Nat>;
+  r = None?(o);
+tel

--- a/tests/ounit/lustre/testLustreFrontend.ml
+++ b/tests/ounit/lustre/testLustreFrontend.ml
@@ -907,6 +907,10 @@ let _ = run_test_tt_main ("frontend LustreTypeChecker error tests" >::: [
     match load_file "./lustreTypeChecker/adt_undeclared_constructor_arg_type.lus" with
     | Error (`LustreTypeCheckerError (_, UndeclaredType _)) -> true
     | _ -> false);
+  mk_test "test undeclared type argument of ADT constructor" (fun () ->
+    match load_file "./lustreTypeChecker/adt_undeclared_type_arg.lus" with
+    | Error (`LustreTypeCheckerError (_, UndeclaredType _)) -> true
+    | _ -> false);
   mk_test "test non-well-founded ADT (every constructor has a recursive field)" (fun () ->
     match load_file "./lustreTypeChecker/adt_non_well_founded.lus" with
     | Error (`LustreTypeCheckerError (_, NonWellFoundedDatatype _)) -> true


### PR DESCRIPTION
An ADT term can carry explicit type arguments that instantiate a polymorphic datatype, as in `None@<int>`. The type checker never looked at them: `infer_type_expr` went straight to `lookup_constructor` and used the arguments as written to substitute into the constructor's field types. Nothing established they were types at all.

An undeclared name therefore passed type checking and reached ADT desugaring, which builds a junk payload value for every constructor the term does not select. Producing that value expands the field type as a type synonym, gets the same unknown `UserType` back, and asserts:

```lustre
datatype Option<T> = Some (value: T) | None;
...
  o = None@<Nat>;   -- Nat is not declared anywhere
```

```
Error opening input file 'model.lus':
        File "src/lustre/lustreDesugarADTs.ml", line 270, characters 23-29: Assertion failed
```

## Fix

Validate the arguments with `check_type_well_formed` before they are used, the way the annotations on `{}@<T>` and `[]@<K,V>` already are, and thread the resulting warnings through. The `Local`, non-constant setting is the least restrictive one that still rejects an undeclared type, so no program that was accepted before is rejected now.

The example above now stops at the front end with its position:

```
Error Parser error at model.lus:6:13: Type 'Nat' is undeclared
```

## Testing

New front-end test `adt_undeclared_type_arg.lus`, next to the existing `adt_undeclared_constructor_arg_type.lus`, pinning `UndeclaredType` for a type argument rather than a constructor field.

Full regression suite passes (485), `make check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
