### PR TITLE
Let the wall clock have the last word on Windows

### DIFF
--- a/scripts/gen-linking-flags.sh
+++ b/scripts/gen-linking-flags.sh
@@ -18,7 +18,12 @@ case "$LINKING_MODE" in
                 FLAGS="-noautolink"
                 NAT=$(echo $OCAML_VERSION | awk -F. '{print ($1 <= 4 || ($1 == 5 && $2 == 0)) ? "" : "nat"}')
                 PTHREAD=$(echo $OCAML_VERSION | awk -F. '{print ($1 <= 4) ? "-lpthread" : ""}')
-                CCLIB="-lthreadsnat -lunix$NAT -lcamlstr$NAT -lnums $PTHREAD";;
+                # -noautolink means every C stub archive has to be named
+                # here. kind2dev_stubs is ours; the rest belong to the
+                # libraries it uses. A stub added to `foreign_stubs`
+                # without a line here fails only in a static build, which
+                # no pull request runs.
+                CCLIB="-lkind2dev_stubs -lthreadsnat -lunix$NAT -lcamlstr$NAT -lnums $PTHREAD";;
             *)
                 echo "No known static compilation flags for '$OS'" >&2
                 exit 1

--- a/src/dune
+++ b/src/dune
@@ -21,6 +21,7 @@
 
 (library
  (name kind2dev)
+ (foreign_stubs (language c) (names kind2_stubs))
  (libraries dune-build-info num str threads yojson menhirLib)
  (modules
   (:standard \ C2Icnf kind2 moxi))

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -136,6 +136,25 @@ let setup : unit -> any_input = fun () ->
   (* Set sigalrm handler. *)
   Signals.set_sigalrm_timeout_from_flag () ;
 
+  (* On Windows there is no SIGALRM, and the wall clock is looked at
+     only in the polling loop of the supervisor. That is enough while
+     the supervisor runs, and on a machine with fewer cores than there
+     are busy engines it stops running: every domain parks in a
+     stop-the-world rendezvous none of them can complete, no OCaml code
+     executes anywhere, and the run goes minutes past the time it was
+     given. Measured on a four core runner, a run given 20s took 227s.
+
+     So the last word on the wall clock there belongs to a thread the
+     operating system schedules, which the runtime cannot stop. It is a
+     backstop and not the timeout: a generous grace on top, so that it
+     only ever fires on a run that has already failed to stop itself. *)
+  ( if Sys.win32 then
+      match Flags.timeout_wall () with
+      | timeout when timeout > 0. ->
+        NativeTimeout.arm
+          (int_of_float timeout + 60) ExitCodes.incomplete_analysis
+      | _ -> () ) ;
+
   (* Install generic signal handlers for other signals. *)
   Signals.set_sigint () ;
   (* SIGPIPE is ignored, not turned into an exception: signal handlers

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -167,8 +167,19 @@ let setup : unit -> any_input = fun () ->
   ( if Sys.win32 then
       match Flags.timeout_wall () with
       | timeout when timeout > 0. ->
-        NativeTimeout.arm
-          (int_of_float timeout + 30) ExitCodes.incomplete_analysis
+        (* A count of seconds the other side can hold. It reaches a
+           thirty-two bit count of milliseconds, and it comes from a
+           float the user chose: [--timeout inf] converts to zero, which
+           would arm the backstop at the grace alone and kill a run that
+           asked for no limit, and a large enough value wraps the
+           multiplication instead. Anything past the ceiling is a run
+           that means to go on indefinitely, and the backstop simply
+           does not arm for it. *)
+        let ceiling = 1_000_000. in
+        if Float.is_nan timeout || timeout > ceiling then ()
+        else
+          NativeTimeout.arm
+            (int_of_float timeout + 30) ExitCodes.incomplete_analysis
       | _ -> () ) ;
 
   (* Install generic signal handlers for other signals. *)

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -145,14 +145,30 @@ let setup : unit -> any_input = fun () ->
      given. Measured on a four core runner, a run given 20s took 227s.
 
      So the last word on the wall clock there belongs to a thread the
-     operating system schedules, which the runtime cannot stop. It is a
-     backstop and not the timeout: a generous grace on top, so that it
-     only ever fires on a run that has already failed to stop itself. *)
+     operating system schedules, which the runtime cannot stop.
+
+     It is a backstop and not the timeout. Windows has the ordinary path
+     too -- the polling loop notices the clock and raises [TimeoutWall],
+     which unwinds through the exit path and reports what was proved,
+     the same as SIGALRM does elsewhere -- and that path works on every
+     run whose supervisor is running, which is every healthy one. The
+     grace is how long to wait for it before concluding it will not
+     come. Measured on a four core runner, a healthy run finishes about
+     ten seconds past its timeout: the polling loop looks at the clock
+     once an iteration, and the teardown prints what it found. Thirty is
+     three times that.
+
+     Not less, and never zero. This ends the process rather than
+     unwinding it, so it forfeits the results and forces its own status
+     -- fire it while an orderly teardown is still running and a run
+     that had disproved a property would report an incomplete analysis
+     instead. The grace is the width of that window, and it is worth
+     being generous with. *)
   ( if Sys.win32 then
       match Flags.timeout_wall () with
       | timeout when timeout > 0. ->
         NativeTimeout.arm
-          (int_of_float timeout + 60) ExitCodes.incomplete_analysis
+          (int_of_float timeout + 30) ExitCodes.incomplete_analysis
       | _ -> () ) ;
 
   (* Install generic signal handlers for other signals. *)

