### PR TITLE
Keep the pipes of a solver off the standard descriptors

### DIFF
--- a/src/smt/SMTLIBSolver.ml
+++ b/src/smt/SMTLIBSolver.ml
@@ -942,16 +942,16 @@ module Make (Driver : SMTLIBSolverDriver) : SolverSig.S = struct
     let solver_executable = solver_cmd.(0) in
     
     (* Create pipes for input, output and error output *)
-    (* Close these on exec, so that the only process to get them is
-       the solver they belong to. [Unix.create_process] passes the
-       three ends it is given to the child whatever this says, by
+    (* [pipe_for_child] closes these on exec, so that the only process
+       to get them is the solver they belong to. [Unix.create_process]
+       passes the three ends it is given to the child all the same, by
        duplicating them onto its standard descriptors; what this stops
        is every later solver inheriting the pipes of every earlier
        one. A solver holding the write end of a pipe of a solver that
        has died keeps Kind 2 from ever reading the end of its output. *)
-    let solver_stdin_in, solver_stdin_out = Unix.pipe ~cloexec:true () in
-    let solver_stdout_in, solver_stdout_out = Unix.pipe ~cloexec:true () in
-    let solver_stderr_in, solver_stderr_out = Unix.pipe ~cloexec:true () in
+    let solver_stdin_in, solver_stdin_out = pipe_for_child () in
+    let solver_stdout_in, solver_stdout_out = pipe_for_child () in
+    let solver_stderr_in, solver_stderr_out = pipe_for_child () in
     
     (* Create solver process *)
     let solver_pid = 

--- a/src/smt/yicesNative.ml
+++ b/src/smt/yicesNative.ml
@@ -1210,9 +1210,9 @@ let create_instance
 
      Closed on exec, so that the only process to get them is the solver
      they belong to: see the same call in [SMTLIBSolver]. *)
-  let solver_stdin_in, solver_stdin_out = Unix.pipe ~cloexec:true () in
-  let solver_stdout_in, solver_stdout_out = Unix.pipe ~cloexec:true () in
-  let solver_stderr_in, solver_stderr_out = Unix.pipe ~cloexec:true () in
+  let solver_stdin_in, solver_stdin_out = pipe_for_child () in
+  let solver_stdout_in, solver_stdout_out = pipe_for_child () in
+  let solver_stderr_in, solver_stderr_out = pipe_for_child () in
 
   
   (* Create solver process *)

--- a/src/utils/lib.ml
+++ b/src/utils/lib.ml
@@ -1018,6 +1018,65 @@ let minisleep sec =
       raise (Signal 0)
 
 
+(* A pipe for a child process to be given one end of.
+
+   Both ends are closed on exec, so that the only process to get one is
+   the child it is meant for, and nothing Kind 2 starts later inherits
+   it. The child still gets its end: [Unix.create_process] duplicates
+   the three it is given onto the standard descriptors of the child,
+   and a duplicate does not carry the flag.
+
+   Unless the end already is the standard descriptor it would be
+   duplicated onto. There is nothing to duplicate then, so the flag
+   stays and the exec closes it, leaving the child without the
+   descriptor it was given: a solver started that way finds its
+   standard input closed, reads an end of file and exits, and the first
+   thing Kind 2 writes to it raises [Sys_error "Broken pipe"]. Reading
+   the input from standard input is enough to get there -- the lexer
+   closes the channel it has read to the end, descriptor 0 is free from
+   then on, and the first pipe made for a solver takes it.
+
+   So keep the ends off the standard descriptors, and leave
+   [Unix.create_process] a duplication to make.
+
+   Nothing to do on Windows, where a descriptor is a handle rather than
+   a number the kernel picks as the lowest free one, and the standard
+   descriptors of Kind 2 are not what a new pipe is made out of. *)
+let pipe_for_child () =
+
+  let is_standard fd =
+    fd = Unix.stdin || fd = Unix.stdout || fd = Unix.stderr
+  in
+
+  (* A duplicate of [fd] that is not a standard descriptor. One that is
+     keeps that descriptor taken while the next duplicate is made, so
+     it is closed only once one has landed elsewhere; with three
+     standard descriptors there are at most three of them. *)
+  let rec dup_off_standard fd =
+    let fd' = Unix.dup ~cloexec:true fd in
+    if is_standard fd' then (
+      let res = dup_off_standard fd in
+      Unix.close fd' ;
+      res
+    )
+    else fd'
+  in
+
+  let off_standard fd =
+    if is_standard fd then (
+      let fd' = dup_off_standard fd in
+      Unix.close fd ;
+      fd'
+    )
+    else fd
+  in
+
+  let read, write = Unix.pipe ~cloexec:true () in
+
+  if Sys.win32 then (read, write)
+  else (off_standard read, off_standard write)
+
+
 (* Return full path to executable, search PATH environment variable
    and current working directory *)
 (* Separator of entries in the PATH environment variable *)

