### PR TITLE
Run the engines the machine can carry, and no more

### DIFF
--- a/src/flags.ml
+++ b/src/flags.ml
@@ -3354,7 +3354,10 @@ module Global = struct
 
      Zero asks the runtime what the machine can carry, which is what
      nearly every run should use: it is a ceiling rather than a target,
-     so it changes nothing where the engines already fit. *)
+     so it changes nothing where the engines already fit. It only asks
+     on Windows, since that is the only platform measured to collapse
+     rather than merely slow down, and limiting costs proofs. Give a
+     number to have the limit anywhere. *)
   let max_engines_default = 0
   let max_engines = ref max_engines_default
   let _ = add_specs ([
@@ -3363,7 +3366,8 @@ module Global = struct
       fun fmt ->
         Format.fprintf fmt
           "\
-            Maximum number of engines running at once (0 to suit the machine)@ \
+            Maximum number of engines running at once@ \
+            0 suits the machine, which limits on Windows and nowhere else@ \
             Engines beyond the limit are not run, dropping the last of@ \
             \"--enable\" first, so the ones that decide properties are kept@ \
             Default: %d\

--- a/src/flags.ml
+++ b/src/flags.ml
@@ -3342,6 +3342,37 @@ module Global = struct
   ])
   let timeout_analysis () = !timeout_analysis
 
+
+  (* How many engines may run at once.
+
+     Every engine is a domain of its own and holds solver processes of
+     its own, so an analysis of the default ten engines puts some forty
+     runnable things on the machine. Where that is well beyond what the
+     machine has, they do not share it, they thrash: on a four core
+     runner the process was descheduled for 95% of the wall clock and
+     failed to reach a counterexample that two engines find in a second.
+
+     Zero asks the runtime what the machine can carry, which is what
+     nearly every run should use: it is a ceiling rather than a target,
+     so it changes nothing where the engines already fit. *)
+  let max_engines_default = 0
+  let max_engines = ref max_engines_default
+  let _ = add_specs ([
+    ( "--max_engines",
+      Arg.Set_int max_engines,
+      fun fmt ->
+        Format.fprintf fmt
+          "\
+            Maximum number of engines running at once (0 to suit the machine)@ \
+            Engines beyond the limit are not run, dropping the last of@ \
+            \"--enable\" first, so the ones that decide properties are kept@ \
+            Default: %d\
+          "
+          max_engines_default
+    )
+  ])
+  let max_engines () = !max_engines
+
   (* Only parse mode. *)
   let only_parse_default = false
   let only_parse = ref only_parse_default
@@ -3877,6 +3908,7 @@ let input_format = Global.input_format
 let real_precision = Global.real_precision
 let timeout_wall = Global.timeout_wall
 let timeout_analysis = Global.timeout_analysis
+let max_engines = Global.max_engines
 let input_file = Global.input_file
 let all_input_files = Global.get_all_input_files
 let clear_input_files = Global.clear_input_files

--- a/src/flags.mli
+++ b/src/flags.mli
@@ -215,6 +215,9 @@ val timeout_wall : unit -> float
 (** Per-run wallclock timeout. *)
 val timeout_analysis : unit -> float
 
+(** Maximum number of engines to run at once, 0 to suit the machine. *)
+val max_engines : unit -> int
+
 (** The Kind modules enabled is a list of [kind_module]s. *)
 type enable = Lib.kind_module list
 

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -737,11 +737,23 @@ let run_process in_sys param sys messaging_setup process =
 
    The runtime's own count is what the machine can carry; the supervisor
    is one of them. Never below two, so that there is always more than
-   one engine on any machine that runs Kind 2 at all. *)
+   one engine on any machine that runs Kind 2 at all.
+
+   By default only on Windows, because only there does the crowd
+   collapse. The same ten engines and thirty solvers pinned to a single
+   Linux core stall not at all and finish in 8.3s: a scheduler that
+   shares the machine proportionally gets the missing domain to the
+   rendezvous, and everything is merely slow. Limiting is not free --
+   forced to three where a machine did not need it, the regression suite
+   takes 211s instead of 35s and one test falls from proved to timed out
+   -- so a platform that does not have the problem should not pay for
+   it. The flag is there on all of them for anyone who wants the limit
+   anyway, on a shared machine or a small one. *)
 let max_engines () =
   match Flags.max_engines () with
   | n when n > 0 -> n
-  | _ -> max 2 (Domain.recommended_domain_count () - 1)
+  | _ when Sys.win32 -> max 2 (Domain.recommended_domain_count () - 1)
+  | _ -> max_int
 
 (* Whether an engine generates invariants, and over which values. *)
 let generator_domain = function

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -725,6 +725,110 @@ let run_process in_sys param sys messaging_setup process =
   |> spawn_process in_sys param
 
 