--- a/src/kind2.ml
+++ b/src/kind2.ml
@@ -153,10 +153,18 @@ let setup : unit -> any_input = fun () ->
      the same as SIGALRM does elsewhere -- and that path works on every
      run whose supervisor is running, which is every healthy one. The
      grace is how long to wait for it before concluding it will not
-     come. Measured on a four core runner, a healthy run finishes about
-     ten seconds past its timeout: the polling loop looks at the clock
-     once an iteration, and the teardown prints what it found. Thirty is
-     three times that.
+     come.
+
+     Sixty, from what CI measures rather than from a multiple. The
+     ordinary path is not quick and steady: it waits out the same
+     stalls the backstop exists because of, so how late it is has no
+     bound to take a multiple of. One test on the Windows runner came
+     in 4.2s past its timeout on one commit, 11.5s on another and 29.0s
+     on a third, all healthy runs reporting what they had proved. A
+     grace of thirty would have killed the third one had it been a
+     second slower, taking its verdict with it -- and the run that most
+     needs the grace is exactly the stalled one, which is the run most
+     likely to exhaust it.
 
      Not less, and never zero. This ends the process rather than
      unwinding it, so it forfeits the results and forces its own status
@@ -179,7 +187,7 @@ let setup : unit -> any_input = fun () ->
         if Float.is_nan timeout || timeout > ceiling then ()
         else
           NativeTimeout.arm
-            (int_of_float timeout + 30) ExitCodes.incomplete_analysis
+            (int_of_float timeout + 60) ExitCodes.incomplete_analysis
       | _ -> () ) ;
 
   (* Install generic signal handlers for other signals. *)

--- a/src/kind2_stubs.c
+++ b/src/kind2_stubs.c
@@ -59,32 +59,27 @@ static LONG kind2_timeout_solvers = -1;
    behind afterwards is not -- an idle solver reads the end of its
    standard input and goes whether or not anything killed it.
 
-   Room for one id is enough. The number of assigned processes comes
-   back in the header even when the buffer cannot hold the list, which
-   is the ERROR_MORE_DATA case, and the ids themselves are of no use
-   here. */
+   The accounting information is a fixed size structure, so there is no
+   buffer that can be too small and nothing to distinguish a short
+   answer from a failed one: -1 here means the query failed and zero
+   means the job really did hold nothing else. */
 static LONG kind2_solvers_in_job(void)
 {
-  JOBOBJECT_BASIC_PROCESS_ID_LIST ids;
+  JOBOBJECT_BASIC_ACCOUNTING_INFORMATION acc;
   DWORD returned = 0;
 
   if (kind2_timeout_job == NULL) return -1;
-  ZeroMemory(&ids, sizeof ids);
+  ZeroMemory(&acc, sizeof acc);
   if (!QueryInformationJobObject(kind2_timeout_job,
-                                 JobObjectBasicProcessIdList,
-                                 &ids, sizeof ids, &returned)
-      && GetLastError() != ERROR_MORE_DATA)
+                                 JobObjectBasicAccountingInformation,
+                                 &acc, sizeof acc, &returned))
     return -1;
-  if (ids.NumberOfAssignedProcesses == 0) return -1;
-  return (LONG) ids.NumberOfAssignedProcesses - 1;   /* less this one */
+  /* Cannot happen while this process is in the job, so treat it as a
+     query that did not answer rather than as an answer of none. */
+  if (acc.ActiveProcesses == 0) return -1;
+  return (LONG) acc.ActiveProcesses - 1;     /* less this one */
 }
 
