### PR TITLE
Publish main's binaries to a rolling release instead of nightlies

### DIFF
--- a/.github/workflows/kind2-ci.yml
+++ b/.github/workflows/kind2-ci.yml
@@ -2,16 +2,10 @@
 name: Kind2 CI
 
 on:
+  # Unfiltered: every branch and every tag is built. (A `latest` tag move is
+  # pushed with GITHUB_TOKEN, which by design starts no workflow run, so the
+  # rolling main-branch build does not double up with the run for its commit.)
   push:
-    # gh-pages carries the website's static pages and the documentation of the
-    # released versions, and no sources: there is nothing on it to build or
-    # test, and every job here would fail on the missing dune-project.
-    branches-ignore:
-      - gh-pages
-    # Naming a branch filter would otherwise drop tag pushes, and the nightly
-    # and release tags are built too.
-    tags:
-      - '**'
   pull_request:
 
 # A new push to a branch cancels this workflow's in-progress runs for it, except

--- a/.github/workflows/kind2-release.yml
+++ b/.github/workflows/kind2-release.yml
@@ -1,47 +1,74 @@
-name: Kind 2 Nightlies / Release
+name: Kind 2 Binaries
 
 on:
   workflow_dispatch:
-  # Run the nightly build at 8 AM UTC / 2 AM Central
+  # A nightly run of the build matrix at 8 AM UTC / 2 AM Central
   schedule:
     - cron: "0 8 * * *"
   push:
+    # Every push to main refreshes the rolling `latest` release
+    branches:
+      - main
     # Sequence of patterns matched against refs/tags
     tags:
       - 'v*'
+
+# One `latest` build at a time: the jobs move a shared tag and clobber shared
+# assets, so overlapping runs would interleave. On main a newer commit makes
+# the run in progress obsolete, so cancel it; a version tag's run is unique to
+# its ref and must always finish.
+#
+# The nightly check gets a group of its own rather than sharing main's. It runs
+# on `refs/heads/main` too, so otherwise a schedule firing minutes after a push
+# would cancel the very run that was publishing that commit's binaries.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'nightly-check' || github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
 env:
     HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
 
 jobs:
-  get-nightly-ready:
-    if: github.repository == 'kind2-mc/kind2' && !startsWith(github.event.ref, 'refs/tags/v')
+  # The `latest` release is created once and then reused forever: its assets
+  # are overwritten in place (see the upload step) rather than deleted and
+  # re-added, so the page never sits empty between two pushes, and the
+  # download URLs stay valid. The tag it points at is moved once the binaries
+  # are actually built, in publish-latest.
+  prepare-latest:
+    # Only main feeds the rolling release: a workflow_dispatch from a topic
+    # branch would otherwise move `latest` onto a commit that is not on main,
+    # which is the one thing the page promises it is. The schedule reaches
+    # this workflow on main as well, and it publishes nothing.
+    if: |
+      github.repository == 'kind2-mc/kind2'
+      && github.ref == 'refs/heads/main'
+      && github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Delete old assets
+    - name: Create the latest release if it does not exist yet
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        ids=$(gh release view nightly --json assets --jq '.assets | map(.name) | .[]')
-        for id in $ids;
-        do
-          gh release delete-asset nightly $id -y
-        done
-
-    - name: Update nightly tag
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git tag -f nightly
-        git push --tags -f
+        set -euo pipefail
+        if gh release view latest --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+          echo "The latest release already exists."
+          exit 0
+        fi
+        # --target creates the tag as well, which is what makes the very first
+        # run work: there is no `latest` tag to verify against yet.
+        gh release create latest --repo "$GITHUB_REPOSITORY" \
+          --target "$GITHUB_SHA" --prerelease \
+          --title 'Kind 2 (main branch)' \
+          --notes 'Binaries automatically built from the `main` branch on every push.'
 
   create-new-release:
-    if: github.repository == 'kind2-mc/kind2' && startsWith(github.event.ref, 'refs/tags/v')
+    if: github.repository == 'kind2-mc/kind2' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Create new release
@@ -59,13 +86,21 @@ jobs:
           --repo $GITHUB_REPOSITORY
 
   build:
+    # A run that publishes has to wait for its release to have been prepared,
+    # so it needs one of the two jobs above to have succeeded. A run that only
+    # checks the build prepares nothing, both of them skip, and there is no
+    # 'success' for it to point at — hence the other two cases.
     if: |
       always()
       && github.repository == 'kind2-mc/kind2'