--- a/src/utils/lib.mli
+++ b/src/utils/lib.mli
@@ -443,6 +443,14 @@ val kind_module_of_string : string -> kind_module
 (** Sleep for seconds, resolution is in ms *)
 val minisleep : float -> unit
 
+(** [pipe_for_child ()] is a pipe for a child process to be given one
+    end of, as [Unix.create_process] gives it: both ends are closed on
+    exec, and neither is left on one of the three standard descriptors,
+    which is what a duplicate onto a standard descriptor of the child
+    needs in order to happen at all. Without it the child starts with
+    that descriptor closed. *)
+val pipe_for_child : unit -> Unix.file_descr * Unix.file_descr
+
 (** Return full path to executable, search PATH environment variable
     and current working directory *)
 val find_on_path : string -> string 

--- a/tests/ounit/utils/dune
+++ b/tests/ounit/utils/dune
@@ -1,3 +1,3 @@
 (tests
-  (names testGraph testSolverExit testSolverPipes)
+  (names testGraph testSolverExit testSolverPipes testSolverStdin)
   (libraries ounit2 unix kind2dev))

--- a/tests/ounit/utils/testSolverStdin.ml
+++ b/tests/ounit/utils/testSolverStdin.ml
@@ -1,0 +1,73 @@
+(* This file is part of the Kind 2 model checker.
+
+   Copyright (c) 2026 by the Board of Trustees of the University of Iowa
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License.  You
+   may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+
+*)
+
+open OUnit2
+
+(* A solver gets its own standard input, even where a standard
+   descriptor of Kind 2 is free.
+
+   Reading the input from standard input leaves descriptor 0 closed --
+   the lexer closes the channel it has read to the end -- and the first
+   pipe made for a solver takes it. A close-on-exec end that already is
+   the descriptor it would be duplicated onto is not duplicated at all,
+   so the flag survives the exec: the solver starts with no standard
+   input, reads an end of file and exits, and the first thing Kind 2
+   writes to it raises [Sys_error "Broken pipe"]. That is what every
+   engine of [kind2 < file] reported.
+
+   A file of its own rather than a case of [testSolverPipes]: the
+   disposal below leaves the process unable to start another solver,
+   which is only not felt because the runner gives each case a process. *)
+
+open TestSolverCommon
+
+let test_a_solver_gets_its_own_standard_input _ =
+  (* The premise is a descriptor the kernel hands out as the lowest
+     free number, which is not what a descriptor is on Windows *)
+  skip_if Sys.win32 "descriptors are not numbered here" ;
+  skip_if (solver_missing ()) "no Z3 on PATH" ;
+
+  (* As Kind 2 does, so that a solver that is not there to be written
+     to fails the write rather than killing the runner outright *)
+  TermLib.Signals.ignore_sigpipe () ;
+
+  (* Leave descriptor 0 free, the way reading the input from standard
+     input does. Put it back afterwards: the rest of the run needs it
+     no more than Kind 2 does, but leaving it free is not this test's
+     to decide for whatever comes next. *)
+  let saved = Unix.dup ~cloexec:true Unix.stdin in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.dup2 ~cloexec:false saved Unix.stdin ;
+      Unix.close saved)
+    (fun () ->
+      Unix.close Unix.stdin ;
+      Fun.protect ~finally:SMTSolver.destroy_all_of_process (fun () ->
+        let solver = new_solver () in
+        (* A round trip. Writing to a solver that has exited is what
+           raises, and reading its answer is the only way to see that
+           it was there to give one. *)
+        assert_bool
+          "the solver did not answer" (SMTSolver.check_sat solver)))
+
+let tests = "SolverStdin" >::: [
+  "a solver gets its own standard input"
+  >:: test_a_solver_gets_its_own_standard_input ;
+]
+
+let () = run_test_tt_main tests