-/* Say what is happening, from a thread of its own.
-
-   A write to the standard error of Kind 2 blocks rather than failing
-   when it is a pipe whose reader has stopped, and this is the path that
-   must not be stoppable. The OCaml last resort bounds its own writes
-   for the same reason. */
 static DWORD WINAPI kind2_timeout_announce(LPVOID unused)
 {
   (void)unused;
@@ -93,6 +88,10 @@ static DWORD WINAPI kind2_timeout_announce(LPVOID unused)
             "Kind 2 ran past its timeout without stopping, terminating it "
             "and the %ld solver processes its job holds.\n",
             kind2_timeout_solvers);
+  else if (kind2_timeout_solvers == 0)
+    fprintf(stderr,
+            "Kind 2 ran past its timeout without stopping, terminating it. "
+            "Its job holds no other process.\n");
   else
     fprintf(stderr,
             "Kind 2 ran past its timeout without stopping, terminating.\n");

--- a/src/kind2_stubs.c
+++ b/src/kind2_stubs.c
@@ -47,16 +47,48 @@
 
 static DWORD kind2_timeout_ms = 0;
 static UINT kind2_timeout_status = 0;
+static HANDLE kind2_timeout_job = NULL;
 
-static DWORD WINAPI kind2_timeout_thread(LPVOID unused)
+/* Say what is happening, from a thread of its own.
+
+   A write to the standard error of Kind 2 blocks rather than failing
+   when it is a pipe whose reader has stopped, and this is the path that
+   must not be stoppable. The OCaml last resort bounds its own writes
+   for the same reason. */
+static DWORD WINAPI kind2_timeout_announce(LPVOID unused)
 {
   (void)unused;
-  Sleep(kind2_timeout_ms);
-  /* Nothing below enters the runtime, so a rendezvous holding every
-     domain does not hold this. */
   fprintf(stderr,
           "Kind 2 ran past its timeout without stopping, terminating.\n");
   fflush(stderr);
+  return 0;
+}
+
+static DWORD WINAPI kind2_timeout_thread(LPVOID unused)
+{
+  HANDLE announce;
+  (void)unused;
+  Sleep(kind2_timeout_ms);
+
+  /* Nothing below enters the runtime, so a rendezvous holding every
+     domain does not hold this. */
+  announce = CreateThread(NULL, 0, kind2_timeout_announce, NULL, 0, NULL);
+  if (announce != NULL) {
+    WaitForSingleObject(announce, 1000);
+    CloseHandle(announce);
+  }
+
+  /* The job first, when there is one: it holds this process and the
+     solvers it started, and ends them together. Ending only this
+     process would leave a solver that is inside a query -- one that is
+     idle reads the end of its standard input and goes, but one that is
+     working does not read it until the query returns, and that is not
+     bounded. Every other exit path kills the solvers for that reason.
+
+     `TerminateJobObject` does not return, so the fallback below runs
+     only if there is no job to end. */
+  if (kind2_timeout_job != NULL)
+    TerminateJobObject(kind2_timeout_job, kind2_timeout_status);
   TerminateProcess(GetCurrentProcess(), kind2_timeout_status);
   return 0;
 }
@@ -67,6 +99,23 @@ CAMLprim value kind2_arm_native_timeout(value seconds, value status)
   HANDLE thread;
   kind2_timeout_ms = (DWORD) (Long_val(seconds) * 1000);
   kind2_timeout_status = (UINT) Long_val(status);
+
+  /* A job this process and its children belong to, so that the thread
+     can end them together. A child joins the job of its parent unless
+     it asks not to, and the solvers do not ask. Nesting has been
+     allowed since Windows 8, so being in a job already -- which a CI
+     runner arranges -- is not a reason this fails.
+
+     The handle stays open for the life of the process, and the job is
+     deliberately not created with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE:
+     closing it must not be what ends the run. */
+  kind2_timeout_job = CreateJobObject(NULL, NULL);
+  if (kind2_timeout_job != NULL
+      && !AssignProcessToJobObject(kind2_timeout_job, GetCurrentProcess())) {
+    CloseHandle(kind2_timeout_job);
+    kind2_timeout_job = NULL;   /* fall back to ending this process alone */
+  }
+
   thread = CreateThread(NULL, 0, kind2_timeout_thread, NULL, 0, NULL);
   if (thread != NULL) CloseHandle(thread);
   CAMLreturn(Val_unit);

