### PR TITLE
Compare branch conditions when simplifying if blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,5 @@
 # Unreleased
 
-Bug fixes:
-- An `if` block whose branches assigned the same values under different conditions
-  could have a branch condition dropped during simplification, silently giving the
-  node the wrong semantics.
-
 Breaking changes:
 - A user-written [ADT selector](https://kind.cs.uiowa.edu/kind2_user_doc/2_input/14_algebraic_datatypes.html#selectors) `e.f` now generates a proof obligation that the constructor owning `f` is active, reported as a property named `Selector[L<line>C<column>]`. Models that read a field without establishing its constructor will report a new failing property. The obligation is discharged by the short-circuiting operators (`and then`, `or else`, `==>`), `when ... then ... else` expressions, `when` blocks, and `match` arms; their eager counterparts (`and`, `or`, `=>`, `if` expressions and `if` blocks) do not discharge it.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+Bug fixes:
+- An `if` block whose branches assigned the same values under different conditions
+  could have a branch condition dropped during simplification, silently giving the
+  node the wrong semantics.
+
 Breaking changes:
 - A user-written [ADT selector](https://kind.cs.uiowa.edu/kind2_user_doc/2_input/14_algebraic_datatypes.html#selectors) `e.f` now generates a proof obligation that the constructor owning `f` is active, reported as a property named `Selector[L<line>C<column>]`. Models that read a field without establishing its constructor will report a new failing property. The obligation is discharged by the short-circuiting operators (`and then`, `or else`, `==>`), `when ... then ... else` expressions, `when` blocks, and `match` arms; their eager counterparts (`and`, `or`, `=>`, `if` expressions and `if` blocks) do not discharge it.
 

--- a/src/lustre/lustreDesugarIfBlocks.ml
+++ b/src/lustre/lustreDesugarIfBlocks.ml
@@ -370,8 +370,11 @@ let rec trees_eq node1 node2 = match node1, node2 with
     | Ok n -> n
     | Error _ -> false
   )
-  | Node (l1, _, r1), Node (l2, _, r2) -> 
-    trees_eq l1 l2 && trees_eq r1 r2
+  | Node (l1, c1, r1), Node (l2, c2, r2) ->
+    (match (AH.syn_expr_equal None c1 c2) with
+      | Ok n -> n && trees_eq l1 l2 && trees_eq r1 r2
+      | Error _ -> false
+    )
   | _ -> false
 
   

--- a/tests/regression/success/if_block_nested_distinct_conds.lus
+++ b/tests/regression/success/if_block_nested_distinct_conds.lus
@@ -1,0 +1,14 @@
+node main(c, p, q: bool) returns (g: bool);
+let
+  if p then
+    if c then g = true ; else g = false ; fi
+  elsif q then
+    g = true ;
+  else
+    g = false ;
+  fi
+
+  check (not p and not q) => not g ;
+  check (p and c) => g ;
+  check (not p and q) => g ;
+tel


### PR DESCRIPTION
`simplify_tree` dropped a branch condition when two sibling branches assigned the same values under different tests, silently giving the node the wrong semantics; reproducer in `tests/regression/success/if_block_nested_distinct_conds.lus`.