### PR TITLE
Give Windows engines a larger minor heap

### DIFF
--- a/src/engineDomains.ml
+++ b/src/engineDomains.ml
@@ -97,10 +97,42 @@ let signals_to_block =
    noticeably slower than the separate processes they replaced, which
    had a collector each.
 
-   Collecting four times less often is enough to close that gap, and
-   costs 8MB per engine. The setting is not inherited from the
-   supervisor, so each domain must apply it to itself. *)
-let engine_minor_heap_size = 1 lsl 20
+   Collecting four times less often was enough to close that gap on
+   Linux and macOS. It is not enough on Windows, where the wait at that
+   safe point costs enormously more: a run of
+   `test-issue-127.lus [slice_on]` there freezes for about 5.7 seconds
+   at a time, every domain at once, and how often it does so tracks how
+   often the engines collect. Measured on a four core Windows runner,
+   two runs at each size, `--timeout 84`:
+
+     minor heap    wall clock          freezes
+     1M words      70s, 73s, and       ~50 per run
+                   killed at 204s
+                   twice on a later
+                   run
+     4M words      14s, 15s            1 per run
+     16M words     20s, 24s            0 to 1
+     64M words     25s, 9s             0 to 1
+
+   Four million is where it flattens: sixteen and sixty-four buy
+   nothing further, and the collection count stops falling with them,
+   so most of what remains is not collections. What the step from one
+   to four buys is the difference between a run that is sometimes
+   killed at the harness budget and one that is consistently fifteen
+   seconds. Linux and macOS do not move across that whole range --
+   5s and 5 to 7s at every size -- so this costs them nothing but
+   memory.
+
+   So the larger heap is given to Windows alone. It is not free:
+   thirty-two megabytes per engine against eight, and on this model
+   peak resident memory went from 162MB to 432MB. That is worth paying
+   where it turns a killed run into a fifteen second one, and worth
+   paying nowhere else. The setting is not inherited from the
+   supervisor, so each domain must apply it to itself.
+
+   This is a mitigation and not a diagnosis: why the wait costs what it
+   does on Windows is not established. See #1477. *)
+let engine_minor_heap_size = if Sys.win32 then 1 lsl 22 else 1 lsl 20
 
 (* Give the minor heap of the supervisor the size the engines use.
 

--- a/src/engineDomains.ml
+++ b/src/engineDomains.ml
@@ -97,41 +97,29 @@ let signals_to_block =
    noticeably slower than the separate processes they replaced, which
    had a collector each.
 
-   Collecting four times less often was enough to close that gap on
-   Linux and macOS. It is not enough on Windows, where the wait at that
-   safe point costs enormously more: a run of
-   `test-issue-127.lus [slice_on]` there freezes for about 5.7 seconds
-   at a time, every domain at once, and how often it does so tracks how
-   often the engines collect. Measured on a four core Windows runner,
-   two runs at each size, `--timeout 84`:
+   Four times less often closes that gap on Linux and macOS. On
+   Windows the wait at that safe point costs seconds, so it does not.
+   Measured there on four cores, `test-issue-127.lus [slice_on]` at
+   `--timeout 84`, two runs per size:
 
-     minor heap    wall clock          freezes
-     1M words      70s, 73s, and       ~50 per run
-                   killed at 204s
-                   twice on a later
-                   run
-     4M words      14s, 15s            1 per run
-     16M words     20s, 24s            0 to 1
-     64M words     25s, 9s             0 to 1
+     1M words   70s, 73s, killed at 204s twice    ~50 freezes
+     4M words   14s, 15s                          1
+     16M words  20s, 24s                          0 to 1
+     64M words  25s, 9s                           0 to 1
 
-   Four million is where it flattens: sixteen and sixty-four buy
-   nothing further, and the collection count stops falling with them,
-   so most of what remains is not collections. What the step from one
-   to four buys is the difference between a run that is sometimes
-   killed at the harness budget and one that is consistently fifteen
-   seconds. Linux and macOS do not move across that whole range --
-   5s and 5 to 7s at every size -- so this costs them nothing but
-   memory.
+   Four million is where it flattens, and the collection count stops
+   falling past it. The step from one to four is what turns a run
+   sometimes killed at the harness budget into one that is reliably
+   fifteen seconds.
 
-   So the larger heap is given to Windows alone. It is not free:
-   thirty-two megabytes per engine against eight, and on this model
-   peak resident memory went from 162MB to 432MB. That is worth paying
-   where it turns a killed run into a fifteen second one, and worth
-   paying nowhere else. The setting is not inherited from the
-   supervisor, so each domain must apply it to itself.
+   Windows alone, because Linux and macOS do not move across that whole
+   range and the memory is not free: 32MB per engine against 8, and
+   162MB to 432MB of peak resident memory on that model. The setting is
+   not inherited from the supervisor, so each domain applies it to
+   itself.
 
-   This is a mitigation and not a diagnosis: why the wait costs what it
-   does on Windows is not established. See #1477. *)
+   A mitigation, not a diagnosis: why the wait costs seconds on Windows
+   is not established. See #1477. *)
 let engine_minor_heap_size = if Sys.win32 then 1 lsl 22 else 1 lsl 20
 
 (* Give the minor heap of the supervisor the size the engines use.


### PR DESCRIPTION
Windows CI still overruns the budget on `test-issue-127.lus [slice_on]` intermittently, after ocaml/ocaml#15029 fixed the runtime bug we thought was the cause. This is the only lever that has moved it. It is a mitigation, not a diagnosis.

## What was measured

Four core Windows runner, the harness's own arguments, `--timeout 84`, two runs per size, on an instrumented build that reports how long the process goes without executing any OCaml:

| minor heap | wall clock | freezes per run |
|---|---|---|
| 1M words (ships today) | 70s, 73s — and **killed at 204s twice** on a later run | ~50 |
| **4M words** | **14s, 15s** | 1 |
| 16M words | 20s, 24s | 0–1 |
| 64M words | 25s, 9s | 0–1 |

The freezes are the thing: about 5.7 seconds each, every domain at once — including a domain with nothing to do but tick — collecting almost nothing while they last. How many there are tracks how often the engines collect, which is what the minor heap sets.

**Four million is where it flattens.** 16M and 64M buy nothing further, and the collection count stops falling with them (~190 whatever the size), so most of what remains is not collections at all. The step from 1M to 4M is the one that matters: it is the difference between a run that is sometimes killed at the harness budget and one that is consistently fifteen seconds.

## Why Windows only

Linux and macOS do not move across that entire 64× range — 5s and 5–7s at every size. They would pay the memory for nothing:

```
peak resident set, test-issue-127.lus, this machine
  1M words   162 MB
  4M words   432 MB
```

Nearly 3×, which is worth paying where it turns a killed run into a fifteen second one and worth paying nowhere else. `engineDomains.ml` already branches on `Sys.win32` for signal masks, and the comment there now carries these numbers and the reason.

## Why fewer collections helps (this has since been measured)

When this was opened the mechanism was unknown and the change rested on the improvement alone. It no longer does.

Every minor collection is a stop-the-world section: all domains stop, and the collecting domain waits for each of them to be reached. **On Windows that section takes five to ten seconds** when allocating domains run beside a domain that repeatedly enters and leaves a blocking section — which is Kind 2's shape exactly, with a supervisor polling every 10ms and engines waiting on solvers between queries. Measured on Kind 2 with `runtime_events`, read from outside the process, the longest spans during a freeze are always the same:

```
PAUSE stw_handler          14.16s in domain 4
PAUSE interrupt_remote     14.21s in domain 0
PAUSE minor_leave_barrier  14.16s in domain 4
```

So a larger minor heap helps for a reason: fewer collections, hence fewer of these sections to be caught in. That is also why the curve flattens at 4M — beyond it the collection count stops falling.

It is reproducible without Kind 2. [`barrier.ml`](https://github.com/daniel-larraz/ocaml-windows-thread-starvation) — N domains allocating, M sleeping 10ms in a loop — freezes for 5.9s on Windows with one sleeping domain and never freezes without one (0.12s, 0.13s, 0.13s across three runs), while Linux and macOS stay at hundredths in both cases.

## What this still does not do

It does not fix the cause, which is in the runtime and not in Kind 2, and it is not the upstream bug we already had fixed — ocaml/ocaml#15029 is released in 5.5.1 and every measurement here is on 5.5.1. Why the barrier is slow on Windows remains unknown; `interrupt_remote` reaching the same lengths as `stw_handler` suggests the time goes into reaching the other domains rather than waiting for them to finish work, but that is an observation and not a diagnosis.

Windows also still takes 14s where Linux takes 5s for the same work. #1477 tracks all of it, and the native backstop stays regardless.

## Verified

- `dune build --profile strict` clean; `cd tests && ./run` — 555 passed in 37.3s.
- Peak resident memory on Linux unchanged by this patch: 160MB, against 162MB before it.
- The Windows job of this pull request is the test that matters: `test-issue-127` should come in around 15s rather than riding the budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