--- a/src/kind2_stubs.c
+++ b/src/kind2_stubs.c
@@ -74,7 +74,15 @@ static DWORD WINAPI kind2_timeout_thread(LPVOID unused)
      domain does not hold this. */
   announce = CreateThread(NULL, 0, kind2_timeout_announce, NULL, 0, NULL);
   if (announce != NULL) {
-    WaitForSingleObject(announce, 1000);
+    /* Above the rest, and given several seconds. This fires on a
+       machine whose every core is held by domains spinning at a
+       rendezvous, and a thread of ordinary priority given a second did
+       not get to run at all: the process was ended on time and said
+       nothing about why, which is the one thing it is here to do.
+       Bounded still, since a standard error nobody drains must not be
+       what keeps us from exiting. */
+    SetThreadPriority(announce, THREAD_PRIORITY_HIGHEST);
+    WaitForSingleObject(announce, 5000);
     CloseHandle(announce);
   }
 

--- a/src/kind2_stubs.c
+++ b/src/kind2_stubs.c
@@ -1,0 +1,83 @@
+/* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2026 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+
+*/
+
+/* A wall clock for Windows that the runtime cannot stop.
+
+   Kind 2 checks its own wall clock in the polling loop of the
+   supervisor, which is enough while the supervisor runs. On Windows
+   with more engines busy than the machine has cores it stops running:
+   the domains cannot all reach a stop-the-world rendezvous, so every
+   one of them parks in it, and no OCaml code executes anywhere in the
+   process for seconds at a stretch. A thread of the supervisor's domain
+   and a domain of its own were both measured stopped throughout. So no
+   timeout written in OCaml can fire, and the process runs minutes past
+   the timeout it was given.
+
+   The process itself is not stopped -- it holds every core while this
+   happens, spinning in the runtime. What is stopped is OCaml. A thread
+   the operating system made, which never takes the master lock and
+   calls nothing in the runtime, is scheduled as usual and can end the
+   process on time.
+
+   POSIX needs none of this: `setitimer` delivers SIGALRM, and the
+   handler runs at the next poll point. */
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <stdio.h>
+
+static DWORD kind2_timeout_ms = 0;
+static UINT kind2_timeout_status = 0;
+
+static DWORD WINAPI kind2_timeout_thread(LPVOID unused)
+{
+  (void)unused;
+  Sleep(kind2_timeout_ms);
+  /* Nothing below enters the runtime, so a rendezvous holding every
+     domain does not hold this. */
+  fprintf(stderr,
+          "Kind 2 ran past its timeout without stopping, terminating.\n");
+  fflush(stderr);
+  TerminateProcess(GetCurrentProcess(), kind2_timeout_status);
+  return 0;
+}
+
+CAMLprim value kind2_arm_native_timeout(value seconds, value status)
+{
+  CAMLparam2(seconds, status);
+  HANDLE thread;
+  kind2_timeout_ms = (DWORD) (Long_val(seconds) * 1000);
+  kind2_timeout_status = (UINT) Long_val(status);
+  thread = CreateThread(NULL, 0, kind2_timeout_thread, NULL, 0, NULL);
+  if (thread != NULL) CloseHandle(thread);
+  CAMLreturn(Val_unit);
+}
+
+#else
+
+CAMLprim value kind2_arm_native_timeout(value seconds, value status)
+{
+  CAMLparam2(seconds, status);
+  CAMLreturn(Val_unit);
+}
+
+#endif

--- a/src/kind2_stubs.c
+++ b/src/kind2_stubs.c
@@ -48,6 +48,36 @@
 static DWORD kind2_timeout_ms = 0;
 static UINT kind2_timeout_status = 0;
 static HANDLE kind2_timeout_job = NULL;
