### PR TITLE
Give the last resort time to say why it fired

### DIFF
--- a/src/kind2Flow.ml
+++ b/src/kind2Flow.ml
@@ -493,11 +493,20 @@ let arm_exit_watchdog () =
                as long as an insertion or a swap takes, so waiting for
                it cannot become the reason we never get to [_exit]. *)
             ( try SMTSolver.destroy_all_of_process () with _ -> () ) ;
-            (* Saying so, and the tail of the output, are worth a
-               moment and no more. Both write to descriptors that may
-               be pipes nobody is draining, and neither may become the
-               reason we do not exit. *)
-            within 1.0 (fun () ->
+            (* Saying so, and the tail of the output, are worth
+               waiting a little for and no more. Both write to
+               descriptors that may be pipes nobody is draining, and
+               neither may become the reason we do not exit.
+
+               Five seconds rather than one. The bound has to survive a
+               reader that never drains, which one second does; but it
+               also has to let the write happen on a machine in the
+               state that made this thread necessary, and one second is
+               not enough for that. A run that reaches here has already
+               waited ten, and this line is the only account anyone
+               gets of why it ended: losing it turns a kill that
+               explains itself into one that looks like a crash. *)
+            within 5.0 (fun () ->
               prerr_endline "Kind 2 did not exit in time, terminating." ;
               Stdlib.flush_all ()) ;
             Unix._exit (Atomic.get watchdog_status))


### PR DESCRIPTION
The exit watchdog added in #1450 writes one line before it kills the process:

```
Kind 2 did not exit in time, terminating.
```

It writes it on a thread with a bound on it, because the standard output of Kind 2 may be a pipe whose reader has stalled, and a write to it blocks rather than failing. That bound was one second. One second is the right shape and the wrong number: it was chosen for the reader that never drains, and it does not leave room for the other case the bound has to survive — the write actually happening on a machine in the state that made the watchdog necessary. A thread waiting behind a run that has stopped making progress does not get its turn inside a second.

Raised to five.

## Measured

The body of `within` as written, at both bounds:

| case | bound | returned after | the line |
| --- | --- | --- | --- |
| instant write | 5.0s | 0.02s | landed |
| starved writer (2.5s) | 1.0s | 1.01s | **lost** |
| starved writer (2.5s) | 5.0s | 2.50s | landed |
| reader that never drains | 5.0s | 5.02s | lost |

The last row is the point of the bound and it still holds: a reader that never drains costs five seconds and then the process exits anyway. The middle two are the change.

This is the bound's behaviour, not a field observation. I have no measurement of how long the write actually takes on a machine in the state that makes the watchdog fire, and no run in which the line was seen to be lost. What the change rests on is that one second was picked to bound a blocking write and was never chosen against the write succeeding, and that the two seconds a starved thread can easily take are inside the range one second excludes and five does not.

## Cost

Four seconds, on a path that has already waited ten and is about to `_exit`. Against that, the line is the only account anyone gets of why the run ended. Without it a kill that explains itself looks like a crash.

## Where it does not apply

Not on Windows, in the failure mode of #1449. The watchdog is an OCaml thread, and while the domains are livelocked at a stop-the-world rendezvous nothing can release the runtime lock it needs: across nine runs there, the three that hung wrote neither of its lines and none of them exited. It never reaches the bound this changes. Windows is covered by the native backstop of #1459 instead, and that one — with a five-second bound and a raised thread priority — was seen to land its line at 51.7s on a saturated runner.

## Verified

- `dune build --profile strict` clean.
- `cd tests && ./run` — 486 passed in 35.6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)