### PR TITLE
Restore the PDF title page and table of contents

### DIFF
--- a/doc/pdf-tools/README.md
+++ b/doc/pdf-tools/README.md
@@ -38,3 +38,21 @@ second Sphinx-era page map.
 `pdf-tools/build_pdf.sh` renders that to
 `print/kind2-user-documentation.pdf` with WeasyPrint.
 
+Only the `div.content` body of each page is kept. Hextra also puts the
+breadcrumb trail and the previous/next pager inside `<main>`; both are site
+navigation with nothing to point at in a PDF, and their chevron icons render at
+full size here because the theme stylesheet that shrinks them is not part of the
+print CSS.
+
+The merged file opens with a title page carrying the version and build date
+followed by a table of contents, as the old Sphinx/LaTeX PDF did. Headings are
+numbered `1`, `1.1`, `1.1.1` (one chapter per docs page) and the TOC lists
+chapters and sections; WeasyPrint fills in the page numbers at render time via
+`target-counter()`. Unlike the LaTeX build, page numbering does not restart
+after the front matter — WeasyPrint ignores `counter-reset: page` in margin
+boxes — so the whole PDF is numbered from the title page.
+
+The version comes from `base_version` in `src/version.ml`, the same string the
+`kind2` binary reports. Override it with `KIND2_DOC_VERSION` if needed. The date
+is the build date; set `SOURCE_DATE_EPOCH` for a reproducible build.
+

--- a/doc/pdf-tools/README.md
+++ b/doc/pdf-tools/README.md
@@ -48,9 +48,15 @@ The merged file opens with a title page carrying the version and build date
 followed by a table of contents, as the old Sphinx/LaTeX PDF did. Headings are
 numbered `1`, `1.1`, `1.1.1` (one chapter per docs page) and the TOC lists
 chapters and sections; WeasyPrint fills in the page numbers at render time via
-`target-counter()`. Unlike the LaTeX build, page numbering does not restart
-after the front matter — WeasyPrint ignores `counter-reset: page` in margin
-boxes — so the whole PDF is numbered from the title page.
+`target-counter()`.
+
+The front matter is numbered in lower-case roman and the body restarts at 1, so
+chapter 1 opens on page 1. WeasyPrint ignores `counter-reset: page` on an
+element, so the reset lives in an `@page` rule picked by GCPM's document
+sequence selector, `@page :nth(1 of body)`. A page group is one element's run of
+pages, which is why every chapter is wrapped in a single `div.body-matter`:
+putting `page: body` on each chapter section instead would open a new group, and
+restart the numbering, at every chapter.
 
 The version comes from `base_version` in `src/version.ml`, the same string the
 `kind2` binary reports. Override it with `KIND2_DOC_VERSION` if needed. The date