+static LONG kind2_timeout_solvers = -1;
+
+/* How many processes the job holds besides this one, or -1 if it
+   cannot be told.
+
+   The count is what makes the job visible from outside: a line saying
+   the run was ended along with the solvers it started is evidence that
+   they were in the job when it fired, which counting the ones left
+   behind afterwards is not -- an idle solver reads the end of its
+   standard input and goes whether or not anything killed it.
+
+   Room for one id is enough. The number of assigned processes comes
+   back in the header even when the buffer cannot hold the list, which
+   is the ERROR_MORE_DATA case, and the ids themselves are of no use
+   here. */
+static LONG kind2_solvers_in_job(void)
+{
+  JOBOBJECT_BASIC_PROCESS_ID_LIST ids;
+  DWORD returned = 0;
+
+  if (kind2_timeout_job == NULL) return -1;
+  ZeroMemory(&ids, sizeof ids);
+  if (!QueryInformationJobObject(kind2_timeout_job,
+                                 JobObjectBasicProcessIdList,
+                                 &ids, sizeof ids, &returned)
+      && GetLastError() != ERROR_MORE_DATA)
+    return -1;
+  if (ids.NumberOfAssignedProcesses == 0) return -1;
+  return (LONG) ids.NumberOfAssignedProcesses - 1;   /* less this one */
+}
 
 /* Say what is happening, from a thread of its own.
 
@@ -58,8 +88,14 @@ static HANDLE kind2_timeout_job = NULL;
 static DWORD WINAPI kind2_timeout_announce(LPVOID unused)
 {
   (void)unused;
-  fprintf(stderr,
-          "Kind 2 ran past its timeout without stopping, terminating.\n");
+  if (kind2_timeout_solvers > 0)
+    fprintf(stderr,
+            "Kind 2 ran past its timeout without stopping, terminating it "
+            "and the %ld solver processes its job holds.\n",
+            kind2_timeout_solvers);
+  else
+    fprintf(stderr,
+            "Kind 2 ran past its timeout without stopping, terminating.\n");
   fflush(stderr);
   return 0;
 }
@@ -70,9 +106,16 @@ static DWORD WINAPI kind2_timeout_thread(LPVOID unused)
   (void)unused;
   Sleep(kind2_timeout_ms);
 
+  /* Before anything is ended, while the job still holds them. */
+  kind2_timeout_solvers = kind2_solvers_in_job();
+
   /* Nothing below enters the runtime, so a rendezvous holding every
-     domain does not hold this. */
-  announce = CreateThread(NULL, 0, kind2_timeout_announce, NULL, 0, NULL);
+     domain does not hold this.
+
+     Suspended, so that it is raised before it can be scheduled at
+     ordinary priority. */
+  announce = CreateThread(NULL, 0, kind2_timeout_announce, NULL,
+                          CREATE_SUSPENDED, NULL);
   if (announce != NULL) {
     /* Above the rest, and given several seconds. This fires on a
        machine whose every core is held by domains spinning at a
@@ -82,6 +125,7 @@ static DWORD WINAPI kind2_timeout_thread(LPVOID unused)
        Bounded still, since a standard error nobody drains must not be
        what keeps us from exiting. */
     SetThreadPriority(announce, THREAD_PRIORITY_HIGHEST);
+    ResumeThread(announce);
     WaitForSingleObject(announce, 5000);
     CloseHandle(announce);
   }
@@ -124,8 +168,19 @@ CAMLprim value kind2_arm_native_timeout(value seconds, value status)
     kind2_timeout_job = NULL;   /* fall back to ending this process alone */
   }
 
+  /* Raised for the same reason the announcing thread is, and for the
+     whole of its life rather than at the end of it: this thread has to
+     wake from `Sleep` and then reach `TerminateJobObject`, both on a
+     machine whose every core is held by domains spinning at a
+     rendezvous. Ordinary priority put the observed bound thirteen
+     seconds past the nominal one. It cannot raise itself after waking,
+     since making that call is already the part that needs a slice, and
+     it costs nothing meanwhile -- it is asleep for the whole run. */
   thread = CreateThread(NULL, 0, kind2_timeout_thread, NULL, 0, NULL);
-  if (thread != NULL) CloseHandle(thread);
+  if (thread != NULL) {
+    SetThreadPriority(thread, THREAD_PRIORITY_HIGHEST);
+    CloseHandle(thread);
+  }
   CAMLreturn(Val_unit);
 }
 

--- a/src/nativeTimeout.ml
+++ b/src/nativeTimeout.ml
@@ -1,0 +1,23 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2026 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+
+*)
+
+(* End the process after the given number of seconds with the given
+   status, from a thread the operating system schedules rather than the
+   runtime. Does nothing outside Windows, where SIGALRM already does
+   this properly. See the stub for why one is needed. *)
+external arm : int -> int -> unit = "kind2_arm_native_timeout"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,27 +181,6 @@ def pytest_collection_modifyitems(session, items):
 unfinished_runs = []
 
 
