### PR TITLE
Look up global constant bounds in the global table

### DIFF
--- a/src/lustre/lustreNodeGen.ml
+++ b/src/lustre/lustreNodeGen.ml
@@ -1313,7 +1313,14 @@ and compile_ast_expr
            drop the leading ones and keep the [List.length idx_tys] bounds that
            correspond to [e1]'s own remaining dimensions. *)
         let bounds =
-          let all_bounds = SVT.find !map.bounds sv in
+          let all_bounds =
+            try SVT.find !map.bounds sv with
+            | Not_found ->
+              (* A global free constant is compiled with the map of the
+                 declaration it appears in, not with the map of the node that
+                 uses it, so its bounds are only in the global table. *)
+              SVT.find cstate.state_var_bounds sv
+          in
           let drop = List.length all_bounds - List.length idx_tys in
           if drop > 0 then snd (list_split drop all_bounds) else all_bounds
         in

--- a/tests/regression/success/global_const_set_map_equality.lus
+++ b/tests/regression/success/global_const_set_map_equality.lus
@@ -1,0 +1,12 @@
+const R : set<int>;
+const M : map<int, int>;
+const A : int^3;
+
+node N () returns ()
+let
+  check "empty_has_no_member" (R = {}@<int>) => not (0 in R);
+  check "member_implies_nonempty" (0 in R) => (R <> {}@<int>);
+  check "set_self_equality" R = R;
+  check "map_self_equality" M = M;
+  check "array_self_equality" A = A;
+tel


### PR DESCRIPTION
Comparing a global free constant of container type for equality crashed the frontend:

```lustre
const R : set<int>;
node N() returns (x: bool);
let
  x = (R = {}@<int>);
  check "p" x => x;
tel
```

```
<Error> Error opening input file 'bug.lus': Not_found
```

## Cause

`compile_equality` reads the array/set/map bounds of a state variable from `!map.bounds`, the identifier map of the node being compiled. A global free constant is compiled by `compile_const_decl` with the map of its own declaration, and its bounds are only copied into the global `cstate.state_var_bounds` table. The lookup therefore raised `Not_found`, which propagated all the way to the input-reading handler and was reported as a file error.

## Fix

Fall back to the global table when the state variable is not in the node's map. This covers global free constants of set, map, and array type alike — all three hit the same crash.

## Testing

- The example above now proves `p` valid.
- Semantics check out: `(R = {}@<int>) => not (0 in R)` and `(0 in R) => R <> {}@<int>` are both valid, while `R = {}@<int>` on its own is correctly falsifiable.
- Added `tests/regression/success/global_const_set_map_equality.lus`, confirmed to reproduce the `Not_found` crash with the fix reverted.
- Full regression suite: 486 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)