### PR TITLE
Let the last resort report the verdict the run reached

### DIFF
--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -420,15 +420,18 @@ let slaughter_kids ?(exiting = false) process sys =
    only the tail of what can wedge.
 
    The status the watchdog exits with is kept in a cell rather than
-   captured, and it is not lowered before [status_of_exn] has run: until
-   the exception has been accounted for, the only honest thing to report
-   is that Kind 2 had to be terminated. [post_clean_exit] sets the
-   verdict of the run once it knows it.
+   captured, and it carries the best verdict known so far.
+   [post_clean_exit] sets the final one once [status_of_exn] has run;
+   before that, [on_exit] sets what the results already say, which for
+   a run out of time is [incomplete_analysis] and for a falsified one
+   is [unsafe_result]. Those are the answers the run had reached, and
+   reporting them beats reporting an error the run did not have.
 
-   It never reports success. A run the watchdog had to kill did not
-   finish, whatever it had proved by then, and the output saying so is
+   It never reports success, though, whatever the results say: a run
+   the watchdog had to kill did not finish, and the output saying so is
    the output that was cut short. A hang fails loudly wherever Kind 2
-   runs; a zero passes silently. *)
+   runs; a zero passes silently. So success becomes [error], and
+   nothing else is touched. *)
 let watchdog_status = Atomic.make ExitCodes.error
 let watchdog_armed = Atomic.make false
 
@@ -482,9 +485,11 @@ let arm_exit_watchdog () =
       with _ -> () )
 
 (* The verdict of the run, for the watchdog to exit with if it has to.
-   Never success: see [watchdog_status]. *)
+   Success becomes an error, since a killed run did not finish; every
+   other verdict is what the run had reached. See [watchdog_status]. *)
 let watchdog_reports status =
-  if status <> ExitCodes.success then Atomic.set watchdog_status status
+  Atomic.set watchdog_status
+    (if status = ExitCodes.success then ExitCodes.error else status)
 
 (** Called after everything has been cleaned up. *)
 let post_clean_exit process base_status exn =
@@ -511,11 +516,19 @@ let post_clean_exit process base_status exn =
 (** Clean up before exit *)
 let on_exit sys process status exn =
   (* From here to [exit] nothing bounds the teardown but the watchdog,
-     so it starts now. Without a status: [status] here has not been
-     through [status_of_exn], and on the paths that pass a results
-     verdict it can be success, which is not something a killed run may
-     report. *)
+     so it starts now, carrying what the results already say.
+
+     [status] has not been through [status_of_exn] yet, but it is not
+     nothing: on the paths that reach here with a results verdict it is
+     what the analysis reached, and [status_of_exn] leaves it alone for
+     the exceptions that end a run normally, a wall clock timeout among
+     them. Arming with [ExitCodes.error] instead cost a run its answer:
+     on Windows the teardown can outlast the watchdog's ten seconds, and
+     a run that had printed `Incomplete analysis result` exited 1 rather
+     than 30, which reads as a crash rather than as running out of
+     time. *)
   arm_exit_watchdog () ;
+  watchdog_reports status ;
   try
     slaughter_kids ~exiting:true process sys;
     post_clean_exit process status exn

--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -307,6 +307,27 @@ let status_of_exn process status = function
     ExitCodes.error
   )
 
