### PR TITLE
Keep branch conditions that carry proof obligations

### DIFF
--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -181,10 +181,17 @@ let fold_label_or_index empty union f idx =
    LustreAstNormalizer), so an expression containing one has to be kept even
    where its value is irrelevant, or the obligation silently disappears.
 
-   The test is a whitelist: node calls, binders, pattern matching, and any
-   expression form added later are all reported as not droppable. The only
-   caller (LustreDesugarIfBlocks) uses the answer to decide whether it may
-   simplify away a branch condition, and keeping a condition is always sound. *)
+   The test is a conservative whitelist: only the forms matched below as
+   droppable are recognized as such, and every other form, including any added
+   later, is reported as not droppable. The only caller (LustreDesugarIfBlocks)
+   uses the answer to decide whether it may simplify a branch condition away,
+   and keeping a condition is always sound, so a too-strict answer costs no
+   more than a redundant 'ite'.
+
+   Only expressions are inspected. The types carried by the droppable forms
+   below (the type arguments of a record or ADT construction, and the type of
+   an abstract symbolic constant) are type instantiations: unlike a variable
+   declaration, they carry no refinement-type obligation of their own. *)
 let rec expr_is_droppable = function
   | Ident _ | ModeRef _ | Const _ | Last _ | AbstractSymConst _
   | EmptyMap (_, None) | EmptySet (_, None) -> true
@@ -200,9 +207,10 @@ let rec expr_is_droppable = function
   | GroupExpr (_, _, es) | ADTTerm (_, _, _, es) -> List.for_all expr_is_droppable es
   | RecordExpr (_, _, _, fields) ->
     List.for_all (fun (_, e) -> expr_is_droppable e) fields
-  (* Node calls, binders, pattern matching, and every construct whose operands
-     include a type (which may carry a refinement predicate) are conservatively
-     reported as not droppable *)
+  (* Everything else is kept without further analysis: node calls and the clock
+     operators over them bring in a callee, the binders and pattern matching
+     introduce bound variables, and the remaining forms are not worth
+     recognizing here *)
   | AnyOp _ | ChooseOp _ | Quantifier _ | Match _ | Call _ | Condact _
   | Activate _ | Merge _ | RestartEvery _ | TypeAscription _ | StructUpdate _
   | ArrayConstr _ | IndexAccess _ | EmptyMap (_, Some _)

--- a/src/lustre/lustreAstHelpers.ml
+++ b/src/lustre/lustreAstHelpers.ml
@@ -172,6 +172,42 @@ let fold_label_or_index empty union f idx =
       union acc (f e)
   ) empty idx
 
+(* Whether an expression can be deleted from the AST without changing what
+   Kind 2 verifies, i.e. whether evaluating it contributes nothing besides its
+   value.
+
+   A user-written ADT selector carries a proof obligation that the scrutinee was
+   built with the constructor owning the field (see 'mk_selector_obligation' in
+   LustreAstNormalizer), so an expression containing one has to be kept even
+   where its value is irrelevant, or the obligation silently disappears.
+
+   The test is a whitelist: node calls, binders, pattern matching, and any
+   expression form added later are all reported as not droppable. The only
+   caller (LustreDesugarIfBlocks) uses the answer to decide whether it may
+   simplify away a branch condition, and keeping a condition is always sound. *)
+let rec expr_is_droppable = function
+  | Ident _ | ModeRef _ | Const _ | Last _ | AbstractSymConst _
+  | EmptyMap (_, None) | EmptySet (_, None) -> true
+  (* Only user-written selectors carry a proof obligation *)
+  | FieldProject (_, _, _, Selector (UserWritten, _, _)) -> false
+  | FieldProject (_, e, _, (RecordField | Unresolved | Selector (Kind2Generated, _, _)))
+  | UnaryOp (_, _, e) | ConvOp (_, _, e) | Extract (_, e, _, _)
+  | When (_, e, _) | Pre (_, e) | ADTTester (_, e, _) -> expr_is_droppable e
+  | BinaryOp (_, _, e1, e2) | CompOp (_, _, e1, e2) | Arrow (_, e1, e2) ->
+    expr_is_droppable e1 && expr_is_droppable e2
+  | TernaryOp (_, _, e1, e2, e3) ->
+    expr_is_droppable e1 && expr_is_droppable e2 && expr_is_droppable e3
+  | GroupExpr (_, _, es) | ADTTerm (_, _, _, es) -> List.for_all expr_is_droppable es
+  | RecordExpr (_, _, _, fields) ->
+    List.for_all (fun (_, e) -> expr_is_droppable e) fields
+  (* Node calls, binders, pattern matching, and every construct whose operands
+     include a type (which may carry a refinement predicate) are conservatively
+     reported as not droppable *)
+  | AnyOp _ | ChooseOp _ | Quantifier _ | Match _ | Call _ | Condact _
+  | Activate _ | Merge _ | RestartEvery _ | TypeAscription _ | StructUpdate _
+  | ArrayConstr _ | IndexAccess _ | EmptyMap (_, Some _)
+  | EmptySet (_, Some _) -> false
+
 let rec expr_contains_call = function
   | Ident (_, _) | ModeRef (_, _) | Const (_, _) | Last (_, _) -> false
   | EmptySet (_, Some ty) -> 

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -42,9 +42,11 @@ val id_of_expr : expr -> HString.t option
 
 val expr_is_droppable : expr -> bool
 (** Checks whether the expression can be deleted from the AST without losing a
-    proof obligation, i.e. whether it contains neither a user-written ADT
-    selector nor a node call. Answers conservatively: an expression form the
-    check does not recognize is reported as not droppable. *)
+    proof obligation. The check is a conservative whitelist: an expression form
+    it does not explicitly recognize as droppable, including any form added
+    later, is reported as not droppable. Answering [false] is always sound, so
+    a new expression form only needs to be listed as droppable if the caller
+    should be allowed to delete it. *)
 
 val expr_contains_call : expr -> bool
 (** Checks if the expression contains a call to a node *)

