### PR TITLE
Fix contract checker on a model with a recursive function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 Improvements:
+- Fixed an assertion failure in the contract checker on a model with a recursive function. The state variable dependencies it computes are built callees first, but a recursive function is its own callee, so nothing was computed yet for the call in its body when its turn came. The dependencies of such a call now fall back on all the inputs of the call.
 - A recursive function that has no contract (no guarantee or mode, explicit or through a refinement type of an output) or is declared `transparent` is now also defined at the SMT level with an SMT-LIB `define-funs-rec` command, when the solver is Z3 or cvc5 and the logic is inferred rather than set with `--smt_logic`, so that the solver can unfold its definition instead of only seeing its recursive calls abstracted by its contract. Properties about concrete arguments of such functions (e.g. `Fact(4) = 24`) become provable. The new option `--define_fun_rec false` restores the previous encoding. IC3IA turns itself off on systems with such definitions.
 - The inductive step now assumes, at every state of its path, the part of the transition relation that only constrains one state. It previously had nothing to say about the first state of the path, where the transition relation is not asserted, so a variable defined from others was assumed there without its definition. Properties that are 1-inductive are now proved at k=1 rather than at a larger k, if they were provable at all.
 

--- a/src/lustre/lustreSlicing.ml
+++ b/src/lustre/lustreSlicing.ml
@@ -235,10 +235,19 @@ let rec node_state_var_dependencies' init output_input_deps
             with Not_found -> D.empty
           in
 
-          (* Get indexes of inputs the output depends on. All outputs must
-              have dependencies computed *)
+          (* Get indexes of inputs the output depends on.
+
+             The dependencies of the callee have been computed before those of
+             this node, except when the callee is the node itself, or another
+             function of the same recursive group: a dependency is then still
+             being computed, and there is nothing to read. Fall back on the
+             assumption that the output depends on every input, which is the
+             worst a fixed point could converge to, and is safe for the two
+             things these dependencies are used for: keeping a variable in the
+             cone of influence of another, and ordering equations by what they
+             read. *)
           (try D.find output_index output_input_dep
-            with Not_found -> assert false)
+            with Not_found -> D.keys call_inputs)
 
           |> List.fold_left (fun accum i -> 
               (* Get actual input by index, and add as dependency *)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,14 @@ ic3ia_declined_dir_name = "declined"
 ic3ia_args = {"--enable": "IC3IA", "--smt_itp_solver": "MathSAT"}
 ic3ia_solver = "mathsat"
 
+# Tests under a directory with this name run the contract checker rather than
+# the verification engines, which is the only way to reach the realizability
+# path from the regression tree. A `success` case there means every contract
+# was found realizable; `error` means Kind 2 rejected the model before getting
+# that far.
+contractck_dir_name = "contractck"
+contractck_args = {"--enable": "CONTRACTCK"}
+
 # Where to write log files
 log_dir = Path("logs")
 
@@ -290,6 +298,9 @@ class LustreItem(pytest.Item):
         if self._is_ic3ia():
             args |= ic3ia_args
 
+        if self._is_contractck():
+            args |= contractck_args
+
         arg_list = list(itertools.chain.from_iterable(args.items()))
         return [kind2_bin, *arg_list, self.path]
 
@@ -304,6 +315,9 @@ class LustreItem(pytest.Item):
 
     def _is_ic3ia(self):
         return ic3ia_dir_name in self._regression_parts()
+
+    def _is_contractck(self):
+        return contractck_dir_name in self._regression_parts()
 
     def _ic3ia_declines(self):
         return self._is_ic3ia() and ic3ia_declined_dir_name in self._regression_parts()

--- a/tests/regression/success/contractck/rec_func_called_in_imported_contract.lus
+++ b/tests/regression/success/contractck/rec_func_called_in_imported_contract.lus
@@ -1,0 +1,25 @@
+-- The contract checker computes the state variable dependencies of every node,
+-- callees first. A recursive function is its own callee, so there is nothing
+-- computed for the call in its body when its turn comes; it used to fail an
+-- assertion in LustreSlicing rather than fall back on the inputs of the call.
+
+datatype Nat = Zero | Succ (p: Nat);
+
+function rec Even (n: Nat) returns (r: bool)
+con
+  decreases n;
+noc
+let
+  r = match n with | Zero : true | Succ(m) : not Even(m) end;
+tel
+
+function imported P (x: Nat) returns (r: bool)
+con
+  guarantee r = Even(x);
+noc
+
+node main (x: Nat) returns (y: bool);
+let
+  y = P(x);
+  check y or not y;
+tel


### PR DESCRIPTION
## Summary

The contract checker fails an assertion on any model that has both a recursive function and an imported node:

```
<Error> Runtime error in contract checker: File "src/lustre/lustreSlicing.ml", line 241, characters 30-36: Assertion failed
```

`InputSystem.state_var_dependencies` walks the subsystems leaves first, so that the dependencies of a node call are read from the ones already computed for the callee. A recursive function is its own callee: when its turn comes, nothing is computed yet for the call in its own body, and `LustreSlicing.node_state_var_dependencies'` failed an assertion rather than account for it.

The dependencies of such a call now fall back on every input of the call. That is the worst a fixed point could converge to, and it is safe for the two things these dependencies are used for: keeping a variable in the cone of influence of another, and ordering equations by what they read. The transition system build is unaffected -- it computes the dependencies of the unrolled instance of the function before those of the caller, so it never reaches the fallback.

## Tests

The regression tree had no way to reach the realizability path, so tests under a `contractck` directory now run with `--enable CONTRACTCK`, the way the ones under `ic3ia` pin their engine. The new `success/contractck/rec_func_called_in_imported_contract.lus` exits 1 on the current `main` and 0 with this change.

Full suite green in all three slicing modes (`--slice-off --slice-experimental`).