### PR TITLE
Report a bad set element or map key instead of crashing

### DIFF
--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1372,8 +1372,8 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
               (let* e_ty, e, warnings3 = infer_type_expr ctx nname (Option.get e) in
                 R.ifM (eq_lustre_type ctx e_ty vt)
                   (R.ok (ue_ty', LA.StructUpdate (pos, ue, [LA.MapIndex (p, idx_e)], Some e), warnings1 @ warnings2 @ warnings3))
-                  (type_error pos (ExpectedType (e_ty, vt))))
-              (type_error pos (ExpectedType (index_type, kt)))
+                  (type_error pos (ExpectedType (vt, e_ty))))
+              (type_error pos (ExpectedType (kt, index_type)))
           )
          | _ -> type_error pos (IlltypedUpdateWithIndex ue_ty))
       | LA.SetIndex (p, idx_e) ->
@@ -1385,7 +1385,7 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
             let* index_type = expand_type_syn_reftype_history ctx index_type in
             R.ifM (eq_lustre_type ctx index_type kt)
               (R.ok (ue_ty', LA.StructUpdate (pos, ue, [LA.SetIndex (p, idx_e)], None), warnings1 @ warnings2))
-              (type_error pos (ExpectedType (index_type, kt)))
+              (type_error pos (ExpectedType (kt, index_type)))
           )
          | _ -> type_error pos (IlltypedUpdateWithIndex ue_ty))
 

--- a/src/lustre/lustreTypeChecker.ml
+++ b/src/lustre/lustreTypeChecker.ml
@@ -1089,10 +1089,16 @@ and infer_type_expr: tc_context -> NI.t option -> LA.expr -> (tc_type * LA.expr 
   | LA.StructUpdate (pos, (EmptyMap (_, None) as e1), [MapIndex (p2, e2)], Some e3) ->
     let* ty1, e2, warnings1 = infer_type_expr ctx nname e2 in 
     let* ty2, e3, warnings2 = infer_type_expr ctx nname e3 in 
+    (* The key type of a map literal is inferred rather than written down, so
+       it has not been through the check a declared one gets *)
+    let* _ = check_map_set_key_expr_type ctx (LH.pos_of_expr e2) ty1 in
     let e = LA.StructUpdate (pos, e1, [MapIndex (p2, e2)], Some e3) in 
     R.ok (LA.Map (pos, ty1, ty2), e, warnings1 @ warnings2)
   | LA.StructUpdate (pos, (EmptySet (_, None) as e1), [SetIndex (p2, e2)], None) ->
     let* ty, e2, warnings = infer_type_expr ctx nname e2 in 
+    (* The element type of a set literal is inferred rather than written down,
+       so it has not been through the check a declared one gets *)
+    let* _ = check_map_set_key_expr_type ctx (LH.pos_of_expr e2) ty in
     let e = LA.StructUpdate (pos, e1, [SetIndex (p2, e2)], None) in
     R.ok (LA.Set (pos, ty), e, warnings)
   (* only reachable through previous 2 cases *)
@@ -2933,6 +2939,19 @@ and check_ref_type_assumptions ctx src nname bound_var e =
     | h :: _ -> (type_error (LH.pos_of_expr e) (AssumptionOnCurrentOutput h)) 
   )
   | Output | Local | Ghost | Global -> R.ok ()
+
+(* Check that the inferred type of an expression used as a set element or a map
+   key is a legal one. An expression list is singled out because a user reaching
+   for a tuple is the way one shows up here, and the type of a list prints just
+   like the tuple that was meant. *)
+and check_map_set_key_expr_type ctx pos ty =
+  match ty with
+  | LA.GroupType _ ->
+    type_error pos
+      (Unsupported "A set element or a map key must be a single expression, \
+                    not a list of them; a tuple is written '(e1, e2) rather \
+                    than (e1, e2)")
+  | _ -> check_map_set_type pos ctx ty
 
 and check_map_set_type pos ctx ty = let r = check_map_set_type pos ctx in match ty with  
 | LA.Map _ | Set _ | GroupType _ | ArrayType _ | History _ 

--- a/tests/regression/error/map_literal_expression_list_key.lus
+++ b/tests/regression/error/map_literal_expression_list_key.lus
@@ -1,0 +1,6 @@
+(* Same as set_literal_expression_list_element, for the key of a map literal. *)
+node N() returns (ok: bool);
+let
+  ok = true;
+  check map[ (1, true) := 3 ] = map[ (1, true) := 3 ];
+tel

--- a/tests/regression/error/set_literal_container_element.lus
+++ b/tests/regression/error/set_literal_container_element.lus
@@ -1,0 +1,8 @@
+(* A set cannot hold sets, maps, or arrays; the element type of a set literal
+   is inferred rather than written down, so this used to crash the frontend
+   instead of being reported. *)
+node N(s: set<int>) returns (ok: bool);
+let
+  ok = true;
+  check { s } = { s };
+tel