-      && contains(needs.*.result, 'success')
       && !contains(needs.*.result, 'failure')
+      && (contains(needs.*.result, 'success')
+          || github.event_name == 'schedule'
+          || github.event_name == 'workflow_dispatch')
 
-    needs: [get-nightly-ready, create-new-release]
+    needs: [prepare-latest, create-new-release]
+    permissions:
+      contents: write
     strategy:
       matrix:
         name: [ linux-x86_64, linux-arm64, macos-x86_64, macos-arm64, windows-x86_64 ]
@@ -90,6 +125,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
+    # Built inside the Alpine image so the result is linked against musl
+    # statically and carries no libc dependency of its own.
     - name: Build Kind 2 linux binary
       if: runner.os == 'Linux'
       uses: docker/build-push-action@v7
@@ -130,7 +167,7 @@ jobs:
         cache-prefix: macos${{ matrix.macos-target }}
         flambda: true
         build-target: static
-    
+
     # Not built statically: the linking flags have no Windows case, and it
     # needs none. Every library the binary imports ships with Windows —
     # kernel32, msvcrt, advapi32, ws2_32, shell32, shlwapi, ole32, version
@@ -155,18 +192,31 @@ jobs:
       id: create_asset
       shell: bash
       run: |
+        set -euo pipefail
         cd bin
         if [[ "$GITHUB_REF" =~ ^refs/tags/v.* ]]; then
