### PR TITLE
Guard the properties of a clocked call with its own clock only

### DIFF
--- a/src/lustre/lustreTransSys.ml
+++ b/src/lustre/lustreTransSys.ml
@@ -1266,12 +1266,16 @@ let rec constraints_of_node_calls
       with Not_found -> assert false
     in
 
-    let state_var_map_up, state_var_map_down, node_locals, node_props, node_hist_svars,
+    (* Only the properties lifted from this call are guarded with its
+       restart condition below, so the accumulator of properties lifted
+       from previous calls is not handed to [call_terms_of_node_call]
+       but appended afterwards. *)
+    let state_var_map_up, state_var_map_down, node_locals, call_props, node_hist_svars,
         node_crt_svars, node_assumes, _, init_term, _, trans_term =
       (* Create node call *)
       call_terms_of_node_call
         mk_fresh_state_var globals comp_type node_call node_locals
-        node_props node_hist_svars node_crt_svars node_def
+        [] node_hist_svars node_crt_svars node_def
     in
 
     (* Guard lifted property with restart conditions of node *)
@@ -1289,7 +1293,8 @@ let rec constraints_of_node_calls
              { p with
                P.prop_term =
                  Term.mk_implies [Term.negate restart_prop; prop_term] })
-        node_props
+        call_props
+      @ node_props
     in
 
     
@@ -1454,7 +1459,7 @@ let rec constraints_of_node_calls
       state_var_map_up, 
       state_var_map_down, 
       node_locals, 
-      node_props,
+      call_props,
       node_hist_svars,
       node_crt_svars,
       node_assumes,
@@ -1463,6 +1468,10 @@ let rec constraints_of_node_calls
       init_term_trans, 
       trans_term =
 
+      (* Only the properties lifted from this call are guarded with its
+         activation condition below, so the accumulator of properties
+         lifted from previous calls is not handed to
+         [call_terms_of_node_call] but appended afterwards. *)
       call_terms_of_node_call
         mk_fresh_state_var
         globals
@@ -1470,7 +1479,7 @@ let rec constraints_of_node_calls
         (* Modify node call to use shadow inputs *)
         { node_call with N.call_inputs = shadow_inputs }
         node_locals
-        node_props
+        []
         node_hist_svars
         node_crt_svars
         node_def
@@ -1695,7 +1704,8 @@ let rec constraints_of_node_calls
            { p with
              P.prop_term =
                Term.mk_implies [guard_prop is_one_state; prop_term] })
-        node_props
+        call_props
+      @ node_props
     in
 
     (* Candidate invariants from when-block ties: once the activation clock

--- a/tests/regression/falsifiable/clocked_call_props_exclusive_clocks.lus
+++ b/tests/regression/falsifiable/clocked_call_props_exclusive_clocks.lus
@@ -1,0 +1,30 @@
+-- A property lifted from a clocked node call must be guarded by the
+-- activation condition of that call only. It used to be guarded by the
+-- clocks of every other clocked call in the same node as well: the
+-- properties lifted so far were accumulated in one list, and each clocked
+-- call added its clock as a guard to the whole list rather than to the
+-- properties it lifted itself. With two calls whose clocks cannot both hold,
+-- the antecedent of the over-guarded property is unsatisfiable and the
+-- property is vacuously valid. Here the property 'reached' of 'Sub' is
+-- plainly false, but it was reported valid because the call to 'Other' on
+-- the opposite clock added 'c' to its guard, which already had 'not c'.
+-- The value constraints of the calls were guarded correctly, so the outputs
+-- of 'main' were right and only the lifted property was affected.
+
+node Sub() returns (p: bool);
+let
+  p = true;
+  check "reached" false;
+tel
+
+node Other() returns (q: bool);
+let
+  q = true;
+tel
+
+node main(c: bool) returns (x, y: bool);
+let
+  when not c then y = Sub(); else y = true; end
+  when c then x = Other(); else x = true; end
+  check x and y;
+tel

--- a/tests/regression/falsifiable/clocked_call_props_independent_clocks.lus
+++ b/tests/regression/falsifiable/clocked_call_props_independent_clocks.lus
@@ -1,0 +1,20 @@
+-- Same defect as clocked_call_props_exclusive_clocks.lus, with clocks that
+-- are independent inputs: the clock of a sibling clocked call need not
+-- contradict the call's own clock to hide a violation, it only needs to be
+-- false in the violating states. The property of the second instance of
+-- 'Sub' is 'c2 => c1', violated whenever 'c2 and not c1'. Over-guarded by
+-- the clock 'c1' of the first call it became 'c1 => c2 => c1', which holds
+-- trivially, and a genuine counterexample was lost.
+
+node Sub(b: bool) returns (p: bool);
+let
+  p = true;
+  check "b holds" b;
+tel
+
+node main(c1, c2: bool) returns (x, y: bool);
+let
+  when c1 then x = Sub(true); else x = true; end
+  when c2 then y = Sub(c1);   else y = true; end
+  check x and y;
+tel


### PR DESCRIPTION
Fixes #1472.

Properties lifted from a clocked (`when`-block / condact) node call were guarded not only by that call's own activation clock, but also by the clocks of every other clocked call in the same node. With two clocked calls whose clocks cannot both hold, one instance's properties became vacuously true and were reported **valid** even when plainly false; with independent clocks, a genuine counterexample could be lost. The value constraints of the calls were guarded correctly, per call, so outputs stayed right and only the lifted properties were affected.

## Cause

`constraints_of_node_calls` in `src/lustre/lustreTransSys.ml` threads a single accumulator of lifted properties through the node's calls. `call_terms_of_node_call` prepends the properties lifted from the current call to it, and the clocked-call branch then mapped the call's clock guard over the **whole** accumulator, sibling properties included. The restart-only branch had the same shape.

## Fix

Both branches now hand `call_terms_of_node_call` an empty accumulator, guard only the properties it returns, and prepend them to the accumulator afterwards. The order of the properties is unchanged. The `call_ties` candidates and the `guard_clock` passed to `add_subsystem` were already per call.

The restart-only branch only guards two-state property terms, and the term of a lifted property is a single state variable at `prop_base`, so that change has no observable effect (a restarted variant of the reproducer reports correctly before and after); it is made for consistency.

## Results

Reproducer 1 from the issue (mutually exclusive clocks):

| property | before | after |
|---|---|---|
| `Sub[L9C23].reached` | valid (k=1) | invalid after 0 steps |
| `Sub[L10C19].reached` | invalid after 0 steps | invalid after 0 steps |

Reproducer 2 (independent clocks, property `c2 => c1` on the second instance):

| property | before | after |
|---|---|---|
| `Sub[L9C20].b holds` | valid (k=1) | valid (k=1) |
| `Sub[L10C20].b holds` | valid (k=1) | invalid after 0 steps |

## Tests

Two new tests under `tests/regression/falsifiable`, both exiting `success` on the previous binary and `falsifiable` on this one, with node slicing on and off:

- `clocked_call_props_exclusive_clocks.lus` — `Sub` with a `false` property on `not c`, and a property-free sibling call on `c` (so the verdict flips regardless of which call is processed first).
- `clocked_call_props_independent_clocks.lus` — the issue's second reproducer.

Full regression suite: 488 passed. Strict build profile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