--- a/tests/regression/error/set_literal_expression_list_element.lus
+++ b/tests/regression/error/set_literal_expression_list_element.lus
@@ -1,0 +1,9 @@
+(* `(1, true)` is an expression list, not a tuple -- a tuple literal is written
+   `'(1, true)`. The element type of a set literal is inferred rather than
+   written down, so it used to skip the check a declared one gets, and the
+   frontend crashed later instead of reporting the error. *)
+node N() returns (ok: bool);
+let
+  ok = true;
+  check { (1, true) } = { (1, true) };
+tel

--- a/tests/regression/error/set_literal_mismatched_element.lus
+++ b/tests/regression/error/set_literal_mismatched_element.lus
@@ -1,0 +1,7 @@
+(* The set's element type comes from the first element, so `1` is what the
+   second element is expected to match, not the other way round. *)
+node N() returns (ok: bool);
+let
+  ok = true;
+  check { 1, '(1, true) } = { 1 };
+tel

--- a/tests/regression/success/set_tuple_literal.lus
+++ b/tests/regression/success/set_tuple_literal.lus
@@ -1,0 +1,9 @@
+(* A tuple set element is written with the tuple literal syntax `'(...)` *)
+node N(s: set<[int, bool]>) returns (ok: bool);
+let
+  ok = true;
+  check "member" '(1, true) in { '(1, true), '(2, false) };
+  check "non member" not ('(3, true) in { '(1, true), '(2, false) });
+  check "equality" { '(1, true), '(2, false) } = { '(2, false), '(1, true) };
+  check "insertion" forall (p: [int, bool]) (p in s) => (p in s + { '(0, false) });
+tel


### PR DESCRIPTION
Set and map literals crashed the frontend whenever their element (resp. key) type was not a legal one:

```lustre
node N() returns (ok: bool);
let ok = true; check {(1, true)} = {(1, true)}; tel
```

```
<Error> Error opening input file 'bug.lus':
        File "src/lustre/lustreAstNormalizer.ml", line 109, characters 4-10: Assertion failed
```

Not just tuples — a set of a set (`{s}`), a set of an array (`{a}`), a set over a multiple-output node call (`{F(x)}`), and the same four cases for a map key (`map[(1, true) := 3]`) all crashed identically.

## Cause

The element type of a set literal and the key type of a map literal are inferred from the first element (`infer_type_expr`, `src/lustre/lustreTypeChecker.ml:1109`), and that path never ran `check_map_set_type` — the check a written-down `set<...>` or `map<...>` type goes through in `check_type_well_formed`. An illegal element type therefore passed type checking.

`LustreAstNormalizer` then annotates the literal with the inferred type (`src/lustre/lustreAstNormalizer.ml:2611`) and asks the type checker about it again. That second question goes through `EmptySet (_, Some ty)`, which *does* check — and the normalizer can only turn the resulting error into an assertion failure.

## Fix

Check the inferred type where it is inferred, for both literal forms.

An expression list gets its own message rather than falling into `UnsupportedMapType`. `(1, true)` is a list, not a tuple — a tuple literal is written `'(1, true)` — and the type of a list prints exactly like the tuple that was meant, so `UnsupportedMapType` would name `(int, bool)` and then go on to list tuples among the types it supports.

A second commit, separable from the fix, corrects the argument order of three `ExpectedType` errors in the same arms. It takes the expected type first and the actual one second, as its message ("Expected type ... but found type ...") and its other uses have it, so `{ 1, '(1, true) }` reported

```
Expected type [int, bool] but found type int
```

naming as expected the very type it had just rejected. The element type comes from the first element, so `int` is what the second one had to match.

## Testing

- All eight crashing cases above now report a type error; each was confirmed to crash before the fix.
- Added four `tests/regression/error/` cases (expression-list element, container element, expression-list map key, mismatched element type) and `tests/regression/success/set_tuple_literal.lus`, which pins that `'(...)` tuple elements keep working through membership, equality, and insertion.
- Full test suite (`make test`) after merging current main: 619 passed. Two unrelated ADT tests (`msg_enc_commutative.lus`, `invgen_adt_selector.lus`) ran out of time, which the runner does not count as a failure, and they do the same on main without this change. OUnit suites clean, strict build clean.
- A set or map literal whose element is a recursive ADT, such as `{Cons(i, Nil)}` or `map[Cons(i, Nil) := 3]`, is still accepted and verified. The check added here goes through `check_map_set_type`, which main now guards against infinite recursion on recursive ADTs.

## Update after merging main

Merged current main. The only conflict was in `lustreTypeChecker.ml`: main rewrote `check_map_set_type` to stop it recursing forever on recursive ADTs, and this PR adds `check_map_set_key_expr_type` just above it. The resolution keeps both unchanged. Main does not fix the crash itself: all eight cases above still fail with the `lustreAstNormalizer.ml` assertion there, and the `ExpectedType` arguments are still reversed.

## Note

`map[1 := (1, true)]` — an expression list in the *value* position — stays accepted. It behaves correctly within an expression (reads back, membership, and equality all work, and `map[1 := (1, true)] = map[1 := (2, true)]` is correctly falsifiable), but its value type cannot be written down, so such a map can never be bound to a variable, passed to a node, or unified with the tuple-valued map that was meant. Tightening it is a separate decision from this crash, so it is left alone here and tracked in #1543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