+(* Engines to run at once, at most.
+
+   Every engine is a domain of its own, and each holds solver processes
+   of its own: the default ten put some forty runnable things on the
+   machine. Where that is well beyond what the machine has they do not
+   share it, they thrash. Measured on a four core runner, an analysis of
+   the whole set was descheduled for 95% of its wall clock and did not
+   reach a counterexample that two engines find in a second, while the
+   same test under this limit stalled not at all and answered in one.
+
+   The runtime's own count is what the machine can carry; the supervisor
+   is one of them. Never below two, so that there is always more than
+   one engine on any machine that runs Kind 2 at all. *)
+let max_engines () =
+  match Flags.max_engines () with
+  | n when n > 0 -> n
+  | _ -> max 2 (Domain.recommended_domain_count () - 1)
+
+(* Whether an engine generates invariants, and over which values. *)
+let generator_domain = function
+  | `INVGEN | `INVGENOS -> Some `Bool
+  | `INVGENINT | `INVGENINTOS -> Some `Int
+  | `INVGENREAL | `INVGENREALOS -> Some `Real
+  | `INVGENMACH | `INVGENMACHOS
+  | `INVGENBV _ | `INVGENBVOS _
+  | `INVGENUBV _ | `INVGENUBVOS _ -> Some `Machine
+  | _ -> None
+
+(* Whether an engine can generate anything for this system.
+
+   An invariant generator works over one kind of value, and there is one
+   of them per kind: a system with no reals in it gets nothing from the
+   generator over reals, whatever else it gets. So when there is not
+   room for them all, the ones whose values the system does not use go
+   first -- otherwise which generator survives is decided by the order
+   of [--enable], which knows nothing about the system.
+
+   Only asked of a system whose logic was inferred. Where it was given
+   rather than inferred, nothing here can tell, and none is demoted. *)
+let generates_something_for sys m =
+  match generator_domain m with
+  | None -> true
+  | Some domain ->
+    match TSys.get_logic sys with
+    | `Inferred fs ->
+      let has f = TermLib.FeatureSet.mem f fs in
+      ( match domain with
+        | `Bool -> true            (* every Lustre system has booleans *)
+        | `Int -> has TermLib.IA
+        | `Real -> has TermLib.RA
+        | `Machine -> has TermLib.BV )
+    | `None | `SMTLogic _ -> true
+
+(* The order engines are given up in when the machine cannot carry them
+   all, most worth keeping first.
+
+   Not the order of [--enable], which puts IND2 third. IND2 earns its
+   keep from the invariants another engine generates, so it goes after
+   the first generator that can generate something here, and a prefix
+   too short to reach one is better spent on an engine that decides
+   properties by itself. What a machine that can carry only three should
+   run is BMC, k-induction and IC3QE. *)
+let core_rank = function
+  | `BMC -> 0
+  | `IND -> 1
+  | `IC3 | `IC3QE -> 2
+  | `BMCSKIP -> 3
+  | `IC3IA -> 4
+  | _ -> 5
+
+let is_core m = core_rank m < 5
+
+(* Keep the engines a machine can carry, and say which were left out. *)
+let cap_engines_to_machine sys modules =
+  let cap = max_engines () in
+  if List.length modules <= cap then modules
+  else (
+    let core, rest = List.partition is_core modules in
+    let core =
+      List.stable_sort (fun a b -> compare (core_rank a) (core_rank b)) core
+    in
+    let generators, rest =
+      List.partition (fun m -> generator_domain m <> None) rest
+    in
+    let useful, idle =
+      List.partition (generates_something_for sys) generators
+    in
+    let ind2, others = List.partition (fun m -> m = `IND2) rest in
+    let ordered =
+      match useful with
+      | first :: more -> core @ (first :: ind2) @ more @ idle @ others
+      | [] -> core @ ind2 @ idle @ others
+    in
+    let kept, dropped = list_split cap ordered in
+    KEvent.log L_note
+      "@[<hov>Running %d of %d engines at once, which is what this machine \
+       carries.@ Not run:@ %a.@ Use `--max_engines` to ask for more.@]"
+      cap (List.length modules)
+      (pp_print_list pp_print_kind_module ",@ ") dropped ;
+    (* Back in the order they were given, so nothing downstream sees the
+       ranking *)
+    List.filter (fun m -> List.mem m kept) modules
+  )
+
 let create_processes slice_to_prop modules sys =
   let ic3ia_module, other_modules = modules |> List.partition (
     function `IC3IA -> true | _ -> false)
@@ -859,6 +963,8 @@ let analyze msg_setup save_results ignore_props stop_if_falsified slice_to_prop 
         query with a lower bound *)
       let modules = process_bmc_modules sys modules in
       let modules = process_ic3_modules modules in
+      (* Last, so that the count is of the engines that would really run *)
+      let modules = cap_engines_to_machine sys modules in
 
       let to_run, pending = create_processes slice_to_prop modules sys in
 


### PR DESCRIPTION
Fixes the Windows CI failures of #1449, and the reason behind them.

## What goes wrong

An analysis starts an engine per enabled module, each a domain of its own, and nothing asks how many the machine has. The default is ten. On a four-core Windows runner that does not run slowly, it collapses:

- 95% of the wall clock spent making no progress
- 227s against a `--timeout` of 20s, and runs killed by the harness at 204s
- **the run fails to reach a counterexample that BMC alone finds in one second** — it loses answers, not just time

## Why, measured

It is not the machine running short of CPU. During a stall Kind 2 holds all four cores across ~29 threads while the solvers it is waiting on accrue nothing:

```
stall of 44.2s: Kind 2 165.33s CPU (3.7 cores) across 29 threads,
                its 32 solvers 2.64s (0.1 cores)
```

Threads that are all runnable and producing no solver work are spinning, not working. Domains that cannot all be scheduled cannot all reach a stop-the-world rendezvous, and the ones that are scheduled spin holding the cores the missing ones need.

Sweeping the limit on that runner puts the threshold exactly where that account predicts — where the engines plus the supervisor stop fitting on the cores:

| engines | 3 | 4 | 5 | 6 | unbounded |
|---|---|---|---|---|---|
| stalled | **0%, 0%** | 0%, 58% | 33%, 26% | 75%, 59% | 96%, 78% |

That is why the count is the runtime's own, less one for the supervisor. It is a ceiling and not a target: where the engines already fit, which is every machine of any size, nothing changes.

## Why the limit applies by default on Windows only

Limiting is not free: forced to three where a machine did not need it, the regression suite takes 211s instead of 35s and one test falls from proved to timed out. The runners CI uses are small enough that an unconditional limit would engage on all three platforms, so this matters.

It is not about size. The same unlimited run on the runners themselves, three times each:

| platform | CPUs | share of each run stalled | exit | wall |
|---|---|---|---|---|
| macOS arm64 | **3** | 0%, 0%, 0% | 40 | 5s, 5s, 6s |
| Linux | 4 | 0%, 0%, 0% | 40 | 5s, 4s, 4s |
| Windows | 4 | **92%, 51%, 36%** | **30** | 61s, 31s, 25s |

macOS has *fewer* cores than Windows and does not stall at all, and both it and Linux reach the counterexample uncapped in seconds — which is exactly what a limit would take from them. What differs is the scheduler: where the machine is shared proportionally, the domain that is late to the rendezvous arrives and the others merely wait.

So the default limits on Windows and nowhere else. `--max_engines` is available on every platform for anyone who wants the limit anyway, on a shared machine or a small one.

## Which engines go, when they must

The order of `--enable` is not the order to give them up in. Two rules, both about what an engine is worth when there is no room for it.

**An engine that decides properties by itself outranks one that helps another engine decide them.** So the shortest prefix is BMC, k-induction and IC3QE, and IND2 — which earns its keep from invariants another engine generates — goes after the first generator rather than third.

**An invariant generator works over one kind of value, and there is one of them per kind.** A system with no reals in it gets nothing whatever from the generator over reals. So ask the inferred logic which kinds the system uses — the way `process_invgen_mach_modules` already asks it about machine integers — and let the ones with nothing to generate go first. Otherwise which generator survives is settled by the order of `--enable`, which knows nothing about the system.

`--max_engines` overrides the count for anyone whose machine is not what the runtime thinks.

## Validation

| | without | with |
|---|---|---|
| runs hung and killed | 3 of 6 | **0 of 6** |
| stall share | 76–98% | **0% every run** |
| wall clock | 28s–285s | **1–2s** |
| exit code | 30, or killed | **40 — the counterexample** |

(Windows runner, six runs each way.)

- The limit chosen on that runner was `Running 3 of 9 engines at once`.
- Given a system over integers the generator over reals goes first, and given one over reals the generator over integers does. Before this change both dropped the same one.
- On a twenty-core machine the limit does not engage: 482 regression tests unchanged, 36.2s against 35.8s. Forced to three there they still all pass, in 211s, with one test falling from proved to timed out — the cost of the limit where the machine did not need it, and the reason the default suits the machine rather than being a number.
- The strict profile builds clean.

## Worth knowing

- This is a mitigation for a livelock in the runtime's rendezvous under oversubscription, not a cure for it. It keeps Kind 2 below the point where its own domains fight each other.
- The workaround in #1451 can come out once this lands, and #1449 closed with it.
- Not addressed here, and arguably a bug of its own: a system with no integers still *runs* an integer invariant generator when there is room for it. This change orders those last under a limit but does not stop them running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

