### PR TITLE
Keep an abstraction's proof obligations defined when slicing is off

### DIFF
--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -1262,6 +1262,7 @@ let no_slice {N.inputs; N.outputs ; N.locals ; N.contract; N.props } is_impl =
       )
     else
       (roots_of_contract ~with_sofar_var:true contract)
+      |> SVS.union (roots_of_props_contract props)
   in
   Some vars
 

--- a/tests/regression/success/imported_ghost_refinement_type.lus
+++ b/tests/regression/success/imported_ghost_refinement_type.lus
@@ -1,0 +1,20 @@
+-- The refinement type of a ghost variable of an imported node becomes a proof
+-- obligation that the abstraction of the node keeps.  It is a property only as
+-- long as the equation defining it is kept as well, which node slicing has to
+-- arrange whether or not it reduces to the cone of influence.  Without that,
+-- "--slice_nodes off" leaves the obligation undefined and reports it invalid,
+-- where the other slicing modes report it valid.
+
+type Nat = subtype { x: int | x >= 0 };
+
+node imported g(u: int) returns (r: int);
+(*@contract
+  var gh: Nat = 5;
+  guarantee r = gh;
+*)
+
+node main(u: int) returns (o: int);
+let
+  o = g(u);
+  check o >= 0;
+tel


### PR DESCRIPTION
A proof obligation generated for the contract of an imported node survives that node's abstraction, but the equation defining it does not when node slicing is off. Its state variable is left unconstrained, and the property — a tautology in the reproducer — is reported **invalid**. The other two slicing modes report it valid, so the verdict depends on `--slice_nodes`.

```
type Nat = subtype { x: int | x >= 0 };

node imported g(u: int) returns (r: int);
(*@contract
  var gh: Nat = 5;
  guarantee r = gh;
*)

node main(u: int) returns (o: int);
let
  o = g(u);
  check o >= 0;
tel
```

| `--slice_nodes` | `g[L11C7].SubType[L5C7]` (`gh >= 0`) |
|---|---|
| `on` (default) | valid (k=1) |
| `experimental` | valid (k=1) |
| `off` | **invalid after 0 steps** |

## Cause

`slice_all_of_node ~for_contract:true` keeps only the properties `filter_props_contract` selects — those with source `Property.Generated (_, _, Property.Contract)` — in a node's abstraction. Keeping the property is not enough on its own: the equation that defines its state variable has to be kept too, so that state variable must be a slicing root.

`root_and_leaves_of_contracts` in `src/lustre/lustreSlicing.ml` does that when it computes the roots itself, unioning `roots_of_props_contract props` into the root set. But that union sits in the branch taken only when the `roots` function returns `None`. With `--slice_nodes off` the `roots` function is `no_slice`, which always returns `Some`, and its abstraction case listed `roots_of_contract` alone. The obligation's defining equation was therefore sliced out of the very abstraction that had kept the obligation.

## Fix

`no_slice` unions `roots_of_props_contract props` into the abstraction root set, matching what the cone-of-influence path already does. The implementation case is unchanged; it already roots every local.

## Results

The reproducer reports the obligation valid in all three slicing modes.

The obligation is reachable today through the refinement type of a ghost variable of an imported node, which is the case above. It also affects [#1437](https://github.com/kind2-mc/kind2/pull/1437), where ADT selector obligations take the same route: on that branch `tests/regression/success/adt_selector_any_guarded.lus` and `tests/regression/success/two_phase_commit.lus` both fail under `--slice-off` and pass with this fix.

## Tests

One new test, `tests/regression/success/imported_ghost_refinement_type.lus` — the reproducer above. It exits `falsifiable` on the previous binary under `--slice_nodes off` and `success` on this one, and exits `success` in the other two modes either way.

Full regression suite with `make test TEST_ARGS="--slice-off --slice-experimental"`: 1470 passed. Unit tests pass. Strict build profile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