--- a/doc/pdf-tools/build_print_html.py
+++ b/doc/pdf-tools/build_print_html.py
@@ -255,6 +255,16 @@ def build_merged_html():
     css = """
     %s
     @page { size: A4; @bottom-center { content: counter(page); font-size: .8rem; color: #555; } }
+    /* Front matter is numbered in roman and the body restarts at 1, as the
+       LaTeX build did. The reset has to live in an @page rule -- WeasyPrint
+       ignores counter-reset: page on an element -- and :nth(1 of body) picks
+       the first page of the body page group. That group is the .body-matter
+       wrapper: one element, hence one group. Naming the pages on each section
+       instead would start a fresh group, and a fresh page 1, per chapter. */
+    @page front { @bottom-center { content: counter(page, lower-roman); } }
+    @page :nth(1 of body) { counter-reset: page 1; }
+    .front-matter { page: front; }
+    .body-matter { page: body; }
     body { font-family: -apple-system, Helvetica, Arial, sans-serif; line-height: 1.55; color: #1a1a1a; max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
     h1 { font-size: 1.8rem; margin-top: 3rem; border-bottom: 2px solid #ddd; padding-bottom: .3rem; }
     h2 { font-size: 1.4rem; margin-top: 2rem; }
@@ -293,7 +303,7 @@ def build_merged_html():
 <style>%s</style>
 </head><body>
 %s
-%s
+<div class="body-matter">%s</div>
 </body></html>''' % (DOC_TITLE, version, css, front_matter, ''.join(sections_html))
     OUT_HTML.write_text(doc, encoding="utf-8")
     print("Wrote", OUT_HTML, len(sections_html), "sections,", len(toc_entries), "TOC entries")

--- a/doc/pdf-tools/build_print_html.py
+++ b/doc/pdf-tools/build_print_html.py
@@ -1,4 +1,6 @@
+import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 import os
@@ -9,6 +11,10 @@ CONTENT_DOCS = ROOT / "content" / "docs"
 PUBLIC = ROOT / "public"
 OUT_HTML = ROOT / "print" / "all-docs.html"
 KATEX_CSS = ROOT / "assets" / "vendor" / "katex" / "dist" / "katex.min.css"
+# Single source of truth for the version, shared with the binary itself.
+VERSION_ML = ROOT.parent / "src" / "version.ml"
+
+DOC_TITLE = "Kind 2 User Documentation"
 
 # Hugo bakes the baseURL's path into every site-root-absolute URL it writes, so
 # mapping one back to a file under public/ means stripping that path first.
@@ -17,6 +23,38 @@ KATEX_CSS = ROOT / "assets" / "vendor" / "katex" / "dist" / "katex.min.css"
 BASE_PATH = urlparse(os.environ.get("HUGO_BASEURL", "/")).path or "/"
 if not BASE_PATH.endswith("/"):
     BASE_PATH += "/"
+
+
+def project_version():
+    """Version shown on the title page: 'v3.0.0' in version.ml prints as '3.0.0'."""
+    override = os.environ.get("KIND2_DOC_VERSION")
+    if override:
+        return override.lstrip("v")
+    if not VERSION_ML.exists():
+        print(f"MISSING {VERSION_ML} (set KIND2_DOC_VERSION to override)", file=sys.stderr)
+        sys.exit(1)
+    match = re.search(
+        r'^\s*let\s+base_version\s*=\s*"v?([^"]+)"',
+        VERSION_ML.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if not match:
+        print(f"No base_version found in {VERSION_ML} (set KIND2_DOC_VERSION to override)", file=sys.stderr)
+        sys.exit(1)
+    return match.group(1)
+
+
+def build_date():
+    """Title-page date, honouring SOURCE_DATE_EPOCH for reproducible builds."""
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch:
+        stamp = datetime.fromtimestamp(int(epoch), tz=timezone.utc)
+    else:
+        stamp = datetime.now()
+    # Written out rather than strftime("%B %-d, %Y") because the no-pad flag
+    # isn't portable.
+    return f"{stamp.strftime('%B')} {stamp.day}, {stamp.year}"
+
 
 def frontmatter_weight(path):
     text = path.read_text(encoding="utf-8")
@@ -84,10 +122,85 @@ def rewrite_image_sources(main, page_path):
         # the build machine's checkout and break when the tree is moved.
         img["src"] = Path(os.path.relpath(candidate, OUT_HTML.parent)).as_posix()
 
+
+def number_headings(soup, main, chapter):
+    """Number a page's headings the way the Sphinx build did (chapter 1, section
+    1.1, subsection 1.1.1) and return the chapter/section entries for the table
+    of contents. Each numbered heading gets a unique id so the TOC can link to
+    it and ask WeasyPrint for its page number."""
+    entries = []
+    section = subsection = 0
+    for heading in main.find_all(["h1", "h2", "h3"]):
+        if heading.name == "h1":
+            section = subsection = 0
+            number = str(chapter)
+        elif heading.name == "h2":
+            section += 1
+            subsection = 0
+            number = f"{chapter}.{section}"
+        else:
+            if not section:
+                # An h3 with no h2 above it has no number to hang off of.
+                continue
+            subsection += 1
+            number = f"{chapter}.{section}.{subsection}"
+        title = heading.get_text(strip=True)
+        anchor = "pdf-sec-" + number.replace(".", "-")
+        heading["id"] = anchor
+        label = soup.new_tag("span", attrs={"class": "heading-number"})
+        label.string = number
+        heading.insert(0, label)
+        if heading.name in {"h1", "h2"}:
+            entries.append((heading.name, number, title, anchor))
+    return entries
+
+
+def render_toc(soup, entries):
+    """Table of contents; page numbers are filled in at render time by the
+    target-counter() rule in the stylesheet."""
+    nav = soup.new_tag("nav", attrs={"class": "print-toc"})
+    items = soup.new_tag("ul")
+    nav.append(items)
+    for level, number, title, anchor in entries:
+        item = soup.new_tag(
+            "li", attrs={"class": "toc-chapter" if level == "h1" else "toc-section"}
+        )
+        link = soup.new_tag("a", href="#" + anchor)
+        label = soup.new_tag("span", attrs={"class": "toc-number"})
+        label.string = number
+        link.append(label)
+        text = soup.new_tag("span", attrs={"class": "toc-title"})
+        text.string = title
+        link.append(text)
+        item.append(link)
+        items.append(item)
+    return nav
+
+
+def build_front_matter(soup, entries):
+    """Title page: title, version, date, then the table of contents, as the
+    Sphinx-generated PDF had it."""
+    front = soup.new_tag("div", attrs={"class": "front-matter"})
+    title = soup.new_tag("h1", attrs={"class": "doc-title"})
+    title.string = DOC_TITLE
+    front.append(title)
+    version = soup.new_tag("p", attrs={"class": "doc-version"})
+    version.string = f"Version {project_version()}"
+    front.append(version)
+    date = soup.new_tag("p", attrs={"class": "doc-date"})
+    date.string = build_date()
+    front.append(date)
+    front.append(render_toc(soup, entries))
+    return front
+
+
 def build_merged_html():
     errors = 0
     OUT_HTML.parent.mkdir(parents=True, exist_ok=True)
+    version = project_version()
     sections_html = []
+    toc_entries = []
+    chapter = 0
     for source_path in ordered_page_paths():
         path = public_path_for(source_path)
         if not path.exists():
@@ -100,17 +213,29 @@ def build_merged_html():
             print("NO MAIN", source_path)
             errors += 1
             continue
-        for sel in main.select('[class*="hextra-toc"], nav[aria-label], a[href*="edit/main"], button'):
+        # Take only the page body. Hextra wraps it in <main> together with the
+        # breadcrumb trail and the previous/next pager, which are site
+        # navigation with nothing to point at in a PDF -- and whose chevron
+        # icons render at full size here, since the theme's stylesheet that
+        # shrinks them is not part of the print CSS.
+        content = main.find("div", class_="content", recursive=False)
+        if not content:
+            print("NO CONTENT", source_path)
+            errors += 1
+            continue
+        for sel in content.select('[class*="hextra-toc"], nav[aria-label], a[href*="edit/main"], button'):
             sel.decompose()
-        for mathml in main.select(".katex-mathml"):
+        for mathml in content.select(".katex-mathml"):
             mathml.decompose()
         try:
-            rewrite_image_sources(main, path)
+            rewrite_image_sources(content, path)
         except FileNotFoundError as exc:
             print("MISSING IMAGE", exc)
             errors += 1
             continue
-        sections_html.append(f'<section class="doc-page">{main}</section>')
+        chapter += 1
+        toc_entries.extend(number_headings(soup, content, chapter))
+        sections_html.append(f'<section class="doc-page">{content}</section>')
     if errors:
         print(f"PDF merge failed: {errors} page(s) or assets missing", file=sys.stderr)
         sys.exit(1)
@@ -129,10 +254,12 @@ def build_merged_html():
     katex_css = katex_css.replace("url(fonts/", f"url({font_url}")
     css = """
     %s