### PR DESCRIPTION
Follow-up to #1447. `./bin/kind2 < examples/two_counters.lus` has been failing since it landed:

```
<Error> Runtime error in bounded model checking: Sys_error("Broken pipe")
<Error> Runtime error in inductive step: Sys_error("Broken pipe")
<Error> Runtime error in 2-induction: Sys_error("Broken pipe")
...
InvProp[L24C3]: unknown
```

Every engine, on every input, whenever the input is read from standard input. The same file given as an argument is proved valid.

## A pipe end that is already the descriptor it would be duplicated onto

#1447 made the pipes of a solver close on exec, so that no solver would be handed the pipes of another. What lets the solver keep its own is that `Unix.create_process` duplicates the three ends it is given onto the standard descriptors of the child, and a duplicate does not carry the flag.

Unless the end already **is** the descriptor it would be duplicated onto. There is nothing to duplicate then, the flag stays, and the exec closes it.

Reading the input from standard input is all it takes to get there. The lexer closes the channel it has read to the end, standard input included, so descriptor 0 is free from then on and the first pipe made for a solver takes it. `strace` of the failing run says the rest:

```
175042 close(0)                     = 0      Kind 2 closes its own standard input
175088 pipe2([0, 3], O_CLOEXEC)     = 0      the standard input of a solver lands on 0
175093 dup2(5, 1)                   = 1
175093 dup2(7, 2)                   = 2      no dup2 for 0 -- nothing to duplicate
175093 execve(".../z3", ["-smt2", "-in"])    z3 starts with descriptor 0 closed
```

`z3 -in` reads an end of file and exits before the first command reaches it, and the write raises `Sys_error "Broken pipe"`. Twelve lines of OCaml outside Kind 2 say the same on this switch (5.5.0): a `cat` fed from a `~cloexec:true` pipe whose read end is descriptor 0 dies of `SIGPIPE`.

## Keep the ends off the standard descriptors

`Lib.pipe_for_child` is `Unix.pipe ~cloexec:true` with neither end left on one of the three standard descriptors, and both solver call sites use it. Moving an end is a duplicate that refuses to be standard itself -- more than one free descriptor is handled -- and a close of the original, which leaves `Unix.create_process` a duplication to make.

Nothing to do on Windows, where a descriptor is a handle rather than a number the kernel picks as the lowest free one, so the standard descriptors of Kind 2 are not what a new pipe is made out of.

Every solver exec now has its `dup2(N, 0)`.

## Validation

A new ounit test frees descriptor 0 the way reading the input does, starts a solver and requires an answer. It reverts to `Sys_error("Broken pipe")` with the relocation taken out -- the failure this fixes, in one case rather than in every engine of a run. It is a file of its own because disposing of the solver leaves the process unable to start another, which is only not felt today because the runner gives each case a process.

The test #1447 added -- each solver holds exactly the three pipes it was given -- still passes, so nothing here gives the pipes back.

- `./bin/kind2 < examples/two_counters.lus`: valid, exit 0. Also over standard input: a falsifiable case, `examples/inc.lus`, and a run with descriptors 0 and 2 both free, which is the path that has to move two ends.
- The ounit suite, the 527 regression tests, and `make check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
