### PR TITLE
Publish the documentation on the Kind 2 website

### DIFF
--- a/.github/workflows/kind2-ci.yml
+++ b/.github/workflows/kind2-ci.yml
@@ -1,7 +1,18 @@
 
 name: Kind2 CI
 
-on: [push, pull_request]
+on:
+  push:
+    # gh-pages carries the website's static pages and the documentation of the
+    # released versions, and no sources: there is nothing on it to build or
+    # test, and every job here would fail on the missing dune-project.
+    branches-ignore:
+      - gh-pages
+    # Naming a branch filter would otherwise drop tag pushes, and the nightly
+    # and release tags are built too.
+    tags:
+      - '**'
+  pull_request:
 
 # A new push to a branch cancels this workflow's in-progress runs for it, except
 # on main, where every commit is built so its CI status is recorded.

--- a/.github/workflows/kind2-website.yml
+++ b/.github/workflows/kind2-website.yml
@@ -1,0 +1,49 @@
+name: Kind 2 Website
+
+# The website is published from kind2-mc/kind2-mc.github.io, which serves it at
+# the root of https://kind2-mc.github.io/ rather than under a /kind2/ prefix.
+# That repository holds the static pages and the documentation of every released
+# version, and rebuilds main's documentation from the sources here on every run,
+# so all this repository has to do is tell it that there is something new.
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  notify:
+    # A fork has neither the secret nor any business republishing the website.
+    if: github.repository == 'kind2-mc/kind2'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # A release tag is passed along by name: the website repository builds that
+    # version's documentation once and keeps it, where main's is rebuilt every
+    # time.
+    #
+    # GITHUB_TOKEN is scoped to this repository, so it cannot reach the website
+    # one. WEBSITE_DISPATCH_TOKEN is a fine-grained personal access token whose
+    # resource owner is the kind2-mc organization -- a token owned by an account
+    # cannot see the organization's repositories -- limited to the single
+    # repository kind2-mc/kind2-mc.github.io, with the Contents permission set
+    # to read and write, which is what the dispatch endpoint requires. Such a
+    # token expires within a year, and this job is where that shows up: reissue
+    # it to the same shape and this keeps working.
+    - name: Ask the website repository to publish
+      env:
+        GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+      run: |
+        if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+          version=$GITHUB_REF_NAME
+        else
+          version=main
+        fi
+        jq -n --arg version "$version" \
+          '{event_type: "kind2-docs", client_payload: {version: $version}}' \
+          | gh api repos/kind2-mc/kind2-mc.github.io/dispatches --input -

--- a/doc/README.md
+++ b/doc/README.md
@@ -45,5 +45,16 @@ Output goes to `public/`.
 ## Deploying
 
 Any static host works (GitHub Pages, Netlify, Vercel, Cloudflare Pages).
-Update `baseURL` in `hugo.yaml` to match your production domain before
-building for deployment.
+`hugo.yaml` sets no `baseURL`, so Hugo defaults to `/`, which is what
+`hugo server` and the PDF build want. Hugo bakes the baseURL into every asset
+and cross-page link, so set `HUGO_BASEURL` to the URL the site will actually be
+served from when building for deployment:
+
+```bash
+HUGO_BASEURL=https://example.org/kind2/docs/main/user/ make html
+```
+
+The website is published from the `kind2-mc/kind2-mc.github.io` repository,
+which does this for you: it publishes this documentation to
+<https://kind2-mc.github.io/docs/main/user> on every push to `main`, and a copy
+of each release's to `docs/<version>/user` alongside it.

--- a/doc/content/README.md
+++ b/doc/content/README.md
@@ -44,5 +44,16 @@ Output goes to `public/`.
 ## Deploying
 
 Any static host works (GitHub Pages, Netlify, Vercel, Cloudflare Pages).
-Update `baseURL` in `hugo.yaml` to match your production domain before
-building for deployment.
+`hugo.yaml` sets no `baseURL`, so Hugo defaults to `/`, which is what
+`hugo server` and the PDF build want. Hugo bakes the baseURL into every asset
+and cross-page link, so set `HUGO_BASEURL` to the URL the site will actually be
+served from when building for deployment:
+
+```bash
+HUGO_BASEURL=https://example.org/kind2/docs/main/user/ make html
+```
+
+The website is published from the `kind2-mc/kind2-mc.github.io` repository,
+which does this for you: it publishes this documentation to
+<https://kind2-mc.github.io/docs/main/user> on every push to `main`, and a copy
+of each release's to `docs/<version>/user` alongside it.

--- a/doc/hugo.yaml
+++ b/doc/hugo.yaml
@@ -1,4 +1,7 @@
-baseURL: "https://kind.cs.uiowa.edu/kind2_user_doc/"
+# No baseURL: the site is built for whatever location it is published at,
+# and Hugo bakes that into every asset and cross-page link. Set HUGO_BASEURL
+# when building for publication (the website workflow does); without it Hugo
+# defaults to "/", which is what `hugo server` and the PDF build want.
 title: Kind 2 User Documentation
 
 theme: hextra