-# Runs the Windows stalls of #1449 take past the harness budget.
-#
-# On Windows the whole Kind 2 process stops running for seconds at a time,
-# repeatedly, so a run overruns the `--timeout` it was given by minutes and
-# this one, the longest of the suite, sometimes crosses `run_timeout` and is
-# killed. Accepting that here is a workaround for the CI noise and not a
-# mitigation: Kind 2 still does not honour its timeout on Windows, which is
-# what #1449 is about.
-#
-# Narrow on purpose -- this test, that platform, that one outcome -- so that
-# any other test crossing the budget, or this one failing any other way,
-# still fails. Reported at the end rather than passed over in silence, so
-# that the day it stops happening is visible.
-stalled_on_windows = {
-    "regression/falsifiable/test-issue-127.lus::test-issue-127 [slice_on]",
-}
-
-# The runs of `stalled_on_windows` that had to be killed this session.
-stalled_runs = []
-
-
 class LustreException(Exception): ...
 
 
@@ -327,13 +306,7 @@ class LustreItem(pytest.Item):
         if self._is_ic3ia() and shutil.which(ic3ia_solver) is None:
             pytest.skip(f"{ic3ia_solver} is not installed")
 
-        try:
-            self.res = run_kind2(self._command())
-        except LustreTimeout:
-            if os.name == "nt" and self.nodeid in stalled_on_windows:
-                stalled_runs.append(self.nodeid)
-                return
-            raise
+        self.res = run_kind2(self._command())
 
         if self._ic3ia_declines():
             # Answering is allowed, answering `falsifiable` is not
@@ -391,27 +364,18 @@ class LustreItem(pytest.Item):
         return super().repr_failure(excinfo, style)
 
 
-# Report the runs that gave up, and the ones we had to kill and accepted,
-# which pass and would otherwise leave no trace
+# Report the runs that gave up, which pass and would otherwise leave no trace
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    if unfinished_runs:
-        terminalreporter.section("Kind 2 ran out of time")
-        terminalreporter.write_line(
-            f"{len(unfinished_runs)} test(s) exited 30 after the "
-            f"{common_args['--timeout']}s budget (not counted as failures):"
-        )
-        for nodeid in unfinished_runs:
-            terminalreporter.write_line(f"  {nodeid}")
+    if not unfinished_runs:
+        return
 
-    if stalled_runs:
-        terminalreporter.section("Killed and accepted (see #1449)")
-        terminalreporter.write_line(
-            f"{len(stalled_runs)} test(s) did not stop within {run_timeout:.0f}s "
-            f"and were accepted rather than failed, which only happens on "
-            f"Windows and only for these:"
-        )
-        for nodeid in stalled_runs:
-            terminalreporter.write_line(f"  {nodeid}")
+    terminalreporter.section("Kind 2 ran out of time")
+    terminalreporter.write_line(
+        f"{len(unfinished_runs)} test(s) exited 30 after the "
+        f"{common_args['--timeout']}s budget (not counted as failures):"
+    )
+    for nodeid in unfinished_runs:
+        terminalreporter.write_line(f"  {nodeid}")
 
 
 # Log test failures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import signal
 import subprocess
+import time
 from pathlib import Path
 from subprocess import PIPE, STDOUT, CompletedProcess, Popen, TimeoutExpired
 
@@ -177,7 +178,12 @@ def pytest_collection_modifyitems(session, items):
 # `falsifiable` and `error` cases. It is accepted anyway, since a large model
 # on a slow machine may legitimately run out of time, but accepting it
 # silently means a run that stops making progress passes without a trace.
-# Collect them so that the session reports them at the end.
+# Collect them, with how long each took, so that the session reports them at
+# the end. The elapsed time is what separates a run the polling loop of the
+# supervisor ended at its own timeout from one a last resort had to kill:
+# the first comes in around the budget, the second only after the grace
+# those add to it. Both exit 30, and the output that would tell them apart
+# is printed only when a test fails.
 unfinished_runs = []
 
 
@@ -306,7 +312,11 @@ class LustreItem(pytest.Item):
         if self._is_ic3ia() and shutil.which(ic3ia_solver) is None:
             pytest.skip(f"{ic3ia_solver} is not installed")
 
-        self.res = run_kind2(self._command())
+        started = time.monotonic()
+        try:
+            self.res = run_kind2(self._command())
+        finally:
+            self.elapsed = time.monotonic() - started
 
         if self._ic3ia_declines():
             # Answering is allowed, answering `falsifiable` is not
