### PR TITLE
Remove the Z3 relevancy option for recursive definitions

### DIFF
--- a/src/smt/Z3Driver.ml
+++ b/src/smt/Z3Driver.ml
@@ -20,7 +20,7 @@ include GenericSMTLIBDriver
 
 (* Configuration for Z3 *)
 let cmd_line
-    logic
+    _ (* logic *)
     timeout
     _ (* produce_models *) 
     _ (* produce_proofs *)
@@ -47,18 +47,6 @@ let cmd_line
   let timeout = Lib.min_option timeout_global timeout_local in
 
   let base_cmd = [| z3_bin; "-smt2"; "-in" |] in
-
-  (* Relevancy propagation makes Z3 diverge on the unfolding of recursive
-     function definitions (a satisfiability check that takes it a fraction
-     of a second without it can then run for minutes), so it is turned off
-     when the system defines recursive functions *)
-  let base_cmd =
-    match logic with
-    | `Inferred l when TermLib.FeatureSet.mem TermLib.RF l ->
-      Array.append base_cmd [| "smt.relevancy=0" |]
-    | _ -> base_cmd
-  in
-
   match timeout with
   | None -> base_cmd
   | Some timeout ->

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ common_args = {
     "--timeout": "84",
     "--color": "false",
     "--check_subproperties": "true",
-    "--check_sat_assume": "false",
 }
 
 # How long we let a single Kind 2 run take before killing it, in seconds.


### PR DESCRIPTION
## Summary

#1507 made the Z3 driver pass `smt.relevancy=0` on every system that defines recursive functions with `define-funs-rec` (logic feature `RF`), because relevancy propagation made Z3 diverge on the base case of `even_odd_sum_props.lus`. That measurement only holds in the push/pop mode the regression runner forced with `--check_sat_assume false`. In the default check-sat-assuming mode, the option is what makes Z3 diverge, on that very test and, catastrophically, on systems with quantifiers.

This PR:

- removes the option, reverting `Z3Driver.cmd_line` to what it was before #1507;
- drops `--check_sat_assume false` from the regression runner's common arguments, so the suite runs the mode every user runs. The flag entered the old shell runner in July 2020 (09c0d8b8) without a stated reason, and no test needs it: the solver layer already turns check-sat-assuming off by itself for the solvers that lack it.

Nothing else in #1507 is touched.

## Measurements

All on the same machine, sequential, nothing else running.

`tests/regression/success/even_odd_sum_props.lus`, whole run, Z3 4.16.0:

| mode | with `smt.relevancy=0` (main) | without (this PR) |
|---|---|---|
| check-sat-assuming (default) | timeout at 60s, also at 290s | valid, 10s |
| push/pop (`--check_sat_assume false`) | valid, 1s | timeout at 84s |

Same test in the default mode with Z3 4.15.3 (CI): timeout with the option, 9.5s without. With Z3 4.13.3 both take about 2s.

A security-protocol model with sets of ADT messages, a recursive function over them, and an invariant made of `forall`/`exists` formulas over the sets. Its first BMC and inductive-step queries replayed standalone from `--smt_trace`, Z3 in incremental mode, 60s timeout:

| Z3 | query | with `smt.relevancy=0` | without |
|---|---|---|---|
| 4.13.3 | IND k=1 / BMC k=1 | timeout / timeout | unsat 0.12s / unsat 0.10s |
| 4.15.3 | IND k=1 / BMC k=1 | timeout / unsat 21s | unsat 0.20s / unsat 0.21s |
| 4.16.0 | IND k=1 / BMC k=1 | timeout / timeout | unsat 0.20s / unsat 0.20s |

Here the option loses in both modes: with it Kind 2 proves nothing on that model in 5 minutes; without it every node contract but one that needs an auxiliary invariant is proved in under 2s, with `--check_sat_assume` on or off. `smt.relevancy=1` is in between and `smt.mbqi=false` does not help.

Full regression suite in the default mode, Z3 4.16.0: with the option, 594 passed but `even_odd_sum_props.lus` reaches its 84s budget; without it, 594 passed in 49s with no test near its budget. So in the default mode no test needs the option and one test needs its absence.

No regression test is added for the quantified case: reduced models with a recursive ADT function under a quantifier over a set (in the style of `rec_quantified_call.lus`) are solved in 0.1s with or without the option, and the hang needs the size of the full model.

## Test plan

- [x] `dune build --profile release @runtest` (OUnit) passes
- [x] Full regression suite with the updated runner (Z3 4.16.0): 594 passed, no test reaching its time budget
- [x] The protocol model: with `main`, no node proved in 5 minutes; with this branch, `KeyGenStep`, `SendStep`, `RecvStep` proved in 0.2s, 1.7s, 1.9s in both solver modes (the remaining node needs an invariant that is out of the scope of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