--- a/doc/pdf-tools/build_print_html.py
+++ b/doc/pdf-tools/build_print_html.py
@@ -10,6 +10,14 @@ PUBLIC = ROOT / "public"
 OUT_HTML = ROOT / "print" / "all-docs.html"
 KATEX_CSS = ROOT / "assets" / "vendor" / "katex" / "dist" / "katex.min.css"
 
+# Hugo bakes the baseURL's path into every site-root-absolute URL it writes, so
+# mapping one back to a file under public/ means stripping that path first.
+# HUGO_BASEURL is the only thing that sets it (hugo.yaml deliberately carries no
+# baseURL), and unset means Hugo defaulted to "/".
+BASE_PATH = urlparse(os.environ.get("HUGO_BASEURL", "/")).path or "/"
+if not BASE_PATH.endswith("/"):
+    BASE_PATH += "/"
+
 def frontmatter_weight(path):
     text = path.read_text(encoding="utf-8")
     if not text.startswith("---"):
@@ -66,8 +74,7 @@ def rewrite_image_sources(main, page_path):
         if parsed.scheme in {"http", "https", "data"} or src.startswith("//"):
             continue
         if src.startswith("/"):
-            base = "/kind2_user_doc/"
-            rel = src[len(base):] if src.startswith(base) else src.lstrip("/")
+            rel = src[len(BASE_PATH):] if src.startswith(BASE_PATH) else src.lstrip("/")
             candidate = PUBLIC / rel
         else:
             candidate = (page_path.parent / src).resolve()


### PR DESCRIPTION
The user and developer documentation is now served from the website:

| | |
| --- | --- |
| User documentation | <https://kind2-mc.github.io/docs/main/user> |
| Developer documentation | <https://kind2-mc.github.io/docs/main/developer> |

with a copy of each release's kept alongside under `docs/<version>/`.

**This is already live.** The website side is deployed and serving; this PR is the half that lives here.

## How it fits together

The site is published by [kind2-mc/kind2-mc.github.io](https://github.com/kind2-mc/kind2-mc.github.io), whose workflow builds this repository's documentation and assembles the whole site on every deployment. Pages is set to *Deploy using GitHub Actions*, which replaces the site wholesale rather than adding to it, so every deployment has to reassemble all of it: the static pages, the documentation of each archived release, and a fresh build of `main`'s.

Publishing from the organization's user site rather than from this repository's project site is what keeps the documentation at `/docs/...` instead of under a `/kind2/` prefix — which in turn lets `kind.cs.uiowa.edu` reverse-proxy the site with no path prefix to reconcile.

Nothing here deploys. `GITHUB_TOKEN` is confined to the repository it runs in, so `kind2-website.yml` only tells the website repository that there is something new, naming the release when a tag is what triggered it. It authenticates with `WEBSITE_DISPATCH_TOKEN`, a fine-grained PAT owned by the `kind2-mc` organization and limited to the website repository with `Contents: read and write`; the secret is already configured.

## The baseURL

Hugo bakes the baseURL into every asset and cross-page link, and each copy of the documentation is served from a subdirectory that depends on the version being built. `doc/hugo.yaml` therefore no longer carries one: `HUGO_BASEURL` settles it at build time, and Hugo's default of `/` is what `hugo server` and the PDF build want.

The PDF build had the same URL hardcoded a second time, to map Hugo's site-root-absolute image URLs back to files under `public/`. It now derives that path from `HUGO_BASEURL`, so it follows wherever the site is published.

## CI on gh-pages

Pushes to `gh-pages` no longer start a CI run: the branch holds the old static pages and no sources, so every job failed on the missing `dune-project`. Naming a branch filter would otherwise drop tag pushes, hence the explicit `tags: ['**']` — the nightly and release tags are still built.

Once `gh-pages` is deleted this hunk can be reverted.

## Verification

The website workflow has run end to end against real infrastructure. `configure-pages` resolves the base URL with no path prefix, the cross-repo checkout and both doc builds succeed, `archive-release-docs` correctly skips on a non-tag run, and the deployment serves:

```
/docs/main/user/                                        200
/docs/main/user/docs/                                   200
/docs/main/user/css/…                                   200
/docs/main/developer/                                   200
/docs/main/developer/kind2dev@…/HString/index.html      200
/docs/main/developer/odoc.support/odoc.css              200
```

Separately, every `href`/`src`/`srcset` in an assembled copy of the site was resolved against the tree: 17900 internal links, the only failures being the five pre-existing `HString.HStringMap`/`HStringSet` links in the developer documentation (#1481 addresses those; not required here).

## Before merging

Pages has to be disabled on this repository (Settings → Pages → Source: None), or `/kind2/` keeps resolving to the old project site and shadows that path on the organization site.

The `repository_dispatch` in `kind2-website.yml` is the one path not yet exercised — it fires on the first push to `main` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)