+(* The exceptions for which [status_of_exn] returns the status it was
+   given rather than one of its own.
+
+   Kept beside it deliberately: the two have to agree. An exception not
+   named here ends the run with a verdict of its own -- a signal, a
+   parse error, a runtime failure -- and the status the results reached
+   is not what such a run should report.
+
+   [Failure] is left out although two of its messages do pass through:
+   which they are depends on the text of the message, and reporting an
+   error for the rest is the safe way to be wrong. *)
+let keeps_the_given_status = function
+  | Exit
+  | SMTSolver.Unknown
+  | KEvent.Terminate
+  | TimeoutWall
+  | TimeoutVirtual
+  | IC3.UnsupportedFeature _
+  | IC3IA.UnsupportedFeature _ -> true
+  | _ -> false
+
 (** Terminate all engine domains of the current analysis.
 
     Termination is cooperative: {!InvarManager.on_exit} broadcasts a
@@ -518,17 +539,23 @@ let on_exit sys process status exn =
   (* From here to [exit] nothing bounds the teardown but the watchdog,
      so it starts now, carrying what the results already say.
 
-     [status] has not been through [status_of_exn] yet, but it is not
-     nothing: on the paths that reach here with a results verdict it is
-     what the analysis reached, and [status_of_exn] leaves it alone for
-     the exceptions that end a run normally, a wall clock timeout among
-     them. Arming with [ExitCodes.error] instead cost a run its answer:
-     on Windows the teardown can outlast the watchdog's ten seconds, and
-     a run that had printed `Incomplete analysis result` exited 1 rather
-     than 30, which reads as a crash rather than as running out of
-     time. *)
+     [status] has not been through [status_of_exn] yet, but for the
+     exceptions that end a run without a verdict of their own it is
+     already the answer: it is what the analysis reached, and
+     [status_of_exn] will return it unchanged. Arming with
+     [ExitCodes.error] instead cost a run its answer: on Windows the
+     teardown can outlast the watchdog's ten seconds, and a run that had
+     printed `Incomplete analysis result` exited 1 rather than 30, which
+     reads as a crash rather than as running out of time.
+
+     Only for those exceptions, though. A signal, a parse error or a
+     runtime failure ends the run with a verdict of its own, and
+     reporting what the results happened to say would be worse than
+     reporting an error: a crash that exits 40, or a Ctrl-C that exits
+     30, reads as an ordinary answer, and 30 passes a regression run as
+     silently as a zero would. *)
   arm_exit_watchdog () ;
-  watchdog_reports status ;
+  if keeps_the_given_status exn then watchdog_reports status ;
   try
     slaughter_kids ~exiting:true process sys;
     post_clean_exit process status exn


### PR DESCRIPTION
A regression I introduced in #1450, caught by the Windows job of #1459.

## What happens

The last-resort watchdog exits with `ExitCodes.error` unless `post_clean_exit` has already told it the verdict. On Windows it often has not: the teardown there can outlast the watchdog's ten seconds — the stalls of #1449 make `slaughter_kids` slow — so it fires mid-teardown and reports **1**. A run that had completed its analysis, printed `Incomplete analysis result` and reached verdict **30** exits as though it had crashed.

It is not hypothetical. The Windows regression job failed on it:

```
FAILED regression/success/quant_finite_nested_binders.lus::quant_finite_nested_binders [slice_on]
       - Expected: success, got Unknown return code: 1
```

That test ordinarily runs out of its budget and is forgiven for it, since 30 is a timeout rather than a failure. Reported as 1, it is a failure.

And nothing in the output explained why: the line the watchdog prints goes through a bounded helper thread, which a stalled process does not schedule either, so the run exits silently with the wrong code. Both halves of that come from the same commit of mine.

## The fix

Arm with what the results already say. `on_exit` is handed the analysis verdict, and `status_of_exn` leaves it alone for the exceptions that end a run normally — a wall clock timeout among them — so it is already the right answer before `post_clean_exit` confirms it.

**Success still becomes an error**, which is what that rule was for: a run the watchdog had to kill did not finish, and a zero would pass silently. Every other verdict is now the one the run actually reached.

## How it got in

The review of #1450 asked that a killed run not report a status that reads as a normal verdict. What it meant was *success*; I applied it to every status. The measurement was in front of me at the time — I recorded that the wedged run went from exiting 30 to exiting 1, and called that the fix rather than the regression it was.

## Validation

Wedging the teardown past the watchdog's ten seconds:

| wedged run | before | after |
|---|---|---|
| times out (verdict 30) | **1** | **30** |
| falsifies a property (verdict 40) | 1 | **40** |
| would have succeeded (verdict 0) | 1 | **1** — never success |

The 486 regression tests pass in 36.0s and the strict profile builds clean.

## Relation to the other work

Independent of #1459 and of the reverted workaround in #1451, which never covered this test. It has been latent on main since #1450 and shows only when a teardown outlasts ten seconds, which is a Windows symptom of #1449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