@@ -317,7 +327,7 @@ class LustreItem(pytest.Item):
         # Timeout is OK, except for the IC3IA tests: see `ic3ia_dir_name`
         result = code_to_expected.get(self.res.returncode)
         if result == "timeout" and not self._is_ic3ia():
-          unfinished_runs.append(self.nodeid)
+          unfinished_runs.append((self.nodeid, self.elapsed))
           return
 
         if self.res.returncode != expected_to_code[self.expected]:
@@ -374,8 +384,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         f"{len(unfinished_runs)} test(s) exited 30 after the "
         f"{common_args['--timeout']}s budget (not counted as failures):"
     )
-    for nodeid in unfinished_runs:
-        terminalreporter.write_line(f"  {nodeid}")
+    for nodeid, elapsed in unfinished_runs:
+        terminalreporter.write_line(f"  {elapsed:6.1f}s  {nodeid}")
 
 
 # Log test failures


### PR DESCRIPTION
Makes `--timeout` mean something on Windows. Fixes the CI failures of #1449 without touching which engines run.

## The problem

Kind 2 looks at its wall clock in the polling loop of the supervisor, and on Windows that is the only place it looks — there is no SIGALRM, and `Unix.setitimer` raises there. That is enough while the supervisor runs.

It stops running. Where more engines are busy than the machine has cores, the domains cannot all reach a stop-the-world rendezvous, so every one of them parks in it and **no OCaml code executes anywhere in the process** for seconds at a stretch — a thread of the supervisor's domain and a domain of its own were both measured stopped throughout. Runs given `--timeout 20` have been killed by the harness still running at 243s, 251s, 269s and 270s.

The last resort added in #1450 does not save these runs. It is an OCaml thread, so it needs the runtime lock that nothing can release, and across twelve runs here it never once fired: of the four that hung, none wrote its line and none exited. That is not an argument against it — it does its job on the paths where OCaml still runs — it is the reason this one cannot be written in OCaml.

## Why a thread can still do it

The process is not stopped. It holds all four cores throughout, spinning inside the runtime:

```
stall of 44.2s: Kind 2 165.33s CPU (3.7 cores) across 29 threads,
                its 32 solvers 2.64s (0.1 cores)
```

What is stopped is *OCaml*. A thread the operating system made, which never takes the master lock and calls nothing in the runtime, is scheduled as usual. So the last word on the wall clock goes to one of those: it sleeps, says what it is doing on standard error, takes the solvers with it through a job object, and ends the process with `ExitCodes.incomplete_analysis` — the status a wall clock timeout produces on every other platform.

## How long to wait: sixty

It is a backstop and not the timeout. Windows has the ordinary path too — the polling loop notices the clock, raises `TimeoutWall`, and the teardown reports what was proved — and that path works on every run whose supervisor is running, which is every healthy one. The grace is how long to wait for it before concluding it will not come, and firing early forfeits a verdict the run already had.

It was thirty, on the reasoning that a healthy run finishes about ten seconds past its timeout and three times that is safe. **CI has since produced 29.** The same test, `quant_finite_nested_binders.lus [slice_on]`, on the Windows runner across three commits, every one of them a healthy run reporting what it proved:

| job | elapsed | past its 84s budget |
|---|---|---|
| `main` 6ac334cb | 95.5s | +11.5s |
| `5fd366cb` | 88.2s | +4.2s |
| `77cd7e3a` | 113.0s | **+29.0s** |

A grace of thirty would have killed that third run had it been one second slower, and reported an incomplete analysis in place of a verdict it already had. The multiple was the wrong shape of argument: the ordinary path waits out the same stalls this exists because of, so how late it can be has no bound to take a multiple of, and the run that most needs the grace is the stalled one that is most likely to exhaust it. Sixty, from the measurements.

Nothing is at risk from the wait itself: at the 84s the harness asks for, this bounds a wedged run at 144s inside a budget of 204s.

## Validation

Four core runner, `--timeout 20`, with the grace at thirty as it then was, so the backstop falls due at 50s. Twelve runs each way, over four jobs:

| | wall clock | exit |
|---|---|---|
| without | 26s, 28s, 31s, 31s, 38s, 54s, 72s, 88s, 144s, **killed still running at 243s, 251s, 269s, 270s** | 30 where it finished, — where it did not |
| with | 23s, 31s, 33s, 33s, 37s, 39s, 40s, 53s, 55s, 56s, 58s, **63s** | **30 throughout** |