-          vtag=$GITHUB_REF_NAME
-          echo "release=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
+          # A released asset names the version it was cut from
+          prefix=kind2-$GITHUB_REF_NAME
+          release=$GITHUB_REF_NAME
+        elif [[ "$GITHUB_EVENT_NAME" != "schedule" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+          # The main-branch assets carry no version segment, so their download
+          # URLs are permanent. What they were built from is the commit the
+          # `latest` tag points at, recorded in the release notes as well.
+          prefix=kind2
+          release=latest
         else
-          vtag=$(date "+%Y-%m-%d")
-          echo "release=nightly" >> $GITHUB_OUTPUT
+          # A build check with nothing to publish: the nightly run, or a
+          # dispatch from a topic branch. Package the binary anyway, so that
+          # step is covered too, and leave the release empty to say there is
+          # nowhere to upload it to.
+          prefix=kind2
+          release=
         fi
+        echo "release=$release" >> $GITHUB_OUTPUT
         if [[ "$RUNNER_OS" == "Windows" ]]; then
           # A zip is what a Windows user expects, and Compress-Archive is
           # always there, where zip and 7z are not guaranteed.
-          asset=kind2-$vtag-windows-x86_64.zip
+          asset=$prefix-windows-x86_64.zip
           powershell -NoProfile -Command \
             "Compress-Archive -Path kind2.exe -DestinationPath $asset"
         else
@@ -176,16 +226,63 @@ jobs:
           else
             ptag="macos-${{ matrix.macos-target }}-$(uname -m)"
           fi
-          asset=kind2-$vtag-$ptag.tar.gz
+          asset=$prefix-$ptag.tar.gz
           tar -czf $asset kind2
         fi
         echo "filepath=./bin/$asset" >> $GITHUB_OUTPUT
 
+    # An empty release name is the build check saying it is done: it has built
+    # and packaged the binary, which is all it set out to prove, and it has no
+    # release to touch.
+    #
+    # --clobber so that a push to main replaces the asset of the same name
+    # left by the previous one. A draft release for a version tag has no
+    # asset to replace, and the flag is harmless there.
     - name: Upload release asset
+      if: steps.create_asset.outputs.release != ''
       shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release upload ${{ steps.create_asset.outputs.release }} \
           ${{ steps.create_asset.outputs.filepath }} \
-          --repo $GITHUB_REPOSITORY
+          --clobber --repo $GITHUB_REPOSITORY
+
+  # Only now that every binary is uploaded is the tag moved onto the commit
+  # they were built from: had it moved up front, a build that failed halfway
+  # would leave the page advertising a commit whose binaries are not there.
+  publish-latest:
+    if: |
+      github.repository == 'kind2-mc/kind2'
+      && github.ref == 'refs/heads/main'
+      && github.event_name != 'schedule'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Move the latest tag to this commit
+      run: |
+        set -euo pipefail
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git tag -f latest
+        git push -f origin refs/tags/latest
+
+    - name: Record the commit in the release notes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        commit_url="https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
+        cat > notes.md << EOF
+        Binaries automatically built from the \`main\` branch on every push.
+
+        Built from [\`${GITHUB_SHA:0:7}\`]($commit_url) on $(date -u '+%Y-%m-%d %H:%M UTC').
+        EOF
+        gh release edit latest --repo "$GITHUB_REPOSITORY" --prerelease \
+          --title 'Kind 2 (main branch)' --notes-file notes.md


### PR DESCRIPTION
## What this changes

The nightly release ties the binaries to the date they were built rather than to what they were built from, so a user reporting a bug against them has no commit to name, and a fix landing on `main` waits until the next morning to be downloadable.

Every push to `main` now refreshes a **`latest`** release, titled **Kind 2 (main branch)**, whose tag is moved onto the commit the binaries came from:

> Binaries automatically built from the `main` branch on every push.
>
> Built from [`ad05fce`](https://github.com/kind2-mc/kind2/commit/ad05fce) on 2026-09-09 17:53 UTC.

How the binaries are built is **unchanged** — that part was the point of the nightly job and is kept as-is. Linux still comes out of the Alpine image in `docker/Dockerfile`, so it carries no libc dependency, and macOS is still built with `MACOSX_DEPLOYMENT_TARGET=12` and flambda.

### Details worth review

- **The tag moves last.** A new `publish-latest` job moves `latest` only after every binary has uploaded. The old job moved the tag up front, which left the page advertising a commit whose binaries were not there whenever a build failed halfway.
- **Fixed asset names, uploaded with `--clobber`.** `kind2-linux-x86_64.tar.gz`, `kind2-macos-12-arm64.tar.gz`, `kind2-windows-x86_64.zip`, and so on. Download URLs become permanent, and replacing assets in place removes the window in which the old delete-then-upload left the page with no binaries at all. Release (`v*`) assets keep their version segment and are untouched.
- **The release is a prerelease**, so it does not displace the real latest release on the repository front page.
- **The nightly schedule stays, as a build check that uploads nothing.** It is what catches the build breaking underneath us with no commit to blame — a base image, an opam package, a runner image or an action that moved. It still builds and packages on all five platforms and runs `kind2 --version`; only the upload is skipped.
- **Concurrency.** The nightly gets its own group: it runs on `refs/heads/main` too, so sharing main's group meant a schedule firing minutes after a merge would cancel the run publishing that commit.
- **One decision point.** Whether a run has anywhere to upload to is decided once, in the step that packages the asset, which emits an empty release name when the answer is "nowhere"; the upload step is gated on that. Keeps the logic in shell that can actually be run, instead of spread across Actions expressions.

### Unrelated cleanup in `kind2-ci.yml`

Drops the `gh-pages` branch filter — the website moved to `kind2-mc/kind2-mc.github.io` and no such branch remains on the remote. Its companion `tags: '**'` filter goes with it: that existed only to undo the side effect of naming a branch filter, and left alone it would have stopped CI from running on branch pushes entirely. A bare `push:` gives the same coverage both filters combined to produce.

## Behavior by trigger

| Trigger | prepare | create-release | build | publish | uploads to |
|---|---|---|---|---|---|
| nightly schedule | skip | skip | **run** | skip | — |
| push to `main` | run | skip | run | run | `latest` |
| push `v*` tag | skip | run | run | skip | draft `v*` |
| dispatch on `main` | run | skip | run | run | `latest` |
| dispatch on topic branch | skip | skip | **run** | skip | — |

A dispatch from a topic branch now behaves like the nightly check — it builds and packages but publishes nothing, rather than pushing a non-`main` commit's binaries to a page that promises they came from `main`.

## Testing

Neither workflow can run its changed paths until this is on `main`, so verification was done locally:

- Both workflows parse.
- The rewritten `Create asset` step was **executed** across all trigger/platform combinations in the table above, confirming asset names and the upload gate.
- The release-notes heredoc was executed to confirm it renders without indentation leaking in and that the commit link is well-formed.
- The four job-level `if` expressions were evaluated against every trigger and match the table, including that a failed `prepare-latest` stops the build rather than publishing stale binaries.

## After merge

The first push to `main` creates the `latest` release. Once it has published its five assets, the old page needs removing by hand — the workflow deliberately does not touch it:

```bash
gh release delete nightly -y --repo kind2-mc/kind2
git push --delete origin nightly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
