### PR TITLE
Stop publish-latest from skipping on every push to main

### DIFF
--- a/.github/workflows/kind2-release.yml
+++ b/.github/workflows/kind2-release.yml
@@ -252,10 +252,18 @@ jobs:
   # they were built from: had it moved up front, a build that failed halfway
   # would leave the page advertising a commit whose binaries are not there.
   publish-latest:
+    # A skip propagates along the whole `needs` chain, and create-new-release
+    # skips on a push to main, so without a status function here this job is
+    # never evaluated. !cancelled() rather than always(): a cancelled run has
+    # been superseded by a newer commit, whose own run moves the tag instead.
+    # A status function also stops `needs` from implying success on its own,
+    # hence the explicit check on build's result.
     if: |
-      github.repository == 'kind2-mc/kind2'
+      !cancelled()
+      && github.repository == 'kind2-mc/kind2'
       && github.ref == 'refs/heads/main'
       && github.event_name != 'schedule'
+      && needs.build.result == 'success'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Follow-up to #1492.

## What went wrong

On the merge of #1492 ([run 34393170106](https://github.com/kind2-mc/kind2/actions/runs/34393170106)) every job succeeded and all five assets uploaded, but `publish-latest` **skipped**, so the release notes kept the placeholder text `prepare-latest` writes and no commit was recorded.

The condition was not at fault. `prepare-latest` carries the *identical* three clauses and ran successfully in the same run:

```yaml
github.repository == 'kind2-mc/kind2'
&& github.ref == 'refs/heads/main'
&& github.event_name != 'schedule'
```

The cause is the `needs` graph. `publish-latest` needs `build`, which needs `[prepare-latest, create-new-release]` — and `create-new-release` skips on every push to `main`. A skipped job propagates its skip along the **whole** chain, not just to its immediate dependents. `build` survives because its condition opens with `always()`. `publish-latest` had no status function, so it was never evaluated at all.

## The part that wasn't visible

The missing notes line was the symptom; the stuck tag was the real bug.

`latest` is currently at the right commit only because `prepare-latest` created the release with `--target $GITHUB_SHA` on that first run. From the next push onward `prepare-latest` no-ops (the release exists), so with `publish-latest` skipping, **nothing would ever have moved the tag again** — it would have sat frozen at `d9d2157` while the assets beneath it kept changing on every push. That is precisely the "page advertises a commit whose binaries are not there" failure #1492 set out to avoid.

## The fix

Guard the condition with `!cancelled()` so the job is evaluated despite the upstream skip, and re-assert the dependency explicitly:

```yaml
if: |
  !cancelled()
  && github.repository == 'kind2-mc/kind2'
  && github.ref == 'refs/heads/main'
  && github.event_name != 'schedule'
  && needs.build.result == 'success'
```

`!cancelled()` rather than `always()`: a run the concurrency rule cancels has been superseded by a newer commit, and the tag is that run's to move. `needs.build.result == 'success'` restores what `needs` alone was meant to guarantee — the tag moves onto a commit only once its binaries are on the release.

## Verification

I rebuilt the local simulation to model GitHub's skip-propagation rule, which the one I ran for #1492 did not — that omission is exactly why this slipped through review. It now reproduces the observed skip against the old condition, and gives this against the new one:

| scenario | prepare | create | build | publish |
|---|---|---|---|---|
| nightly schedule | skipped | skipped | success | skipped |
| push to `main` | success | skipped | success | **success** |
| push to `main`, build fails | success | skipped | failure | skipped |
| push `v*` tag | skipped | success | success | skipped |
| dispatch on `main` | success | skipped | success | **success** |
| dispatch on topic branch | skipped | skipped | success | skipped |

The first push to `main` after this merges will move the tag and write the commit line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