The runs that come in under the due time never met the backstop, which is the point: it does nothing to a healthy run. Raising the grace to sixty moves the due time and nothing else.

**In this pull request's own CI, not only in a throwaway harness.** `kind2-build (windows-x86_64)` is green on every commit here, with #1451's workaround gone. In the job on `5fd366cb`, `test-issue-127.lus` took **117.9s** (22:51:55.255 → 22:53:53.179) against a backstop then due at 114s, and was one of the two entries under "Kind 2 ran out of time" — the grace plus a few seconds, not the ordinary path. Both that run and an ordinary one exit 30, and until now nothing in the report told them apart, so this branch adds the elapsed seconds to that summary:

```
1 test(s) exited 30 after the 84s budget (not counted as failures):
   113.0s  regression/success/quant_finite_nested_binders.lus::quant_finite_nested_binders [slice_on]
```

## Punctuality, and the thread that has to wake up

The backstop is due at a known second, and it cannot speak before it has been scheduled. Twenty runs over two jobs at a grace of five, so that it fires on runs that would otherwise finish first, with the raise on the sleeping thread switched off in one arm:

| | fired | slack |
|---|---|---|
| raised | 8 of 10 | **+0.0s, eight of eight** |
| ordinary priority | 8 of 10 | +0.0s, +1.3s, +2.4s, +2.7s, **+4.6s, +4.8s, +5.7s, +6.0s** |

Every raised run that met the backstop was ended at the second it was due; seven of the eight ordinary ones were late, by up to six seconds. So the raise is what makes it punctual, and the 63s in the table above — thirteen seconds past a nominal fifty — was measured before the thread that sleeps was raised. Ordinary priority is not enough on a machine whose every core is held by domains spinning at a rendezvous: `Sleep` returning is not the same as the thread running. It is raised at its creation site, since it cannot raise itself after waking — making that call is already the part that needs a slice — and it costs nothing, being asleep for the whole run.

The runs that did not fire came in under the due time on their own, except for two in the second job which ended at about thirty seconds without the line appearing. That is consistent with the backstop firing on time and the write being starved through its five second bound, and equally with the run finishing by itself just after — both exit 30, and the harness cannot tell them apart. What it does bound either way is the process: the write never becomes the reason it stays alive.

## The job holds the solvers

Counting the solvers left behind afterwards proves nothing: an idle solver reads the end of its standard input and goes whether or not anything killed it. Asking the job what it holds, at the moment the backstop fires, does:

```
Kind 2 ran past its timeout without stopping, terminating it and the
31 solver processes its job holds.
```

Counts of 7 to 36 across the runs that carried one — the low ones from late-firing runs whose solvers had already begun to go, which is the point of asking at the moment it fires rather than counting what is left afterwards. The query is `JobObjectBasicAccountingInformation`, a fixed size structure, so a buffer too small for the answer is not among the ways it can fail, and a job that holds nothing else says so:

```
Kind 2 ran past its timeout without stopping, terminating it. Its job
holds no other process.
```

which one run produced, so the plain line now means only that the query failed.

`dune build --profile strict` clean; 486 regression tests pass in 35.6s here and in 647.6s on the Windows runner. These are the first C stubs in the tree; outside Windows the file compiles to a stub that does nothing, since SIGALRM already does this properly.

## What it does not do

- **It does not make Windows faster.** A heavy model still takes minutes there; why is #1449. This only stops those minutes being unbounded.
- **It is a hard stop**, so whatever the run had computed is lost. That is the same trade the last resort in `post_clean_exit` already makes, and the alternative is a run that never stops. The grace is the width of the window in which that trade can go wrong, which is why it is set from measurements rather than from a multiple.
- **It is not a substitute for the OCaml watchdog.** That one runs everywhere and can still exit cleanly; this one only knows how to stop the process.

## Bearing on the other work

- **Supersedes #1458** (now closed), which limited how many engines run at once. That works — 0% stalls, right answers, 6/6 — but it costs proofs on every Windows run to prevent an occasional overrun, which is a bad trade for the benchmarks. Closing it in favour of this.
- **Reverts #1451 here**, the workaround the harness carried for this. It accepted that one test being killed after the budget on Windows rather than failing. **The Windows job of this pull request is therefore the evidence**, and it is green.
- #1449 stays open. The slowness is real and undiagnosed beyond "the domains livelock at the rendezvous when they outnumber the cores".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