--- a/src/lustre/lustreAstHelpers.mli
+++ b/src/lustre/lustreAstHelpers.mli
@@ -40,6 +40,12 @@ val pos_of_expr : expr -> Lib.position
 val id_of_expr : expr -> HString.t option
 (** Return a lustre id if the expression is an Ident variant or None otherwise *)
 
+val expr_is_droppable : expr -> bool
+(** Checks whether the expression can be deleted from the AST without losing a
+    proof obligation, i.e. whether it contains neither a user-written ADT
+    selector nor a node call. Answers conservatively: an expression form the
+    check does not recognize is reported as not droppable. *)
+
 val expr_contains_call : expr -> bool
 (** Checks if the expression contains a call to a node *)
 

--- a/src/lustre/lustreDesugarIfBlocks.ml
+++ b/src/lustre/lustreDesugarIfBlocks.ml
@@ -385,7 +385,10 @@ let rec trees_eq node1 node2 = match node1, node2 with
       | Node (i, str, j) -> 
         let i = simplify_tree i in
         let j = simplify_tree j in
-        if trees_eq i j then i else
+        (* Collapsing the node deletes the condition from the AST, so it is only
+           sound when the condition carries no proof obligation of its own; see
+           AH.expr_is_droppable. *)
+        if trees_eq i j && AH.expr_is_droppable str then i else
         Node (i, str, j)
 
 

--- a/tests/regression/falsifiable/if_block_collapsed_cond_selector.lus
+++ b/tests/regression/falsifiable/if_block_collapsed_cond_selector.lus
@@ -1,0 +1,14 @@
+-- The two branches assign the same value, so desugaring collapses the if block
+-- and drops its condition. The proof obligation carried by the 'p.val'
+-- selector in that condition must survive the collapse.
+
+datatype IntOpt = None | Some (val: int);
+
+node main(p: IntOpt) returns (g: bool);
+let
+  if p.val > 0 then
+    g = true ;
+  else
+    g = true ;
+  fi
+tel

--- a/tests/regression/falsifiable/when_block_collapsed_cond_selector.lus
+++ b/tests/regression/falsifiable/when_block_collapsed_cond_selector.lus
@@ -1,0 +1,13 @@
+-- Same as if_block_collapsed_cond_selector.lus, for when blocks: they share
+-- 'simplify_tree' with if blocks, and so the same collapse.
+
+datatype IntOpt = None | Some (val: int);
+
+node main(p: IntOpt) returns (g: bool);
+let
+  when p.val > 0 then
+    g = true ;
+  else
+    g = true ;
+  end
+tel

--- a/tests/regression/success/when_block_collapsed_cond_selector_guarded.lus
+++ b/tests/regression/success/when_block_collapsed_cond_selector_guarded.lus
@@ -1,0 +1,21 @@
+-- The inner when block collapses, but its condition is kept because of the
+-- 'p.val' selector. The obligation the selector carries is still discharged by
+-- the enclosing 'Some?(p)' branch, so keeping the condition must not turn into
+-- a false alarm.
+
+datatype IntOpt = None | Some (val: int);
+
+node main(p: IntOpt) returns (g: bool);
+let
+  when Some?(p) then
+    when p.val > 0 then
+      g = true ;
+    else
+      g = true ;
+    end
+  else
+    g = false ;
+  end
+
+  check None?(p) => not g ;
+tel


### PR DESCRIPTION
Follow-up to #1478, which fixed one way `simplify_tree` lost information. This fixes the other one.

`simplify_tree` collapses `Node (i, c, j)` into `i` when the two subtrees are equal, which deletes the condition `c` from the AST. If `c` contains a user-written ADT selector, the proof obligation that selector carries (`mk_selector_obligation`, `lustreAstNormalizer.ml`) is deleted along with it, and Kind 2 silently stops checking that the scrutinee was built with the constructor owning the field:

```lustre
datatype IntOpt = None | Some (val: int);

node main(p: IntOpt) returns (g: bool);
let
  if p.val > 0 then g = true; else g = true; fi
tel
```

Before: `System main has no property, skipping verification step.`
After: `Selector[L5C6]: invalid after 0 steps -- Some?(p)`

The same program written as a plain ITE (`g = if p.val > 0 then true else true;`) already reported the obligation, and so did the if block as soon as its two branches differed — only the collapsed case lost it. `when` blocks share `simplify_tree`, so they had it too.

## The fix

Collapse a branch only when its condition can be dropped without losing an obligation. `AH.expr_is_droppable` decides that with a whitelist, so an expression form added later defaults to keeping the condition, which is always sound. Node calls, binders, pattern matching, and constructs whose operands include a type (which may carry a refinement predicate) are all conservatively kept.

Keeping the condition costs only a redundant `ite`, so being conservative here is cheap.

## Tests

- `falsifiable/if_block_collapsed_cond_selector.lus` and `falsifiable/when_block_collapsed_cond_selector.lus` — both report `success` (exit 0) on `main` and `falsifiable` (exit 40) with this change.
- `success/when_block_collapsed_cond_selector_guarded.lus` — pins that keeping the condition does not turn into a false alarm: the inner `when` condition is kept, but its obligation is still discharged by the enclosing `Some?(p)` branch, so the guard context `mk_selector_obligation` builds is unaffected.

Full regression suite passes in all three slicing modes (1581 passed), as do the OUnit suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)