+    @page { size: A4; @bottom-center { content: counter(page); font-size: .8rem; color: #555; } }
     body { font-family: -apple-system, Helvetica, Arial, sans-serif; line-height: 1.55; color: #1a1a1a; max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
     h1 { font-size: 1.8rem; margin-top: 3rem; border-bottom: 2px solid #ddd; padding-bottom: .3rem; }
     h2 { font-size: 1.4rem; margin-top: 2rem; }
     h3 { font-size: 1.15rem; }
+    .heading-number { margin-right: .5em; }
     pre { background: #f5f5f5; padding: .75rem 1rem; overflow-x: auto; border-radius: 6px; font-size: .85rem; }
     code { background: #f0f0f0; padding: .1rem .3rem; border-radius: 4px; font-size: .9em; }
     pre code { background: none; padding: 0; }
@@ -140,20 +267,36 @@ def build_merged_html():
     th, td { border: 1px solid #ccc; padding: .4rem .6rem; text-align: left; }
     img { max-width: 100%%; height: auto; }
     section.doc-page { page-break-before: always; }
-    section.doc-page:first-child { page-break-before: avoid; }
     a { color: #0969da; text-decoration: none; }
     blockquote { border-left: 4px solid #ccc; margin: 1rem 0; padding: .2rem 1rem; color: #555; background: #fafafa; }
+    .front-matter { text-align: center; }
+    .front-matter h1.doc-title { border: none; font-size: 2.4rem; margin: 0 0 1.4rem; }
+    .front-matter .doc-version { font-size: 1.25rem; font-weight: bold; margin: 0; }
+    .front-matter .doc-date { font-size: 1.05rem; margin: .3rem 0 2.5rem; }
+    nav.print-toc { text-align: left; }
+    nav.print-toc ul { list-style: none; margin: 0; padding: 0; }
+    nav.print-toc li { margin: .1rem 0; }
+    nav.print-toc a { display: block; color: #1a1a1a; }
+    /* WeasyPrint resolves the page each entry's target lives on, and leader()
+       fills the gap in between with dots. */
+    nav.print-toc a::after { content: leader('.') target-counter(attr(href), page); }
+    nav.print-toc .toc-number { display: inline-block; min-width: 2.4em; }
+    nav.print-toc li.toc-chapter { font-weight: bold; margin-top: .5rem; }
+    nav.print-toc li.toc-section { padding-left: 2.4em; font-size: .95rem; }
+    nav.print-toc li.toc-section .toc-number { min-width: 3em; }
     """ % katex_css
+    front_soup = BeautifulSoup("", "lxml")
+    front_matter = build_front_matter(front_soup, toc_entries)
     doc = '''<!DOCTYPE html>
 <html><head><meta charset="utf-8">
-<title>Kind 2 User Documentation</title>
+<title>%s %s</title>
 <style>%s</style>
 </head><body>
-<h1 style="border:none; font-size:2.4rem; text-align:center; margin-top:0;">Kind 2 User Documentation</h1>
 %s
-</body></html>''' % (css, ''.join(sections_html))
+%s
+</body></html>''' % (DOC_TITLE, version, css, front_matter, ''.join(sections_html))
     OUT_HTML.write_text(doc, encoding="utf-8")
-    print("Wrote", OUT_HTML, len(sections_html), "sections")
+    print("Wrote", OUT_HTML, len(sections_html), "sections,", len(toc_entries), "TOC entries")
 
 if __name__ == "__main__":
     build_merged_html()


### PR DESCRIPTION
The Sphinx/LaTeX build put the version, the build date and a table of contents right after the title. The Hugo/WeasyPrint build lost all three; this brings them back.

## Title page and TOC

`doc/pdf-tools/build_print_html.py` now emits a front matter block — title, `Version 3.0.0`, the build date — followed by the table of contents, matching the old `maketitle`.

Headings are numbered `1`, `1.1`, `1.1.1` (one chapter per docs page, as Sphinx's `secnumdepth 2` did) and the TOC lists chapters and sections (`tocdepth 1`). Each numbered heading gets a unique id, and WeasyPrint resolves the page numbers at render time via `content: leader('.') target-counter(attr(href), page)`, so they cannot drift.

Page footers are new as well: the PDF had no page numbers at all before, which would have left the TOC pointing at nothing. The front matter is numbered in lower-case roman and the body restarts at 1, so chapter 1 opens on page 1 as it used to. WeasyPrint ignores `counter-reset: page` on an element, so the reset hangs off GCPM's document sequence selector, `@page :nth(1 of body)`. A page group is one element's run of pages, hence the `div.body-matter` wrapper around every chapter: naming the pages on each chapter section instead would open a new group, and restart the numbering, at every chapter.

The version is parsed from `base_version` in `src/version.ml`, the same string the binary reports, so it tracks releases on its own. `KIND2_DOC_VERSION` overrides it; `SOURCE_DATE_EPOCH` pins the date for reproducible builds.

## Dropping the breadcrumb and pager

Only each page's `div.content` is kept now. Hextra also puts the breadcrumb trail and the previous/next pager inside `<main>`, and their chevron icons carry a `viewBox` but no intrinsic size — on the website `hx:w-3.5` shrinks them to 14px, but Tailwind is not part of the print CSS, so WeasyPrint drew each at the default replaced-element size. That was the stray oversized `>` appearing between chapters.

Removing those 124 icons takes the PDF from **278 pages to 165** body pages plus four of front matter. Nothing real was lost: comparing the merged HTML before and after gives 35,090 → 35,383 words (the increase is the new TOC text, less the removed breadcrumb/pager labels), all 4 images still embedded, and the SVG count drops 129 → 5, the remainder being inline SVGs in actual documentation content.

## Testing

`make doc` from the repo root, and `make pdf` in `doc/`, both succeed — including `build_pdf.sh`'s existing `pdfinfo`/`pdfimages` validation. Checked the rendered title page, a chapter opening and a chapter ending visually, confirmed the roman/arabic split and that TOC targets match their printed page numbers, and confirmed both the `KIND2_DOC_VERSION` and `SOURCE_DATE_EPOCH` overrides take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)